### PR TITLE
refactor(pubsub): fully qualify `LogWrapper()` calls

### DIFF
--- a/google/cloud/pubsub/internal/publisher_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_decorator.cc
@@ -20,11 +20,9 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::LogWrapper;
-
 StatusOr<google::pubsub::v1::Topic> PublisherLogging::CreateTopic(
     grpc::ClientContext& context, google::pubsub::v1::Topic const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::Topic const& request) {
         return child_->CreateTopic(context, request);
@@ -35,7 +33,7 @@ StatusOr<google::pubsub::v1::Topic> PublisherLogging::CreateTopic(
 StatusOr<google::pubsub::v1::Topic> PublisherLogging::UpdateTopic(
     grpc::ClientContext& context,
     google::pubsub::v1::UpdateTopicRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::UpdateTopicRequest const& request) {
         return child_->UpdateTopic(context, request);
@@ -46,7 +44,7 @@ StatusOr<google::pubsub::v1::Topic> PublisherLogging::UpdateTopic(
 StatusOr<google::pubsub::v1::PublishResponse> PublisherLogging::Publish(
     grpc::ClientContext& context,
     google::pubsub::v1::PublishRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::PublishRequest const& request) {
         return child_->Publish(context, request);
@@ -57,7 +55,7 @@ StatusOr<google::pubsub::v1::PublishResponse> PublisherLogging::Publish(
 StatusOr<google::pubsub::v1::Topic> PublisherLogging::GetTopic(
     grpc::ClientContext& context,
     google::pubsub::v1::GetTopicRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::GetTopicRequest const& request) {
         return child_->GetTopic(context, request);
@@ -68,7 +66,7 @@ StatusOr<google::pubsub::v1::Topic> PublisherLogging::GetTopic(
 StatusOr<google::pubsub::v1::ListTopicsResponse> PublisherLogging::ListTopics(
     grpc::ClientContext& context,
     google::pubsub::v1::ListTopicsRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ListTopicsRequest const& request) {
         return child_->ListTopics(context, request);
@@ -80,7 +78,7 @@ StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
 PublisherLogging::ListTopicSubscriptions(
     grpc::ClientContext& context,
     google::pubsub::v1::ListTopicSubscriptionsRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ListTopicSubscriptionsRequest const& request) {
         return child_->ListTopicSubscriptions(context, request);
@@ -92,7 +90,7 @@ StatusOr<google::pubsub::v1::ListTopicSnapshotsResponse>
 PublisherLogging::ListTopicSnapshots(
     grpc::ClientContext& context,
     google::pubsub::v1::ListTopicSnapshotsRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ListTopicSnapshotsRequest const& request) {
         return child_->ListTopicSnapshots(context, request);
@@ -103,7 +101,7 @@ PublisherLogging::ListTopicSnapshots(
 Status PublisherLogging::DeleteTopic(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteTopicRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::DeleteTopicRequest const& request) {
         return child_->DeleteTopic(context, request);
@@ -115,7 +113,7 @@ StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
 PublisherLogging::DetachSubscription(
     grpc::ClientContext& context,
     google::pubsub::v1::DetachSubscriptionRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::DetachSubscriptionRequest const& request) {
         return child_->DetachSubscription(context, request);
@@ -128,7 +126,7 @@ PublisherLogging::AsyncPublish(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::pubsub::v1::PublishRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::unique_ptr<grpc::ClientContext> context,
              google::pubsub::v1::PublishRequest const& request) {

--- a/google/cloud/pubsub/internal/schema_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/schema_logging_decorator.cc
@@ -20,12 +20,10 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::LogWrapper;
-
 StatusOr<google::pubsub::v1::Schema> SchemaServiceLogging::CreateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::CreateSchemaRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::CreateSchemaRequest const& request) {
         return child_->CreateSchema(context, request);
@@ -36,7 +34,7 @@ StatusOr<google::pubsub::v1::Schema> SchemaServiceLogging::CreateSchema(
 StatusOr<google::pubsub::v1::Schema> SchemaServiceLogging::GetSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::GetSchemaRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::GetSchemaRequest const& request) {
         return child_->GetSchema(context, request);
@@ -48,7 +46,7 @@ StatusOr<google::pubsub::v1::ListSchemasResponse>
 SchemaServiceLogging::ListSchemas(
     grpc::ClientContext& context,
     google::pubsub::v1::ListSchemasRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ListSchemasRequest const& request) {
         return child_->ListSchemas(context, request);
@@ -59,7 +57,7 @@ SchemaServiceLogging::ListSchemas(
 Status SchemaServiceLogging::DeleteSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteSchemaRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::DeleteSchemaRequest const& request) {
         return child_->DeleteSchema(context, request);
@@ -71,7 +69,7 @@ StatusOr<google::pubsub::v1::ValidateSchemaResponse>
 SchemaServiceLogging::ValidateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateSchemaRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ValidateSchemaRequest const& request) {
         return child_->ValidateSchema(context, request);
@@ -83,7 +81,7 @@ StatusOr<google::pubsub::v1::ValidateMessageResponse>
 SchemaServiceLogging::ValidateMessage(
     grpc::ClientContext& context,
     google::pubsub::v1::ValidateMessageRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ValidateMessageRequest const& request) {
         return child_->ValidateMessage(context, request);

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
@@ -21,13 +21,12 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using ::google::cloud::internal::DebugString;
-using ::google::cloud::internal::LogWrapper;
 
 StatusOr<google::pubsub::v1::Subscription>
 SubscriberLogging::CreateSubscription(
     grpc::ClientContext& context,
     google::pubsub::v1::Subscription const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::Subscription const& request) {
         return child_->CreateSubscription(context, request);
@@ -38,7 +37,7 @@ SubscriberLogging::CreateSubscription(
 StatusOr<google::pubsub::v1::Subscription> SubscriberLogging::GetSubscription(
     grpc::ClientContext& context,
     google::pubsub::v1::GetSubscriptionRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::GetSubscriptionRequest const& request) {
         return child_->GetSubscription(context, request);
@@ -50,7 +49,7 @@ StatusOr<google::pubsub::v1::Subscription>
 SubscriberLogging::UpdateSubscription(
     grpc::ClientContext& context,
     google::pubsub::v1::UpdateSubscriptionRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::UpdateSubscriptionRequest const& request) {
         return child_->UpdateSubscription(context, request);
@@ -62,7 +61,7 @@ StatusOr<google::pubsub::v1::ListSubscriptionsResponse>
 SubscriberLogging::ListSubscriptions(
     grpc::ClientContext& context,
     google::pubsub::v1::ListSubscriptionsRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ListSubscriptionsRequest const& request) {
         return child_->ListSubscriptions(context, request);
@@ -73,7 +72,7 @@ SubscriberLogging::ListSubscriptions(
 Status SubscriberLogging::DeleteSubscription(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteSubscriptionRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::DeleteSubscriptionRequest const& request) {
         return child_->DeleteSubscription(context, request);
@@ -99,7 +98,7 @@ SubscriberLogging::AsyncStreamingPull(
 Status SubscriberLogging::ModifyPushConfig(
     grpc::ClientContext& context,
     google::pubsub::v1::ModifyPushConfigRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ModifyPushConfigRequest const& request) {
         return child_->ModifyPushConfig(context, request);
@@ -110,7 +109,7 @@ Status SubscriberLogging::ModifyPushConfig(
 StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::GetSnapshot(
     grpc::ClientContext& context,
     google::pubsub::v1::GetSnapshotRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::GetSnapshotRequest const& request) {
         return child_->GetSnapshot(context, request);
@@ -122,7 +121,7 @@ StatusOr<google::pubsub::v1::ListSnapshotsResponse>
 SubscriberLogging::ListSnapshots(
     grpc::ClientContext& context,
     google::pubsub::v1::ListSnapshotsRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::ListSnapshotsRequest const& request) {
         return child_->ListSnapshots(context, request);
@@ -133,7 +132,7 @@ SubscriberLogging::ListSnapshots(
 StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::CreateSnapshot(
     grpc::ClientContext& context,
     google::pubsub::v1::CreateSnapshotRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::CreateSnapshotRequest const& request) {
         return child_->CreateSnapshot(context, request);
@@ -144,7 +143,7 @@ StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::CreateSnapshot(
 StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::UpdateSnapshot(
     grpc::ClientContext& context,
     google::pubsub::v1::UpdateSnapshotRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::UpdateSnapshotRequest const& request) {
         return child_->UpdateSnapshot(context, request);
@@ -155,7 +154,7 @@ StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::UpdateSnapshot(
 Status SubscriberLogging::DeleteSnapshot(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteSnapshotRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::DeleteSnapshotRequest const& request) {
         return child_->DeleteSnapshot(context, request);
@@ -166,7 +165,7 @@ Status SubscriberLogging::DeleteSnapshot(
 StatusOr<google::pubsub::v1::SeekResponse> SubscriberLogging::Seek(
     grpc::ClientContext& context,
     google::pubsub::v1::SeekRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
              google::pubsub::v1::SeekRequest const& request) {
         return child_->Seek(context, request);
@@ -178,7 +177,7 @@ future<Status> SubscriberLogging::AsyncModifyAckDeadline(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::unique_ptr<grpc::ClientContext> context,
              google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
@@ -191,7 +190,7 @@ future<Status> SubscriberLogging::AsyncAcknowledge(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::pubsub::v1::AcknowledgeRequest const& request) {
-  return LogWrapper(
+  return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::unique_ptr<grpc::ClientContext> context,
              google::pubsub::v1::AcknowledgeRequest const& request) {


### PR DESCRIPTION
This is to match what the generator does.

Part of the changes for #7187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10069)
<!-- Reviewable:end -->
