### PR TITLE
refactor(pubsub): rename `SchemaStub`

### DIFF
--- a/google/cloud/pubsub/internal/schema_auth_decorator.cc
+++ b/google/cloud/pubsub/internal/schema_auth_decorator.cc
@@ -20,7 +20,7 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<google::pubsub::v1::Schema> SchemaAuth::CreateSchema(
+StatusOr<google::pubsub::v1::Schema> SchemaServiceAuth::CreateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::CreateSchemaRequest const& request) {
   auto status = auth_->ConfigureContext(context);
@@ -28,7 +28,7 @@ StatusOr<google::pubsub::v1::Schema> SchemaAuth::CreateSchema(
   return child_->CreateSchema(context, request);
 }
 
-StatusOr<google::pubsub::v1::Schema> SchemaAuth::GetSchema(
+StatusOr<google::pubsub::v1::Schema> SchemaServiceAuth::GetSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::GetSchemaRequest const& request) {
   auto status = auth_->ConfigureContext(context);
@@ -36,7 +36,8 @@ StatusOr<google::pubsub::v1::Schema> SchemaAuth::GetSchema(
   return child_->GetSchema(context, request);
 }
 
-StatusOr<google::pubsub::v1::ListSchemasResponse> SchemaAuth::ListSchemas(
+StatusOr<google::pubsub::v1::ListSchemasResponse>
+SchemaServiceAuth::ListSchemas(
     grpc::ClientContext& context,
     google::pubsub::v1::ListSchemasRequest const& request) {
   auto status = auth_->ConfigureContext(context);
@@ -44,7 +45,7 @@ StatusOr<google::pubsub::v1::ListSchemasResponse> SchemaAuth::ListSchemas(
   return child_->ListSchemas(context, request);
 }
 
-Status SchemaAuth::DeleteSchema(
+Status SchemaServiceAuth::DeleteSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteSchemaRequest const& request) {
   auto status = auth_->ConfigureContext(context);
@@ -52,7 +53,8 @@ Status SchemaAuth::DeleteSchema(
   return child_->DeleteSchema(context, request);
 }
 
-StatusOr<google::pubsub::v1::ValidateSchemaResponse> SchemaAuth::ValidateSchema(
+StatusOr<google::pubsub::v1::ValidateSchemaResponse>
+SchemaServiceAuth::ValidateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateSchemaRequest const& request) {
   auto status = auth_->ConfigureContext(context);
@@ -61,7 +63,7 @@ StatusOr<google::pubsub::v1::ValidateSchemaResponse> SchemaAuth::ValidateSchema(
 }
 
 StatusOr<google::pubsub::v1::ValidateMessageResponse>
-SchemaAuth::ValidateMessage(
+SchemaServiceAuth::ValidateMessage(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateMessageRequest const& request) {
   auto status = auth_->ConfigureContext(context);

--- a/google/cloud/pubsub/internal/schema_auth_decorator.h
+++ b/google/cloud/pubsub/internal/schema_auth_decorator.h
@@ -26,13 +26,13 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * A Decorator for `SchemaStub` that logs each request and response.
+ * A Decorator for `SchemaServiceStub` that logs each request and response.
  */
-class SchemaAuth : public SchemaStub {
+class SchemaServiceAuth : public SchemaServiceStub {
  public:
-  SchemaAuth(
+  SchemaServiceAuth(
       std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth,
-      std::shared_ptr<SchemaStub> child)
+      std::shared_ptr<SchemaServiceStub> child)
       : auth_(std::move(auth)), child_(std::move(child)) {}
 
   StatusOr<google::pubsub::v1::Schema> CreateSchema(
@@ -56,7 +56,7 @@ class SchemaAuth : public SchemaStub {
 
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
-  std::shared_ptr<SchemaStub> child_;
+  std::shared_ptr<SchemaServiceStub> child_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/schema_auth_test.cc
+++ b/google/cloud/pubsub/internal/schema_auth_test.cc
@@ -35,7 +35,7 @@ TEST(SchemaAuthTest, CreateSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, CreateSchema)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-  auto under_test = SchemaAuth(MakeTypicalMockAuth(), mock);
+  auto under_test = SchemaServiceAuth(MakeTypicalMockAuth(), mock);
   grpc::ClientContext ctx;
   google::pubsub::v1::CreateSchemaRequest request;
   auto auth_failure = under_test.CreateSchema(ctx, request);
@@ -51,7 +51,7 @@ TEST(SchemaAuthTest, GetSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, GetSchema)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-  auto under_test = SchemaAuth(MakeTypicalMockAuth(), mock);
+  auto under_test = SchemaServiceAuth(MakeTypicalMockAuth(), mock);
   grpc::ClientContext ctx;
   google::pubsub::v1::GetSchemaRequest request;
   auto auth_failure = under_test.GetSchema(ctx, request);
@@ -67,7 +67,7 @@ TEST(SchemaAuthTest, ListSchemas) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, ListSchemas)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-  auto under_test = SchemaAuth(MakeTypicalMockAuth(), mock);
+  auto under_test = SchemaServiceAuth(MakeTypicalMockAuth(), mock);
   grpc::ClientContext ctx;
   google::pubsub::v1::ListSchemasRequest request;
   auto auth_failure = under_test.ListSchemas(ctx, request);
@@ -83,7 +83,7 @@ TEST(SchemaAuthTest, DeleteSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, DeleteSchema)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-  auto under_test = SchemaAuth(MakeTypicalMockAuth(), mock);
+  auto under_test = SchemaServiceAuth(MakeTypicalMockAuth(), mock);
   grpc::ClientContext ctx;
   google::pubsub::v1::DeleteSchemaRequest request;
   auto auth_failure = under_test.DeleteSchema(ctx, request);
@@ -99,7 +99,7 @@ TEST(SchemaAuthTest, ValidateSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, ValidateSchema)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-  auto under_test = SchemaAuth(MakeTypicalMockAuth(), mock);
+  auto under_test = SchemaServiceAuth(MakeTypicalMockAuth(), mock);
   grpc::ClientContext ctx;
   google::pubsub::v1::ValidateSchemaRequest request;
   auto auth_failure = under_test.ValidateSchema(ctx, request);
@@ -115,7 +115,7 @@ TEST(SchemaAuthTest, ValidateMessage) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, ValidateMessage)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-  auto under_test = SchemaAuth(MakeTypicalMockAuth(), mock);
+  auto under_test = SchemaServiceAuth(MakeTypicalMockAuth(), mock);
   grpc::ClientContext ctx;
   google::pubsub::v1::ValidateMessageRequest request;
   auto auth_failure = under_test.ValidateMessage(ctx, request);

--- a/google/cloud/pubsub/internal/schema_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/schema_logging_decorator.cc
@@ -22,7 +22,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using ::google::cloud::internal::LogWrapper;
 
-StatusOr<google::pubsub::v1::Schema> SchemaLogging::CreateSchema(
+StatusOr<google::pubsub::v1::Schema> SchemaServiceLogging::CreateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::CreateSchemaRequest const& request) {
   return LogWrapper(
@@ -33,7 +33,7 @@ StatusOr<google::pubsub::v1::Schema> SchemaLogging::CreateSchema(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::pubsub::v1::Schema> SchemaLogging::GetSchema(
+StatusOr<google::pubsub::v1::Schema> SchemaServiceLogging::GetSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::GetSchemaRequest const& request) {
   return LogWrapper(
@@ -44,7 +44,8 @@ StatusOr<google::pubsub::v1::Schema> SchemaLogging::GetSchema(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::pubsub::v1::ListSchemasResponse> SchemaLogging::ListSchemas(
+StatusOr<google::pubsub::v1::ListSchemasResponse>
+SchemaServiceLogging::ListSchemas(
     grpc::ClientContext& context,
     google::pubsub::v1::ListSchemasRequest const& request) {
   return LogWrapper(
@@ -55,7 +56,7 @@ StatusOr<google::pubsub::v1::ListSchemasResponse> SchemaLogging::ListSchemas(
       context, request, __func__, tracing_options_);
 }
 
-Status SchemaLogging::DeleteSchema(
+Status SchemaServiceLogging::DeleteSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteSchemaRequest const& request) {
   return LogWrapper(
@@ -67,7 +68,7 @@ Status SchemaLogging::DeleteSchema(
 }
 
 StatusOr<google::pubsub::v1::ValidateSchemaResponse>
-SchemaLogging::ValidateSchema(
+SchemaServiceLogging::ValidateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateSchemaRequest const& request) {
   return LogWrapper(
@@ -79,7 +80,7 @@ SchemaLogging::ValidateSchema(
 }
 
 StatusOr<google::pubsub::v1::ValidateMessageResponse>
-SchemaLogging::ValidateMessage(
+SchemaServiceLogging::ValidateMessage(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateMessageRequest const& request) {
   return LogWrapper(

--- a/google/cloud/pubsub/internal/schema_logging_decorator.h
+++ b/google/cloud/pubsub/internal/schema_logging_decorator.h
@@ -26,12 +26,12 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * A Decorator for `SchemaStub` that logs each request and response.
+ * A Decorator for `SchemaServiceStub` that logs each request and response.
  */
-class SchemaLogging : public SchemaStub {
+class SchemaServiceLogging : public SchemaServiceStub {
  public:
-  SchemaLogging(std::shared_ptr<SchemaStub> child,
-                TracingOptions tracing_options)
+  SchemaServiceLogging(std::shared_ptr<SchemaServiceStub> child,
+                       TracingOptions tracing_options)
       : child_(std::move(child)),
         tracing_options_(std::move(tracing_options)) {}
 
@@ -55,7 +55,7 @@ class SchemaLogging : public SchemaStub {
       google::pubsub::v1::ValidateMessageRequest const& request) override;
 
  private:
-  std::shared_ptr<SchemaStub> child_;
+  std::shared_ptr<SchemaServiceStub> child_;
   TracingOptions tracing_options_;
 };
 

--- a/google/cloud/pubsub/internal/schema_logging_test.cc
+++ b/google/cloud/pubsub/internal/schema_logging_test.cc
@@ -42,7 +42,8 @@ TEST_F(SchemaLoggingTest, CreateSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, CreateSchema)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Schema{})));
-  SchemaLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(mock,
+                            TracingOptions{}.SetOptions("single_line_mode"));
   grpc::ClientContext context;
   google::pubsub::v1::CreateSchemaRequest request;
   auto status = stub.CreateSchema(context, request);
@@ -54,7 +55,8 @@ TEST_F(SchemaLoggingTest, GetSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, GetSchema)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Schema{})));
-  SchemaLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(mock,
+                            TracingOptions{}.SetOptions("single_line_mode"));
   grpc::ClientContext context;
   google::pubsub::v1::GetSchemaRequest request;
   auto status = stub.GetSchema(context, request);
@@ -67,7 +69,8 @@ TEST_F(SchemaLoggingTest, ListSchemas) {
   EXPECT_CALL(*mock, ListSchemas)
       .WillOnce(
           Return(make_status_or(google::pubsub::v1::ListSchemasResponse{})));
-  SchemaLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(mock,
+                            TracingOptions{}.SetOptions("single_line_mode"));
   grpc::ClientContext context;
   google::pubsub::v1::ListSchemasRequest request;
   auto status = stub.ListSchemas(context, request);
@@ -78,7 +81,8 @@ TEST_F(SchemaLoggingTest, ListSchemas) {
 TEST_F(SchemaLoggingTest, DeleteSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, DeleteSchema).WillOnce(Return(Status{}));
-  SchemaLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(mock,
+                            TracingOptions{}.SetOptions("single_line_mode"));
   grpc::ClientContext context;
   google::pubsub::v1::DeleteSchemaRequest request;
   auto status = stub.DeleteSchema(context, request);
@@ -91,7 +95,8 @@ TEST_F(SchemaLoggingTest, ValidateSchema) {
   EXPECT_CALL(*mock, ValidateSchema)
       .WillOnce(
           Return(make_status_or(google::pubsub::v1::ValidateSchemaResponse{})));
-  SchemaLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(mock,
+                            TracingOptions{}.SetOptions("single_line_mode"));
   grpc::ClientContext context;
   google::pubsub::v1::ValidateSchemaRequest request;
   auto status = stub.ValidateSchema(context, request);
@@ -104,7 +109,8 @@ TEST_F(SchemaLoggingTest, ValidateMessage) {
   EXPECT_CALL(*mock, ValidateMessage)
       .WillOnce(Return(
           make_status_or(google::pubsub::v1::ValidateMessageResponse{})));
-  SchemaLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(mock,
+                            TracingOptions{}.SetOptions("single_line_mode"));
   grpc::ClientContext context;
   google::pubsub::v1::ValidateMessageRequest request;
   auto status = stub.ValidateMessage(context, request);

--- a/google/cloud/pubsub/internal/schema_metadata_decorator.cc
+++ b/google/cloud/pubsub/internal/schema_metadata_decorator.cc
@@ -20,32 +20,34 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-SchemaMetadata::SchemaMetadata(std::shared_ptr<SchemaStub> child)
+SchemaServiceMetadata::SchemaServiceMetadata(
+    std::shared_ptr<SchemaServiceStub> child)
     : child_(std::move(child)),
       x_goog_api_client_(google::cloud::internal::ApiClientHeader()) {}
 
-StatusOr<google::pubsub::v1::Schema> SchemaMetadata::CreateSchema(
+StatusOr<google::pubsub::v1::Schema> SchemaServiceMetadata::CreateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::CreateSchemaRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->CreateSchema(context, request);
 }
 
-StatusOr<google::pubsub::v1::Schema> SchemaMetadata::GetSchema(
+StatusOr<google::pubsub::v1::Schema> SchemaServiceMetadata::GetSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::GetSchemaRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetSchema(context, request);
 }
 
-StatusOr<google::pubsub::v1::ListSchemasResponse> SchemaMetadata::ListSchemas(
+StatusOr<google::pubsub::v1::ListSchemasResponse>
+SchemaServiceMetadata::ListSchemas(
     grpc::ClientContext& context,
     google::pubsub::v1::ListSchemasRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListSchemas(context, request);
 }
 
-Status SchemaMetadata::DeleteSchema(
+Status SchemaServiceMetadata::DeleteSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteSchemaRequest const& request) {
   SetMetadata(context, "name=" + request.name());
@@ -53,7 +55,7 @@ Status SchemaMetadata::DeleteSchema(
 }
 
 StatusOr<google::pubsub::v1::ValidateSchemaResponse>
-SchemaMetadata::ValidateSchema(
+SchemaServiceMetadata::ValidateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateSchemaRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
@@ -61,15 +63,15 @@ SchemaMetadata::ValidateSchema(
 }
 
 StatusOr<google::pubsub::v1::ValidateMessageResponse>
-SchemaMetadata::ValidateMessage(
+SchemaServiceMetadata::ValidateMessage(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateMessageRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ValidateMessage(context, request);
 }
 
-void SchemaMetadata::SetMetadata(grpc::ClientContext& context,
-                                 std::string const& request_params) {
+void SchemaServiceMetadata::SetMetadata(grpc::ClientContext& context,
+                                        std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);
   context.AddMetadata("x-goog-api-client", x_goog_api_client_);
   auto const& options = internal::CurrentOptions();

--- a/google/cloud/pubsub/internal/schema_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/schema_metadata_decorator.h
@@ -26,11 +26,11 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * A Decorator for `SchemaStub` that logs each request and response.
+ * A Decorator for `SchemaServiceStub` that logs each request and response.
  */
-class SchemaMetadata : public SchemaStub {
+class SchemaServiceMetadata : public SchemaServiceStub {
  public:
-  explicit SchemaMetadata(std::shared_ptr<SchemaStub> child);
+  explicit SchemaServiceMetadata(std::shared_ptr<SchemaServiceStub> child);
 
   StatusOr<google::pubsub::v1::Schema> CreateSchema(
       grpc::ClientContext& context,
@@ -55,7 +55,7 @@ class SchemaMetadata : public SchemaStub {
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);
 
-  std::shared_ptr<SchemaStub> child_;
+  std::shared_ptr<SchemaServiceStub> child_;
   std::string x_goog_api_client_;
 };
 

--- a/google/cloud/pubsub/internal/schema_metadata_test.cc
+++ b/google/cloud/pubsub/internal/schema_metadata_test.cc
@@ -83,7 +83,7 @@ TEST_F(SchemaMetadataTest, CreateSchema) {
         return make_status_or(google::pubsub::v1::Schema{});
       });
 
-  SchemaMetadata stub(mock);
+  SchemaServiceMetadata stub(mock);
   for (auto const* user_project : {"", "", "test-project"}) {
     internal::OptionsSpan span(TestOptions(user_project));
     grpc::ClientContext context;
@@ -114,7 +114,7 @@ TEST_F(SchemaMetadataTest, GetSchema) {
         return make_status_or(google::pubsub::v1::Schema{});
       });
 
-  SchemaMetadata stub(mock);
+  SchemaServiceMetadata stub(mock);
   for (auto const* user_project : {"", "", "test-project"}) {
     internal::OptionsSpan span(TestOptions(user_project));
     grpc::ClientContext context;
@@ -145,7 +145,7 @@ TEST_F(SchemaMetadataTest, ListSchemas) {
         return make_status_or(google::pubsub::v1::ListSchemasResponse{});
       });
 
-  SchemaMetadata stub(mock);
+  SchemaServiceMetadata stub(mock);
   for (auto const* user_project : {"", "", "test-project"}) {
     internal::OptionsSpan span(TestOptions(user_project));
     grpc::ClientContext context;
@@ -176,7 +176,7 @@ TEST_F(SchemaMetadataTest, DeleteSchema) {
         return Status{};
       });
 
-  SchemaMetadata stub(mock);
+  SchemaServiceMetadata stub(mock);
   for (auto const* user_project : {"", "", "test-project"}) {
     internal::OptionsSpan span(TestOptions(user_project));
     grpc::ClientContext context;
@@ -208,7 +208,7 @@ TEST_F(SchemaMetadataTest, ValidateSchema) {
         return make_status_or(google::pubsub::v1::ValidateSchemaResponse{});
       });
 
-  SchemaMetadata stub(mock);
+  SchemaServiceMetadata stub(mock);
   for (auto const* user_project : {"", "", "test-project"}) {
     internal::OptionsSpan span(TestOptions(user_project));
     grpc::ClientContext context;
@@ -240,7 +240,7 @@ TEST_F(SchemaMetadataTest, ValidateMessage) {
         return make_status_or(google::pubsub::v1::ValidateMessageResponse{});
       });
 
-  SchemaMetadata stub(mock);
+  SchemaServiceMetadata stub(mock);
   for (auto const* user_project : {"", "", "test-project"}) {
     internal::OptionsSpan span(TestOptions(user_project));
     grpc::ClientContext context;

--- a/google/cloud/pubsub/internal/schema_stub.cc
+++ b/google/cloud/pubsub/internal/schema_stub.cc
@@ -22,7 +22,7 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<google::pubsub::v1::Schema> DefaultSchemaStub::CreateSchema(
+StatusOr<google::pubsub::v1::Schema> DefaultSchemaServiceStub::CreateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::CreateSchemaRequest const& request) {
   google::pubsub::v1::Schema response;
@@ -31,7 +31,7 @@ StatusOr<google::pubsub::v1::Schema> DefaultSchemaStub::CreateSchema(
   return response;
 }
 
-StatusOr<google::pubsub::v1::Schema> DefaultSchemaStub::GetSchema(
+StatusOr<google::pubsub::v1::Schema> DefaultSchemaServiceStub::GetSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::GetSchemaRequest const& request) {
   google::pubsub::v1::Schema response;
@@ -41,7 +41,7 @@ StatusOr<google::pubsub::v1::Schema> DefaultSchemaStub::GetSchema(
 }
 
 StatusOr<google::pubsub::v1::ListSchemasResponse>
-DefaultSchemaStub::ListSchemas(
+DefaultSchemaServiceStub::ListSchemas(
     grpc::ClientContext& context,
     google::pubsub::v1::ListSchemasRequest const& request) {
   google::pubsub::v1::ListSchemasResponse response;
@@ -50,7 +50,7 @@ DefaultSchemaStub::ListSchemas(
   return response;
 }
 
-Status DefaultSchemaStub::DeleteSchema(
+Status DefaultSchemaServiceStub::DeleteSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteSchemaRequest const& request) {
   google::protobuf::Empty response;
@@ -60,7 +60,7 @@ Status DefaultSchemaStub::DeleteSchema(
 }
 
 StatusOr<google::pubsub::v1::ValidateSchemaResponse>
-DefaultSchemaStub::ValidateSchema(
+DefaultSchemaServiceStub::ValidateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateSchemaRequest const& request) {
   google::pubsub::v1::ValidateSchemaResponse response;
@@ -70,7 +70,7 @@ DefaultSchemaStub::ValidateSchema(
 }
 
 StatusOr<google::pubsub::v1::ValidateMessageResponse>
-DefaultSchemaStub::ValidateMessage(
+DefaultSchemaServiceStub::ValidateMessage(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateMessageRequest const& request) {
   google::pubsub::v1::ValidateMessageResponse response;

--- a/google/cloud/pubsub/internal/schema_stub.h
+++ b/google/cloud/pubsub/internal/schema_stub.h
@@ -28,16 +28,16 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Define the interface for the gRPC wrapper.
  *
- * We wrap the gRPC-generated `SchemaStub` to:
+ * We wrap the gRPC-generated `SchemaServiceStub` to:
  *   - Return a `StatusOr<T>` instead of using a `grpc::Status` and an "output
  *     parameter" for the response.
  *   - To be able to mock the stubs.
  *   - To be able to decompose some functionality (logging, adding metadata
  *     information) into layers.
  */
-class SchemaStub {
+class SchemaServiceStub {
  public:
-  virtual ~SchemaStub() = default;
+  virtual ~SchemaServiceStub() = default;
 
   /// Creates a schema.
   virtual StatusOr<google::pubsub::v1::Schema> CreateSchema(
@@ -70,12 +70,12 @@ class SchemaStub {
       google::pubsub::v1::ValidateMessageRequest const& request) = 0;
 };
 
-class DefaultSchemaStub : public SchemaStub {
+class DefaultSchemaServiceStub : public SchemaServiceStub {
  public:
-  explicit DefaultSchemaStub(
+  explicit DefaultSchemaServiceStub(
       std::unique_ptr<google::pubsub::v1::SchemaService::StubInterface> impl)
       : grpc_stub_(std::move(impl)) {}
-  ~DefaultSchemaStub() override = default;
+  ~DefaultSchemaServiceStub() override = default;
 
   StatusOr<google::pubsub::v1::Schema> CreateSchema(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/schema_stub_factory.cc
+++ b/google/cloud/pubsub/internal/schema_stub_factory.cc
@@ -20,9 +20,9 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-std::shared_ptr<SchemaStub> CreateDefaultSchemaStub(
+std::shared_ptr<SchemaServiceStub> CreateDefaultSchemaStub(
     std::shared_ptr<grpc::Channel> channel) {
-  return std::make_shared<DefaultSchemaStub>(
+  return std::make_shared<DefaultSchemaServiceStub>(
       google::pubsub::v1::SchemaService::NewStub(std::move(channel)));
 }
 

--- a/google/cloud/pubsub/internal/schema_stub_factory.h
+++ b/google/cloud/pubsub/internal/schema_stub_factory.h
@@ -24,18 +24,18 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/// Create a SchemaStub using a pre-configured channel.
-std::shared_ptr<SchemaStub> CreateDefaultSchemaStub(
+/// Create a SchemaServiceStub using a pre-configured channel.
+std::shared_ptr<SchemaServiceStub> CreateDefaultSchemaStub(
     std::shared_ptr<grpc::Channel> channel);
 
 /**
- * Creates a SchemaStub configured with @p opts and @p channel_id.
+ * Creates a SchemaServiceStub configured with @p opts and @p channel_id.
  *
  * @p channel_id should be unique among all stubs in the same Connection pool,
  * to ensure they use different underlying connections.
  */
-std::shared_ptr<SchemaStub> CreateDefaultSchemaStub(Options const& opts,
-                                                    int channel_id);
+std::shared_ptr<SchemaServiceStub> CreateDefaultSchemaStub(Options const& opts,
+                                                           int channel_id);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/schema_admin_connection.cc
+++ b/google/cloud/pubsub/schema_admin_connection.cc
@@ -39,7 +39,7 @@ class SchemaAdminConnectionImpl : public pubsub::SchemaAdminConnection {
  public:
   explicit SchemaAdminConnectionImpl(
       std::unique_ptr<google::cloud::BackgroundThreads> background,
-      std::shared_ptr<pubsub_internal::SchemaStub> stub, Options options)
+      std::shared_ptr<pubsub_internal::SchemaServiceStub> stub, Options options)
       : background_(std::move(background)),
         stub_(std::move(stub)),
         options_(std::move(options)) {}
@@ -150,23 +150,24 @@ class SchemaAdminConnectionImpl : public pubsub::SchemaAdminConnection {
   }
 
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
-  std::shared_ptr<pubsub_internal::SchemaStub> stub_;
+  std::shared_ptr<pubsub_internal::SchemaServiceStub> stub_;
   Options options_;
 };
 
 // Decorates a SchemaAdminStub. This works for both mock and real stubs.
-std::shared_ptr<pubsub_internal::SchemaStub> DecorateSchemaAdminStub(
+std::shared_ptr<pubsub_internal::SchemaServiceStub> DecorateSchemaAdminStub(
     Options const& opts,
     std::shared_ptr<internal::GrpcAuthenticationStrategy> auth,
-    std::shared_ptr<pubsub_internal::SchemaStub> stub) {
+    std::shared_ptr<pubsub_internal::SchemaServiceStub> stub) {
   if (auth->RequiresConfigureContext()) {
-    stub = std::make_shared<pubsub_internal::SchemaAuth>(std::move(auth),
-                                                         std::move(stub));
+    stub = std::make_shared<pubsub_internal::SchemaServiceAuth>(
+        std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<pubsub_internal::SchemaMetadata>(std::move(stub));
+  stub =
+      std::make_shared<pubsub_internal::SchemaServiceMetadata>(std::move(stub));
   if (internal::Contains(opts.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    stub = std::make_shared<pubsub_internal::SchemaLogging>(
+    stub = std::make_shared<pubsub_internal::SchemaServiceLogging>(
         std::move(stub), opts.get<GrpcTracingOptionsOption>());
   }
   return stub;
@@ -216,7 +217,7 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::shared_ptr<pubsub::SchemaAdminConnection> MakeTestSchemaAdminConnection(
-    Options const& opts, std::shared_ptr<SchemaStub> stub) {
+    Options const& opts, std::shared_ptr<SchemaServiceStub> stub) {
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto auth = google::cloud::internal::CreateAuthenticationStrategy(
       background->cq(), opts);

--- a/google/cloud/pubsub/schema_admin_connection.h
+++ b/google/cloud/pubsub/schema_admin_connection.h
@@ -179,7 +179,7 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::shared_ptr<pubsub::SchemaAdminConnection> MakeTestSchemaAdminConnection(
-    Options const& opts, std::shared_ptr<SchemaStub> stub);
+    Options const& opts, std::shared_ptr<SchemaServiceStub> stub);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/schema_admin_connection_test.cc
+++ b/google/cloud/pubsub/schema_admin_connection_test.cc
@@ -40,7 +40,8 @@ using ::testing::HasSubstr;
 using ::testing::Return;
 
 std::shared_ptr<SchemaAdminConnection> MakeTestSchemaAdminConnection(
-    std::shared_ptr<pubsub_internal::SchemaStub> mock, Options opts = {}) {
+    std::shared_ptr<pubsub_internal::SchemaServiceStub> mock,
+    Options opts = {}) {
   opts = pubsub_internal::DefaultCommonOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
   return pubsub_internal::MakeTestSchemaAdminConnection(std::move(opts),

--- a/google/cloud/pubsub/testing/mock_schema_stub.h
+++ b/google/cloud/pubsub/testing/mock_schema_stub.h
@@ -25,9 +25,9 @@ namespace pubsub_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * A class to mock pubsub_internal::SchemaStub
+ * A class to mock pubsub_internal::SchemaServiceStub
  */
-class MockSchemaStub : public pubsub_internal::SchemaStub {
+class MockSchemaStub : public pubsub_internal::SchemaServiceStub {
  public:
   ~MockSchemaStub() override = default;
 


### PR DESCRIPTION
Use the name that the generator will use: `SchemaServiceStub`.

Part of the work for #7187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10064)
<!-- Reviewable:end -->
