### PR TITLE
cleanup: use more precise globs for generated files

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -259,24 +259,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_$library$",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -287,12 +300,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_$library$_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_$library$",

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -277,19 +277,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_$library$",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -300,9 +294,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_$library$_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_$library$",

--- a/google/cloud/accessapproval/BUILD.bazel
+++ b/google/cloud/accessapproval/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_accessapproval",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_accessapproval_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_accessapproval",

--- a/google/cloud/accessapproval/BUILD.bazel
+++ b/google/cloud/accessapproval/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_accessapproval",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_accessapproval_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_accessapproval",

--- a/google/cloud/accesscontextmanager/BUILD.bazel
+++ b/google/cloud/accesscontextmanager/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_accesscontextmanager",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_accesscontextmanager_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_accesscontextmanager",

--- a/google/cloud/accesscontextmanager/BUILD.bazel
+++ b/google/cloud/accesscontextmanager/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_accesscontextmanager",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_accesscontextmanager_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_accesscontextmanager",

--- a/google/cloud/apigateway/BUILD.bazel
+++ b/google/cloud/apigateway/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_apigateway",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_apigateway_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apigateway",

--- a/google/cloud/apigateway/BUILD.bazel
+++ b/google/cloud/apigateway/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_apigateway",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_apigateway_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apigateway",

--- a/google/cloud/apigeeconnect/BUILD.bazel
+++ b/google/cloud/apigeeconnect/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_apigeeconnect",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_apigeeconnect_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apigeeconnect",

--- a/google/cloud/apigeeconnect/BUILD.bazel
+++ b/google/cloud/apigeeconnect/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_apigeeconnect",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_apigeeconnect_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apigeeconnect",

--- a/google/cloud/apikeys/BUILD.bazel
+++ b/google/cloud/apikeys/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_apikeys",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_apikeys_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apikeys",

--- a/google/cloud/apikeys/BUILD.bazel
+++ b/google/cloud/apikeys/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_apikeys",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_apikeys_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apikeys",

--- a/google/cloud/appengine/BUILD.bazel
+++ b/google/cloud/appengine/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_appengine",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -59,9 +53,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_appengine_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_appengine",

--- a/google/cloud/appengine/BUILD.bazel
+++ b/google/cloud/appengine/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_appengine",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -46,12 +59,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_appengine_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_appengine",

--- a/google/cloud/artifactregistry/BUILD.bazel
+++ b/google/cloud/artifactregistry/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_artifactregistry",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_artifactregistry_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_artifactregistry",

--- a/google/cloud/artifactregistry/BUILD.bazel
+++ b/google/cloud/artifactregistry/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_artifactregistry",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_artifactregistry_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_artifactregistry",

--- a/google/cloud/asset/BUILD.bazel
+++ b/google/cloud/asset/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_asset",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     # TODO(#8145): Enable on windows.
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
@@ -49,12 +62,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_asset_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_asset",

--- a/google/cloud/asset/BUILD.bazel
+++ b/google/cloud/asset/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_asset",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     # TODO(#8145): Enable on windows.
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
@@ -62,9 +56,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_asset_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_asset",

--- a/google/cloud/assuredworkloads/BUILD.bazel
+++ b/google/cloud/assuredworkloads/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_assuredworkloads",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_assuredworkloads_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_assuredworkloads",

--- a/google/cloud/assuredworkloads/BUILD.bazel
+++ b/google/cloud/assuredworkloads/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_assuredworkloads",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_assuredworkloads_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_assuredworkloads",

--- a/google/cloud/automl/BUILD.bazel
+++ b/google/cloud/automl/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_automl",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_automl_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_automl",

--- a/google/cloud/automl/BUILD.bazel
+++ b/google/cloud/automl/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_automl",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_automl_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_automl",

--- a/google/cloud/baremetalsolution/BUILD.bazel
+++ b/google/cloud/baremetalsolution/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_baremetalsolution",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_baremetalsolution_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_baremetalsolution",

--- a/google/cloud/baremetalsolution/BUILD.bazel
+++ b/google/cloud/baremetalsolution/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_baremetalsolution",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_baremetalsolution_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_baremetalsolution",

--- a/google/cloud/batch/BUILD.bazel
+++ b/google/cloud/batch/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_batch",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_batch_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_batch",

