### PR TITLE
test(spanner): loosen message expectation on column not found

### DIFF
--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -417,8 +417,9 @@ TEST_F(PgDataTypeIntegrationTest, WriteReadArrayJson) {
   auto result = WriteReadData(*client_, data, "ArrayJsonValue");
   {
     // TODO(#10095): Remove this when JSONB[] is supported.
-    auto matcher = testing_util::StatusIs(
-        StatusCode::kNotFound, testing::HasSubstr("Column not found in table"));
+    auto matcher = StatusIs(StatusCode::kNotFound,
+                            AnyOf(HasSubstr("Column not found in table"),
+                                  HasSubstr("is not a column in")));
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(result, &listener)) {
       GTEST_SKIP();


### PR DESCRIPTION
It looks like different versions/configs of the backend respond in slightly different ways, so loosen the #10095 workaround expectation. In particular, this accounts for the current state of the staging service.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10099)
<!-- Reviewable:end -->
