### PR TITLE
cleanup(pubsub): logging decorator constructors

### DIFF
--- a/google/cloud/pubsub/internal/publisher_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_decorator.cc
@@ -20,6 +20,13 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+PublisherLogging::PublisherLogging(std::shared_ptr<PublisherStub> child,
+                                   TracingOptions tracing_options,
+                                   std::set<std::string> components)
+    : child_(std::move(child)),
+      tracing_options_(std::move(tracing_options)),
+      components_(std::move(components)) {}
+
 StatusOr<google::pubsub::v1::Topic> PublisherLogging::CreateTopic(
     grpc::ClientContext& context, google::pubsub::v1::Topic const& request) {
   return google::cloud::internal::LogWrapper(

--- a/google/cloud/pubsub/internal/publisher_logging_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_logging_decorator.h
@@ -19,6 +19,8 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/tracing_options.h"
 #include <memory>
+#include <set>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -28,9 +30,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PublisherLogging : public PublisherStub {
  public:
   PublisherLogging(std::shared_ptr<PublisherStub> child,
-                   TracingOptions tracing_options)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+                   TracingOptions tracing_options,
+                   std::set<std::string> components);
 
   StatusOr<google::pubsub::v1::Topic> CreateTopic(
       grpc::ClientContext& context,
@@ -78,6 +79,7 @@ class PublisherLogging : public PublisherStub {
  private:
   std::shared_ptr<PublisherStub> child_;
   TracingOptions tracing_options_;
+  std::set<std::string> components_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/publisher_logging_test.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_test.cc
@@ -43,7 +43,8 @@ TEST_F(PublisherLoggingTest, CreateTopic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, CreateTopic)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Topic{})));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::Topic topic;
   topic.set_name("test-topic-name");
@@ -56,7 +57,8 @@ TEST_F(PublisherLoggingTest, GetTopic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, GetTopic)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Topic{})));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::GetTopicRequest request;
   request.set_topic("test-topic-name");
@@ -69,7 +71,8 @@ TEST_F(PublisherLoggingTest, UpdateTopic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, UpdateTopic)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Topic{})));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::UpdateTopicRequest request;
   request.mutable_topic()->set_name("test-topic-name");