--- a/google/cloud/batch/BUILD.bazel
+++ b/google/cloud/batch/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_batch",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_batch_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_batch",

--- a/google/cloud/beyondcorp/BUILD.bazel
+++ b/google/cloud/beyondcorp/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_beyondcorp",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     # TODO(#9340): fix the Windows builds.
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
@@ -53,12 +66,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_beyondcorp_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_beyondcorp",

--- a/google/cloud/beyondcorp/BUILD.bazel
+++ b/google/cloud/beyondcorp/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_beyondcorp",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     # TODO(#9340): fix the Windows builds.
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
@@ -66,9 +60,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_beyondcorp_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_beyondcorp",

--- a/google/cloud/billing/BUILD.bazel
+++ b/google/cloud/billing/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_billing",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -45,12 +58,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_billing_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_billing",

--- a/google/cloud/billing/BUILD.bazel
+++ b/google/cloud/billing/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_billing",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -58,9 +52,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_billing_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_billing",

--- a/google/cloud/binaryauthorization/BUILD.bazel
+++ b/google/cloud/binaryauthorization/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_binaryauthorization",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_binaryauthorization_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_binaryauthorization",

--- a/google/cloud/binaryauthorization/BUILD.bazel
+++ b/google/cloud/binaryauthorization/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_binaryauthorization",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_binaryauthorization_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_binaryauthorization",

--- a/google/cloud/certificatemanager/BUILD.bazel
+++ b/google/cloud/certificatemanager/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_certificatemanager",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -58,9 +52,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_certificatemanager_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_certificatemanager",

--- a/google/cloud/certificatemanager/BUILD.bazel
+++ b/google/cloud/certificatemanager/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_certificatemanager",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -45,12 +58,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_certificatemanager_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_certificatemanager",

--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_channel",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     # TODO(#8125): Re-enable the macos and Windows builds.
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
@@ -50,12 +63,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_channel_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_channel",

--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_channel",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     # TODO(#8125): Re-enable the macos and Windows builds.
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
@@ -63,9 +57,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_channel_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_channel",

--- a/google/cloud/cloudbuild/BUILD.bazel
+++ b/google/cloud/cloudbuild/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_cloudbuild",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_cloudbuild_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_cloudbuild",

--- a/google/cloud/cloudbuild/BUILD.bazel
+++ b/google/cloud/cloudbuild/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_cloudbuild",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_cloudbuild_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_cloudbuild",

--- a/google/cloud/composer/BUILD.bazel
+++ b/google/cloud/composer/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_composer",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_composer_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_composer",

--- a/google/cloud/composer/BUILD.bazel
+++ b/google/cloud/composer/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_composer",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_composer_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_composer",

--- a/google/cloud/contactcenterinsights/BUILD.bazel
+++ b/google/cloud/contactcenterinsights/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_contactcenterinsights",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_contactcenterinsights_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_contactcenterinsights",

--- a/google/cloud/contactcenterinsights/BUILD.bazel
+++ b/google/cloud/contactcenterinsights/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_contactcenterinsights",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_contactcenterinsights_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_contactcenterinsights",

--- a/google/cloud/container/BUILD.bazel
+++ b/google/cloud/container/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_container",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_container_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_container",

--- a/google/cloud/container/BUILD.bazel
+++ b/google/cloud/container/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_container",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_container_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_container",

--- a/google/cloud/containeranalysis/BUILD.bazel
+++ b/google/cloud/containeranalysis/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_containeranalysis",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -45,12 +58,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_containeranalysis_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_containeranalysis",

--- a/google/cloud/containeranalysis/BUILD.bazel
+++ b/google/cloud/containeranalysis/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_containeranalysis",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -58,9 +52,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_containeranalysis_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_containeranalysis",

--- a/google/cloud/datacatalog/BUILD.bazel
+++ b/google/cloud/datacatalog/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_datacatalog",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_datacatalog_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datacatalog",

--- a/google/cloud/datacatalog/BUILD.bazel
+++ b/google/cloud/datacatalog/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_datacatalog",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_datacatalog_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datacatalog",

--- a/google/cloud/datamigration/BUILD.bazel
+++ b/google/cloud/datamigration/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_datamigration",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -58,9 +52,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_datamigration_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datamigration",

--- a/google/cloud/datamigration/BUILD.bazel
+++ b/google/cloud/datamigration/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_datamigration",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -45,12 +58,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_datamigration_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datamigration",

