### PR TITLE
feat(generator): add markers during scaffold generation

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -588,6 +588,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -602,6 +611,9 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/$library$/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -106,3 +115,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/accessapproval/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/accesscontextmanager/doc/main.dox
+++ b/google/cloud/accesscontextmanager/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/accesscontextmanager/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/apigateway/doc/main.dox
+++ b/google/cloud/apigateway/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/apigateway/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/apigeeconnect/doc/main.dox
+++ b/google/cloud/apigeeconnect/doc/main.dox
@@ -89,6 +89,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -103,3 +112,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/apigeeconnect/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/apikeys/doc/main.dox
+++ b/google/cloud/apikeys/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/apikeys/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/appengine/doc/main.dox
+++ b/google/cloud/appengine/doc/main.dox
@@ -113,6 +113,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -127,3 +136,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/appengine/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/artifactregistry/doc/main.dox
+++ b/google/cloud/artifactregistry/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/artifactregistry/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/asset/doc/main.dox
+++ b/google/cloud/asset/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/asset/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/assuredworkloads/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -90,6 +90,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -104,3 +113,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/automl/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/baremetalsolution/doc/main.dox
+++ b/google/cloud/baremetalsolution/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/baremetalsolution/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/batch/doc/main.dox
+++ b/google/cloud/batch/doc/main.dox
@@ -84,6 +84,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -98,3 +107,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/batch/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/beyondcorp/doc/main.dox
+++ b/google/cloud/beyondcorp/doc/main.dox
@@ -105,6 +105,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -119,3 +128,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/beyondcorp/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/bigquery/doc/main.dox
+++ b/google/cloud/bigquery/doc/main.dox
@@ -141,6 +141,15 @@ there is no value.
 @par Example
 @snippet bigquery_read_samples.cc example-status-or
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Next Steps
 
 * @ref bigquery-read-mock
