### PR TITLE
ci: skip sample directories without a CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,8 @@ function (google_cloud_cpp_enable_features)
             if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES
                 AND IS_DIRECTORY
                     "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/samples"
+                AND EXISTS
+                    "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/samples/CMakeLists.txt"
             )
                 add_subdirectory(google/cloud/${feature}/samples)
             endif ()


### PR DESCRIPTION
This will make it easier to add generated files in said directories and then add build scripts for them later.

Part of the work for #10114

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10117)
<!-- Reviewable:end -->