--- a/google/cloud/dataplex/BUILD.bazel
+++ b/google/cloud/dataplex/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_dataplex",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dataplex_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dataplex",

--- a/google/cloud/dataplex/BUILD.bazel
+++ b/google/cloud/dataplex/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_dataplex",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dataplex_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dataplex",

--- a/google/cloud/dataproc/BUILD.bazel
+++ b/google/cloud/dataproc/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_dataproc",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dataproc_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dataproc",

--- a/google/cloud/dataproc/BUILD.bazel
+++ b/google/cloud/dataproc/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_dataproc",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dataproc_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dataproc",

--- a/google/cloud/datastream/BUILD.bazel
+++ b/google/cloud/datastream/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_datastream",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_datastream_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datastream",

--- a/google/cloud/datastream/BUILD.bazel
+++ b/google/cloud/datastream/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_datastream",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_datastream_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datastream",

--- a/google/cloud/debugger/BUILD.bazel
+++ b/google/cloud/debugger/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_debugger",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_debugger_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_debugger",

--- a/google/cloud/debugger/BUILD.bazel
+++ b/google/cloud/debugger/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_debugger",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_debugger_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_debugger",

--- a/google/cloud/deploy/BUILD.bazel
+++ b/google/cloud/deploy/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_deploy",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_deploy_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_deploy",

--- a/google/cloud/deploy/BUILD.bazel
+++ b/google/cloud/deploy/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_deploy",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_deploy_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_deploy",

--- a/google/cloud/dialogflow_cx/BUILD.bazel
+++ b/google/cloud/dialogflow_cx/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_dialogflow_cx",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dialogflow_cx_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dialogflow_cx",

--- a/google/cloud/dialogflow_cx/BUILD.bazel
+++ b/google/cloud/dialogflow_cx/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_dialogflow_cx",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dialogflow_cx_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dialogflow_cx",

--- a/google/cloud/dialogflow_es/BUILD.bazel
+++ b/google/cloud/dialogflow_es/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_dialogflow_es",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dialogflow_es_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dialogflow_es",

--- a/google/cloud/dialogflow_es/BUILD.bazel
+++ b/google/cloud/dialogflow_es/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_dialogflow_es",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dialogflow_es_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dialogflow_es",

--- a/google/cloud/dlp/BUILD.bazel
+++ b/google/cloud/dlp/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_dlp",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dlp_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dlp",

--- a/google/cloud/dlp/BUILD.bazel
+++ b/google/cloud/dlp/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_dlp",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_dlp_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dlp",

--- a/google/cloud/documentai/BUILD.bazel
+++ b/google/cloud/documentai/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_documentai",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_documentai_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_documentai",

--- a/google/cloud/documentai/BUILD.bazel
+++ b/google/cloud/documentai/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_documentai",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_documentai_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_documentai",

--- a/google/cloud/edgecontainer/BUILD.bazel
+++ b/google/cloud/edgecontainer/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_edgecontainer",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_edgecontainer_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_edgecontainer",

--- a/google/cloud/edgecontainer/BUILD.bazel
+++ b/google/cloud/edgecontainer/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_edgecontainer",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_edgecontainer_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_edgecontainer",

--- a/google/cloud/eventarc/BUILD.bazel
+++ b/google/cloud/eventarc/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_eventarc",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -45,12 +58,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_eventarc_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_eventarc",

--- a/google/cloud/eventarc/BUILD.bazel
+++ b/google/cloud/eventarc/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_eventarc",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -58,9 +52,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_eventarc_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_eventarc",

--- a/google/cloud/filestore/BUILD.bazel
+++ b/google/cloud/filestore/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_filestore",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_filestore_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_filestore",

--- a/google/cloud/filestore/BUILD.bazel
+++ b/google/cloud/filestore/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_filestore",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_filestore_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_filestore",

--- a/google/cloud/functions/BUILD.bazel
+++ b/google/cloud/functions/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_functions",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_functions_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_functions",

--- a/google/cloud/functions/BUILD.bazel
+++ b/google/cloud/functions/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_functions",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_functions_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_functions",

--- a/google/cloud/gameservices/BUILD.bazel
+++ b/google/cloud/gameservices/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_gameservices",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_gameservices_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_gameservices",