@@ -155,3 +164,6 @@ there is no value.
 [status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -95,6 +95,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -108,3 +117,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/billing/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/binaryauthorization/doc/main.dox
+++ b/google/cloud/binaryauthorization/doc/main.dox
@@ -94,6 +94,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -108,3 +117,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/binaryauthorization/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/certificatemanager/doc/main.dox
+++ b/google/cloud/certificatemanager/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/certificatemanager/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/channel/doc/main.dox
+++ b/google/cloud/channel/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/channel/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/cloudbuild/doc/main.dox
+++ b/google/cloud/cloudbuild/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/cloudbuild/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/composer/doc/main.dox
+++ b/google/cloud/composer/doc/main.dox
@@ -89,6 +89,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -103,3 +112,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/composer/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/contactcenterinsights/doc/main.dox
+++ b/google/cloud/contactcenterinsights/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/contactcenterinsights/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/container/doc/main.dox
+++ b/google/cloud/container/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/container/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/containeranalysis/doc/main.dox
+++ b/google/cloud/containeranalysis/doc/main.dox
@@ -91,6 +91,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -105,3 +114,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/containeranalysis/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/datacatalog/doc/main.dox
+++ b/google/cloud/datacatalog/doc/main.dox
@@ -93,6 +93,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -107,3 +116,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/datacatalog/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/datamigration/doc/main.dox
+++ b/google/cloud/datamigration/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/datamigration/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dataplex/doc/main.dox
+++ b/google/cloud/dataplex/doc/main.dox
@@ -94,6 +94,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -108,3 +117,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/dataplex/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -104,6 +104,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -118,3 +127,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/dataproc/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/datastream/doc/main.dox
+++ b/google/cloud/datastream/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -102,3 +111,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/datastream/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/debugger/doc/main.dox
+++ b/google/cloud/debugger/doc/main.dox
@@ -90,6 +90,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -104,3 +113,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/debugger/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/deploy/doc/main.dox
+++ b/google/cloud/deploy/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/deploy/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -148,6 +148,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -162,3 +171,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/dialogflow_cx/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -152,6 +152,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -166,3 +175,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/dialogflow_es/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dlp/doc/main.dox
+++ b/google/cloud/dlp/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -102,3 +111,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/dlp/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/documentai/doc/main.dox
+++ b/google/cloud/documentai/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/documentai/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/edgecontainer/doc/main.dox
+++ b/google/cloud/edgecontainer/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -102,3 +111,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/edgecontainer/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -89,6 +89,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -103,3 +112,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/eventarc/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/filestore/doc/main.dox
+++ b/google/cloud/filestore/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/filestore/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/functions/doc/main.dox
+++ b/google/cloud/functions/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/functions/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/gameservices/doc/main.dox
+++ b/google/cloud/gameservices/doc/main.dox
@@ -98,6 +98,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -112,3 +121,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/gameservices/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/gkehub/doc/main.dox
+++ b/google/cloud/gkehub/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/gkehub/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/iam/doc/main.dox
+++ b/google/cloud/iam/doc/main.dox
@@ -121,6 +121,15 @@ there is no value.
 @par Example
 @snippet iam_samples.cc example-status-or
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Next Steps
 
 * @ref iam-mock
@@ -136,3 +145,9 @@ there is no value.
 [status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/iap/doc/main.dox
+++ b/google/cloud/iap/doc/main.dox
@@ -89,6 +89,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -103,3 +112,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/iap/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/ids/doc/main.dox
+++ b/google/cloud/ids/doc/main.dox
@@ -90,6 +90,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -104,3 +113,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/ids/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/iot/doc/main.dox
+++ b/google/cloud/iot/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/iot/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -92,6 +92,16 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -105,3 +115,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/kms/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/language/doc/main.dox
+++ b/google/cloud/language/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/language/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/logging/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/managedidentities/doc/main.dox
+++ b/google/cloud/managedidentities/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/managedidentities/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/memcache/doc/main.dox
+++ b/google/cloud/memcache/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/memcache/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -120,6 +120,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -134,3 +143,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/monitoring/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/networkconnectivity/doc/main.dox
+++ b/google/cloud/networkconnectivity/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -102,3 +111,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/networkconnectivity/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/networkmanagement/doc/main.dox
+++ b/google/cloud/networkmanagement/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/networkmanagement/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -90,6 +90,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -105,3 +114,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/notebooks/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/optimization/doc/main.dox
+++ b/google/cloud/optimization/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/optimization/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/orgpolicy/doc/main.dox
+++ b/google/cloud/orgpolicy/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/orgpolicy/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -90,6 +90,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -104,3 +113,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/osconfig/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/oslogin/doc/main.dox
+++ b/google/cloud/oslogin/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/oslogin/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/policytroubleshooter/doc/main.dox
+++ b/google/cloud/policytroubleshooter/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/policytroubleshooter/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/privateca/doc/main.dox
+++ b/google/cloud/privateca/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -102,3 +111,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/privateca/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/profiler/doc/main.dox
+++ b/google/cloud/profiler/doc/main.dox
@@ -93,6 +93,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -107,3 +116,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/profiler/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -92,6 +92,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -105,3 +114,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/pubsublite/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/recommender/doc/main.dox
+++ b/google/cloud/recommender/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/recommender/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/redis/doc/main.dox
+++ b/google/cloud/redis/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/redis/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -94,6 +94,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -108,3 +117,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/resourcemanager/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/resourcesettings/doc/main.dox
+++ b/google/cloud/resourcesettings/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/resourcesettings/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -107,6 +107,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -121,3 +130,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/retail/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/run/doc/main.dox
+++ b/google/cloud/run/doc/main.dox
@@ -99,6 +99,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -113,3 +122,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/run/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/scheduler/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/secretmanager/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/securitycenter/doc/main.dox
+++ b/google/cloud/securitycenter/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/securitycenter/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/servicecontrol/doc/main.dox
+++ b/google/cloud/servicecontrol/doc/main.dox
@@ -90,6 +90,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -104,3 +113,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/servicecontrol/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/servicedirectory/doc/main.dox
+++ b/google/cloud/servicedirectory/doc/main.dox
@@ -90,6 +90,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -104,3 +113,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/servicedirectory/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/servicemanagement/doc/main.dox
+++ b/google/cloud/servicemanagement/doc/main.dox
@@ -84,6 +84,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -98,3 +107,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/servicemanagement/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/serviceusage/doc/main.dox
+++ b/google/cloud/serviceusage/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/serviceusage/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/shell/doc/main.dox
+++ b/google/cloud/shell/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/shell/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/speech/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/storagetransfer/doc/main.dox
+++ b/google/cloud/storagetransfer/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/storagetransfer/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/talent/doc/main.dox
+++ b/google/cloud/talent/doc/main.dox
@@ -102,6 +102,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -116,3 +125,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/talent/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/tasks/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/texttospeech/doc/main.dox
+++ b/google/cloud/texttospeech/doc/main.dox
@@ -86,6 +86,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/texttospeech/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/tpu/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/trace/doc/main.dox
+++ b/google/cloud/trace/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -102,3 +111,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/trace/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/translate/doc/main.dox
+++ b/google/cloud/translate/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/translate/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/video/doc/main.dox
+++ b/google/cloud/video/doc/main.dox
@@ -101,6 +101,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -117,3 +126,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/video/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/videointelligence/doc/main.dox
+++ b/google/cloud/videointelligence/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/videointelligence/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -91,6 +91,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -105,3 +114,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/vision/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/vmmigration/doc/main.dox
+++ b/google/cloud/vmmigration/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/vmmigration/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/vpcaccess/doc/main.dox
+++ b/google/cloud/vpcaccess/doc/main.dox
@@ -85,6 +85,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -99,3 +108,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/vpcaccess/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -87,6 +87,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -100,3 +109,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/webrisk/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -88,6 +88,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -101,3 +110,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/websecurityscanner/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -91,6 +91,15 @@ It will return the `T` value or throw on error.
 For operations that do not return a value the library simply returns
 `google::cloud::Status`.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.
+
+<!-- inject-endpoint-snippet-start -->
+<!-- inject-endpoint-snippet-end -->
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -104,3 +113,6 @@ can override the default policies.
 [github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/workflows/quickstart/README%2Emd
 
 */
+
+// <!-- inject-endpoint-pages-start -->
+// <!-- inject-endpoint-pages-end -->


### PR DESCRIPTION
The scaffold for `main.dox` will include new markers to inject the
snippets showing how to override the default endpoint.

Part of the work for #10114 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10127)
<!-- Reviewable:end -->