@@ -83,7 +86,8 @@ TEST_F(PublisherLoggingTest, ListTopics) {
   EXPECT_CALL(*mock, ListTopics)
       .WillOnce(
           Return(make_status_or(google::pubsub::v1::ListTopicsResponse{})));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::ListTopicsRequest request;
   request.set_project("test-project-name");
@@ -97,7 +101,8 @@ TEST_F(PublisherLoggingTest, ListTopics) {
 TEST_F(PublisherLoggingTest, DeleteTopic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, DeleteTopic).WillOnce(Return(Status{}));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::DeleteTopicRequest request;
   request.set_topic("test-topic-name");
@@ -113,7 +118,8 @@ TEST_F(PublisherLoggingTest, DetachSubscription) {
   EXPECT_CALL(*mock, DetachSubscription)
       .WillOnce(Return(
           make_status_or(google::pubsub::v1::DetachSubscriptionResponse{})));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::DetachSubscriptionRequest request;
   request.set_subscription("test-subscription-name");
@@ -129,7 +135,8 @@ TEST_F(PublisherLoggingTest, ListTopicSubscriptions) {
   EXPECT_CALL(*mock, ListTopicSubscriptions)
       .WillOnce(Return(make_status_or(
           google::pubsub::v1::ListTopicSubscriptionsResponse{})));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::ListTopicSubscriptionsRequest request;
   request.set_topic("test-topic-name");
@@ -145,7 +152,8 @@ TEST_F(PublisherLoggingTest, ListTopicSnapshots) {
   EXPECT_CALL(*mock, ListTopicSnapshots)
       .WillOnce(Return(
           make_status_or(google::pubsub::v1::ListTopicSnapshotsResponse{})));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::ListTopicSnapshotsRequest request;
   request.set_topic("test-topic-name");
@@ -165,7 +173,8 @@ TEST_F(PublisherLoggingTest, AsyncPublish) {
         return make_ready_future(
             make_status_or(google::pubsub::v1::PublishResponse{}));
       });
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   google::cloud::CompletionQueue cq;
   google::pubsub::v1::PublishRequest request;
   request.set_topic("test-topic-name");
@@ -182,7 +191,8 @@ TEST_F(PublisherLoggingTest, Publish) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, Publish)
       .WillOnce(Return(make_status_or(google::pubsub::v1::PublishResponse{})));
-  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                        {});
   grpc::ClientContext context;
   google::pubsub::v1::PublishRequest request;
   request.set_topic("test-topic-name");

--- a/google/cloud/pubsub/internal/publisher_stub_factory.cc
+++ b/google/cloud/pubsub/internal/publisher_stub_factory.cc
@@ -38,7 +38,8 @@ std::shared_ptr<pubsub_internal::PublisherStub> DecoratePublisherStub(
   if (internal::Contains(opts.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::PublisherLogging>(
-        std::move(stub), opts.get<GrpcTracingOptionsOption>());
+        std::move(stub), opts.get<GrpcTracingOptionsOption>(),
+        opts.get<TracingComponentsOption>());
   }
   return stub;
 }

--- a/google/cloud/pubsub/internal/schema_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/schema_logging_decorator.cc
@@ -20,6 +20,13 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+SchemaServiceLogging::SchemaServiceLogging(
+    std::shared_ptr<SchemaServiceStub> child, TracingOptions tracing_options,
+    std::set<std::string> components)
+    : child_(std::move(child)),
+      tracing_options_(std::move(tracing_options)),
+      components_(std::move(components)) {}
+
 StatusOr<google::pubsub::v1::Schema> SchemaServiceLogging::CreateSchema(
     grpc::ClientContext& context,
     google::pubsub::v1::CreateSchemaRequest const& request) {

--- a/google/cloud/pubsub/internal/schema_logging_decorator.h
+++ b/google/cloud/pubsub/internal/schema_logging_decorator.h
@@ -19,6 +19,8 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/tracing_options.h"
 #include <memory>
+#include <set>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -31,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SchemaServiceLogging : public SchemaServiceStub {
  public:
   SchemaServiceLogging(std::shared_ptr<SchemaServiceStub> child,
-                       TracingOptions tracing_options)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+                       TracingOptions tracing_options,
+                       std::set<std::string> components);
 
   StatusOr<google::pubsub::v1::Schema> CreateSchema(
       grpc::ClientContext& context,
@@ -57,6 +58,7 @@ class SchemaServiceLogging : public SchemaServiceStub {
  private:
   std::shared_ptr<SchemaServiceStub> child_;
   TracingOptions tracing_options_;
+  std::set<std::string> components_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/schema_logging_test.cc
+++ b/google/cloud/pubsub/internal/schema_logging_test.cc
@@ -42,8 +42,8 @@ TEST_F(SchemaLoggingTest, CreateSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, CreateSchema)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Schema{})));
-  SchemaServiceLogging stub(mock,
-                            TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(
+      mock, TracingOptions{}.SetOptions("single_line_mode"), {});
   grpc::ClientContext context;
   google::pubsub::v1::CreateSchemaRequest request;
   auto status = stub.CreateSchema(context, request);
@@ -55,8 +55,8 @@ TEST_F(SchemaLoggingTest, GetSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, GetSchema)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Schema{})));
-  SchemaServiceLogging stub(mock,
-                            TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(
+      mock, TracingOptions{}.SetOptions("single_line_mode"), {});
   grpc::ClientContext context;
   google::pubsub::v1::GetSchemaRequest request;
   auto status = stub.GetSchema(context, request);
@@ -69,8 +69,8 @@ TEST_F(SchemaLoggingTest, ListSchemas) {
   EXPECT_CALL(*mock, ListSchemas)
       .WillOnce(
           Return(make_status_or(google::pubsub::v1::ListSchemasResponse{})));
-  SchemaServiceLogging stub(mock,
-                            TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(
+      mock, TracingOptions{}.SetOptions("single_line_mode"), {});
   grpc::ClientContext context;
   google::pubsub::v1::ListSchemasRequest request;
   auto status = stub.ListSchemas(context, request);
@@ -81,8 +81,8 @@ TEST_F(SchemaLoggingTest, ListSchemas) {
 TEST_F(SchemaLoggingTest, DeleteSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, DeleteSchema).WillOnce(Return(Status{}));
-  SchemaServiceLogging stub(mock,
-                            TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(
+      mock, TracingOptions{}.SetOptions("single_line_mode"), {});
   grpc::ClientContext context;
   google::pubsub::v1::DeleteSchemaRequest request;
   auto status = stub.DeleteSchema(context, request);
@@ -95,8 +95,8 @@ TEST_F(SchemaLoggingTest, ValidateSchema) {
   EXPECT_CALL(*mock, ValidateSchema)
       .WillOnce(
           Return(make_status_or(google::pubsub::v1::ValidateSchemaResponse{})));
-  SchemaServiceLogging stub(mock,
-                            TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(
+      mock, TracingOptions{}.SetOptions("single_line_mode"), {});
   grpc::ClientContext context;
   google::pubsub::v1::ValidateSchemaRequest request;
   auto status = stub.ValidateSchema(context, request);
@@ -109,8 +109,8 @@ TEST_F(SchemaLoggingTest, ValidateMessage) {
   EXPECT_CALL(*mock, ValidateMessage)
       .WillOnce(Return(
           make_status_or(google::pubsub::v1::ValidateMessageResponse{})));
-  SchemaServiceLogging stub(mock,
-                            TracingOptions{}.SetOptions("single_line_mode"));
+  SchemaServiceLogging stub(
+      mock, TracingOptions{}.SetOptions("single_line_mode"), {});
   grpc::ClientContext context;
   google::pubsub::v1::ValidateMessageRequest request;
   auto status = stub.ValidateMessage(context, request);

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
@@ -21,6 +21,13 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+SubscriberLogging::SubscriberLogging(std::shared_ptr<SubscriberStub> child,
+                                     TracingOptions tracing_options,
+                                     std::set<std::string> components)
+    : child_(std::move(child)),
+      tracing_options_(std::move(tracing_options)),
+      components_(std::move(components)) {}
+
 StatusOr<google::pubsub::v1::Subscription>
 SubscriberLogging::CreateSubscription(
     grpc::ClientContext& context,
@@ -92,7 +99,7 @@ SubscriberLogging::AsyncStreamingPull(
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
   auto stream = child_->AsyncStreamingPull(cq, std::move(context));
-  if (trace_streams_) {
+  if (components_.count("rpc-streams") > 0) {
     stream = absl::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
   }

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.h
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/tracing_options.h"
 #include <memory>
+#include <set>
 #include <string>
 
 namespace google {
@@ -29,10 +30,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SubscriberLogging : public SubscriberStub {
  public:
   SubscriberLogging(std::shared_ptr<SubscriberStub> child,
-                    TracingOptions tracing_options, bool trace_streams)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)),
-        trace_streams_(trace_streams) {}
+                    TracingOptions tracing_options,
+                    std::set<std::string> components);
 
   StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
       grpc::ClientContext& context,
@@ -101,7 +100,7 @@ class SubscriberLogging : public SubscriberStub {
  private:
   std::shared_ptr<SubscriberStub> child_;
   TracingOptions tracing_options_;
-  bool trace_streams_;
+  std::set<std::string> components_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/subscriber_logging_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_test.cc
@@ -44,7 +44,7 @@ TEST_F(SubscriberLoggingTest, CreateSubscription) {
   EXPECT_CALL(*mock, CreateSubscription)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Subscription{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::Subscription subscription;
   auto status = stub.CreateSubscription(context, subscription);
@@ -57,7 +57,7 @@ TEST_F(SubscriberLoggingTest, GetSubscription) {
   EXPECT_CALL(*mock, GetSubscription)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Subscription{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::GetSubscriptionRequest request;
   auto status = stub.GetSubscription(context, request);
@@ -70,7 +70,7 @@ TEST_F(SubscriberLoggingTest, UpdateSubscription) {
   EXPECT_CALL(*mock, UpdateSubscription)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Subscription{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::UpdateSubscriptionRequest request;
   auto status = stub.UpdateSubscription(context, request);
@@ -84,7 +84,7 @@ TEST_F(SubscriberLoggingTest, ListSubscriptions) {
       .WillOnce(Return(
           make_status_or(google::pubsub::v1::ListSubscriptionsResponse{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::ListSubscriptionsRequest request;
   request.set_project("test-project-name");
@@ -99,7 +99,7 @@ TEST_F(SubscriberLoggingTest, DeleteSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, DeleteSubscription).WillOnce(Return(Status{}));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::DeleteSubscriptionRequest request;
   request.set_subscription("test-subscription-name");
@@ -114,7 +114,7 @@ TEST_F(SubscriberLoggingTest, ModifyPushConfig) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, ModifyPushConfig).WillOnce(Return(Status{}));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::ModifyPushConfigRequest request;
   request.set_subscription("test-subscription-name");
@@ -158,7 +158,7 @@ TEST_F(SubscriberLoggingTest, AsyncStreamingPull) {
         return stream;
       });
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         true);
+                         {"rpc-streams"});
   google::cloud::CompletionQueue cq;
 
   google::pubsub::v1::StreamingPullRequest request;
@@ -201,7 +201,7 @@ TEST_F(SubscriberLoggingTest, AsyncAcknowledge) {
         return make_ready_future(Status{});
       });
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   google::cloud::CompletionQueue cq;
   google::pubsub::v1::AcknowledgeRequest request;
   request.set_subscription("test-subscription-name");
@@ -223,7 +223,7 @@ TEST_F(SubscriberLoggingTest, AsyncModifyAckDeadline) {
         return make_ready_future(Status{});
       });
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   google::cloud::CompletionQueue cq;
   google::pubsub::v1::ModifyAckDeadlineRequest request;
   request.set_subscription("test-subscription-name");
@@ -241,7 +241,7 @@ TEST_F(SubscriberLoggingTest, CreateSnapshot) {
   EXPECT_CALL(*mock, CreateSnapshot)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Snapshot{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::CreateSnapshotRequest request;
   auto status = stub.CreateSnapshot(context, request);
@@ -254,7 +254,7 @@ TEST_F(SubscriberLoggingTest, GetSnapshot) {
   EXPECT_CALL(*mock, GetSnapshot)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Snapshot{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::GetSnapshotRequest request;
   auto status = stub.GetSnapshot(context, request);
@@ -268,7 +268,7 @@ TEST_F(SubscriberLoggingTest, ListSnapshots) {
       .WillOnce(
           Return(make_status_or(google::pubsub::v1::ListSnapshotsResponse{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::ListSnapshotsRequest request;
   request.set_project("test-project-name");
@@ -284,7 +284,7 @@ TEST_F(SubscriberLoggingTest, UpdateSnapshot) {
   EXPECT_CALL(*mock, UpdateSnapshot)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Snapshot{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::UpdateSnapshotRequest request;
   auto status = stub.UpdateSnapshot(context, request);
@@ -296,7 +296,7 @@ TEST_F(SubscriberLoggingTest, DeleteSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, DeleteSnapshot).WillOnce(Return(Status{}));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::DeleteSnapshotRequest request;
   auto status = stub.DeleteSnapshot(context, request);
@@ -309,7 +309,7 @@ TEST_F(SubscriberLoggingTest, Seek) {
   EXPECT_CALL(*mock, Seek)
       .WillOnce(Return(make_status_or(google::pubsub::v1::SeekResponse{})));
   SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
-                         false);
+                         {});
   grpc::ClientContext context;
   google::pubsub::v1::SeekRequest request;
   request.set_subscription("test-subscription-name");

--- a/google/cloud/pubsub/schema_admin_connection.cc
+++ b/google/cloud/pubsub/schema_admin_connection.cc
@@ -168,7 +168,8 @@ std::shared_ptr<pubsub_internal::SchemaServiceStub> DecorateSchemaAdminStub(
   if (internal::Contains(opts.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::SchemaServiceLogging>(
-        std::move(stub), opts.get<GrpcTracingOptionsOption>());
+        std::move(stub), opts.get<GrpcTracingOptionsOption>(),
+        opts.get<TracingComponentsOption>());
   }
   return stub;
 }

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -94,8 +94,7 @@ std::shared_ptr<pubsub_internal::SubscriberStub> DecorateSubscriberStub(
   if (internal::Contains(tracing, "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::SubscriberLogging>(
-        std::move(stub), opts.get<GrpcTracingOptionsOption>(),
-        internal::Contains(tracing, "rpc-streams"));
+        std::move(stub), opts.get<GrpcTracingOptionsOption>(), tracing);
   }
   return stub;
 }

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -270,8 +270,7 @@ std::shared_ptr<pubsub_internal::SubscriberStub> DecorateSubscriptionAdminStub(
   if (internal::Contains(tracing, "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::SubscriberLogging>(
-        std::move(stub), opts.get<GrpcTracingOptionsOption>(),
-        internal::Contains(tracing, "rpc-streams"));
+        std::move(stub), opts.get<GrpcTracingOptionsOption>(), tracing);
   }
   return stub;
 }


### PR DESCRIPTION
Change the constructors for logging decorators to match the generated code.

Part of the work for #7187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10073)
<!-- Reviewable:end -->
