### PR TITLE
cleanup(pubsub): match generated function parameters names

### DIFF
--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -22,87 +22,90 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::CreateTopic(
-    grpc::ClientContext& context, google::pubsub::v1::Topic const& request) {
+    grpc::ClientContext& client_context,
+    google::pubsub::v1::Topic const& request) {
   google::pubsub::v1::Topic response;
-  auto status = grpc_stub_->CreateTopic(&context, request, &response);
+  auto status = grpc_stub_->CreateTopic(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
 
   return response;
 }
 
 StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::UpdateTopic(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::UpdateTopicRequest const& request) {
   google::pubsub::v1::Topic response;
-  auto status = grpc_stub_->UpdateTopic(&context, request, &response);
+  auto status = grpc_stub_->UpdateTopic(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::PublishResponse> DefaultPublisherStub::Publish(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::PublishRequest const& request) {
   google::pubsub::v1::PublishResponse response;
-  auto status = grpc_stub_->Publish(&context, request, &response);
+  auto status = grpc_stub_->Publish(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::GetTopic(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::GetTopicRequest const& request) {
   google::pubsub::v1::Topic response;
-  auto status = grpc_stub_->GetTopic(&context, request, &response);
+  auto status = grpc_stub_->GetTopic(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::ListTopicsResponse>
 DefaultPublisherStub::ListTopics(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ListTopicsRequest const& request) {
   google::pubsub::v1::ListTopicsResponse response;
-  auto status = grpc_stub_->ListTopics(&context, request, &response);
+  auto status = grpc_stub_->ListTopics(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
 DefaultPublisherStub::ListTopicSubscriptions(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ListTopicSubscriptionsRequest const& request) {
   google::pubsub::v1::ListTopicSubscriptionsResponse response;
   auto status =
-      grpc_stub_->ListTopicSubscriptions(&context, request, &response);
+      grpc_stub_->ListTopicSubscriptions(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::ListTopicSnapshotsResponse>
 DefaultPublisherStub::ListTopicSnapshots(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ListTopicSnapshotsRequest const& request) {
   google::pubsub::v1::ListTopicSnapshotsResponse response;
-  auto status = grpc_stub_->ListTopicSnapshots(&context, request, &response);
+  auto status =
+      grpc_stub_->ListTopicSnapshots(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 Status DefaultPublisherStub::DeleteTopic(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::DeleteTopicRequest const& request) {
   google::protobuf::Empty response;
-  auto status = grpc_stub_->DeleteTopic(&context, request, &response);
+  auto status = grpc_stub_->DeleteTopic(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return {};
 }
 
 StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
 DefaultPublisherStub::DetachSubscription(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::DetachSubscriptionRequest const& request) {
   google::pubsub::v1::DetachSubscriptionResponse response;
-  auto status = grpc_stub_->DetachSubscription(&context, request, &response);
+  auto status =
+      grpc_stub_->DetachSubscription(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -42,56 +42,56 @@ class PublisherStub {
 
   /// Create a new topic.
   virtual StatusOr<google::pubsub::v1::Topic> CreateTopic(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::Topic const& request) = 0;
 
   /// Update the configuration of an existing topic.
   virtual StatusOr<google::pubsub::v1::Topic> UpdateTopic(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::UpdateTopicRequest const& request) = 0;
 
   /// Publish a batch of messages.
   virtual StatusOr<google::pubsub::v1::PublishResponse> Publish(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::PublishRequest const& request) = 0;
 
   /// Get information about an existing topic.
   virtual StatusOr<google::pubsub::v1::Topic> GetTopic(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::GetTopicRequest const& request) = 0;
 
   /// List existing topics.
   virtual StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::ListTopicsRequest const& request) = 0;
 
   /// List subscriptions for a topic.
   virtual StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
   ListTopicSubscriptions(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::ListTopicSubscriptionsRequest const& request) = 0;
 
   /// List snapshots for a topic.
   virtual StatusOr<google::pubsub::v1::ListTopicSnapshotsResponse>
   ListTopicSnapshots(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::ListTopicSnapshotsRequest const& request) = 0;
 
   /// Delete a topic.
   virtual Status DeleteTopic(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::DeleteTopicRequest const& request) = 0;
 
   /// Detach a subscription.
   virtual StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
   DetachSubscription(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::DetachSubscriptionRequest const& request) = 0;
 
   /// Publish a batch of messages.
   virtual future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> client_context,
+      std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::PublishRequest const& request) = 0;
 };
 
@@ -143,7 +143,7 @@ class DefaultPublisherStub : public PublisherStub {
 
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> client_context,
+      std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/schema_stub.cc
+++ b/google/cloud/pubsub/internal/schema_stub.cc
@@ -23,58 +23,59 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<google::pubsub::v1::Schema> DefaultSchemaServiceStub::CreateSchema(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::CreateSchemaRequest const& request) {
   google::pubsub::v1::Schema response;
-  auto status = grpc_stub_->CreateSchema(&context, request, &response);
+  auto status = grpc_stub_->CreateSchema(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::Schema> DefaultSchemaServiceStub::GetSchema(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::GetSchemaRequest const& request) {
   google::pubsub::v1::Schema response;
-  auto status = grpc_stub_->GetSchema(&context, request, &response);
+  auto status = grpc_stub_->GetSchema(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::ListSchemasResponse>
 DefaultSchemaServiceStub::ListSchemas(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ListSchemasRequest const& request) {
   google::pubsub::v1::ListSchemasResponse response;
-  auto status = grpc_stub_->ListSchemas(&context, request, &response);
+  auto status = grpc_stub_->ListSchemas(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 Status DefaultSchemaServiceStub::DeleteSchema(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::DeleteSchemaRequest const& request) {
   google::protobuf::Empty response;
-  auto status = grpc_stub_->DeleteSchema(&context, request, &response);
+  auto status = grpc_stub_->DeleteSchema(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return Status{};
 }
 
 StatusOr<google::pubsub::v1::ValidateSchemaResponse>
 DefaultSchemaServiceStub::ValidateSchema(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ValidateSchemaRequest const& request) {
   google::pubsub::v1::ValidateSchemaResponse response;
-  auto status = grpc_stub_->ValidateSchema(&context, request, &response);
+  auto status = grpc_stub_->ValidateSchema(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::ValidateMessageResponse>
 DefaultSchemaServiceStub::ValidateMessage(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ValidateMessageRequest const& request) {
   google::pubsub::v1::ValidateMessageResponse response;
-  auto status = grpc_stub_->ValidateMessage(&context, request, &response);
+  auto status =
+      grpc_stub_->ValidateMessage(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }

--- a/google/cloud/pubsub/internal/schema_stub.h
+++ b/google/cloud/pubsub/internal/schema_stub.h
@@ -78,27 +78,27 @@ class DefaultSchemaServiceStub : public SchemaServiceStub {
   ~DefaultSchemaServiceStub() override = default;
 
   StatusOr<google::pubsub::v1::Schema> CreateSchema(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::CreateSchemaRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Schema> GetSchema(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::GetSchemaRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ListSchemasResponse> ListSchemas(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::ListSchemasRequest const& request) override;
 
   Status DeleteSchema(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::DeleteSchemaRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ValidateSchemaResponse> ValidateSchema(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::ValidateSchemaRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ValidateMessageResponse> ValidateMessage(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::ValidateMessageRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -24,49 +24,54 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<google::pubsub::v1::Subscription>
 DefaultSubscriberStub::CreateSubscription(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::Subscription const& request) {
   google::pubsub::v1::Subscription response;
-  auto status = grpc_stub_->CreateSubscription(&context, request, &response);
+  auto status =
+      grpc_stub_->CreateSubscription(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::Subscription>
 DefaultSubscriberStub::GetSubscription(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::GetSubscriptionRequest const& request) {
   google::pubsub::v1::Subscription response;
-  auto status = grpc_stub_->GetSubscription(&context, request, &response);
+  auto status =
+      grpc_stub_->GetSubscription(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::Subscription>
 DefaultSubscriberStub::UpdateSubscription(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::UpdateSubscriptionRequest const& request) {
   google::pubsub::v1::Subscription response;
-  auto status = grpc_stub_->UpdateSubscription(&context, request, &response);
+  auto status =
+      grpc_stub_->UpdateSubscription(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::ListSubscriptionsResponse>
 DefaultSubscriberStub::ListSubscriptions(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ListSubscriptionsRequest const& request) {
   google::pubsub::v1::ListSubscriptionsResponse response;
-  auto status = grpc_stub_->ListSubscriptions(&context, request, &response);
+  auto status =
+      grpc_stub_->ListSubscriptions(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 Status DefaultSubscriberStub::DeleteSubscription(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::DeleteSubscriptionRequest const& request) {
   google::protobuf::Empty response;
-  auto status = grpc_stub_->DeleteSubscription(&context, request, &response);
+  auto status =
+      grpc_stub_->DeleteSubscription(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return {};
 }
@@ -82,71 +87,72 @@ DefaultSubscriberStub::AsyncStreamingPull(
       google::pubsub::v1::StreamingPullRequest,
       google::pubsub::v1::StreamingPullResponse>(
       cq, std::move(context),
-      [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
-        return grpc_stub_->PrepareAsyncStreamingPull(context, cq);
+      [this](grpc::ClientContext* client_context, grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncStreamingPull(client_context, cq);
       });
 }
 
 Status DefaultSubscriberStub::ModifyPushConfig(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ModifyPushConfigRequest const& request) {
   google::protobuf::Empty response;
-  auto status = grpc_stub_->ModifyPushConfig(&context, request, &response);
+  auto status =
+      grpc_stub_->ModifyPushConfig(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return {};
 }
 
 StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::GetSnapshot(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::GetSnapshotRequest const& request) {
   google::pubsub::v1::Snapshot response;
-  auto status = grpc_stub_->GetSnapshot(&context, request, &response);
+  auto status = grpc_stub_->GetSnapshot(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::ListSnapshotsResponse>
 DefaultSubscriberStub::ListSnapshots(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::ListSnapshotsRequest const& request) {
   google::pubsub::v1::ListSnapshotsResponse response;
-  auto status = grpc_stub_->ListSnapshots(&context, request, &response);
+  auto status = grpc_stub_->ListSnapshots(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::CreateSnapshot(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::CreateSnapshotRequest const& request) {
   google::pubsub::v1::Snapshot response;
-  auto status = grpc_stub_->CreateSnapshot(&context, request, &response);
+  auto status = grpc_stub_->CreateSnapshot(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::UpdateSnapshot(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::UpdateSnapshotRequest const& request) {
   google::pubsub::v1::Snapshot response;
-  auto status = grpc_stub_->UpdateSnapshot(&context, request, &response);
+  auto status = grpc_stub_->UpdateSnapshot(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }
 
 Status DefaultSubscriberStub::DeleteSnapshot(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::DeleteSnapshotRequest const& request) {
   google::protobuf::Empty response;
-  auto status = grpc_stub_->DeleteSnapshot(&context, request, &response);
+  auto status = grpc_stub_->DeleteSnapshot(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return {};
 }
 
 StatusOr<google::pubsub::v1::SeekResponse> DefaultSubscriberStub::Seek(
-    grpc::ClientContext& context,
+    grpc::ClientContext& client_context,
     google::pubsub::v1::SeekRequest const& request) {
   google::pubsub::v1::SeekResponse response;
-  auto status = grpc_stub_->Seek(&context, request, &response);
+  auto status = grpc_stub_->Seek(&client_context, request, &response);
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
   return response;
 }

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -42,28 +42,28 @@ class SubscriberStub {
 
   /// Create a new subscription.
   virtual StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::Subscription const& request) = 0;
 
   /// Get full metadata information about a subscription.
   virtual StatusOr<google::pubsub::v1::Subscription> GetSubscription(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::GetSubscriptionRequest const& request) = 0;
 
   /// Update an existing subscription.
   virtual StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::UpdateSubscriptionRequest const& request) = 0;
 
   /// List existing subscriptions.
   virtual StatusOr<google::pubsub::v1::ListSubscriptionsResponse>
   ListSubscriptions(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::ListSubscriptionsRequest const& request) = 0;
 
   /// Delete a subscription.
   virtual Status DeleteSubscription(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) = 0;
 
   using AsyncPullStream = ::google::cloud::AsyncStreamingReadWriteRpc<
@@ -77,37 +77,37 @@ class SubscriberStub {
 
   /// Modify the push configuration of an existing subscription.
   virtual Status ModifyPushConfig(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::ModifyPushConfigRequest const& request) = 0;
 
   /// Get information about an existing snapshot.
   virtual StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::GetSnapshotRequest const& request) = 0;
 
   /// List existing snapshots.
   virtual StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::ListSnapshotsRequest const& request) = 0;
 
   /// Create a new snapshot.
   virtual StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::CreateSnapshotRequest const& request) = 0;
 
   /// Update an existing snapshot.
   virtual StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::UpdateSnapshotRequest const& request) = 0;
 
   /// Delete a snapshot.
   virtual Status DeleteSnapshot(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::DeleteSnapshotRequest const& request) = 0;
 
   /// Seeks an existing subscription to a point in time or a snapshot.
   virtual StatusOr<google::pubsub::v1::SeekResponse> Seek(
-      grpc::ClientContext& client_context,
+      grpc::ClientContext& context,
       google::pubsub::v1::SeekRequest const& request) = 0;
 
   /// Acknowledge exactly one message.
@@ -163,19 +163,19 @@ class DefaultSubscriberStub : public SubscriberStub {
       google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::GetSnapshotRequest const& request) override;
 
   StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::ListSnapshotsRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::CreateSnapshotRequest const& request) override;
 
   StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
-      grpc::ClientContext& context,
+      grpc::ClientContext& client_context,
       google::pubsub::v1::UpdateSnapshotRequest const& request) override;
 
   Status DeleteSnapshot(


### PR DESCRIPTION
Use the same names the generator does.

Part of the work for #7187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10070)
<!-- Reviewable:end -->
