### PR TITLE
cleanup: use `git ls-files` to filter files

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -43,7 +43,7 @@ bazel run --action_env=GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes \
 # TODO(#5821): The generator should run clang-format on its output files itself
 # so we don't need this extra step.
 io::log_h2 "Formatting generated code"
-git ls-files -z | grep -zE '\.(cc|h)$' |
+git ls-files -z -- '*.h' '*.cc' |
   xargs -P "$(nproc)" -n 1 -0 clang-format -i
 
 io::log_h2 "Updating protobuf lists/deps"


### PR DESCRIPTION
When possible, use `git ls-files` to filter files by extension or name. It should be possible to use `--exclude` to exclude files, but I left that for another day.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10084)
<!-- Reviewable:end -->
