### PR TITLE
ci: group renovate PRs for direct dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,18 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["com_google_protobuf", "com_google_absl"],
+      "matchPackageNames": ["com_google_absl", "abseil/abseil-cpp"],
+      "groupName": "Abseil",
+      "versioning": "loose"
+    },
+    {
+      "matchPackageNames": ["com_google_protobuf", "protocolbuffers/protobuf"],
+      "groupName": "Protobuf",
+      "versioning": "loose"
+    },
+    {
+      "matchPackageNames": ["com_github_grpc_grpc", "grpc/grpc"],
+      "groupName": "gRPC",
       "versioning": "loose"
     },
     {


### PR DESCRIPTION
If I read the documentation correctly, this will group updates for gRPC and Protobuf and Abseil into a single PR, as opposed to one PR for Bazel and one for the Dockerfiles.