--- a/google/cloud/gameservices/BUILD.bazel
+++ b/google/cloud/gameservices/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_gameservices",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_gameservices_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_gameservices",

--- a/google/cloud/gkehub/BUILD.bazel
+++ b/google/cloud/gkehub/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_gkehub",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_gkehub_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_gkehub",

--- a/google/cloud/gkehub/BUILD.bazel
+++ b/google/cloud/gkehub/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_gkehub",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_gkehub_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_gkehub",

--- a/google/cloud/iap/BUILD.bazel
+++ b/google/cloud/iap/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_iap",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_iap_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iap",

--- a/google/cloud/iap/BUILD.bazel
+++ b/google/cloud/iap/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_iap",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_iap_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iap",

--- a/google/cloud/ids/BUILD.bazel
+++ b/google/cloud/ids/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_ids",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_ids_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_ids",

--- a/google/cloud/ids/BUILD.bazel
+++ b/google/cloud/ids/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_ids",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_ids_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_ids",

--- a/google/cloud/iot/BUILD.bazel
+++ b/google/cloud/iot/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_iot",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_iot_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iot",

--- a/google/cloud/iot/BUILD.bazel
+++ b/google/cloud/iot/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_iot",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_iot_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iot",

--- a/google/cloud/kms/BUILD.bazel
+++ b/google/cloud/kms/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_kms",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_kms_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_kms",

--- a/google/cloud/kms/BUILD.bazel
+++ b/google/cloud/kms/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_kms",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_kms_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_kms",

--- a/google/cloud/language/BUILD.bazel
+++ b/google/cloud/language/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_language",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_language_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_language",

--- a/google/cloud/language/BUILD.bazel
+++ b/google/cloud/language/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_language",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_language_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_language",

--- a/google/cloud/managedidentities/BUILD.bazel
+++ b/google/cloud/managedidentities/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_managedidentities",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_managedidentities_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_managedidentities",

--- a/google/cloud/managedidentities/BUILD.bazel
+++ b/google/cloud/managedidentities/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_managedidentities",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_managedidentities_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_managedidentities",

--- a/google/cloud/memcache/BUILD.bazel
+++ b/google/cloud/memcache/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_memcache",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_memcache_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_memcache",

--- a/google/cloud/memcache/BUILD.bazel
+++ b/google/cloud/memcache/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_memcache",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_memcache_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_memcache",

--- a/google/cloud/monitoring/BUILD.bazel
+++ b/google/cloud/monitoring/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_monitoring",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -46,12 +59,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_monitoring_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_monitoring",

--- a/google/cloud/monitoring/BUILD.bazel
+++ b/google/cloud/monitoring/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_monitoring",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -59,9 +53,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_monitoring_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_monitoring",

--- a/google/cloud/networkconnectivity/BUILD.bazel
+++ b/google/cloud/networkconnectivity/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_networkconnectivity",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_networkconnectivity_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_networkconnectivity",

--- a/google/cloud/networkconnectivity/BUILD.bazel
+++ b/google/cloud/networkconnectivity/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_networkconnectivity",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_networkconnectivity_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_networkconnectivity",

--- a/google/cloud/networkmanagement/BUILD.bazel
+++ b/google/cloud/networkmanagement/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_networkmanagement",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_networkmanagement_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_networkmanagement",

--- a/google/cloud/networkmanagement/BUILD.bazel
+++ b/google/cloud/networkmanagement/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_networkmanagement",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_networkmanagement_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_networkmanagement",

--- a/google/cloud/notebooks/BUILD.bazel
+++ b/google/cloud/notebooks/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_notebooks",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_notebooks_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_notebooks",

--- a/google/cloud/notebooks/BUILD.bazel
+++ b/google/cloud/notebooks/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_notebooks",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_notebooks_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_notebooks",

--- a/google/cloud/optimization/BUILD.bazel
+++ b/google/cloud/optimization/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_optimization",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_optimization_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_optimization",

--- a/google/cloud/optimization/BUILD.bazel
+++ b/google/cloud/optimization/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_optimization",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_optimization_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_optimization",

--- a/google/cloud/orgpolicy/BUILD.bazel
+++ b/google/cloud/orgpolicy/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_orgpolicy",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_orgpolicy_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_orgpolicy",

--- a/google/cloud/orgpolicy/BUILD.bazel
+++ b/google/cloud/orgpolicy/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_orgpolicy",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_orgpolicy_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_orgpolicy",

