### PR TITLE
feat(spanner): add support for RowStream::RowsModified()

### DIFF
--- a/google/cloud/spanner/results.cc
+++ b/google/cloud/spanner/results.cc
@@ -39,7 +39,8 @@ absl::optional<Timestamp> GetReadTimestamp(
 
 std::int64_t GetRowsModified(
     std::unique_ptr<spanner_internal::ResultSourceInterface> const& source) {
-  return source->Stats()->row_count_exact();
+  auto stats = source->Stats();
+  return stats ? stats->row_count_exact() : 0;
 }
 
 absl::optional<std::unordered_map<std::string, std::string>> GetExecutionStats(
@@ -66,11 +67,11 @@ absl::optional<spanner::ExecutionPlan> GetExecutionPlan(
 }
 }  // namespace
 
-absl::optional<Timestamp> RowStream::ReadTimestamp() const {
-  return GetReadTimestamp(source_);
+std::int64_t RowStream::RowsModified() const {
+  return GetRowsModified(source_);
 }
 
-absl::optional<Timestamp> ProfileQueryResult::ReadTimestamp() const {
+absl::optional<Timestamp> RowStream::ReadTimestamp() const {
   return GetReadTimestamp(source_);
 }
 
@@ -78,8 +79,8 @@ std::int64_t DmlResult::RowsModified() const {
   return GetRowsModified(source_);
 }
 
-std::int64_t ProfileDmlResult::RowsModified() const {
-  return GetRowsModified(source_);
+absl::optional<Timestamp> ProfileQueryResult::ReadTimestamp() const {
+  return GetReadTimestamp(source_);
 }
 
 absl::optional<std::unordered_map<std::string, std::string>>
@@ -90,6 +91,10 @@ ProfileQueryResult::ExecutionStats() const {
 absl::optional<spanner::ExecutionPlan> ProfileQueryResult::ExecutionPlan()
     const {
   return GetExecutionPlan(source_);
+}
+
+std::int64_t ProfileDmlResult::RowsModified() const {
+  return GetRowsModified(source_);
 }
 
 absl::optional<std::unordered_map<std::string, std::string>>

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -91,6 +91,9 @@ class RowStream {
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   RowStreamIterator end() { return {}; }
 
+  /// Returns the number of rows modified by a DML statement.
+  std::int64_t RowsModified() const;
+
   /**
    * Retrieves the timestamp at which the read occurred.
    *

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -150,6 +150,19 @@ TEST(RowStream, TimestampPresent) {
   EXPECT_EQ(*rows.ReadTimestamp(), timestamp);
 }
 
+TEST(RowStream, RowsModified) {
+  auto mock_source = absl::make_unique<MockResultSetSource>();
+  auto constexpr kText = R"pb(
+    row_count_exact: 42
+  )pb";
+  google::spanner::v1::ResultSetStats stats;
+  ASSERT_TRUE(TextFormat::ParseFromString(kText, &stats));
+  EXPECT_CALL(*mock_source, Stats()).WillOnce(Return(stats));
+
+  RowStream rows(std::move(mock_source));
+  EXPECT_EQ(rows.RowsModified(), 42);
+}
+
 TEST(ProfileQueryResult, TimestampPresent) {
   auto mock_source = absl::make_unique<MockResultSetSource>();
   google::spanner::v1::ResultSetMetadata transaction_with_timestamp;


### PR DESCRIPTION
Soon it will be possible for `Client::ExecuteQuery()` to execute a DML statement (within a read/write transaction) that both modifies and returns data.  So, if the result source behind the `RowStream` can produce `ResultSetStats`, we can return the number of rows that were modified.  Otherwise, for a normal query, return zero.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10102)
<!-- Reviewable:end -->
