### PR TITLE
cleanup(pubsub): signature for bidir streaming RPC

### DIFF
--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -180,9 +180,10 @@ TEST_F(SubscriberIntegrationTest, RawStub) {
   request.set_max_outstanding_messages(1000);
   request.set_stream_ack_deadline_seconds(600);
 
-  auto stream = [&stub, &request](CompletionQueue cq) {
-    return stub->AsyncStreamingPull(
-        cq, absl::make_unique<grpc::ClientContext>(), request);
+  auto stream = [&stub](CompletionQueue const& cq) {
+    auto context = absl::make_unique<grpc::ClientContext>();
+
+    return stub->AsyncStreamingPull(cq, std::move(context));
   }(background.cq());
 
   ASSERT_TRUE(stream->Start().get());

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
@@ -203,8 +203,10 @@ void StreamingSubscriptionBatchSource::StartStream(
   // these steps in an asynchronous retry loop.
 
   auto request = InitialRequest();
-  auto stream = stub_->AsyncStreamingPull(
-      cq_, absl::make_unique<grpc::ClientContext>(), request);
+  auto context = absl::make_unique<grpc::ClientContext>();
+  context->AddMetadata("x-goog-request-params",
+                       "subscription=" + request.subscription());
+  auto stream = stub_->AsyncStreamingPull(cq_, std::move(context));
   if (!stream) {
     OnRetryFailure(Status(StatusCode::kUnknown, "null stream"));
     return;

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
@@ -59,7 +59,9 @@ class StreamingSubscriptionBatchSource
   void ExtendLeases(std::vector<std::string> ack_ids,
                     std::chrono::seconds extension) override;
 
-  using AsyncPullStream = SubscriberStub::AsyncPullStream;
+  using AsyncPullStream = google::cloud::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>;
 
   enum class StreamState {
     kNull,

--- a/google/cloud/pubsub/internal/subscriber_auth_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_auth_decorator.cc
@@ -61,19 +61,19 @@ Status SubscriberAuth::DeleteSubscription(
   return child_->DeleteSubscription(context, request);
 }
 
-std::unique_ptr<SubscriberStub::AsyncPullStream>
+std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+    google::pubsub::v1::StreamingPullRequest,
+    google::pubsub::v1::StreamingPullResponse>>
 SubscriberAuth::AsyncStreamingPull(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::StreamingPullRequest const& request) {
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
       google::pubsub::v1::StreamingPullRequest,
       google::pubsub::v1::StreamingPullResponse>;
 
   auto& child = child_;
-  auto call = [child, cq,
-               request](std::unique_ptr<grpc::ClientContext> ctx) mutable {
-    return child->AsyncStreamingPull(cq, std::move(ctx), request);
+  auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) mutable {
+    return child->AsyncStreamingPull(cq, std::move(ctx));
   };
   return absl::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/google/cloud/pubsub/internal/subscriber_auth_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_auth_decorator.h
@@ -52,10 +52,11 @@ class SubscriberAuth : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) override;
 
-  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::StreamingPullRequest const& request) override;
+  std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>>
+  AsyncStreamingPull(google::cloud::CompletionQueue const& cq,
+                     std::unique_ptr<grpc::ClientContext> context) override;
 
   Status ModifyPushConfig(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/subscriber_auth_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_auth_test.cc
@@ -142,9 +142,8 @@ TEST(SubscriberAuthTest, AsyncStreamingPullFailedAuth) {
       });
   auto under_test = SubscriberAuth(auth, mock);
   google::cloud::CompletionQueue cq;
-  google::pubsub::v1::StreamingPullRequest request;
   auto auth_failure = under_test.AsyncStreamingPull(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, absl::make_unique<grpc::ClientContext>());
   ASSERT_FALSE(auth_failure->Start().get());
   EXPECT_THAT(auth_failure->Finish().get(),
               StatusIs(StatusCode::kInvalidArgument));
@@ -159,7 +158,7 @@ TEST(SubscriberAuthTest, AsyncStreamingPullAuthSuccess) {
   auto mock =
       std::make_shared<StrictMock<pubsub_testing::MockSubscriberStub>>();
   EXPECT_CALL(*mock, AsyncStreamingPull)
-      .WillOnce([](::testing::Unused, ::testing::Unused, ::testing::Unused) {
+      .WillOnce([](::testing::Unused, ::testing::Unused) {
         return absl::make_unique<ErrorStream>(
             Status(StatusCode::kPermissionDenied, "uh-oh"));
       });
@@ -172,9 +171,8 @@ TEST(SubscriberAuthTest, AsyncStreamingPullAuthSuccess) {
       });
   auto under_test = SubscriberAuth(auth, mock);
   google::cloud::CompletionQueue cq;
-  google::pubsub::v1::StreamingPullRequest request;
   auto auth_failure = under_test.AsyncStreamingPull(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, absl::make_unique<grpc::ClientContext>());
   ASSERT_FALSE(auth_failure->Start().get());
   EXPECT_THAT(auth_failure->Finish().get(),
               StatusIs(StatusCode::kPermissionDenied));

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
@@ -79,18 +79,19 @@ Status SubscriberLogging::DeleteSubscription(
       context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<SubscriberStub::AsyncPullStream>
+std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+    google::pubsub::v1::StreamingPullRequest,
+    google::pubsub::v1::StreamingPullResponse>>
 SubscriberLogging::AsyncStreamingPull(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::StreamingPullRequest const& request) {
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
   using LoggingStream =
       ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<
           google::pubsub::v1::StreamingPullRequest,
           google::pubsub::v1::StreamingPullResponse>;
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncStreamingPull(cq, std::move(context), request);
+  auto stream = child_->AsyncStreamingPull(cq, std::move(context));
   if (trace_streams_) {
     stream = absl::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.h
@@ -54,10 +54,11 @@ class SubscriberLogging : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) override;
 
-  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::StreamingPullRequest const& request) override;
+  std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>>
+  AsyncStreamingPull(google::cloud::CompletionQueue const& cq,
+                     std::unique_ptr<grpc::ClientContext> context) override;
 
   Status ModifyPushConfig(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/subscriber_logging_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_test.cc
@@ -128,9 +128,8 @@ TEST_F(SubscriberLoggingTest, ModifyPushConfig) {
 TEST_F(SubscriberLoggingTest, AsyncStreamingPull) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncStreamingPull)
-      .WillOnce([](google::cloud::CompletionQueue&,
-                   std::unique_ptr<grpc::ClientContext>,
-                   google::pubsub::v1::StreamingPullRequest const&) {
+      .WillOnce([](google::cloud::CompletionQueue const&,
+                   std::unique_ptr<grpc::ClientContext>) {
         auto stream = absl::make_unique<pubsub_testing::MockAsyncPullStream>();
         EXPECT_CALL(*stream, Cancel).Times(1);
         EXPECT_CALL(*stream, Start).WillOnce([&] {
@@ -164,8 +163,8 @@ TEST_F(SubscriberLoggingTest, AsyncStreamingPull) {
 
   google::pubsub::v1::StreamingPullRequest request;
   request.set_subscription("test-subscription-name");
-  auto stream = stub.AsyncStreamingPull(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+  auto stream =
+      stub.AsyncStreamingPull(cq, absl::make_unique<grpc::ClientContext>());
   EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("AsyncStreamingPull")));
 
   EXPECT_TRUE(stream->Start().get());

--- a/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
@@ -50,10 +50,11 @@ class SubscriberMetadata : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) override;
 
-  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::StreamingPullRequest const& request) override;
+  std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>>
+  AsyncStreamingPull(google::cloud::CompletionQueue const& cq,
+                     std::unique_ptr<grpc::ClientContext> context) override;
 
   Status ModifyPushConfig(
       grpc::ClientContext& context,
@@ -96,6 +97,7 @@ class SubscriberMetadata : public SubscriberStub {
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);
+  void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SubscriberStub> child_;
   std::string x_goog_api_client_;

--- a/google/cloud/pubsub/internal/subscriber_round_robin.cc
+++ b/google/cloud/pubsub/internal/subscriber_round_robin.cc
@@ -59,12 +59,13 @@ Status SubscriberRoundRobin::ModifyPushConfig(
   return Child()->ModifyPushConfig(context, request);
 }
 
-std::unique_ptr<SubscriberStub::AsyncPullStream>
+std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+    google::pubsub::v1::StreamingPullRequest,
+    google::pubsub::v1::StreamingPullResponse>>
 SubscriberRoundRobin::AsyncStreamingPull(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::StreamingPullRequest const& request) {
-  return Child()->AsyncStreamingPull(cq, std::move(context), request);
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  return Child()->AsyncStreamingPull(cq, std::move(context));
 }
 
 future<Status> SubscriberRoundRobin::AsyncAcknowledge(

--- a/google/cloud/pubsub/internal/subscriber_round_robin.h
+++ b/google/cloud/pubsub/internal/subscriber_round_robin.h
@@ -56,10 +56,11 @@ class SubscriberRoundRobin : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
-  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::StreamingPullRequest const& request) override;
+  std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>>
+  AsyncStreamingPull(google::cloud::CompletionQueue const& cq,
+                     std::unique_ptr<grpc::ClientContext> context) override;
 
   future<Status> AsyncAcknowledge(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/pubsub/internal/subscriber_round_robin_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_round_robin_test.cc
@@ -161,9 +161,8 @@ TEST(SubscriberRoundRobinTest, AsyncStreamingPull) {
   for (int i = 0; i != kRepeats; ++i) {
     for (auto& m : mocks) {
       EXPECT_CALL(*m, AsyncStreamingPull)
-          .WillOnce([](google::cloud::CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext>,
-                       google::pubsub::v1::StreamingPullRequest const&) {
+          .WillOnce([](google::cloud::CompletionQueue const&,
+                       std::unique_ptr<grpc::ClientContext>) {
             return absl::make_unique<pubsub_testing::MockAsyncPullStream>();
           });
     }
@@ -171,10 +170,8 @@ TEST(SubscriberRoundRobinTest, AsyncStreamingPull) {
   SubscriberRoundRobin stub(AsPlainStubs(mocks));
   google::cloud::CompletionQueue cq;
   for (std::size_t i = 0; i != kRepeats * mocks.size(); ++i) {
-    google::pubsub::v1::StreamingPullRequest request;
-    request.set_subscription("test-subscription-name");
-    auto stream = stub.AsyncStreamingPull(
-        cq, absl::make_unique<grpc::ClientContext>(), request);
+    auto stream =
+        stub.AsyncStreamingPull(cq, absl::make_unique<grpc::ClientContext>());
   }
 }
 

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -80,15 +80,14 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::pubsub::v1::StreamingPullRequest,
     google::pubsub::v1::StreamingPullResponse>>
 DefaultSubscriberStub::AsyncStreamingPull(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::pubsub::v1::StreamingPullRequest const&) {
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
   return google::cloud::internal::MakeStreamingReadWriteRpc<
       google::pubsub::v1::StreamingPullRequest,
       google::pubsub::v1::StreamingPullResponse>(
       cq, std::move(context),
-      [this](grpc::ClientContext* client_context, grpc::CompletionQueue* cq) {
-        return grpc_stub_->PrepareAsyncStreamingPull(client_context, cq);
+      [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncStreamingPull(context, cq);
       });
 }
 

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -66,14 +66,12 @@ class SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) = 0;
 
-  using AsyncPullStream = ::google::cloud::AsyncStreamingReadWriteRpc<
-      google::pubsub::v1::StreamingPullRequest,
-      google::pubsub::v1::StreamingPullResponse>;
-
   /// Start a bi-directional stream to read messages and send ack/nacks.
-  virtual std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
-      google::cloud::CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-      google::pubsub::v1::StreamingPullRequest const& request) = 0;
+  virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>>
+  AsyncStreamingPull(google::cloud::CompletionQueue const& cq,
+                     std::unique_ptr<grpc::ClientContext> context) = 0;
 
   /// Modify the push configuration of an existing subscription.
   virtual Status ModifyPushConfig(
@@ -154,9 +152,8 @@ class DefaultSubscriberStub : public SubscriberStub {
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::pubsub::v1::StreamingPullRequest,
       google::pubsub::v1::StreamingPullResponse>>
-  AsyncStreamingPull(
-      google::cloud::CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-      google::pubsub::v1::StreamingPullRequest const& request) override;
+  AsyncStreamingPull(google::cloud::CompletionQueue const&,
+                     std::unique_ptr<grpc::ClientContext>) override;
 
   Status ModifyPushConfig(
       grpc::ClientContext& client_context,

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -37,7 +37,9 @@ using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::AtLeast;
 using ::testing::Contains;
 using ::testing::HasSubstr;
+using ::testing::Pair;
 using ::testing::StartsWith;
+using ::testing::UnorderedElementsAre;
 
 std::shared_ptr<SubscriberConnection> MakeTestSubscriberConnection(
     Subscription subscription,
@@ -45,6 +47,9 @@ std::shared_ptr<SubscriberConnection> MakeTestSubscriberConnection(
   opts.set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
   opts = pubsub_internal::DefaultSubscriberOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
+  // The CI scripts set an environment variable that overrides this option. We
+  // are not interested in this behavior for this test.
+  opts.unset<google::cloud::UserProjectOption>();
   std::vector<std::shared_ptr<pubsub_internal::SubscriberStub>> children{
       std::move(mock)};
   return MakeTestSubscriberConnection(std::move(subscription), std::move(opts),
@@ -164,19 +169,18 @@ TEST(SubscriberConnectionTest, PullFailure) {
       });
   EXPECT_CALL(*mock, AsyncStreamingPull)
       .Times(AtLeast(1))
-      .WillRepeatedly([](google::cloud::CompletionQueue& cq,
-                         std::unique_ptr<grpc::ClientContext>,
-                         google::pubsub::v1::StreamingPullRequest const&) {
+      .WillRepeatedly([](google::cloud::CompletionQueue const& cq,
+                         std::unique_ptr<grpc::ClientContext>) {
         using TimerFuture =
             future<StatusOr<std::chrono::system_clock::time_point>>;
         using us = std::chrono::microseconds;
 
-        auto start_response = [cq]() mutable {
-          return cq.MakeRelativeTimer(us(10)).then(
+        auto start_response = [q = cq]() mutable {
+          return q.MakeRelativeTimer(us(10)).then(
               [](TimerFuture) { return false; });
         };
-        auto finish_response = [cq]() mutable {
-          return cq.MakeRelativeTimer(us(10)).then([](TimerFuture) {
+        auto finish_response = [q = cq]() mutable {
+          return q.MakeRelativeTimer(us(10)).then([](TimerFuture) {
             return Status{StatusCode::kPermissionDenied, "uh-oh"};
           });
         };
@@ -268,16 +272,18 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsMetadata) {
 
   EXPECT_CALL(*mock, AsyncStreamingPull)
       .Times(AtLeast(1))
-      .WillRepeatedly(
-          [&](google::cloud::CompletionQueue& cq,
-              std::unique_ptr<grpc::ClientContext> context,
-              google::pubsub::v1::StreamingPullRequest const& request) {
-            ValidateMetadataFixture fixture;
-            fixture.IsContextMDValid(
-                *context, "google.pubsub.v1.Subscriber.Pull", request,
-                google::cloud::internal::ApiClientHeader());
-            return FakeAsyncStreamingPull(cq, std::move(context), request);
-          });
+      .WillRepeatedly([&](google::cloud::CompletionQueue const& cq,
+                          std::unique_ptr<grpc::ClientContext> context) {
+        ValidateMetadataFixture fixture;
+        auto metadata = fixture.GetMetadata(*context);
+        EXPECT_THAT(metadata,
+                    UnorderedElementsAre(
+                        Pair("x-goog-api-client",
+                             google::cloud::internal::ApiClientHeader()),
+                        Pair("x-goog-request-params",
+                             "subscription=" + subscription.FullName())));
+        return FakeAsyncStreamingPull(cq, std::move(context));
+      });
 
   auto subscriber = MakeTestSubscriberConnection(subscription, mock);
   std::atomic_flag received_one{false};

--- a/google/cloud/pubsub/testing/fake_streaming_pull.cc
+++ b/google/cloud/pubsub/testing/fake_streaming_pull.cc
@@ -24,11 +24,12 @@ using ::testing::AtLeast;
 using ::testing::AtMost;
 
 std::unique_ptr<pubsub_testing::MockAsyncPullStream> FakeAsyncStreamingPull(
-    google::cloud::CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>,
-    google::pubsub::v1::StreamingPullRequest const&) {
+    google::cloud::CompletionQueue const& completion_queue,
+    std::unique_ptr<grpc::ClientContext>) {
   using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
   using us = std::chrono::microseconds;
 
+  auto cq = completion_queue;
   auto start_response = [cq]() mutable {
     return cq.MakeRelativeTimer(us(10)).then([](TimerFuture) { return true; });
   };

--- a/google/cloud/pubsub/testing/fake_streaming_pull.h
+++ b/google/cloud/pubsub/testing/fake_streaming_pull.h
@@ -24,8 +24,8 @@ namespace pubsub_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::unique_ptr<pubsub_testing::MockAsyncPullStream> FakeAsyncStreamingPull(
-    google::cloud::CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>,
-    google::pubsub::v1::StreamingPullRequest const&);
+    google::cloud::CompletionQueue const& completion_queue,
+    std::unique_ptr<grpc::ClientContext>);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_testing

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -61,11 +61,13 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
                google::pubsub::v1::ModifyPushConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(std::unique_ptr<pubsub_internal::SubscriberStub::AsyncPullStream>,
-              AsyncStreamingPull,
-              (google::cloud::CompletionQueue&,
-               std::unique_ptr<grpc::ClientContext>,
-               google::pubsub::v1::StreamingPullRequest const&),
+  using StreamingPullStream = google::cloud::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>;
+
+  MOCK_METHOD(std::unique_ptr<StreamingPullStream>, AsyncStreamingPull,
+              (google::cloud::CompletionQueue const&,
+               std::unique_ptr<grpc::ClientContext>),
               (override));
 
   MOCK_METHOD(future<Status>, AsyncAcknowledge,
@@ -111,8 +113,7 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
               (override));
 };
 
-class MockAsyncPullStream
-    : public pubsub_internal::SubscriberStub::AsyncPullStream {
+class MockAsyncPullStream : public MockSubscriberStub::StreamingPullStream {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(future<bool>, Start, (), (override));


### PR DESCRIPTION
Use the generator signature for `StreamingPull`, the only bidir streaming RPC in this service. The affected function is in `pubsub_internal`, so the change is non-breaking, but it does require changing a large number of tests.

Part of the work for #7187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10072)
<!-- Reviewable:end -->
