### PR TITLE
refactor(pubsub): reorder `*Stub` functions

### DIFF
--- a/google/cloud/pubsub/internal/publisher_auth_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_auth_decorator.cc
@@ -27,14 +27,6 @@ StatusOr<google::pubsub::v1::Topic> PublisherAuth::CreateTopic(
   return child_->CreateTopic(context, request);
 }
 
-StatusOr<google::pubsub::v1::Topic> PublisherAuth::GetTopic(
-    grpc::ClientContext& context,
-    google::pubsub::v1::GetTopicRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->GetTopic(context, request);
-}
-
 StatusOr<google::pubsub::v1::Topic> PublisherAuth::UpdateTopic(
     grpc::ClientContext& context,
     google::pubsub::v1::UpdateTopicRequest const& request) {
@@ -43,29 +35,28 @@ StatusOr<google::pubsub::v1::Topic> PublisherAuth::UpdateTopic(
   return child_->UpdateTopic(context, request);
 }
 
+StatusOr<google::pubsub::v1::PublishResponse> PublisherAuth::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->Publish(context, request);
+}
+
+StatusOr<google::pubsub::v1::Topic> PublisherAuth::GetTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetTopicRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetTopic(context, request);
+}
+
 StatusOr<google::pubsub::v1::ListTopicsResponse> PublisherAuth::ListTopics(
     grpc::ClientContext& context,
     google::pubsub::v1::ListTopicsRequest const& request) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
   return child_->ListTopics(context, request);
-}
-
-Status PublisherAuth::DeleteTopic(
-    grpc::ClientContext& context,
-    google::pubsub::v1::DeleteTopicRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->DeleteTopic(context, request);
-}
-
-StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
-PublisherAuth::DetachSubscription(
-    grpc::ClientContext& context,
-    google::pubsub::v1::DetachSubscriptionRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->DetachSubscription(context, request);
 }
 
 StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
@@ -86,6 +77,23 @@ PublisherAuth::ListTopicSnapshots(
   return child_->ListTopicSnapshots(context, request);
 }
 
+Status PublisherAuth::DeleteTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteTopicRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DeleteTopic(context, request);
+}
+
+StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+PublisherAuth::DetachSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DetachSubscriptionRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DetachSubscription(context, request);
+}
+
 future<StatusOr<google::pubsub::v1::PublishResponse>>
 PublisherAuth::AsyncPublish(google::cloud::CompletionQueue& cq,
                             std::unique_ptr<grpc::ClientContext> context,
@@ -102,14 +110,6 @@ PublisherAuth::AsyncPublish(google::cloud::CompletionQueue& cq,
         }
         return child->AsyncPublish(cq, *std::move(context), request);
       });
-}
-
-StatusOr<google::pubsub::v1::PublishResponse> PublisherAuth::Publish(
-    grpc::ClientContext& context,
-    google::pubsub::v1::PublishRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->Publish(context, request);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/publisher_auth_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_auth_decorator.h
@@ -36,25 +36,21 @@ class PublisherAuth : public PublisherStub {
       grpc::ClientContext& context,
       google::pubsub::v1::Topic const& request) override;
 
-  StatusOr<google::pubsub::v1::Topic> GetTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::GetTopicRequest const& request) override;
-
   StatusOr<google::pubsub::v1::Topic> UpdateTopic(
       grpc::ClientContext& context,
       google::pubsub::v1::UpdateTopicRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Topic> GetTopic(
+      grpc::ClientContext& context,
+      google::pubsub::v1::GetTopicRequest const& request) override;
+
   StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
       grpc::ClientContext& context,
       google::pubsub::v1::ListTopicsRequest const& request) override;
-
-  Status DeleteTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DeleteTopicRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
   ListTopicSubscriptions(
@@ -66,13 +62,17 @@ class PublisherAuth : public PublisherStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ListTopicSnapshotsRequest const& request) override;
 
