### PR TITLE
test(spanner): restore creating an instance using the custom config

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -304,13 +304,6 @@ TEST_F(InstanceAdminClientTest, InstanceConfigUserManaged) {
                 Eq("updated-value"));
   }
 
-  // TODO(#10006): Temporarily refrain from creating an Instance
-  // that uses the custom InstanceConfig until we can figure out why
-  // the DeleteInstanceConfig() is now failing with "Cannot remove
-  // <name> since it is used by 1 instance(s)." Even retrying the
-  // DeleteInstanceConfig() every second continues to fail, like the
-  // DeleteInstance() is never going to take effect.
-#if 0
   std::string instance_id = spanner_testing::RandomInstanceName(generator_);
   Instance in(project, instance_id);
   auto instance =
@@ -330,7 +323,6 @@ TEST_F(InstanceAdminClientTest, InstanceConfigUserManaged) {
     EXPECT_EQ(instance->labels().at("label-key"), "label-value");
     EXPECT_THAT(client_.DeleteInstance(instance->name()), IsOk());
   }
-#endif
 
   EXPECT_THAT(client_.DeleteInstanceConfig(user_config->name()), IsOk());
 }


### PR DESCRIPTION
Undo the temporary measure that refrained from creating an `Instance` that uses the custom `InstanceConfig`.  Apparently this was due to some rollout skew in the backend, exacerbated by a freeze.

There remains some question about whether the `DeleteInstance()` should be be followed by a `ListInstances()` polling loop, or the `DeleteInstanceConfig()` should be retried while it returns "Cannot remove <name> since it is used", but for now we proceed with neither.

Reverts #10033.  Fixes #10006.