--- a/google/cloud/osconfig/BUILD.bazel
+++ b/google/cloud/osconfig/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_osconfig",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -58,9 +52,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_osconfig_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_osconfig",

--- a/google/cloud/osconfig/BUILD.bazel
+++ b/google/cloud/osconfig/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_osconfig",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -45,12 +58,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_osconfig_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_osconfig",

--- a/google/cloud/oslogin/BUILD.bazel
+++ b/google/cloud/oslogin/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_oslogin",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -58,9 +52,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_oslogin_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_oslogin",

--- a/google/cloud/oslogin/BUILD.bazel
+++ b/google/cloud/oslogin/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_oslogin",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -45,12 +58,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_oslogin_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_oslogin",

--- a/google/cloud/policytroubleshooter/BUILD.bazel
+++ b/google/cloud/policytroubleshooter/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_policytroubleshooter",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_policytroubleshooter_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_policytroubleshooter",

--- a/google/cloud/policytroubleshooter/BUILD.bazel
+++ b/google/cloud/policytroubleshooter/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_policytroubleshooter",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_policytroubleshooter_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_policytroubleshooter",

--- a/google/cloud/privateca/BUILD.bazel
+++ b/google/cloud/privateca/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_privateca",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_privateca_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_privateca",

--- a/google/cloud/privateca/BUILD.bazel
+++ b/google/cloud/privateca/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_privateca",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_privateca_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_privateca",

--- a/google/cloud/profiler/BUILD.bazel
+++ b/google/cloud/profiler/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_profiler",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_profiler_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_profiler",

--- a/google/cloud/profiler/BUILD.bazel
+++ b/google/cloud/profiler/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_profiler",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_profiler_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_profiler",

--- a/google/cloud/recommender/BUILD.bazel
+++ b/google/cloud/recommender/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_recommender",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_recommender_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_recommender",

--- a/google/cloud/recommender/BUILD.bazel
+++ b/google/cloud/recommender/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_recommender",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_recommender_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_recommender",

--- a/google/cloud/redis/BUILD.bazel
+++ b/google/cloud/redis/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_redis",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_redis_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_redis",

--- a/google/cloud/redis/BUILD.bazel
+++ b/google/cloud/redis/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_redis",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_redis_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_redis",

--- a/google/cloud/resourcemanager/BUILD.bazel
+++ b/google/cloud/resourcemanager/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_resourcemanager",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_resourcemanager_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_resourcemanager",

--- a/google/cloud/resourcemanager/BUILD.bazel
+++ b/google/cloud/resourcemanager/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_resourcemanager",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_resourcemanager_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_resourcemanager",

--- a/google/cloud/resourcesettings/BUILD.bazel
+++ b/google/cloud/resourcesettings/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_resourcesettings",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_resourcesettings_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_resourcesettings",

--- a/google/cloud/resourcesettings/BUILD.bazel
+++ b/google/cloud/resourcesettings/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_resourcesettings",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_resourcesettings_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_resourcesettings",

--- a/google/cloud/retail/BUILD.bazel
+++ b/google/cloud/retail/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_retail",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_retail_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_retail",

--- a/google/cloud/retail/BUILD.bazel
+++ b/google/cloud/retail/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_retail",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_retail_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_retail",

--- a/google/cloud/run/BUILD.bazel
+++ b/google/cloud/run/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_run",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_run_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_run",

--- a/google/cloud/run/BUILD.bazel
+++ b/google/cloud/run/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_run",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_run_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_run",

--- a/google/cloud/scheduler/BUILD.bazel
+++ b/google/cloud/scheduler/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_scheduler",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_scheduler_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_scheduler",

--- a/google/cloud/scheduler/BUILD.bazel
+++ b/google/cloud/scheduler/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_scheduler",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_scheduler_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_scheduler",

--- a/google/cloud/secretmanager/BUILD.bazel
+++ b/google/cloud/secretmanager/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_secretmanager",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_secretmanager_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_secretmanager",

--- a/google/cloud/secretmanager/BUILD.bazel
+++ b/google/cloud/secretmanager/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_secretmanager",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_secretmanager_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_secretmanager",

--- a/google/cloud/securitycenter/BUILD.bazel
+++ b/google/cloud/securitycenter/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_securitycenter",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_securitycenter_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_securitycenter",