+  Status DeleteTopic(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DeleteTopicRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
+
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::PublishRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::PublishResponse> Publish(
-      grpc::ClientContext& context,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/publisher_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_decorator.cc
@@ -32,17 +32,6 @@ StatusOr<google::pubsub::v1::Topic> PublisherLogging::CreateTopic(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::pubsub::v1::Topic> PublisherLogging::GetTopic(
-    grpc::ClientContext& context,
-    google::pubsub::v1::GetTopicRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::pubsub::v1::GetTopicRequest const& request) {
-        return child_->GetTopic(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
-
 StatusOr<google::pubsub::v1::Topic> PublisherLogging::UpdateTopic(
     grpc::ClientContext& context,
     google::pubsub::v1::UpdateTopicRequest const& request) {
@@ -54,6 +43,28 @@ StatusOr<google::pubsub::v1::Topic> PublisherLogging::UpdateTopic(
       context, request, __func__, tracing_options_);
 }
 
+StatusOr<google::pubsub::v1::PublishResponse> PublisherLogging::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::PublishRequest const& request) {
+        return child_->Publish(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
+StatusOr<google::pubsub::v1::Topic> PublisherLogging::GetTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetTopicRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::GetTopicRequest const& request) {
+        return child_->GetTopic(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 StatusOr<google::pubsub::v1::ListTopicsResponse> PublisherLogging::ListTopics(
     grpc::ClientContext& context,
     google::pubsub::v1::ListTopicsRequest const& request) {
@@ -61,29 +72,6 @@ StatusOr<google::pubsub::v1::ListTopicsResponse> PublisherLogging::ListTopics(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ListTopicsRequest const& request) {
         return child_->ListTopics(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
-
-Status PublisherLogging::DeleteTopic(
-    grpc::ClientContext& context,
-    google::pubsub::v1::DeleteTopicRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::pubsub::v1::DeleteTopicRequest const& request) {
-        return child_->DeleteTopic(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
-
-StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
-PublisherLogging::DetachSubscription(
-    grpc::ClientContext& context,
-    google::pubsub::v1::DetachSubscriptionRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::pubsub::v1::DetachSubscriptionRequest const& request) {
-        return child_->DetachSubscription(context, request);
       },
       context, request, __func__, tracing_options_);
 }
@@ -112,6 +100,29 @@ PublisherLogging::ListTopicSnapshots(
       context, request, __func__, tracing_options_);
 }
 
+Status PublisherLogging::DeleteTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteTopicRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::DeleteTopicRequest const& request) {
+        return child_->DeleteTopic(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
+StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+PublisherLogging::DetachSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DetachSubscriptionRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::DetachSubscriptionRequest const& request) {
+        return child_->DetachSubscription(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 future<StatusOr<google::pubsub::v1::PublishResponse>>
 PublisherLogging::AsyncPublish(
     google::cloud::CompletionQueue& cq,
@@ -124,17 +135,6 @@ PublisherLogging::AsyncPublish(
         return child_->AsyncPublish(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
-}
-
-StatusOr<google::pubsub::v1::PublishResponse> PublisherLogging::Publish(
-    grpc::ClientContext& context,
-    google::pubsub::v1::PublishRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::pubsub::v1::PublishRequest const& request) {
-        return child_->Publish(context, request);
-      },
-      context, request, __func__, tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/publisher_logging_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_logging_decorator.h
@@ -36,25 +36,21 @@ class PublisherLogging : public PublisherStub {
       grpc::ClientContext& context,
       google::pubsub::v1::Topic const& request) override;
 
-  StatusOr<google::pubsub::v1::Topic> GetTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::GetTopicRequest const& request) override;
-
   StatusOr<google::pubsub::v1::Topic> UpdateTopic(
       grpc::ClientContext& context,
       google::pubsub::v1::UpdateTopicRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Topic> GetTopic(
+      grpc::ClientContext& context,
+      google::pubsub::v1::GetTopicRequest const& request) override;
+
   StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
       grpc::ClientContext& context,
       google::pubsub::v1::ListTopicsRequest const& request) override;
-
-  Status DeleteTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DeleteTopicRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
   ListTopicSubscriptions(
@@ -66,13 +62,17 @@ class PublisherLogging : public PublisherStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ListTopicSnapshotsRequest const& request) override;
 
+  Status DeleteTopic(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DeleteTopicRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
+
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::PublishRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::PublishResponse> Publish(
-      grpc::ClientContext& context,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata_decorator.cc
@@ -30,13 +30,6 @@ StatusOr<google::pubsub::v1::Topic> PublisherMetadata::CreateTopic(
   return child_->CreateTopic(context, request);
 }
 
-StatusOr<google::pubsub::v1::Topic> PublisherMetadata::GetTopic(
-    grpc::ClientContext& context,
-    google::pubsub::v1::GetTopicRequest const& request) {
-  SetMetadata(context, "topic=" + request.topic());
-  return child_->GetTopic(context, request);
-}
-
 StatusOr<google::pubsub::v1::Topic> PublisherMetadata::UpdateTopic(
     grpc::ClientContext& context,
     google::pubsub::v1::UpdateTopicRequest const& request) {
@@ -44,26 +37,25 @@ StatusOr<google::pubsub::v1::Topic> PublisherMetadata::UpdateTopic(
   return child_->UpdateTopic(context, request);
 }
 
+StatusOr<google::pubsub::v1::PublishResponse> PublisherMetadata::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  SetMetadata(context, "topic=" + request.topic());
+  return child_->Publish(context, request);
+}
+
+StatusOr<google::pubsub::v1::Topic> PublisherMetadata::GetTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetTopicRequest const& request) {
+  SetMetadata(context, "topic=" + request.topic());
+  return child_->GetTopic(context, request);
+}
+
 StatusOr<google::pubsub::v1::ListTopicsResponse> PublisherMetadata::ListTopics(
     grpc::ClientContext& context,
     google::pubsub::v1::ListTopicsRequest const& request) {
   SetMetadata(context, "project=" + request.project());
   return child_->ListTopics(context, request);
-}
-
-Status PublisherMetadata::DeleteTopic(
-    grpc::ClientContext& context,
-    google::pubsub::v1::DeleteTopicRequest const& request) {
-  SetMetadata(context, "topic=" + request.topic());
-  return child_->DeleteTopic(context, request);
-}
-
-StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
-PublisherMetadata::DetachSubscription(
-    grpc::ClientContext& context,
-    google::pubsub::v1::DetachSubscriptionRequest const& request) {
-  SetMetadata(context, "subscription=" + request.subscription());
-  return child_->DetachSubscription(context, request);
 }
 
 StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
@@ -82,6 +74,21 @@ PublisherMetadata::ListTopicSnapshots(
   return child_->ListTopicSnapshots(context, request);
 }
 
+Status PublisherMetadata::DeleteTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteTopicRequest const& request) {
+  SetMetadata(context, "topic=" + request.topic());
+  return child_->DeleteTopic(context, request);
+}
+
+StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+PublisherMetadata::DetachSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DetachSubscriptionRequest const& request) {
+  SetMetadata(context, "subscription=" + request.subscription());
+  return child_->DetachSubscription(context, request);
+}
+
 future<StatusOr<google::pubsub::v1::PublishResponse>>
 PublisherMetadata::AsyncPublish(
     google::cloud::CompletionQueue& cq,
@@ -89,13 +96,6 @@ PublisherMetadata::AsyncPublish(
     google::pubsub::v1::PublishRequest const& request) {
   SetMetadata(*context, "topic=" + request.topic());
   return child_->AsyncPublish(cq, std::move(context), request);
-}
-
-StatusOr<google::pubsub::v1::PublishResponse> PublisherMetadata::Publish(
-    grpc::ClientContext& context,
-    google::pubsub::v1::PublishRequest const& request) {
-  SetMetadata(context, "topic=" + request.topic());
-  return child_->Publish(context, request);
 }
 
 void PublisherMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/publisher_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_metadata_decorator.h
@@ -34,25 +34,21 @@ class PublisherMetadata : public PublisherStub {
       grpc::ClientContext& context,
       google::pubsub::v1::Topic const& request) override;
 
-  StatusOr<google::pubsub::v1::Topic> GetTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::GetTopicRequest const& request) override;
-
   StatusOr<google::pubsub::v1::Topic> UpdateTopic(
       grpc::ClientContext& context,
       google::pubsub::v1::UpdateTopicRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Topic> GetTopic(
+      grpc::ClientContext& context,
+      google::pubsub::v1::GetTopicRequest const& request) override;
+
   StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
       grpc::ClientContext& context,
       google::pubsub::v1::ListTopicsRequest const& request) override;
-
-  Status DeleteTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DeleteTopicRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
   ListTopicSubscriptions(
@@ -64,13 +60,17 @@ class PublisherMetadata : public PublisherStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ListTopicSnapshotsRequest const& request) override;
 
+  Status DeleteTopic(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DeleteTopicRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
+
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::PublishRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::PublishResponse> Publish(
-      grpc::ClientContext& context,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -30,20 +30,29 @@ StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::CreateTopic(
   return response;
 }
 
-StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::GetTopic(
-    grpc::ClientContext& context,
-    google::pubsub::v1::GetTopicRequest const& request) {
-  google::pubsub::v1::Topic response;
-  auto status = grpc_stub_->GetTopic(&context, request, &response);
-  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-  return response;
-}
-
 StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::UpdateTopic(
     grpc::ClientContext& context,
     google::pubsub::v1::UpdateTopicRequest const& request) {
   google::pubsub::v1::Topic response;
   auto status = grpc_stub_->UpdateTopic(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
+
+StatusOr<google::pubsub::v1::PublishResponse> DefaultPublisherStub::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  google::pubsub::v1::PublishResponse response;
+  auto status = grpc_stub_->Publish(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
+
+StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::GetTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetTopicRequest const& request) {
+  google::pubsub::v1::Topic response;
+  auto status = grpc_stub_->GetTopic(&context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
@@ -54,25 +63,6 @@ DefaultPublisherStub::ListTopics(
     google::pubsub::v1::ListTopicsRequest const& request) {
   google::pubsub::v1::ListTopicsResponse response;
   auto status = grpc_stub_->ListTopics(&context, request, &response);
-  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-  return response;
-}
-
-Status DefaultPublisherStub::DeleteTopic(
-    grpc::ClientContext& context,
-    google::pubsub::v1::DeleteTopicRequest const& request) {
-  google::protobuf::Empty response;
-  auto status = grpc_stub_->DeleteTopic(&context, request, &response);
-  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-  return {};
-}
-
-StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
-DefaultPublisherStub::DetachSubscription(
-    grpc::ClientContext& context,
-    google::pubsub::v1::DetachSubscriptionRequest const& request) {
-  google::pubsub::v1::DetachSubscriptionResponse response;
-  auto status = grpc_stub_->DetachSubscription(&context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
@@ -98,6 +88,25 @@ DefaultPublisherStub::ListTopicSnapshots(
   return response;
 }
 
+Status DefaultPublisherStub::DeleteTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteTopicRequest const& request) {
+  google::protobuf::Empty response;
+  auto status = grpc_stub_->DeleteTopic(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return {};
+}
+
+StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+DefaultPublisherStub::DetachSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DetachSubscriptionRequest const& request) {
+  google::pubsub::v1::DetachSubscriptionResponse response;
+  auto status = grpc_stub_->DetachSubscription(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
+
 future<StatusOr<google::pubsub::v1::PublishResponse>>
 DefaultPublisherStub::AsyncPublish(
     google::cloud::CompletionQueue& cq,
@@ -110,15 +119,6 @@ DefaultPublisherStub::AsyncPublish(
         return grpc_stub_->AsyncPublish(context, request, cq);
       },
       request, std::move(context));
-}
-
-StatusOr<google::pubsub::v1::PublishResponse> DefaultPublisherStub::Publish(
-    grpc::ClientContext& context,
-    google::pubsub::v1::PublishRequest const& request) {
-  google::pubsub::v1::PublishResponse response;
-  auto status = grpc_stub_->Publish(&context, request, &response);
-  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-  return response;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -45,31 +45,25 @@ class PublisherStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::Topic const& request) = 0;
 
-  /// Get information about an existing topic.
-  virtual StatusOr<google::pubsub::v1::Topic> GetTopic(
-      grpc::ClientContext& client_context,
-      google::pubsub::v1::GetTopicRequest const& request) = 0;
-
   /// Update the configuration of an existing topic.
   virtual StatusOr<google::pubsub::v1::Topic> UpdateTopic(
       grpc::ClientContext& client_context,
       google::pubsub::v1::UpdateTopicRequest const& request) = 0;
 
+  /// Publish a batch of messages.
+  virtual StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::PublishRequest const& request) = 0;
+
+  /// Get information about an existing topic.
+  virtual StatusOr<google::pubsub::v1::Topic> GetTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::GetTopicRequest const& request) = 0;
+
   /// List existing topics.
   virtual StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
       grpc::ClientContext& client_context,
       google::pubsub::v1::ListTopicsRequest const& request) = 0;
-
-  /// Delete a topic.
-  virtual Status DeleteTopic(
-      grpc::ClientContext& client_context,
-      google::pubsub::v1::DeleteTopicRequest const& request) = 0;
-
-  /// Detach a subscription.
-  virtual StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
-  DetachSubscription(
-      grpc::ClientContext& client_context,
-      google::pubsub::v1::DetachSubscriptionRequest const& request) = 0;
 
   /// List subscriptions for a topic.
   virtual StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
@@ -83,15 +77,21 @@ class PublisherStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::ListTopicSnapshotsRequest const& request) = 0;
 
+  /// Delete a topic.
+  virtual Status DeleteTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DeleteTopicRequest const& request) = 0;
+
+  /// Detach a subscription.
+  virtual StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+  DetachSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) = 0;
+
   /// Publish a batch of messages.
   virtual future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> client_context,
-      google::pubsub::v1::PublishRequest const& request) = 0;
-
-  /// Publish a batch of messages.
-  virtual StatusOr<google::pubsub::v1::PublishResponse> Publish(
-      grpc::ClientContext& client_context,
       google::pubsub::v1::PublishRequest const& request) = 0;
 };
 
@@ -107,25 +107,21 @@ class DefaultPublisherStub : public PublisherStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::Topic const& request) override;
 
-  StatusOr<google::pubsub::v1::Topic> GetTopic(
-      grpc::ClientContext& client_context,
-      google::pubsub::v1::GetTopicRequest const& request) override;
-
   StatusOr<google::pubsub::v1::Topic> UpdateTopic(
       grpc::ClientContext& client_context,
       google::pubsub::v1::UpdateTopicRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Topic> GetTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::GetTopicRequest const& request) override;
+
   StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
       grpc::ClientContext& client_context,
       google::pubsub::v1::ListTopicsRequest const& request) override;
-
-  Status DeleteTopic(
-      grpc::ClientContext& client_context,
-      google::pubsub::v1::DeleteTopicRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
-      grpc::ClientContext& client_context,
-      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
   ListTopicSubscriptions(
@@ -137,13 +133,17 @@ class DefaultPublisherStub : public PublisherStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::ListTopicSnapshotsRequest const& request) override;
 
+  Status DeleteTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DeleteTopicRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
+
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> client_context,
-      google::pubsub::v1::PublishRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::PublishResponse> Publish(
-      grpc::ClientContext& client_context,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/subscriber_auth_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_auth_decorator.cc
@@ -61,14 +61,6 @@ Status SubscriberAuth::DeleteSubscription(
   return child_->DeleteSubscription(context, request);
 }
 
-Status SubscriberAuth::ModifyPushConfig(
-    grpc::ClientContext& context,
-    google::pubsub::v1::ModifyPushConfigRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->ModifyPushConfig(context, request);
-}
-
 std::unique_ptr<SubscriberStub::AsyncPullStream>
 SubscriberAuth::AsyncStreamingPull(
     google::cloud::CompletionQueue& cq,
@@ -87,42 +79,20 @@ SubscriberAuth::AsyncStreamingPull(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
 }
 
-future<Status> SubscriberAuth::AsyncAcknowledge(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::AcknowledgeRequest const& request) {
-  auto& child = child_;
-  return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
-             request](future<StatusOr<std::unique_ptr<grpc::ClientContext>>>
-                          f) mutable {
-        auto context = f.get();
-        if (!context) return make_ready_future(std::move(context).status());
-        return child->AsyncAcknowledge(cq, *std::move(context), request);
-      });
-}
-
-future<Status> SubscriberAuth::AsyncModifyAckDeadline(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  auto& child = child_;
-  return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
-             request](future<StatusOr<std::unique_ptr<grpc::ClientContext>>>
-                          f) mutable {
-        auto context = f.get();
-        if (!context) return make_ready_future(std::move(context).status());
-        return child->AsyncModifyAckDeadline(cq, *std::move(context), request);
-      });
-}
-
-StatusOr<google::pubsub::v1::Snapshot> SubscriberAuth::CreateSnapshot(
+Status SubscriberAuth::ModifyPushConfig(
     grpc::ClientContext& context,
-    google::pubsub::v1::CreateSnapshotRequest const& request) {
+    google::pubsub::v1::ModifyPushConfigRequest const& request) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->CreateSnapshot(context, request);
+  return child_->ModifyPushConfig(context, request);
+}
+
+StatusOr<google::pubsub::v1::Snapshot> SubscriberAuth::GetSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetSnapshotRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetSnapshot(context, request);
 }
 
 StatusOr<google::pubsub::v1::ListSnapshotsResponse>
@@ -134,12 +104,12 @@ SubscriberAuth::ListSnapshots(
   return child_->ListSnapshots(context, request);
 }
 
-StatusOr<google::pubsub::v1::Snapshot> SubscriberAuth::GetSnapshot(
+StatusOr<google::pubsub::v1::Snapshot> SubscriberAuth::CreateSnapshot(
     grpc::ClientContext& context,
-    google::pubsub::v1::GetSnapshotRequest const& request) {
+    google::pubsub::v1::CreateSnapshotRequest const& request) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->GetSnapshot(context, request);
+  return child_->CreateSnapshot(context, request);
 }
 
 StatusOr<google::pubsub::v1::Snapshot> SubscriberAuth::UpdateSnapshot(
@@ -164,6 +134,36 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberAuth::Seek(
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
   return child_->Seek(context, request);
+}
+
+future<Status> SubscriberAuth::AsyncModifyAckDeadline(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+  auto& child = child_;
+  return auth_->AsyncConfigureContext(std::move(context))
+      .then([cq, child,
+             request](future<StatusOr<std::unique_ptr<grpc::ClientContext>>>
+                          f) mutable {
+        auto context = f.get();
+        if (!context) return make_ready_future(std::move(context).status());
+        return child->AsyncModifyAckDeadline(cq, *std::move(context), request);
+      });
+}
+
+future<Status> SubscriberAuth::AsyncAcknowledge(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::AcknowledgeRequest const& request) {
+  auto& child = child_;
+  return auth_->AsyncConfigureContext(std::move(context))
+      .then([cq, child,
+             request](future<StatusOr<std::unique_ptr<grpc::ClientContext>>>
+                          f) mutable {
+        auto context = f.get();
+        if (!context) return make_ready_future(std::move(context).status());
+        return child->AsyncAcknowledge(cq, *std::move(context), request);
+      });
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/subscriber_auth_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_auth_decorator.h
@@ -52,28 +52,14 @@ class SubscriberAuth : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) override;
 
-  Status ModifyPushConfig(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
-
   std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::StreamingPullRequest const& request) override;
 
-  future<Status> AsyncAcknowledge(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::AcknowledgeRequest const& request) override;
-
-  future<Status> AsyncModifyAckDeadline(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+  Status ModifyPushConfig(
       grpc::ClientContext& context,
-      google::pubsub::v1::CreateSnapshotRequest const& request) override;
+      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
       grpc::ClientContext& context,
@@ -82,6 +68,10 @@ class SubscriberAuth : public SubscriberStub {
   StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
       grpc::ClientContext& context,
       google::pubsub::v1::ListSnapshotsRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
       grpc::ClientContext& context,
@@ -94,6 +84,16 @@ class SubscriberAuth : public SubscriberStub {
   StatusOr<google::pubsub::v1::SeekResponse> Seek(
       grpc::ClientContext& context,
       google::pubsub::v1::SeekRequest const& request) override;
+
+  future<Status> AsyncModifyAckDeadline(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
+
+  future<Status> AsyncAcknowledge(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
@@ -81,17 +81,6 @@ Status SubscriberLogging::DeleteSubscription(
       context, request, __func__, tracing_options_);
 }
 
-Status SubscriberLogging::ModifyPushConfig(
-    grpc::ClientContext& context,
-    google::pubsub::v1::ModifyPushConfigRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::pubsub::v1::ModifyPushConfigRequest const& request) {
-        return child_->ModifyPushConfig(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
-
 std::unique_ptr<SubscriberStub::AsyncPullStream>
 SubscriberLogging::AsyncStreamingPull(
     google::cloud::CompletionQueue& cq,
@@ -107,39 +96,24 @@ SubscriberLogging::AsyncStreamingPull(
       std::move(stream), tracing_options_, request_id);
 }
 
-future<Status> SubscriberLogging::AsyncAcknowledge(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::AcknowledgeRequest const& request) {
-  return LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
-             std::unique_ptr<grpc::ClientContext> context,
-             google::pubsub::v1::AcknowledgeRequest const& request) {
-        return child_->AsyncAcknowledge(cq, std::move(context), request);
-      },
-      cq, std::move(context), request, __func__, tracing_options_);
-}
-
-future<Status> SubscriberLogging::AsyncModifyAckDeadline(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  return LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
-             std::unique_ptr<grpc::ClientContext> context,
-             google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-        return child_->AsyncModifyAckDeadline(cq, std::move(context), request);
-      },
-      cq, std::move(context), request, __func__, tracing_options_);
-}
-
-StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::CreateSnapshot(
+Status SubscriberLogging::ModifyPushConfig(
     grpc::ClientContext& context,
-    google::pubsub::v1::CreateSnapshotRequest const& request) {
+    google::pubsub::v1::ModifyPushConfigRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             google::pubsub::v1::CreateSnapshotRequest const& request) {
-        return child_->CreateSnapshot(context, request);
+             google::pubsub::v1::ModifyPushConfigRequest const& request) {
+        return child_->ModifyPushConfig(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
+StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::GetSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetSnapshotRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::GetSnapshotRequest const& request) {
+        return child_->GetSnapshot(context, request);
       },
       context, request, __func__, tracing_options_);
 }
@@ -156,13 +130,13 @@ SubscriberLogging::ListSnapshots(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::GetSnapshot(
+StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::CreateSnapshot(
     grpc::ClientContext& context,
-    google::pubsub::v1::GetSnapshotRequest const& request) {
+    google::pubsub::v1::CreateSnapshotRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             google::pubsub::v1::GetSnapshotRequest const& request) {
-        return child_->GetSnapshot(context, request);
+             google::pubsub::v1::CreateSnapshotRequest const& request) {
+        return child_->CreateSnapshot(context, request);
       },
       context, request, __func__, tracing_options_);
 }
@@ -198,6 +172,32 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberLogging::Seek(
         return child_->Seek(context, request);
       },
       context, request, __func__, tracing_options_);
+}
+
+future<Status> SubscriberLogging::AsyncModifyAckDeadline(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+  return LogWrapper(
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
+             google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+        return child_->AsyncModifyAckDeadline(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
+}
+
+future<Status> SubscriberLogging::AsyncAcknowledge(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::AcknowledgeRequest const& request) {
+  return LogWrapper(
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
+             google::pubsub::v1::AcknowledgeRequest const& request) {
+        return child_->AsyncAcknowledge(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 LoggingAsyncPullStream::LoggingAsyncPullStream(

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.h
@@ -54,28 +54,14 @@ class SubscriberLogging : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) override;
 
-  Status ModifyPushConfig(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
-
   std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::StreamingPullRequest const& request) override;
 
-  future<Status> AsyncAcknowledge(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::AcknowledgeRequest const& request) override;
-
-  future<Status> AsyncModifyAckDeadline(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+  Status ModifyPushConfig(
       grpc::ClientContext& context,
-      google::pubsub::v1::CreateSnapshotRequest const& request) override;
+      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
       grpc::ClientContext& context,
@@ -84,6 +70,10 @@ class SubscriberLogging : public SubscriberStub {
   StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
       grpc::ClientContext& context,
       google::pubsub::v1::ListSnapshotsRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
       grpc::ClientContext& context,
@@ -96,6 +86,16 @@ class SubscriberLogging : public SubscriberStub {
   StatusOr<google::pubsub::v1::SeekResponse> Seek(
       grpc::ClientContext& context,
       google::pubsub::v1::SeekRequest const& request) override;
+
+  future<Status> AsyncModifyAckDeadline(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
+
+  future<Status> AsyncAcknowledge(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:
   std::shared_ptr<SubscriberStub> child_;

--- a/google/cloud/pubsub/internal/subscriber_metadata_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata_decorator.cc
@@ -63,13 +63,6 @@ Status SubscriberMetadata::DeleteSubscription(
   return child_->DeleteSubscription(context, request);
 }
 
-Status SubscriberMetadata::ModifyPushConfig(
-    grpc::ClientContext& context,
-    google::pubsub::v1::ModifyPushConfigRequest const& request) {
-  SetMetadata(context, "subscription=" + request.subscription());
-  return child_->ModifyPushConfig(context, request);
-}
-
 std::unique_ptr<SubscriberStub::AsyncPullStream>
 SubscriberMetadata::AsyncStreamingPull(
     google::cloud::CompletionQueue& cq,
@@ -79,27 +72,18 @@ SubscriberMetadata::AsyncStreamingPull(
   return child_->AsyncStreamingPull(cq, std::move(context), request);
 }
 
-future<Status> SubscriberMetadata::AsyncAcknowledge(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::AcknowledgeRequest const& request) {
-  SetMetadata(*context, "subscription=" + request.subscription());
-  return child_->AsyncAcknowledge(cq, std::move(context), request);
-}
-
-future<Status> SubscriberMetadata::AsyncModifyAckDeadline(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  SetMetadata(*context, "subscription=" + request.subscription());
-  return child_->AsyncModifyAckDeadline(cq, std::move(context), request);
-}
-
-StatusOr<google::pubsub::v1::Snapshot> SubscriberMetadata::CreateSnapshot(
+Status SubscriberMetadata::ModifyPushConfig(
     grpc::ClientContext& context,
-    google::pubsub::v1::CreateSnapshotRequest const& request) {
-  SetMetadata(context, "name=" + request.name());
-  return child_->CreateSnapshot(context, request);
+    google::pubsub::v1::ModifyPushConfigRequest const& request) {
+  SetMetadata(context, "subscription=" + request.subscription());
+  return child_->ModifyPushConfig(context, request);
+}
+
+StatusOr<google::pubsub::v1::Snapshot> SubscriberMetadata::GetSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetSnapshotRequest const& request) {
+  SetMetadata(context, "snapshot=" + request.snapshot());
+  return child_->GetSnapshot(context, request);
 }
 
 StatusOr<google::pubsub::v1::ListSnapshotsResponse>
@@ -110,11 +94,11 @@ SubscriberMetadata::ListSnapshots(
   return child_->ListSnapshots(context, request);
 }
 
-StatusOr<google::pubsub::v1::Snapshot> SubscriberMetadata::GetSnapshot(
+StatusOr<google::pubsub::v1::Snapshot> SubscriberMetadata::CreateSnapshot(
     grpc::ClientContext& context,
-    google::pubsub::v1::GetSnapshotRequest const& request) {
-  SetMetadata(context, "snapshot=" + request.snapshot());
-  return child_->GetSnapshot(context, request);
+    google::pubsub::v1::CreateSnapshotRequest const& request) {
+  SetMetadata(context, "name=" + request.name());
+  return child_->CreateSnapshot(context, request);
 }
 
 StatusOr<google::pubsub::v1::Snapshot> SubscriberMetadata::UpdateSnapshot(
@@ -136,6 +120,22 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberMetadata::Seek(
     google::pubsub::v1::SeekRequest const& request) {
   SetMetadata(context, "subscription=" + request.subscription());
   return child_->Seek(context, request);
+}
+
+future<Status> SubscriberMetadata::AsyncModifyAckDeadline(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+  SetMetadata(*context, "subscription=" + request.subscription());
+  return child_->AsyncModifyAckDeadline(cq, std::move(context), request);
+}
+
+future<Status> SubscriberMetadata::AsyncAcknowledge(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::AcknowledgeRequest const& request) {
+  SetMetadata(*context, "subscription=" + request.subscription());
+  return child_->AsyncAcknowledge(cq, std::move(context), request);
 }
 
 void SubscriberMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
@@ -50,28 +50,14 @@ class SubscriberMetadata : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) override;
 
-  Status ModifyPushConfig(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
-
   std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::StreamingPullRequest const& request) override;
 
-  future<Status> AsyncAcknowledge(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::AcknowledgeRequest const& request) override;
-
-  future<Status> AsyncModifyAckDeadline(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+  Status ModifyPushConfig(
       grpc::ClientContext& context,
-      google::pubsub::v1::CreateSnapshotRequest const& request) override;
+      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
       grpc::ClientContext& context,
@@ -80,6 +66,10 @@ class SubscriberMetadata : public SubscriberStub {
   StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
       grpc::ClientContext& context,
       google::pubsub::v1::ListSnapshotsRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
       grpc::ClientContext& context,
@@ -92,6 +82,16 @@ class SubscriberMetadata : public SubscriberStub {
   StatusOr<google::pubsub::v1::SeekResponse> Seek(
       grpc::ClientContext& context,
       google::pubsub::v1::SeekRequest const& request) override;
+
+  future<Status> AsyncModifyAckDeadline(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
+
+  future<Status> AsyncAcknowledge(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -71,15 +71,6 @@ Status DefaultSubscriberStub::DeleteSubscription(
   return {};
 }
 
-Status DefaultSubscriberStub::ModifyPushConfig(
-    grpc::ClientContext& context,
-    google::pubsub::v1::ModifyPushConfigRequest const& request) {
-  google::protobuf::Empty response;
-  auto status = grpc_stub_->ModifyPushConfig(&context, request, &response);
-  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-  return {};
-}
-
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::pubsub::v1::StreamingPullRequest,
     google::pubsub::v1::StreamingPullResponse>>
@@ -96,51 +87,13 @@ DefaultSubscriberStub::AsyncStreamingPull(
       });
 }
 
-future<Status> DefaultSubscriberStub::AsyncAcknowledge(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::AcknowledgeRequest const& request) {
-  return cq
-      .MakeUnaryRpc(
-          [this](grpc::ClientContext* context,
-                 google::pubsub::v1::AcknowledgeRequest const& request,
-                 grpc::CompletionQueue* cq) {
-            return grpc_stub_->AsyncAcknowledge(context, request, cq);
-          },
-          request, std::move(context))
-      .then([](future<StatusOr<google::protobuf::Empty>> f) {
-        auto result = f.get();
-        if (!result) return std::move(result).status();
-        return Status{};
-      });
-}
-
-future<Status> DefaultSubscriberStub::AsyncModifyAckDeadline(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  return cq
-      .MakeUnaryRpc(
-          [this](grpc::ClientContext* context,
-                 google::pubsub::v1::ModifyAckDeadlineRequest const& request,
-                 grpc::CompletionQueue* cq) {
-            return grpc_stub_->AsyncModifyAckDeadline(context, request, cq);
-          },
-          request, std::move(context))
-      .then([](future<StatusOr<google::protobuf::Empty>> f) {
-        auto result = f.get();
-        if (!result) return std::move(result).status();
-        return Status{};
-      });
-}
-
-StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::CreateSnapshot(
+Status DefaultSubscriberStub::ModifyPushConfig(
     grpc::ClientContext& context,
-    google::pubsub::v1::CreateSnapshotRequest const& request) {
-  google::pubsub::v1::Snapshot response;
-  auto status = grpc_stub_->CreateSnapshot(&context, request, &response);
+    google::pubsub::v1::ModifyPushConfigRequest const& request) {
+  google::protobuf::Empty response;
+  auto status = grpc_stub_->ModifyPushConfig(&context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-  return response;
+  return {};
 }
 
 StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::GetSnapshot(
@@ -158,6 +111,15 @@ DefaultSubscriberStub::ListSnapshots(
     google::pubsub::v1::ListSnapshotsRequest const& request) {
   google::pubsub::v1::ListSnapshotsResponse response;
   auto status = grpc_stub_->ListSnapshots(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
+
+StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::CreateSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::CreateSnapshotRequest const& request) {
+  google::pubsub::v1::Snapshot response;
+  auto status = grpc_stub_->CreateSnapshot(&context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
@@ -187,6 +149,44 @@ StatusOr<google::pubsub::v1::SeekResponse> DefaultSubscriberStub::Seek(
   auto status = grpc_stub_->Seek(&context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
+}
+
+future<Status> DefaultSubscriberStub::AsyncModifyAckDeadline(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+  return cq
+      .MakeUnaryRpc(
+          [this](grpc::ClientContext* context,
+                 google::pubsub::v1::ModifyAckDeadlineRequest const& request,
+                 grpc::CompletionQueue* cq) {
+            return grpc_stub_->AsyncModifyAckDeadline(context, request, cq);
+          },
+          request, std::move(context))
+      .then([](future<StatusOr<google::protobuf::Empty>> f) {
+        auto result = f.get();
+        if (!result) return std::move(result).status();
+        return Status{};
+      });
+}
+
+future<Status> DefaultSubscriberStub::AsyncAcknowledge(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::AcknowledgeRequest const& request) {
+  return cq
+      .MakeUnaryRpc(
+          [this](grpc::ClientContext* context,
+                 google::pubsub::v1::AcknowledgeRequest const& request,
+                 grpc::CompletionQueue* cq) {
+            return grpc_stub_->AsyncAcknowledge(context, request, cq);
+          },
+          request, std::move(context))
+      .then([](future<StatusOr<google::protobuf::Empty>> f) {
+        auto result = f.get();
+        if (!result) return std::move(result).status();
+        return Status{};
+      });
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -66,11 +66,6 @@ class SubscriberStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) = 0;
 
-  /// Modify the push configuration of an existing subscription.
-  virtual Status ModifyPushConfig(
-      grpc::ClientContext& client_context,
-      google::pubsub::v1::ModifyPushConfigRequest const& request) = 0;
-
   using AsyncPullStream = ::google::cloud::AsyncStreamingReadWriteRpc<
       google::pubsub::v1::StreamingPullRequest,
       google::pubsub::v1::StreamingPullResponse>;
@@ -80,22 +75,10 @@ class SubscriberStub {
       google::cloud::CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::pubsub::v1::StreamingPullRequest const& request) = 0;
 
-  /// Acknowledge exactly one message.
-  virtual future<Status> AsyncAcknowledge(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::AcknowledgeRequest const& request) = 0;
-
-  /// Modify the acknowledgement deadline for many messages.
-  virtual future<Status> AsyncModifyAckDeadline(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::ModifyAckDeadlineRequest const& request) = 0;
-
-  /// Create a new snapshot.
-  virtual StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+  /// Modify the push configuration of an existing subscription.
+  virtual Status ModifyPushConfig(
       grpc::ClientContext& client_context,
-      google::pubsub::v1::CreateSnapshotRequest const& request) = 0;
+      google::pubsub::v1::ModifyPushConfigRequest const& request) = 0;
 
   /// Get information about an existing snapshot.
   virtual StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
@@ -106,6 +89,11 @@ class SubscriberStub {
   virtual StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
       grpc::ClientContext& client_context,
       google::pubsub::v1::ListSnapshotsRequest const& request) = 0;
+
+  /// Create a new snapshot.
+  virtual StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) = 0;
 
   /// Update an existing snapshot.
   virtual StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
@@ -121,6 +109,18 @@ class SubscriberStub {
   virtual StatusOr<google::pubsub::v1::SeekResponse> Seek(
       grpc::ClientContext& client_context,
       google::pubsub::v1::SeekRequest const& request) = 0;
+
+  /// Acknowledge exactly one message.
+  virtual future<Status> AsyncAcknowledge(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::AcknowledgeRequest const& request) = 0;
+
+  /// Modify the acknowledgement deadline for many messages.
+  virtual future<Status> AsyncModifyAckDeadline(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) = 0;
 };
 
 class DefaultSubscriberStub : public SubscriberStub {
@@ -151,10 +151,6 @@ class DefaultSubscriberStub : public SubscriberStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) override;
 
-  Status ModifyPushConfig(
-      grpc::ClientContext& client_context,
-      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
-
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::pubsub::v1::StreamingPullRequest,
       google::pubsub::v1::StreamingPullResponse>>
@@ -162,30 +158,24 @@ class DefaultSubscriberStub : public SubscriberStub {
       google::cloud::CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::pubsub::v1::StreamingPullRequest const& request) override;
 
-  future<Status> AsyncAcknowledge(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::AcknowledgeRequest const& request) override;
-
-  future<Status> AsyncModifyAckDeadline(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
-
-  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+  Status ModifyPushConfig(
       grpc::ClientContext& client_context,
-      google::pubsub::v1::CreateSnapshotRequest const& request) override;
+      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::GetSnapshotRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::ListSnapshotsRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) override;
+
   StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::UpdateSnapshotRequest const& request) override;
 
   Status DeleteSnapshot(
@@ -195,6 +185,16 @@ class DefaultSubscriberStub : public SubscriberStub {
   StatusOr<google::pubsub::v1::SeekResponse> Seek(
       grpc::ClientContext& client_context,
       google::pubsub::v1::SeekRequest const& request) override;
+
+  future<Status> AsyncModifyAckDeadline(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
+
+  future<Status> AsyncAcknowledge(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:
   std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub_;


### PR DESCRIPTION
This is a large, but trivial change. It reorders the `*Stub` member function declaration and definitions to match the order used by the generator.

Part of the work for #7187.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10066)
<!-- Reviewable:end -->
