### PR TITLE
feat(spanner): support for the PG.JSONB data type

### DIFF
--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -207,6 +207,7 @@ void PgDatabaseIntegrationTest::SetUpTestSuite() {
           BytesValue BYTEA,
           TimestampValue TIMESTAMP WITH TIME ZONE,
           DateValue DATE,
+          JsonValue JSONB,
           NumericValue NUMERIC,
           ArrayBoolValue BOOLEAN[],
           ArrayInt64Value BIGINT[],
@@ -215,6 +216,7 @@ void PgDatabaseIntegrationTest::SetUpTestSuite() {
           ArrayBytesValue BYTEA[],
           ArrayTimestampValue TIMESTAMP WITH TIME ZONE[],
           ArrayDateValue DATE[],
+          -- TODO(#10095): ArrayJsonValue JSONB[],
           ArrayNumericValue NUMERIC[],
           PRIMARY KEY(Id)
         )

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -65,6 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * STRING       | `std::string`
  * BYTES        | `google::cloud::spanner::Bytes`
  * JSON         | `google::cloud::spanner::Json`
+ * JSONB        | `google::cloud::spanner::JsonB`
  * NUMERIC      | `google::cloud::spanner::Numeric`
  * NUMERIC(PG)  | `google::cloud::spanner::PgNumeric`
  * TIMESTAMP    | `google::cloud::spanner::Timestamp`
@@ -193,6 +194,8 @@ class Value {
   explicit Value(Bytes v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
   explicit Value(Json v) : Value(PrivateConstructor{}, std::move(v)) {}
+  /// @copydoc Value(bool)
+  explicit Value(JsonB v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
   explicit Value(Numeric v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
@@ -366,6 +369,7 @@ class Value {
   static bool TypeProtoIs(std::string const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Bytes const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Json const&, google::spanner::v1::Type const&);
+  static bool TypeProtoIs(JsonB const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Numeric const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(PgNumeric const&, google::spanner::v1::Type const&);
   template <typename T>
@@ -414,6 +418,7 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(std::string const&);
   static google::spanner::v1::Type MakeTypeProto(Bytes const&);
   static google::spanner::v1::Type MakeTypeProto(Json const&);
+  static google::spanner::v1::Type MakeTypeProto(JsonB const&);
   static google::spanner::v1::Type MakeTypeProto(Numeric const&);
   static google::spanner::v1::Type MakeTypeProto(PgNumeric const&);
   static google::spanner::v1::Type MakeTypeProto(Timestamp);
@@ -476,6 +481,7 @@ class Value {
   static google::protobuf::Value MakeValueProto(std::string s);
   static google::protobuf::Value MakeValueProto(Bytes b);
   static google::protobuf::Value MakeValueProto(Json j);
+  static google::protobuf::Value MakeValueProto(JsonB j);
   static google::protobuf::Value MakeValueProto(Numeric n);
   static google::protobuf::Value MakeValueProto(PgNumeric n);
   static google::protobuf::Value MakeValueProto(Timestamp ts);
@@ -541,6 +547,8 @@ class Value {
                                   google::spanner::v1::Type const&);
   static StatusOr<Json> GetValue(Json const&, google::protobuf::Value const&,
                                  google::spanner::v1::Type const&);
+  static StatusOr<JsonB> GetValue(JsonB const&, google::protobuf::Value const&,
+                                  google::spanner::v1::Type const&);
   static StatusOr<Numeric> GetValue(Numeric const&,
                                     google::protobuf::Value const&,
                                     google::spanner::v1::Type const&);


### PR DESCRIPTION
Introduce `google::cloud::spanner::JsonB` for PostgreSQL databases. The interface is the same as `Json` (just a strongly-typed string), but `JsonB` values are stored in the database in a decomposed, binary format, which affects performance: `JsonB` is slower to input, but faster to process as it avoids reparsing.

Note: Support for arrays of `JSONB` will come later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10098)
<!-- Reviewable:end -->