--- a/google/cloud/securitycenter/BUILD.bazel
+++ b/google/cloud/securitycenter/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_securitycenter",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_securitycenter_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_securitycenter",

--- a/google/cloud/servicecontrol/BUILD.bazel
+++ b/google/cloud/servicecontrol/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_servicecontrol",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_servicecontrol_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicecontrol",

--- a/google/cloud/servicecontrol/BUILD.bazel
+++ b/google/cloud/servicecontrol/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_servicecontrol",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_servicecontrol_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicecontrol",

--- a/google/cloud/servicedirectory/BUILD.bazel
+++ b/google/cloud/servicedirectory/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_servicedirectory",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_servicedirectory_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicedirectory",

--- a/google/cloud/servicedirectory/BUILD.bazel
+++ b/google/cloud/servicedirectory/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_servicedirectory",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_servicedirectory_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicedirectory",

--- a/google/cloud/servicemanagement/BUILD.bazel
+++ b/google/cloud/servicemanagement/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_servicemanagement",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_servicemanagement_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicemanagement",

--- a/google/cloud/servicemanagement/BUILD.bazel
+++ b/google/cloud/servicemanagement/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_servicemanagement",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_servicemanagement_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicemanagement",

--- a/google/cloud/serviceusage/BUILD.bazel
+++ b/google/cloud/serviceusage/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_serviceusage",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_serviceusage_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_serviceusage",

--- a/google/cloud/serviceusage/BUILD.bazel
+++ b/google/cloud/serviceusage/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_serviceusage",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_serviceusage_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_serviceusage",

--- a/google/cloud/shell/BUILD.bazel
+++ b/google/cloud/shell/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_shell",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_shell_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_shell",

--- a/google/cloud/shell/BUILD.bazel
+++ b/google/cloud/shell/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_shell",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_shell_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_shell",

--- a/google/cloud/speech/BUILD.bazel
+++ b/google/cloud/speech/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_speech",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_speech_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_speech",

--- a/google/cloud/speech/BUILD.bazel
+++ b/google/cloud/speech/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_speech",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_speech_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_speech",

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_storagetransfer",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     # TODO(#8785): Enable on macOS.
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
@@ -49,12 +62,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_storagetransfer_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_storagetransfer",

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_storagetransfer",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     # TODO(#8785): Enable on macOS.
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
@@ -62,9 +56,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_storagetransfer_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_storagetransfer",

--- a/google/cloud/talent/BUILD.bazel
+++ b/google/cloud/talent/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_talent",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_talent_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_talent",

--- a/google/cloud/talent/BUILD.bazel
+++ b/google/cloud/talent/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_talent",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_talent_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_talent",

--- a/google/cloud/tasks/BUILD.bazel
+++ b/google/cloud/tasks/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_tasks",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_tasks_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_tasks",

--- a/google/cloud/tasks/BUILD.bazel
+++ b/google/cloud/tasks/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_tasks",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_tasks_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_tasks",

--- a/google/cloud/texttospeech/BUILD.bazel
+++ b/google/cloud/texttospeech/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_texttospeech",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_texttospeech_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_texttospeech",

--- a/google/cloud/texttospeech/BUILD.bazel
+++ b/google/cloud/texttospeech/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_texttospeech",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_texttospeech_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_texttospeech",

--- a/google/cloud/tpu/BUILD.bazel
+++ b/google/cloud/tpu/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_tpu",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_tpu_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_tpu",

--- a/google/cloud/tpu/BUILD.bazel
+++ b/google/cloud/tpu/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_tpu",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_tpu_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_tpu",

--- a/google/cloud/trace/BUILD.bazel
+++ b/google/cloud/trace/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_trace",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_trace_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_trace",

--- a/google/cloud/trace/BUILD.bazel
+++ b/google/cloud/trace/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_trace",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_trace_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_trace",

--- a/google/cloud/translate/BUILD.bazel
+++ b/google/cloud/translate/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_translate",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_translate_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_translate",

--- a/google/cloud/translate/BUILD.bazel
+++ b/google/cloud/translate/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_translate",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_translate_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_translate",

--- a/google/cloud/video/BUILD.bazel
+++ b/google/cloud/video/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_video",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -46,12 +59,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_video_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_video",

