### PR TITLE
cleanup(generator): improve testing RPC names

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -90,20 +90,6 @@ GoldenKitchenSinkClient::ListLogs(google::test::admin::database::v1::ListLogsReq
   return connection_->ListLogs(std::move(request));
 }
 
-StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkClient::TailLogEntries(std::vector<std::string> const& resource_names, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
-  google::test::admin::database::v1::TailLogEntriesRequest request;
-  *request.mutable_resource_names() = {resource_names.begin(), resource_names.end()};
-  return connection_->TailLogEntries(request);
-}
-
-StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkClient::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
-  return connection_->TailLogEntries(request);
-}
-
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
@@ -132,13 +118,27 @@ GoldenKitchenSinkClient::DoNothing(google::protobuf::Empty const& request, Optio
   return connection_->DoNothing(request);
 }
 
+StreamRange<google::test::admin::database::v1::Response>
+GoldenKitchenSinkClient::StreamingRead(std::string const& stream, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  google::test::admin::database::v1::Request request;
+  request.set_stream(stream);
+  return connection_->StreamingRead(request);
+}
+
+StreamRange<google::test::admin::database::v1::Response>
+GoldenKitchenSinkClient::StreamingRead(google::test::admin::database::v1::Request const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  return connection_->StreamingRead(request);
+}
+
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::test::admin::database::v1::AppendRowsRequest,
-    google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkClient::AsyncAppendRows(ExperimentalTag tag, Options opts) {
+    google::test::admin::database::v1::Request,
+    google::test::admin::database::v1::Response>>
+GoldenKitchenSinkClient::AsyncStreamingReadWrite(ExperimentalTag tag, Options opts) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(opts), options_));
-  return connection_->AsyncAppendRows(std::move(tag));
+  return connection_->AsyncStreamingReadWrite(std::move(tag));
 }
 
 Status

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -110,10 +110,10 @@ class GoldenKitchenSinkClient {
   ///  hour.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L996}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L984}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L996}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L984}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options opts = {});
@@ -121,13 +121,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L956}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L944}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L996}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L984}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L996}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L984}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts = {});
@@ -154,10 +154,10 @@ class GoldenKitchenSinkClient {
   ///  token will contain `email` and `email_verified` claims.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1038}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1026}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1005}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1038}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L993}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1026}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options opts = {});
@@ -165,13 +165,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L1005}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L993}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1038}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1026}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1005}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1038}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L993}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1026}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options opts = {});
@@ -204,10 +204,10 @@ class GoldenKitchenSinkClient {
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1077}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1065}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1044}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1077}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1032}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1065}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options opts = {});
@@ -221,13 +221,13 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1044}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1032}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1077}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1065}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1044}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1077}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1032}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1065}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options opts = {});
@@ -245,7 +245,7 @@ class GoldenKitchenSinkClient {
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1080}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1068}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options opts = {});
@@ -254,54 +254,15 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1080}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1068}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1080}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1068}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options opts = {});
-
-  ///
-  /// Streaming read of log entries as they are ingested. Until the stream is
-  /// terminated, it will continue reading logs.
-  ///
-  /// @param resource_names  Required. Name of a parent resource from which to retrieve log entries:
-  ///      "projects/[PROJECT_ID]"
-  ///      "organizations/[ORGANIZATION_ID]"
-  ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
-  ///      "folders/[FOLDER_ID]"
-  ///  May alternatively be one or more views:
-  ///      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  ///      "organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  ///      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  /// @param opts Optional. Override the class-level options, such as retry and
-  ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1338}
-  ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1306}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1338}
-  ///
-  StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(std::vector<std::string> const& resource_names, Options opts = {});
-
-  ///
-  /// Streaming read of log entries as they are ingested. Until the stream is
-  /// terminated, it will continue reading logs.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1306}
-  /// @param opts Optional. Override the class-level options, such as retry and
-  ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1338}
-  ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1306}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1338}
-  ///
-  StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options opts = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
@@ -316,10 +277,10 @@ class GoldenKitchenSinkClient {
   ///  is provided, all keys are returned.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1410}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1326}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1378}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1410}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1294}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1326}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts = {});
@@ -327,13 +288,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1378}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1294}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1410}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1326}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1378}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1410}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1294}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1326}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options opts = {});
@@ -362,22 +323,50 @@ class GoldenKitchenSinkClient {
   DoNothing(google::protobuf::Empty const& request, Options opts = {});
 
   ///
-  /// A much simplified version of the AppendRows in google.cloud.bigquery.storage.v1.BigQueryWrite
+  /// Tests the generator for streaming read RPCs (aka server-side streaming)
+  ///
+  /// @param stream  A placeholder to test method signatures
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L939}
+  ///
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L933}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L939}
+  ///
+  StreamRange<google::test::admin::database::v1::Response>
+  StreamingRead(std::string const& stream, Options opts = {});
+
+  ///
+  /// Tests the generator for streaming read RPCs (aka server-side streaming)
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L933}
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L939}
+  ///
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L933}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L939}
+  ///
+  StreamRange<google::test::admin::database::v1::Response>
+  StreamingRead(google::test::admin::database::v1::Request const& request, Options opts = {});
+
+  ///
+  /// Tests the generator for streaming read-write RPCs (aka bidir streaming)
   ///
   /// @note The presence of the `ExperimentalTag` means that this function is
   /// experimental. It is subject to change (including removal) without notice.
   ///
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return A bidirectional streaming interface with request (write) type: @googleapis_link{google::test::admin::database::v1::AppendRowsRequest,generator/integration_tests/test.proto#L940} and response (read) type: @googleapis_link{google::test::admin::database::v1::AppendRowsResponse,generator/integration_tests/test.proto#L944}
+  /// @return A bidirectional streaming interface with request (write) type: @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L933} and response (read) type: @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L939}
   ///
-  /// [google.test.admin.database.v1.AppendRowsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L940}
-  /// [google.test.admin.database.v1.AppendRowsResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L933}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L939}
   ///
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(ExperimentalTag, Options opts = {});
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(ExperimentalTag, Options opts = {});
 
   ///
   /// An RPC to test that explicit routing headers are supported.
@@ -397,11 +386,11 @@ class GoldenKitchenSinkClient {
   ///    x-goog-request-params:
   ///    table_location=instances/instance_bar&routing_id=prof_qux
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1417}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1333}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1417}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1333}
   ///
   Status
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});
@@ -410,11 +399,11 @@ class GoldenKitchenSinkClient {
   /// We use this RPC to verify the special case where a routing parameter key
   /// does not require a regex in order to match the correct value.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1417}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1333}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1417}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1333}
   ///
   Status
   ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -110,10 +110,10 @@ class GoldenKitchenSinkClient {
   ///  hour.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L984}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L985}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L984}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L945}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L985}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options opts = {});
@@ -121,13 +121,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L944}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L945}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L984}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L985}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L984}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L945}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L985}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts = {});
@@ -154,10 +154,10 @@ class GoldenKitchenSinkClient {
   ///  token will contain `email` and `email_verified` claims.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1026}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1027}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L993}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1026}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L994}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1027}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options opts = {});
@@ -165,13 +165,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L993}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L994}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1026}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1027}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L993}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1026}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L994}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1027}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options opts = {});
@@ -204,10 +204,10 @@ class GoldenKitchenSinkClient {
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1065}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1066}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1032}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1065}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1033}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1066}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options opts = {});
@@ -221,13 +221,13 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1032}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1033}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1065}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1066}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1032}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1065}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1033}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1066}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options opts = {});
@@ -245,7 +245,7 @@ class GoldenKitchenSinkClient {
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1068}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1069}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options opts = {});
@@ -254,12 +254,12 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1068}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1069}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1068}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1069}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options opts = {});
@@ -277,10 +277,10 @@ class GoldenKitchenSinkClient {
   ///  is provided, all keys are returned.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1326}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1327}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1294}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1326}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1295}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1327}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts = {});
@@ -288,13 +288,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1294}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1295}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1326}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1327}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1294}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1326}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1295}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1327}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options opts = {});
@@ -328,10 +328,10 @@ class GoldenKitchenSinkClient {
   /// @param stream  A placeholder to test method signatures
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L939}
+  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L940}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L933}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L939}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L934}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L940}
   ///
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(std::string const& stream, Options opts = {});
@@ -339,13 +339,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Tests the generator for streaming read RPCs (aka server-side streaming)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L933}
+  /// @param request @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L934}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L939}
+  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L940}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L933}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L939}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L934}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L940}
   ///
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request, Options opts = {});
@@ -358,10 +358,10 @@ class GoldenKitchenSinkClient {
   ///
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return A bidirectional streaming interface with request (write) type: @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L933} and response (read) type: @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L939}
+  /// @return A bidirectional streaming interface with request (write) type: @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L934} and response (read) type: @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L940}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L933}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L939}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L934}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L940}
   ///
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,
@@ -386,11 +386,11 @@ class GoldenKitchenSinkClient {
   ///    x-goog-request-params:
   ///    table_location=instances/instance_bar&routing_id=prof_qux
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1333}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1334}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1333}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1334}
   ///
   Status
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});
@@ -399,11 +399,11 @@ class GoldenKitchenSinkClient {
   /// We use this RPC to verify the special case where a routing parameter key
   /// does not require a regex in order to match the correct value.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1333}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1334}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1333}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1334}
   ///
   Status
   ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -59,16 +59,6 @@ StreamRange<std::string> GoldenKitchenSinkConnection::ListLogs(
       StreamRange<std::string>>();
 }
 
-StreamRange<google::test::admin::database::v1::TailLogEntriesResponse> GoldenKitchenSinkConnection::TailLogEntries(
-    google::test::admin::database::v1::TailLogEntriesRequest const&) {
-  return google::cloud::internal::MakeStreamRange<
-      google::test::admin::database::v1::TailLogEntriesResponse>(
-      []() -> absl::variant<Status,
-      google::test::admin::database::v1::TailLogEntriesResponse>{
-        return Status(StatusCode::kUnimplemented, "not implemented");}
-      );
-}
-
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 GoldenKitchenSinkConnection::ListServiceAccountKeys(
     google::test::admin::database::v1::ListServiceAccountKeysRequest const&) {
@@ -81,14 +71,24 @@ GoldenKitchenSinkConnection::DoNothing(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
+StreamRange<google::test::admin::database::v1::Response> GoldenKitchenSinkConnection::StreamingRead(
+    google::test::admin::database::v1::Request const&) {
+  return google::cloud::internal::MakeStreamRange<
+      google::test::admin::database::v1::Response>(
+      []() -> absl::variant<Status,
+      google::test::admin::database::v1::Response>{
+        return Status(StatusCode::kUnimplemented, "not implemented");}
+      );
+}
+
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::test::admin::database::v1::AppendRowsRequest,
-    google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkConnection::AsyncAppendRows(ExperimentalTag) {
+    google::test::admin::database::v1::Request,
+    google::test::admin::database::v1::Response>>
+GoldenKitchenSinkConnection::AsyncStreamingReadWrite(ExperimentalTag) {
   return absl::make_unique<
       ::google::cloud::internal::AsyncStreamingReadWriteRpcError<
-          google::test::admin::database::v1::AppendRowsRequest,
-          google::test::admin::database::v1::AppendRowsResponse>>(
+          google::test::admin::database::v1::Request,
+          google::test::admin::database::v1::Response>>(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -76,19 +76,19 @@ class GoldenKitchenSinkConnection {
   virtual StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request);
 
-  virtual StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request);
-
   virtual StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);
 
   virtual Status
   DoNothing(google::protobuf::Empty const& request);
 
+  virtual StreamRange<google::test::admin::database::v1::Response>
+  StreamingRead(google::test::admin::database::v1::Request const& request);
+
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(ExperimentalTag);
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(ExperimentalTag);
 
   virtual Status
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
@@ -66,17 +66,6 @@ StatusOr<google::test::admin::database::v1::ListLogsResponse> GoldenKitchenSinkA
   return child_->ListLogs(context, request);
 }
 
-std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
-GoldenKitchenSinkAuth::TailLogEntries(
-   std::unique_ptr<grpc::ClientContext> context,
-   google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-  using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
-      google::test::admin::database::v1::TailLogEntriesResponse>;
-  auto status = auth_->ConfigureContext(*context);
-  if (!status.ok()) return absl::make_unique<ErrorStream>(std::move(status));
-  return child_->TailLogEntries(std::move(context), request);
-}
-
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> GoldenKitchenSinkAuth::ListServiceAccountKeys(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
@@ -93,33 +82,44 @@ Status GoldenKitchenSinkAuth::DoNothing(
   return child_->DoNothing(context, request);
 }
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::test::admin::database::v1::AppendRowsRequest,
-    google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkAuth::AsyncAppendRows(
-    google::cloud::CompletionQueue const& cq,
-    std::unique_ptr<grpc::ClientContext> context) {
-  using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
-    google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>;
-
-  auto& child = child_;
-  auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncAppendRows(cq, std::move(ctx));
-  };
-  return absl::make_unique<StreamAuth>(
-    std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
+GoldenKitchenSinkAuth::StreamingRead(
+   std::unique_ptr<grpc::ClientContext> context,
+   google::test::admin::database::v1::Request const& request) {
+  using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
+      google::test::admin::database::v1::Response>;
+  auto status = auth_->ConfigureContext(*context);
+  if (!status.ok()) return absl::make_unique<ErrorStream>(std::move(status));
+  return child_->StreamingRead(std::move(context), request);
 }
 
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-    google::test::admin::database::v1::WriteObjectRequest,
-    google::test::admin::database::v1::WriteObjectResponse>>
-GoldenKitchenSinkAuth::WriteObject(
+    google::test::admin::database::v1::Request,
+    google::test::admin::database::v1::Response>>
+GoldenKitchenSinkAuth::StreamingWrite(
     std::unique_ptr<grpc::ClientContext> context) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
-      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>;
+      google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return absl::make_unique<ErrorStream>(std::move(status));
-  return child_->WriteObject(std::move(context));
+  return child_->StreamingWrite(std::move(context));
+}
+
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+    google::test::admin::database::v1::Request,
+    google::test::admin::database::v1::Response>>
+GoldenKitchenSinkAuth::AsyncStreamingReadWrite(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
+    google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>;
+
+  auto& child = child_;
+  auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncStreamingReadWrite(cq, std::move(ctx));
+  };
+  return absl::make_unique<StreamAuth>(
+    std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
 }
 
 Status GoldenKitchenSinkAuth::ExplicitRouting1(
@@ -139,33 +139,33 @@ Status GoldenKitchenSinkAuth::ExplicitRouting2(
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-    google::test::admin::database::v1::TailLogEntriesResponse>>
-GoldenKitchenSinkAuth::AsyncTailLogEntries(
+    google::test::admin::database::v1::Response>>
+GoldenKitchenSinkAuth::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+    google::test::admin::database::v1::Request const& request) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
-    google::test::admin::database::v1::TailLogEntriesResponse>;
+    google::test::admin::database::v1::Response>;
 
   auto& child = child_;
   auto call = [child, cq, request](std::unique_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncTailLogEntries(cq, std::move(ctx), request);
+    return child->AsyncStreamingRead(cq, std::move(ctx), request);
   };
   return absl::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-    google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>
-GoldenKitchenSinkAuth::AsyncWriteObject(
+    google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
+GoldenKitchenSinkAuth::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingWriteRpcAuth<
-    google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>;
+    google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>;
 
   auto& child = child_;
   auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncWriteObject(cq, std::move(ctx));
+    return child->AsyncStreamingWrite(cq, std::move(ctx));
   };
   return absl::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -54,11 +54,6 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
-  TailLogEntries(
-      std::unique_ptr<grpc::ClientContext> context,
-      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
-
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
@@ -67,16 +62,21 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::protobuf::Empty const& request) override;
 
-  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(
-      google::cloud::CompletionQueue const& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
+  StreamingRead(
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest,
-      google::test::admin::database::v1::WriteObjectResponse>> WriteObject(
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>> StreamingWrite(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
   Status ExplicitRouting1(
@@ -88,15 +88,15 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      google::test::admin::database::v1::TailLogEntriesResponse>>
-  AsyncTailLogEntries(
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+      google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>
-  AsyncWriteObject(
+      google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
+  AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.cc
@@ -105,24 +105,6 @@ GoldenKitchenSinkConnectionImpl::ListLogs(google::test::admin::database::v1::Lis
       });
 }
 
-StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkConnectionImpl::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-  auto& stub = stub_;
-  auto retry = std::shared_ptr<golden::GoldenKitchenSinkRetryPolicy const>(retry_policy());
-  auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
-
-  auto factory = [stub](google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-    return stub->TailLogEntries(absl::make_unique<grpc::ClientContext>(), request);
-  };
-  auto resumable =
-      internal::MakeResumableStreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse, google::test::admin::database::v1::TailLogEntriesRequest>(
-          retry->clone(), backoff->clone(), [](std::chrono::milliseconds) {},
-          factory,
-          GoldenKitchenSinkTailLogEntriesStreamingUpdater,
-          request);
-  return internal::MakeStreamRange(internal::StreamReader<google::test::admin::database::v1::TailLogEntriesResponse>(
-      [resumable]{return resumable->Read();}));
-}
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 GoldenKitchenSinkConnectionImpl::ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
   return google::cloud::internal::RetryLoop(
@@ -147,6 +129,24 @@ GoldenKitchenSinkConnectionImpl::DoNothing(google::protobuf::Empty const& reques
       request, __func__);
 }
 
+StreamRange<google::test::admin::database::v1::Response>
+GoldenKitchenSinkConnectionImpl::StreamingRead(google::test::admin::database::v1::Request const& request) {
+  auto& stub = stub_;
+  auto retry = std::shared_ptr<golden::GoldenKitchenSinkRetryPolicy const>(retry_policy());
+  auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+
+  auto factory = [stub](google::test::admin::database::v1::Request const& request) {
+    return stub->StreamingRead(absl::make_unique<grpc::ClientContext>(), request);
+  };
+  auto resumable =
+      internal::MakeResumableStreamingReadRpc<google::test::admin::database::v1::Response, google::test::admin::database::v1::Request>(
+          retry->clone(), backoff->clone(), [](std::chrono::milliseconds) {},
+          factory,
+          GoldenKitchenSinkStreamingReadStreamingUpdater,
+          request);
+  return internal::MakeStreamRange(internal::StreamReader<google::test::admin::database::v1::Response>(
+      [resumable]{return resumable->Read();}));
+}
 Status
 GoldenKitchenSinkConnectionImpl::ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return google::cloud::internal::RetryLoop(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.h
@@ -38,9 +38,9 @@ namespace cloud {
 namespace golden_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-void GoldenKitchenSinkTailLogEntriesStreamingUpdater(
-    google::test::admin::database::v1::TailLogEntriesResponse const& response,
-    google::test::admin::database::v1::TailLogEntriesRequest& request);
+void GoldenKitchenSinkStreamingReadStreamingUpdater(
+    google::test::admin::database::v1::Response const& response,
+    google::test::admin::database::v1::Request& request);
 
 class GoldenKitchenSinkConnectionImpl
     : public golden::GoldenKitchenSinkConnection {
@@ -66,19 +66,19 @@ class GoldenKitchenSinkConnectionImpl
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request) override;
 
-  StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
-
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
   Status
   DoNothing(google::protobuf::Empty const& request) override;
 
+  StreamRange<google::test::admin::database::v1::Response>
+  StreamingRead(google::test::admin::database::v1::Request const& request) override;
+
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(ExperimentalTag) override;
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(ExperimentalTag) override;
 
   Status
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -54,11 +54,6 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
-  TailLogEntries(
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
-
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
@@ -67,17 +62,22 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) override;
 
-  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(
-      google::cloud::CompletionQueue const& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
+  StreamingRead(
+    std::unique_ptr<grpc::ClientContext> context,
+    google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest,
-      google::test::admin::database::v1::WriteObjectResponse>>
-   WriteObject(
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+   StreamingWrite(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
   Status ExplicitRouting1(
@@ -89,15 +89,15 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
     google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      google::test::admin::database::v1::TailLogEntriesResponse>>
-  AsyncTailLogEntries(
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+      google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>
-  AsyncWriteObject(
+      google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
+  AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -67,25 +67,6 @@ GoldenKitchenSinkMetadata::ListLogs(
   return child_->ListLogs(context, request);
 }
 
-std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
-GoldenKitchenSinkMetadata::TailLogEntries(
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-  std::vector<std::string> params;
-  params.reserve(1);
-
-  if (!request.filter().empty()) {
-    params.push_back("filter=" + request.filter());
-  }
-
-  if (params.empty()) {
-    SetMetadata(*context);
-  } else {
-    SetMetadata(*context, absl::StrJoin(params, "&"));
-  }
-  return child_->TailLogEntries(std::move(context), request);
-}
-
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 GoldenKitchenSinkMetadata::ListServiceAccountKeys(
     grpc::ClientContext& context,
@@ -102,23 +83,31 @@ GoldenKitchenSinkMetadata::DoNothing(
   return child_->DoNothing(context, request);
 }
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkMetadata::AsyncAppendRows(
-    google::cloud::CompletionQueue const& cq,
-    std::unique_ptr<grpc::ClientContext> context) {
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
+GoldenKitchenSinkMetadata::StreamingRead(
+    std::unique_ptr<grpc::ClientContext> context,
+    google::test::admin::database::v1::Request const& request) {
   SetMetadata(*context);
-  return child_->AsyncAppendRows(cq, std::move(context));
+  return child_->StreamingRead(std::move(context), request);
 }
 
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-    google::test::admin::database::v1::WriteObjectRequest,
-    google::test::admin::database::v1::WriteObjectResponse>>
-GoldenKitchenSinkMetadata::WriteObject(
+    google::test::admin::database::v1::Request,
+    google::test::admin::database::v1::Response>>
+GoldenKitchenSinkMetadata::StreamingWrite(
     std::unique_ptr<grpc::ClientContext> context) {
   SetMetadata(*context);
-  return child_->WriteObject(std::move(context));
+  return child_->StreamingWrite(std::move(context));
+}
+
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+GoldenKitchenSinkMetadata::AsyncStreamingReadWrite(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  SetMetadata(*context);
+  return child_->AsyncStreamingReadWrite(cq, std::move(context));
 }
 
 Status
@@ -198,33 +187,22 @@ GoldenKitchenSinkMetadata::ExplicitRouting2(
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      google::test::admin::database::v1::TailLogEntriesResponse>>
-GoldenKitchenSinkMetadata::AsyncTailLogEntries(
+      google::test::admin::database::v1::Response>>
+GoldenKitchenSinkMetadata::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-  std::vector<std::string> params;
-  params.reserve(1);
-
-  if (!request.filter().empty()) {
-    params.push_back("filter=" + request.filter());
-  }
-
-  if (params.empty()) {
-    SetMetadata(*context);
-  } else {
-    SetMetadata(*context, absl::StrJoin(params, "&"));
-  }
-  return child_->AsyncTailLogEntries(cq, std::move(context), request);
+    google::test::admin::database::v1::Request const& request) {
+  SetMetadata(*context);
+  return child_->AsyncStreamingRead(cq, std::move(context), request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-    google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>
-GoldenKitchenSinkMetadata::AsyncWriteObject(
+    google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
+GoldenKitchenSinkMetadata::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   SetMetadata(*context);
-  return child_->AsyncWriteObject(cq, std::move(context));
+  return child_->AsyncStreamingWrite(cq, std::move(context));
 }
 
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -50,11 +50,6 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
-    TailLogEntries(
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
-
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
@@ -63,17 +58,22 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) override;
 
-  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(
-      google::cloud::CompletionQueue const& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
+    StreamingRead(
+    std::unique_ptr<grpc::ClientContext> context,
+    google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest,
-      google::test::admin::database::v1::WriteObjectResponse>>
-  WriteObject(
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
   Status ExplicitRouting1(
@@ -85,15 +85,15 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
     google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      google::test::admin::database::v1::TailLogEntriesResponse>>
-  AsyncTailLogEntries(
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+      google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>
-  AsyncWriteObject(
+      google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
+  AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -86,16 +86,6 @@ DefaultGoldenKitchenSinkStub::ListLogs(
     return response;
 }
 
-std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
-DefaultGoldenKitchenSinkStub::TailLogEntries(
-    std::unique_ptr<grpc::ClientContext> client_context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-  auto stream = grpc_stub_->TailLogEntries(client_context.get(), request);
-  return absl::make_unique<google::cloud::internal::StreamingReadRpcImpl<
-      google::test::admin::database::v1::TailLogEntriesResponse>>(
-      std::move(client_context), std::move(stream));
-}
-
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 DefaultGoldenKitchenSinkStub::ListServiceAccountKeys(
   grpc::ClientContext& client_context,
@@ -122,29 +112,39 @@ DefaultGoldenKitchenSinkStub::DoNothing(
     return google::cloud::Status();
 }
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::test::admin::database::v1::AppendRowsRequest,
-    google::test::admin::database::v1::AppendRowsResponse>>
-DefaultGoldenKitchenSinkStub::AsyncAppendRows(
-    google::cloud::CompletionQueue const& cq,
-    std::unique_ptr<grpc::ClientContext> context) {
-  return google::cloud::internal::MakeStreamingReadWriteRpc<google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>(
-      cq, std::move(context),
-      [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
-        return grpc_stub_->PrepareAsyncAppendRows(context, cq);
-      });
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
+DefaultGoldenKitchenSinkStub::StreamingRead(
+    std::unique_ptr<grpc::ClientContext> client_context,
+    google::test::admin::database::v1::Request const& request) {
+  auto stream = grpc_stub_->StreamingRead(client_context.get(), request);
+  return absl::make_unique<google::cloud::internal::StreamingReadRpcImpl<
+      google::test::admin::database::v1::Response>>(
+      std::move(client_context), std::move(stream));
 }
 
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-    google::test::admin::database::v1::WriteObjectRequest,
-    google::test::admin::database::v1::WriteObjectResponse>>
-DefaultGoldenKitchenSinkStub::WriteObject(
+    google::test::admin::database::v1::Request,
+    google::test::admin::database::v1::Response>>
+DefaultGoldenKitchenSinkStub::StreamingWrite(
     std::unique_ptr<grpc::ClientContext> context) {
-  auto response = absl::make_unique<google::test::admin::database::v1::WriteObjectResponse>();
-  auto stream = grpc_stub_->WriteObject(context.get(), response.get());
+  auto response = absl::make_unique<google::test::admin::database::v1::Response>();
+  auto stream = grpc_stub_->StreamingWrite(context.get(), response.get());
   return absl::make_unique<::google::cloud::internal::StreamingWriteRpcImpl<
-      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>(
+      google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>(
     std::move(context), std::move(response), std::move(stream));
+}
+
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+    google::test::admin::database::v1::Request,
+    google::test::admin::database::v1::Response>>
+DefaultGoldenKitchenSinkStub::AsyncStreamingReadWrite(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  return google::cloud::internal::MakeStreamingReadWriteRpc<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>(
+      cq, std::move(context),
+      [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncStreamingReadWrite(context, cq);
+      });
 }
 
 Status
@@ -174,27 +174,27 @@ DefaultGoldenKitchenSinkStub::ExplicitRouting2(
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-    google::test::admin::database::v1::TailLogEntriesResponse>>
-DefaultGoldenKitchenSinkStub::AsyncTailLogEntries(
+    google::test::admin::database::v1::Response>>
+DefaultGoldenKitchenSinkStub::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-  return google::cloud::internal::MakeStreamingReadRpc<google::test::admin::database::v1::TailLogEntriesRequest, google::test::admin::database::v1::TailLogEntriesResponse>(
+    google::test::admin::database::v1::Request const& request) {
+  return google::cloud::internal::MakeStreamingReadRpc<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>(
     cq, std::move(context), request,
-    [this](grpc::ClientContext* context, google::test::admin::database::v1::TailLogEntriesRequest const& request, grpc::CompletionQueue* cq) {
-      return grpc_stub_->PrepareAsyncTailLogEntries(context, request, cq);
+    [this](grpc::ClientContext* context, google::test::admin::database::v1::Request const& request, grpc::CompletionQueue* cq) {
+      return grpc_stub_->PrepareAsyncStreamingRead(context, request, cq);
     });
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-    google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>
-DefaultGoldenKitchenSinkStub::AsyncWriteObject(
+    google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
+DefaultGoldenKitchenSinkStub::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
-  return google::cloud::internal::MakeStreamingWriteRpc<google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>(
+  return google::cloud::internal::MakeStreamingWriteRpc<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>(
     cq, std::move(context),
-    [this](grpc::ClientContext* context, google::test::admin::database::v1::WriteObjectResponse* response, grpc::CompletionQueue* cq) {
-      return grpc_stub_->PrepareAsyncWriteObject(context, response, cq);
+    [this](grpc::ClientContext* context, google::test::admin::database::v1::Response* response, grpc::CompletionQueue* cq) {
+      return grpc_stub_->PrepareAsyncStreamingWrite(context, response, cq);
     });
 }
 

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -57,11 +57,6 @@ class GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListLogsRequest const& request) = 0;
 
-  virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
-  TailLogEntries(
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) = 0;
-
   virtual StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) = 0;
@@ -70,17 +65,22 @@ class GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) = 0;
 
-  virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(
-      google::cloud::CompletionQueue const& cq,
-      std::unique_ptr<grpc::ClientContext> context) = 0;
+  virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
+  StreamingRead(
+    std::unique_ptr<grpc::ClientContext> context,
+    google::test::admin::database::v1::Request const& request) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest,
-      google::test::admin::database::v1::WriteObjectResponse>>
-  WriteObject(
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::unique_ptr<grpc::ClientContext> context) = 0;
+
+  virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) = 0;
 
   virtual Status ExplicitRouting1(
@@ -92,15 +92,15 @@ class GoldenKitchenSinkStub {
     google::test::admin::database::v1::ExplicitRoutingRequest const& request) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      google::test::admin::database::v1::TailLogEntriesResponse>>
-  AsyncTailLogEntries(
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      google::test::admin::database::v1::TailLogEntriesRequest const& request) = 0;
+      google::test::admin::database::v1::Request const& request) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>
-  AsyncWriteObject(
+      google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
+  AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) = 0;
 };
@@ -131,11 +131,6 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
-  TailLogEntries(
-    std::unique_ptr<grpc::ClientContext> client_context,
-    google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
-
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
     grpc::ClientContext& client_context,
@@ -146,17 +141,22 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
     grpc::ClientContext& client_context,
     google::protobuf::Empty const& request) override;
 
-  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::test::admin::database::v1::AppendRowsRequest,
-      google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(
-      google::cloud::CompletionQueue const& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
+  StreamingRead(
+    std::unique_ptr<grpc::ClientContext> client_context,
+    google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest,
-      google::test::admin::database::v1::WriteObjectResponse>>
-  WriteObject(
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
   Status
@@ -170,15 +170,15 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
     google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      google::test::admin::database::v1::TailLogEntriesResponse>>
-  AsyncTailLogEntries(
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+      google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>
-  AsyncWriteObject(
+      google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
+  AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 

--- a/generator/integration_tests/golden/internal/streaming.cc
+++ b/generator/integration_tests/golden/internal/streaming.cc
@@ -22,16 +22,16 @@ namespace golden_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::test::admin::database::v1::AppendRowsRequest,
-    google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkConnectionImpl::AsyncAppendRows(ExperimentalTag) {
-  return stub_->AsyncAppendRows(
+    google::test::admin::database::v1::Request,
+    google::test::admin::database::v1::Response>>
+GoldenKitchenSinkConnectionImpl::AsyncStreamingReadWrite(google::cloud::ExperimentalTag) {
+  return stub_->AsyncStreamingReadWrite(
       background_->cq(), absl::make_unique<grpc::ClientContext>());
 }
 
-void GoldenKitchenSinkTailLogEntriesStreamingUpdater(
-    ::google::test::admin::database::v1::TailLogEntriesResponse const&,
-    ::google::test::admin::database::v1::TailLogEntriesRequest&) {
+void GoldenKitchenSinkStreamingReadStreamingUpdater(
+    ::google::test::admin::database::v1::Response const&,
+    ::google::test::admin::database::v1::Request&) {
   // implementation here
 }
 

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -62,10 +62,6 @@ class MockGoldenKitchenSinkConnection : public golden::GoldenKitchenSinkConnecti
   ListLogs,
   (google::test::admin::database::v1::ListLogsRequest request), (override));
 
-  MOCK_METHOD(StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>,
-  TailLogEntries,
-  (google::test::admin::database::v1::TailLogEntriesRequest const& request), (override));
-
   MOCK_METHOD(StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>,
   ListServiceAccountKeys,
   (google::test::admin::database::v1::ListServiceAccountKeysRequest const& request), (override));
@@ -74,10 +70,14 @@ class MockGoldenKitchenSinkConnection : public golden::GoldenKitchenSinkConnecti
   DoNothing,
   (google::protobuf::Empty const& request), (override));
 
+  MOCK_METHOD(StreamRange<google::test::admin::database::v1::Response>,
+  StreamingRead,
+  (google::test::admin::database::v1::Request const& request), (override));
+
   MOCK_METHOD((std::unique_ptr<
       ::google::cloud::AsyncStreamingReadWriteRpc<
-          google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>>),
-      AsyncAppendRows, (ExperimentalTag), (override));
+          google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>),
+      AsyncStreamingReadWrite, (ExperimentalTag), (override));
 
   MOCK_METHOD(Status,
   ExplicitRouting1,

--- a/generator/integration_tests/golden_config.textproto
+++ b/generator/integration_tests/golden_config.textproto
@@ -22,6 +22,6 @@ service {
   omitted_rpcs: ["Omitted1", "GoldenKitchenSink.Omitted2"]
   service_endpoint_env_var: "GOLDEN_KITCHEN_SINK_ENDPOINT"
   emulator_endpoint_env_var: "GOLDEN_KITCHEN_SINK_EMULATOR_HOST"
-  gen_async_rpcs: ["GetDatabase", "DropDatabase", "TailLogEntries", "WriteObject"]
+  gen_async_rpcs: ["GetDatabase", "DropDatabase", "StreamingRead", "StreamingWrite"]
   retryable_status_codes: ["GoldenKitchenSink.kInternal", "kUnavailable", "GoldenThingAdmin.kDeadlineExceeded"]
 }

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -811,19 +811,6 @@ service GoldenKitchenSink {
     option (google.api.method_signature) = "parent";
   }
 
-  // Streaming read of log entries as they are ingested. Until the stream is
-  // terminated, it will continue reading logs.
-  rpc TailLogEntries(TailLogEntriesRequest) returns (stream TailLogEntriesResponse) {
-    option (google.api.http) = {
-      post: "/v2/entries:tail"
-      body: "*"
-    };
-    option (google.api.routing) = {
-      routing_parameters { field: "filter" }
-    };
-    option (google.api.method_signature) = "resource_names";
-  }
-
   // Does nothing and should be omitted by command line arg.
   rpc Omitted1(google.protobuf.Empty) returns (google.protobuf.Empty) {
     option (google.api.http) = {
@@ -856,12 +843,17 @@ service GoldenKitchenSink {
     option (google.api.method_signature) = "";
   }
 
-  // A much simplified version of the AppendRows in google.cloud.bigquery.storage.v1.BigQueryWrite
-  rpc AppendRows(stream AppendRowsRequest) returns (stream AppendRowsResponse) {
+  // Tests the generator for streaming read RPCs (aka server-side streaming)
+  rpc StreamingRead(Request) returns (stream Response) {
+    option (google.api.method_signature) = "stream";
   }
 
-  // A much simplified version of the WriteObject method in google.storage.v2.Storage
-  rpc WriteObject(stream WriteObjectRequest) returns (WriteObjectResponse) {}
+  // Tests the generator for streaming write RPCs (aka client-side streaming)
+  rpc StreamingWrite(stream Request) returns (Response) {}
+
+  // Tests the generator for streaming read-write RPCs (aka bidir streaming)
+  rpc StreamingReadWrite(stream Request) returns (stream Response) {
+  }
 
   // An RPC to test that explicit routing headers are supported.
   //
@@ -937,19 +929,15 @@ service GoldenKitchenSink {
   }
 }
 
-message AppendRowsRequest {
+// A simple message for the streaming test RPCs
+message Request {
+  // A placeholder to test method signatures
   string stream = 1;
 }
 
-message AppendRowsResponse {
-  string response = 1;
-}
-
-message WriteObjectRequest {
-  string stream = 1;
-}
-
-message WriteObjectResponse {
+// A simple message for the streaming test RPCs
+message Response {
+  // A placeholder to test return values
   string response = 1;
 }
 
@@ -1300,78 +1288,6 @@ message LogEntrySourceLocation {
   // `qual.if.ied.Class.method` (Java), `dir/package.func` (Go), `function`
   // (Python).
   string function = 3 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// The parameters to `TailLogEntries`.
-message TailLogEntriesRequest {
-  // Required. Name of a parent resource from which to retrieve log entries:
-  //
-  //     "projects/[PROJECT_ID]"
-  //     "organizations/[ORGANIZATION_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]"
-  //     "folders/[FOLDER_ID]"
-  //
-  // May alternatively be one or more views:
-  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  //     "organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  repeated string resource_names = 1 [(google.api.field_behavior) = REQUIRED];
-
-  // Optional. A filter that chooses which log entries to return.  See [Advanced
-  // Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).
-  // Only log entries that match the filter are returned.  An empty filter
-  // matches all log entries in the resources listed in `resource_names`.
-  // Referencing a parent resource that is not in `resource_names` will cause
-  // the filter to return no results. The maximum length of the filter is 20000
-  // characters.
-  string filter = 2 [(google.api.field_behavior) = OPTIONAL];
-
-  // Optional. The amount of time to buffer log entries at the server before
-  // being returned to prevent out of order results due to late arriving log
-  // entries. Valid values are between 0-60000 milliseconds. Defaults to 2000
-  // milliseconds.
-  google.protobuf.Duration buffer_window = 3 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// Result returned from `TailLogEntries`.
-message TailLogEntriesResponse {
-  // Information about entries that were omitted from the session.
-  message SuppressionInfo {
-    // An indicator of why entries were omitted.
-    enum Reason {
-      // Unexpected default.
-      REASON_UNSPECIFIED = 0;
-
-      // Indicates suppression occurred due to relevant entries being
-      // received in excess of rate limits. For quotas and limits, see
-      // [Logging API quotas and
-      // limits](https://cloud.google.com/logging/quotas#api-limits).
-      RATE_LIMIT = 1;
-
-      // Indicates suppression occurred due to the client not consuming
-      // responses quickly enough.
-      NOT_CONSUMED = 2;
-    }
-
-    // The reason that entries were omitted from the session.
-    Reason reason = 1;
-
-    // A lower bound on the count of entries omitted due to `reason`.
-    int32 suppressed_count = 2;
-  }
-
-  // A list of log entries. Each response in the stream will order entries with
-  // increasing values of `LogEntry.timestamp`. Ordering is not guaranteed
-  // between separate responses.
-  repeated LogEntry entries = 1;
-
-  // If entries that otherwise would have been included in the session were not
-  // sent back to the client, counts of relevant entries omitted from the
-  // session with the reason that they were not included. There will be at most
-  // one of each reason per response. The counts represent the number of
-  // suppressed entries since the last streamed response.
-  repeated SuppressionInfo suppression_info = 2;
 }
 
 // The service account keys list request.

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -849,7 +849,8 @@ service GoldenKitchenSink {
   }
 
   // Tests the generator for streaming write RPCs (aka client-side streaming)
-  rpc StreamingWrite(stream Request) returns (Response) {}
+  rpc StreamingWrite(stream Request) returns (Response) {
+  }
 
   // Tests the generator for streaming read-write RPCs (aka bidir streaming)
   rpc StreamingReadWrite(stream Request) returns (stream Response) {

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -31,10 +31,8 @@ using ::google::cloud::internal::AsyncGrpcOperation;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::google::cloud::testing_util::StatusIs;
-using ::google::test::admin::database::v1::TailLogEntriesRequest;
-using ::google::test::admin::database::v1::TailLogEntriesResponse;
-using ::google::test::admin::database::v1::WriteObjectRequest;
-using ::google::test::admin::database::v1::WriteObjectResponse;
+using ::google::test::admin::database::v1::Request;
+using ::google::test::admin::database::v1::Response;
 using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -141,27 +139,17 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
        ::google::test::admin::database::v1::ListLogsRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
-  MOCK_METHOD(::grpc::ClientReaderInterface<
-                  ::google::test::admin::database::v1::TailLogEntriesResponse>*,
-              TailLogEntriesRaw,
-              (::grpc::ClientContext * context,
-               ::google::test::admin::database::v1::TailLogEntriesRequest const&
-                   request),
+  MOCK_METHOD(::grpc::ClientReaderInterface<Response>*, StreamingReadRaw,
+              (::grpc::ClientContext * context, Request const& request),
               (override));
-  MOCK_METHOD(::grpc::ClientAsyncReaderInterface<
-                  ::google::test::admin::database::v1::TailLogEntriesResponse>*,
-              AsyncTailLogEntriesRaw,
-              (::grpc::ClientContext * context,
-               ::google::test::admin::database::v1::TailLogEntriesRequest const&
-                   request,
+  MOCK_METHOD(::grpc::ClientAsyncReaderInterface<Response>*,
+              AsyncStreamingReadRaw,
+              (::grpc::ClientContext * context, Request const& request,
                ::grpc::CompletionQueue* cq, void* tag),
               (override));
-  MOCK_METHOD(::grpc::ClientAsyncReaderInterface<
-                  ::google::test::admin::database::v1::TailLogEntriesResponse>*,
-              PrepareAsyncTailLogEntriesRaw,
-              (::grpc::ClientContext * context,
-               ::google::test::admin::database::v1::TailLogEntriesRequest const&
-                   request,
+  MOCK_METHOD(::grpc::ClientAsyncReaderInterface<Response>*,
+              PrepareAsyncStreamingReadRaw,
+              (::grpc::ClientContext * context, Request const& request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(::grpc::Status, Omitted1,
@@ -242,39 +230,29 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
        ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
 
-  using AppendRowsInterface = ::grpc::ClientReaderWriterInterface<
-      ::google::test::admin::database::v1::AppendRowsRequest,
-      ::google::test::admin::database::v1::AppendRowsResponse>;
-  using AppendRowsAsyncInterface = ::grpc::ClientAsyncReaderWriterInterface<
-      ::google::test::admin::database::v1::AppendRowsRequest,
-      ::google::test::admin::database::v1::AppendRowsResponse>;
-  MOCK_METHOD(AppendRowsInterface*, AppendRowsRaw,
+  using StreamingReadWriteInterface =
+      ::grpc::ClientReaderWriterInterface<Request, Response>;
+  using StreamingReadWriteAsyncInterface =
+      ::grpc::ClientAsyncReaderWriterInterface<Request, Response>;
+  MOCK_METHOD(StreamingReadWriteInterface*, StreamingReadWriteRaw,
               (::grpc::ClientContext * context), (override));
-  MOCK_METHOD(AppendRowsAsyncInterface*, AsyncAppendRowsRaw,
+  MOCK_METHOD(StreamingReadWriteAsyncInterface*, AsyncStreamingReadWriteRaw,
               (::grpc::ClientContext*, ::grpc::CompletionQueue*, void*),
               (override));
-  MOCK_METHOD(AppendRowsAsyncInterface*, PrepareAsyncAppendRowsRaw,
+  MOCK_METHOD(StreamingReadWriteAsyncInterface*,
+              PrepareAsyncStreamingReadWriteRaw,
               (::grpc::ClientContext*, ::grpc::CompletionQueue*), (override));
 
-  MOCK_METHOD((::grpc::ClientWriterInterface<
-                  ::google::test::admin::database::v1::WriteObjectRequest>*),
-              WriteObjectRaw,
-              (::grpc::ClientContext*,
-               ::google::test::admin::database::v1::WriteObjectResponse*),
+  MOCK_METHOD((::grpc::ClientWriterInterface<Request>*), StreamingWriteRaw,
+              (::grpc::ClientContext*, Response*), (override));
+  MOCK_METHOD((::grpc::ClientAsyncWriterInterface<Request>*),
+              AsyncStreamingWriteRaw,
+              (::grpc::ClientContext*, Response*, ::grpc::CompletionQueue*,
+               void*),
               (override));
-  MOCK_METHOD((::grpc::ClientAsyncWriterInterface<
-                  ::google::test::admin::database::v1::WriteObjectRequest>*),
-              AsyncWriteObjectRaw,
-              (::grpc::ClientContext*,
-               ::google::test::admin::database::v1::WriteObjectResponse*,
-               ::grpc::CompletionQueue*, void*),
-              (override));
-  MOCK_METHOD((::grpc::ClientAsyncWriterInterface<
-                  ::google::test::admin::database::v1::WriteObjectRequest>*),
-              PrepareAsyncWriteObjectRaw,
-              (::grpc::ClientContext*,
-               ::google::test::admin::database::v1::WriteObjectResponse*,
-               ::grpc::CompletionQueue*),
+  MOCK_METHOD((::grpc::ClientAsyncWriterInterface<Request>*),
+              PrepareAsyncStreamingWriteRaw,
+              (::grpc::ClientContext*, Response*, ::grpc::CompletionQueue*),
               (override));
   MOCK_METHOD(
       ::grpc::Status, ExplicitRouting1,
@@ -396,39 +374,6 @@ TEST_F(GoldenKitchenSinkStubTest, ListLogs) {
   EXPECT_EQ(failure.status(), TransientError());
 }
 
-class MockTailLogEntriesResponse
-    : public ::grpc::ClientReaderInterface<TailLogEntriesResponse> {
- public:
-  MOCK_METHOD(::grpc::Status, Finish, (), (override));
-  MOCK_METHOD(bool, NextMessageSize, (uint32_t*), (override));
-  MOCK_METHOD(bool, Read, (TailLogEntriesResponse*), (override));
-  MOCK_METHOD(void, WaitForInitialMetadata, (), (override));
-};
-
-TEST_F(GoldenKitchenSinkStubTest, TailLogEntries) {
-  grpc::Status status;
-  auto success_response = absl::make_unique<MockTailLogEntriesResponse>();
-  auto failure_response = absl::make_unique<MockTailLogEntriesResponse>();
-  EXPECT_CALL(*success_response, Read).WillOnce(Return(false));
-  EXPECT_CALL(*success_response, Finish()).WillOnce(Return(status));
-  EXPECT_CALL(*failure_response, Read).WillOnce(Return(false));
-  EXPECT_CALL(*failure_response, Finish).WillOnce(Return(GrpcTransientError()));
-
-  TailLogEntriesRequest request;
-  EXPECT_CALL(*grpc_stub_, TailLogEntriesRaw)
-      .WillOnce(Return(success_response.release()))
-      .WillOnce(Return(failure_response.release()));
-  DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
-  auto success_stream =
-      stub.TailLogEntries(absl::make_unique<grpc::ClientContext>(), request);
-  auto success_status = absl::get<Status>(success_stream->Read());
-  EXPECT_THAT(success_status, IsOk());
-  auto failure_stream =
-      stub.TailLogEntries(absl::make_unique<grpc::ClientContext>(), request);
-  auto failure_status = absl::get<Status>(failure_stream->Read());
-  EXPECT_THAT(failure_status, StatusIs(StatusCode::kUnavailable));
-}
-
 TEST_F(GoldenKitchenSinkStubTest, ListServiceAccountKeys) {
   grpc::Status status;
   grpc::ClientContext context;
@@ -443,24 +388,53 @@ TEST_F(GoldenKitchenSinkStubTest, ListServiceAccountKeys) {
   EXPECT_EQ(failure.status(), TransientError());
 }
 
+class MockStreamingReadResponse
+    : public ::grpc::ClientReaderInterface<Response> {
+ public:
+  MOCK_METHOD(::grpc::Status, Finish, (), (override));
+  MOCK_METHOD(bool, NextMessageSize, (uint32_t*), (override));
+  MOCK_METHOD(bool, Read, (Response*), (override));
+  MOCK_METHOD(void, WaitForInitialMetadata, (), (override));
+};
+
+TEST_F(GoldenKitchenSinkStubTest, StreamingRead) {
+  grpc::Status status;
+  auto success_response = absl::make_unique<MockStreamingReadResponse>();
+  auto failure_response = absl::make_unique<MockStreamingReadResponse>();
+  EXPECT_CALL(*success_response, Read).WillOnce(Return(false));
+  EXPECT_CALL(*success_response, Finish()).WillOnce(Return(status));
+  EXPECT_CALL(*failure_response, Read).WillOnce(Return(false));
+  EXPECT_CALL(*failure_response, Finish).WillOnce(Return(GrpcTransientError()));
+
+  Request request;
+  EXPECT_CALL(*grpc_stub_, StreamingReadRaw)
+      .WillOnce(Return(success_response.release()))
+      .WillOnce(Return(failure_response.release()));
+  DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
+  auto success_stream =
+      stub.StreamingRead(absl::make_unique<grpc::ClientContext>(), request);
+  auto success_status = absl::get<Status>(success_stream->Read());
+  EXPECT_THAT(success_status, IsOk());
+  auto failure_stream =
+      stub.StreamingRead(absl::make_unique<grpc::ClientContext>(), request);
+  auto failure_status = absl::get<Status>(failure_stream->Read());
+  EXPECT_THAT(failure_status, StatusIs(StatusCode::kUnavailable));
+}
+
 class MockWriteObjectResponse
     : public ::grpc::ClientWriterInterface<
-          google::test::admin::database::v1::WriteObjectRequest> {
+          google::test::admin::database::v1::Request> {
  public:
-  MOCK_METHOD(bool, Write,
-              (google::test::admin::database::v1::WriteObjectRequest const&,
-               grpc::WriteOptions),
-              (override));
+  MOCK_METHOD(bool, Write, (Request const&, grpc::WriteOptions), (override));
   MOCK_METHOD(bool, WritesDone, (), (override));
   MOCK_METHOD(::grpc::Status, Finish, (), (override));
 };
 
-TEST_F(GoldenKitchenSinkStubTest, WriteObject) {
+TEST_F(GoldenKitchenSinkStubTest, StreamingWrite) {
   auto context = absl::make_unique<grpc::ClientContext>();
-  google::test::admin::database::v1::WriteObjectRequest request;
-  EXPECT_CALL(*grpc_stub_, WriteObjectRaw(context.get(), _))
-      .WillOnce([](::grpc::ClientContext*,
-                   ::google::test::admin::database::v1::WriteObjectResponse*) {
+  Request request;
+  EXPECT_CALL(*grpc_stub_, StreamingWriteRaw(context.get(), _))
+      .WillOnce([](::grpc::ClientContext*, Response*) {
         auto stream = absl::make_unique<MockWriteObjectResponse>();
         EXPECT_CALL(*stream, Write).WillOnce(Return(true));
         EXPECT_CALL(*stream, WritesDone).WillOnce(Return(true));
@@ -468,28 +442,104 @@ TEST_F(GoldenKitchenSinkStubTest, WriteObject) {
         return stream.release();
       });
   DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
-  auto stream = stub.WriteObject(std::move(context));
-  EXPECT_TRUE(
-      stream->Write(google::test::admin::database::v1::WriteObjectRequest{},
-                    grpc::WriteOptions()));
+  auto stream = stub.StreamingWrite(std::move(context));
+  EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_THAT(stream->Close(), StatusIs(StatusCode::kOk));
 }
 
-class MockAsyncTailLogEntriesResponse
-    : public grpc::ClientAsyncReaderInterface<TailLogEntriesResponse> {
+class MockAsyncStreamingReadWriteResponse
+    : public grpc::ClientAsyncReaderWriterInterface<Request, Response> {
  public:
-  MOCK_METHOD(void, Read, (TailLogEntriesResponse*, void*), (override));
+  MOCK_METHOD(void, StartCall, (void*), (override));
+  MOCK_METHOD(void, Read, (Response*, void*), (override));
+  MOCK_METHOD(void, Write, (Request const&, grpc::WriteOptions, void*),
+              (override));
+  MOCK_METHOD(void, Write, (Request const&, void*), (override));
+  MOCK_METHOD(void, WritesDone, (void*), (override));
+  MOCK_METHOD(void, Finish, (grpc::Status*, void*), (override));
+  MOCK_METHOD(void, ReadInitialMetadata, (void*), (override));
+};
+
+TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWriteRead) {
+  grpc::Status status;
+  EXPECT_CALL(*grpc_stub_, PrepareAsyncStreamingReadWriteRaw)
+      .WillOnce([](grpc::ClientContext*, grpc::CompletionQueue*) {
+        auto stream = absl::make_unique<MockAsyncStreamingReadWriteResponse>();
+        EXPECT_CALL(*stream, StartCall).Times(1);
+        using ::testing::_;
+        EXPECT_CALL(*stream, Write(_, _, _)).Times(1);
+        EXPECT_CALL(*stream, WritesDone).Times(1);
+        EXPECT_CALL(*stream, Read).Times(2);
+        EXPECT_CALL(*stream, Finish).WillOnce([](grpc::Status* status, void*) {
+          *status = grpc::Status::OK;
+        });
+        return stream.release();  // gRPC assumes ownership of `stream`.
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  grpc::CompletionQueue grpc_cq;
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+
+  std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
+  auto notify_next_op = [&](bool ok) {
+    auto op = std::move(operations.front());
+    operations.pop_front();
+    op->Notify(ok);
+  };
+
+  EXPECT_CALL(*mock_cq, StartOperation)
+      .WillRepeatedly([&operations](std::shared_ptr<AsyncGrpcOperation> op,
+                                    absl::FunctionRef<void(void*)> call) {
+        void* tag = op.get();
+        operations.push_back(std::move(op));
+        call(tag);
+      });
+  google::cloud::CompletionQueue cq(mock_cq);
+
+  DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
+
+  auto stream = stub.AsyncStreamingReadWrite(
+      cq, absl::make_unique<grpc::ClientContext>());
+  auto start = stream->Start();
+  notify_next_op(true);
+  EXPECT_TRUE(start.get());
+
+  auto write = stream->Write(Request{}, grpc::WriteOptions{});
+  notify_next_op(true);
+  EXPECT_TRUE(write.get());
+
+  auto read0 = stream->Read();
+  notify_next_op(true);
+  EXPECT_TRUE(read0.get().has_value());
+
+  auto read1 = stream->Read();
+  notify_next_op(false);
+  EXPECT_FALSE(read1.get().has_value());
+
+  auto writes_done = stream->WritesDone();
+  notify_next_op(true);
+  EXPECT_TRUE(writes_done.get());
+
+  auto finish = stream->Finish();
+  notify_next_op(true);
+  EXPECT_THAT(finish.get(), IsOk());
+}
+
+class MockAsyncStreamingReadResponse
+    : public grpc::ClientAsyncReaderInterface<Response> {
+ public:
+  MOCK_METHOD(void, Read, (Response*, void*), (override));
   MOCK_METHOD(void, Finish, (grpc::Status*, void*), (override));
   MOCK_METHOD(void, StartCall, (void*), (override));
   MOCK_METHOD(void, ReadInitialMetadata, (void*), (override));
 };
 
-TEST_F(GoldenKitchenSinkStubTest, AsyncTailLogEntries) {
+TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingRead) {
   grpc::Status status;
-  EXPECT_CALL(*grpc_stub_, PrepareAsyncTailLogEntriesRaw)
-      .WillOnce([](grpc::ClientContext*, TailLogEntriesRequest const&,
+  EXPECT_CALL(*grpc_stub_, PrepareAsyncStreamingReadRaw)
+      .WillOnce([](grpc::ClientContext*, Request const&,
                    grpc::CompletionQueue*) {
-        auto stream = absl::make_unique<MockAsyncTailLogEntriesResponse>();
+        auto stream = absl::make_unique<MockAsyncStreamingReadResponse>();
         EXPECT_CALL(*stream, StartCall).Times(1);
         EXPECT_CALL(*stream, Read).Times(2);
         EXPECT_CALL(*stream, Finish).WillOnce([](grpc::Status* status, void*) {
@@ -520,8 +570,8 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncTailLogEntries) {
 
   DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
 
-  TailLogEntriesRequest request;
-  auto stream = stub.AsyncTailLogEntries(
+  Request request;
+  auto stream = stub.AsyncStreamingRead(
       cq, absl::make_unique<grpc::ClientContext>(), request);
   auto start = stream->Start();
   notify_next_op(true);
@@ -540,36 +590,35 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncTailLogEntries) {
   EXPECT_THAT(finish.get(), IsOk());
 }
 
-class MockAsyncWriteObjectResponse
-    : public grpc::ClientAsyncWriterInterface<WriteObjectRequest> {
+class MockAsyncStreamingWriteResponse
+    : public grpc::ClientAsyncWriterInterface<Request> {
  public:
   MOCK_METHOD(void, StartCall, (void*), (override));
-  MOCK_METHOD(void, Write,
-              (WriteObjectRequest const&, grpc::WriteOptions, void*),
+  MOCK_METHOD(void, Write, (Request const&, grpc::WriteOptions, void*),
               (override));
-  MOCK_METHOD(void, Write, (WriteObjectRequest const&, void*), (override));
+  MOCK_METHOD(void, Write, (Request const&, void*), (override));
   MOCK_METHOD(void, WritesDone, (void*), (override));
   MOCK_METHOD(void, Finish, (grpc::Status*, void*), (override));
   MOCK_METHOD(void, ReadInitialMetadata, (void*), (override));
 };
 
-TEST_F(GoldenKitchenSinkStubTest, AsyncWriteObject) {
+TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWrite) {
   grpc::Status status;
-  EXPECT_CALL(*grpc_stub_, PrepareAsyncWriteObjectRaw)
-      .WillOnce([](grpc::ClientContext*, WriteObjectResponse* response,
-                   grpc::CompletionQueue*) {
-        auto stream = absl::make_unique<MockAsyncWriteObjectResponse>();
-        EXPECT_CALL(*stream, StartCall).Times(1);
-        using ::testing::_;
-        EXPECT_CALL(*stream, Write(_, _, _)).Times(1);
-        EXPECT_CALL(*stream, WritesDone).Times(1);
-        EXPECT_CALL(*stream, Finish)
-            .WillOnce([response](grpc::Status* status, void*) {
-              response->set_response("Finish()");
-              *status = grpc::Status::OK;
-            });
-        return stream.release();  // gRPC assumes ownership of `stream`.
-      });
+  EXPECT_CALL(*grpc_stub_, PrepareAsyncStreamingWriteRaw)
+      .WillOnce(
+          [](grpc::ClientContext*, Response* response, grpc::CompletionQueue*) {
+            auto stream = absl::make_unique<MockAsyncStreamingWriteResponse>();
+            EXPECT_CALL(*stream, StartCall).Times(1);
+            using ::testing::_;
+            EXPECT_CALL(*stream, Write(_, _, _)).Times(1);
+            EXPECT_CALL(*stream, WritesDone).Times(1);
+            EXPECT_CALL(*stream, Finish)
+                .WillOnce([response](grpc::Status* status, void*) {
+                  response->set_response("Finish()");
+                  *status = grpc::Status::OK;
+                });
+            return stream.release();  // gRPC assumes ownership of `stream`.
+          });
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
@@ -594,12 +643,12 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncWriteObject) {
   DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
 
   auto stream =
-      stub.AsyncWriteObject(cq, absl::make_unique<grpc::ClientContext>());
+      stub.AsyncStreamingWrite(cq, absl::make_unique<grpc::ClientContext>());
   auto start = stream->Start();
   notify_next_op(true);
   EXPECT_TRUE(start.get());
 
-  auto write = stream->Write(WriteObjectRequest{}, grpc::WriteOptions());
+  auto write = stream->Write(Request{}, grpc::WriteOptions());
   notify_next_op(true);
   EXPECT_TRUE(write.get());
 

--- a/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
@@ -52,13 +52,6 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
                ::google::test::admin::database::v1::ListLogsRequest const&),
               (override));
   MOCK_METHOD(
-      (std::unique_ptr<internal::StreamingReadRpc<
-           ::google::test::admin::database::v1::TailLogEntriesResponse>>),
-      TailLogEntries,
-      (std::unique_ptr<grpc::ClientContext> context,
-       ::google::test::admin::database::v1::TailLogEntriesRequest const&),
-      (override));
-  MOCK_METHOD(
       StatusOr<
           ::google::test::admin::database::v1::ListServiceAccountKeysResponse>,
       ListServiceAccountKeys,
@@ -70,36 +63,25 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
               (override));
 
   MOCK_METHOD((std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-                   ::google::test::admin::database::v1::AppendRowsRequest,
-                   ::google::test::admin::database::v1::AppendRowsResponse>>),
-              AsyncAppendRows,
-              (google::cloud::CompletionQueue const& cq,
-               std::unique_ptr<grpc::ClientContext> context),
+                   ::google::test::admin::database::v1::Request,
+                   ::google::test::admin::database::v1::Response>>),
+              AsyncStreamingReadWrite,
+              (google::cloud::CompletionQueue const&,
+               std::unique_ptr<grpc::ClientContext>),
               (override));
 
   MOCK_METHOD((std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-                   ::google::test::admin::database::v1::WriteObjectRequest,
-                   ::google::test::admin::database::v1::WriteObjectResponse>>),
-              WriteObject, (std::unique_ptr<grpc::ClientContext> context),
+                   ::google::test::admin::database::v1::Request,
+                   ::google::test::admin::database::v1::Response>>),
+              StreamingWrite, (std::unique_ptr<grpc::ClientContext>),
               (override));
 
-  MOCK_METHOD(
-      (std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-           ::google::test::admin::database::v1::TailLogEntriesResponse>>),
-      AsyncTailLogEntries,
-      (google::cloud::CompletionQueue const& cq,
-       std::unique_ptr<grpc::ClientContext> context,
-       ::google::test::admin::database::v1::TailLogEntriesRequest const&),
-      (override));
-
-  MOCK_METHOD(
-      (std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-           ::google::test::admin::database::v1::WriteObjectRequest,
-           ::google::test::admin::database::v1::WriteObjectResponse>>),
-      AsyncWriteObject,
-      (google::cloud::CompletionQueue const& cq,
-       std::unique_ptr<grpc::ClientContext> context),
-      (override));
+  MOCK_METHOD((std::unique_ptr<::google::cloud::internal::StreamingReadRpc<
+                   ::google::test::admin::database::v1::Response>>),
+              StreamingRead,
+              (std::unique_ptr<grpc::ClientContext>,
+               ::google::test::admin::database::v1::Request const&),
+              (override));
 
   MOCK_METHOD(
       Status, ExplicitRouting1,
@@ -112,66 +94,97 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       (grpc::ClientContext&,
        ::google::test::admin::database::v1::ExplicitRoutingRequest const&),
       (override));
+
+  MOCK_METHOD((std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+                   ::google::test::admin::database::v1::Response>>),
+              AsyncStreamingRead,
+              (google::cloud::CompletionQueue const&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::test::admin::database::v1::Request const&),
+              (override));
+
+  MOCK_METHOD(
+      (std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
+           ::google::test::admin::database::v1::Request,
+           ::google::test::admin::database::v1::Response>>),
+      AsyncStreamingWrite,
+      (google::cloud::CompletionQueue const& cq,
+       std::unique_ptr<grpc::ClientContext> context),
+      (override));
 };
 
-class MockTailLogEntriesStreamingReadRpc
+class MockStreamingReadRpc
     : public google::cloud::internal::StreamingReadRpc<
-          ::google::test::admin::database::v1::TailLogEntriesResponse> {
+          ::google::test::admin::database::v1::Response> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(
-      (absl::variant<
-          Status, ::google::test::admin::database::v1::TailLogEntriesResponse>),
+      (absl::variant<Status, ::google::test::admin::database::v1::Response>),
       Read, (), (override));
   MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
               (const, override));
 };
 
-class MockWriteObjectStreamingWriteRpc
+class MockStreamingWriteRpc
     : public internal::StreamingWriteRpc<
-          ::google::test::admin::database::v1::WriteObjectRequest,
-          ::google::test::admin::database::v1::WriteObjectResponse> {
+          ::google::test::admin::database::v1::Request,
+          ::google::test::admin::database::v1::Response> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(bool, Write,
-              (::google::test::admin::database::v1::WriteObjectRequest const&,
+              (::google::test::admin::database::v1::Request const&,
                grpc::WriteOptions),
               (override));
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::WriteObjectResponse>, Close,
-      (), (override));
+  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Response>, Close,
+              (), (override));
   MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
               (const, override));
 };
 
-class MockTailLogEntriesAsyncStreamingReadRpc
-    : public google::cloud::internal::AsyncStreamingReadRpc<
-          ::google::test::admin::database::v1::TailLogEntriesResponse> {
+class MockAsyncStreamingReadWriteRpc
+    : public AsyncStreamingReadWriteRpc<
+          ::google::test::admin::database::v1::Request,
+          ::google::test::admin::database::v1::Response> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(future<bool>, Start, (), (override));
-  MOCK_METHOD(future<absl::optional<
-                  ::google::test::admin::database::v1::TailLogEntriesResponse>>,
-              Read, (), (override));
+  MOCK_METHOD(
+      future<absl::optional<::google::test::admin::database::v1::Response>>,
+      Read, (), (override));
+  MOCK_METHOD(future<bool>, Write,
+              (::google::test::admin::database::v1::Request const&,
+               grpc::WriteOptions),
+              (override));
+  MOCK_METHOD(future<bool>, WritesDone, (), (override));
   MOCK_METHOD(future<Status>, Finish, (), (override));
 };
 
-class MockWriteObjectAsyncStreamingWriteRpc
+class MockAsyncStreamingReadRpc
+    : public google::cloud::internal::AsyncStreamingReadRpc<
+          ::google::test::admin::database::v1::Response> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(
+      future<absl::optional<::google::test::admin::database::v1::Response>>,
+      Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
+};
+
+class MockAsyncStreamingWriteRpc
     : public internal::AsyncStreamingWriteRpc<
-          ::google::test::admin::database::v1::WriteObjectRequest,
-          ::google::test::admin::database::v1::WriteObjectResponse> {
+          ::google::test::admin::database::v1::Request,
+          ::google::test::admin::database::v1::Response> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(future<bool>, Start, (), (override));
   MOCK_METHOD(future<bool>, Write,
-              (::google::test::admin::database::v1::WriteObjectRequest const&,
+              (::google::test::admin::database::v1::Request const&,
                grpc::WriteOptions),
               (override));
   MOCK_METHOD(future<bool>, WritesDone, (), (override));
-  MOCK_METHOD(
-      future<
-          StatusOr<::google::test::admin::database::v1::WriteObjectResponse>>,
-      Finish, (), (override));
+  MOCK_METHOD(future<StatusOr<::google::test::admin::database::v1::Response>>,
+              Finish, (), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
The test RPCs had names inspired by their source service.  I found this
confusing when trying to determine if a new RPC for "streaming reads"
was needed, or what the right RPC for a "streaming read-write" test
would be.  This PR changes their names to `StreamingRead()`,
`StreamingWrite()`, and `StreamginReadWrite()`.  It also changes the
request and response messages to be shared across RPCs, and they are
simply named `Request` and `Response`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10086)
<!-- Reviewable:end -->