--- a/google/cloud/video/BUILD.bazel
+++ b/google/cloud/video/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_video",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -59,9 +53,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_video_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_video",

--- a/google/cloud/videointelligence/BUILD.bazel
+++ b/google/cloud/videointelligence/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_videointelligence",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_videointelligence_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_videointelligence",

--- a/google/cloud/videointelligence/BUILD.bazel
+++ b/google/cloud/videointelligence/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_videointelligence",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_videointelligence_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_videointelligence",

--- a/google/cloud/vision/BUILD.bazel
+++ b/google/cloud/vision/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_vision",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_vision_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vision",

--- a/google/cloud/vision/BUILD.bazel
+++ b/google/cloud/vision/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_vision",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_vision_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vision",

--- a/google/cloud/vmmigration/BUILD.bazel
+++ b/google/cloud/vmmigration/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_vmmigration",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_vmmigration_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vmmigration",

--- a/google/cloud/vmmigration/BUILD.bazel
+++ b/google/cloud/vmmigration/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_vmmigration",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_vmmigration_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vmmigration",

--- a/google/cloud/vpcaccess/BUILD.bazel
+++ b/google/cloud/vpcaccess/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_vpcaccess",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_vpcaccess_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vpcaccess",

--- a/google/cloud/vpcaccess/BUILD.bazel
+++ b/google/cloud/vpcaccess/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_vpcaccess",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_vpcaccess_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vpcaccess",

--- a/google/cloud/webrisk/BUILD.bazel
+++ b/google/cloud/webrisk/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_webrisk",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_webrisk_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_webrisk",

--- a/google/cloud/webrisk/BUILD.bazel
+++ b/google/cloud/webrisk/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_webrisk",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_webrisk_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_webrisk",

--- a/google/cloud/websecurityscanner/BUILD.bazel
+++ b/google/cloud/websecurityscanner/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_websecurityscanner",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -57,9 +51,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_websecurityscanner_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_websecurityscanner",

--- a/google/cloud/websecurityscanner/BUILD.bazel
+++ b/google/cloud/websecurityscanner/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_websecurityscanner",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -44,12 +57,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_websecurityscanner_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_websecurityscanner",

--- a/google/cloud/workflows/BUILD.bazel
+++ b/google/cloud/workflows/BUILD.bazel
@@ -34,19 +34,13 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([
-        "mocks/*.h",
-    ]),
+    srcs = glob(["mocks/*.h"]),
 )
 
 cc_library(
     name = "google_cloud_cpp_workflows",
-    srcs = [
-        ":srcs",
-    ],
-    hdrs = [
-        ":hdrs",
-    ],
+    srcs = [":srcs"],
+    hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -58,9 +52,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_workflows_mocks",
-    hdrs = [
-        ":mocks",
-    ],
+    hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_workflows",

--- a/google/cloud/workflows/BUILD.bazel
+++ b/google/cloud/workflows/BUILD.bazel
@@ -16,24 +16,37 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-SOURCE_GLOB = "**/*.cc"
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "*.cc",
+        "internal/*.cc",
+    ]),
+)
 
-MOCK_SOURCE_GLOB = "mocks/*.cc"
+filegroup(
+    name = "hdrs",
+    srcs = glob([
+        "*.h",
+        "internal/*.h",
+    ]),
+)
 
-HEADER_GLOB = "**/*.h"
-
-MOCK_HEADER_GLOB = "mocks/*.h"
+filegroup(
+    name = "mocks",
+    srcs = glob([
+        "mocks/*.h",
+    ]),
+)
 
 cc_library(
     name = "google_cloud_cpp_workflows",
-    srcs = glob(
-        include = [SOURCE_GLOB],
-        exclude = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [HEADER_GLOB],
-        exclude = [MOCK_HEADER_GLOB],
-    ),
+    srcs = [
+        ":srcs",
+    ],
+    hdrs = [
+        ":hdrs",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
@@ -45,12 +58,9 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_workflows_mocks",
-    srcs = glob(
-        include = [MOCK_SOURCE_GLOB],
-    ),
-    hdrs = glob(
-        include = [MOCK_HEADER_GLOB],
-    ),
+    hdrs = [
+        ":mocks",
+    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_workflows",


### PR DESCRIPTION
The previous globs would capture too many sources and headers.

Part of the work for #10114

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10121)
<!-- Reviewable:end -->
