### PR TITLE
doc: add endpoint override snippets to generated libs

### DIFF
--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AccessApprovalClient`:
+
+@snippet access_approval_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -117,4 +121,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AccessApprovalClient-endpoint-snippet Override AccessApprovalClient Endpoint Configuration
+
+@snippet google/cloud/accessapproval/samples/access_approval_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/accesscontextmanager/doc/main.dox
+++ b/google/cloud/accesscontextmanager/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AccessContextManagerClient`:
+
+@snippet access_context_manager_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AccessContextManagerClient-endpoint-snippet Override AccessContextManagerClient Endpoint Configuration
+
+@snippet google/cloud/accesscontextmanager/samples/access_context_manager_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/apigateway/doc/main.dox
+++ b/google/cloud/apigateway/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ApiGatewayServiceClient`:
+
+@snippet api_gateway_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ApiGatewayServiceClient-endpoint-snippet Override ApiGatewayServiceClient Endpoint Configuration
+
+@snippet google/cloud/apigateway/samples/api_gateway_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/apigeeconnect/doc/main.dox
+++ b/google/cloud/apigeeconnect/doc/main.dox
@@ -96,6 +96,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ConnectionServiceClient`:
+
+@snippet connection_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -114,4 +118,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ConnectionServiceClient-endpoint-snippet Override ConnectionServiceClient Endpoint Configuration
+
+@snippet google/cloud/apigeeconnect/samples/connection_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/apikeys/doc/main.dox
+++ b/google/cloud/apikeys/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ApiKeysClient`:
+
+@snippet api_keys_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ApiKeysClient-endpoint-snippet Override ApiKeysClient Endpoint Configuration
+
+@snippet google/cloud/apikeys/samples/api_keys_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/appengine/doc/main.dox
+++ b/google/cloud/appengine/doc/main.dox
@@ -120,6 +120,20 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ApplicationsClient`:
+
+@snippet applications_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [ApplicationsClient](@ref ApplicationsClient-endpoint-snippet)
+ [AuthorizedCertificatesClient](@ref AuthorizedCertificatesClient-endpoint-snippet)
+ [AuthorizedDomainsClient](@ref AuthorizedDomainsClient-endpoint-snippet)
+ [DomainMappingsClient](@ref DomainMappingsClient-endpoint-snippet)
+ [FirewallClient](@ref FirewallClient-endpoint-snippet)
+ [InstancesClient](@ref InstancesClient-endpoint-snippet)
+ [ServicesClient](@ref ServicesClient-endpoint-snippet)
+ [VersionsClient](@ref VersionsClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -138,4 +152,52 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ApplicationsClient-endpoint-snippet Override ApplicationsClient Endpoint Configuration
+
+@snippet google/cloud/appengine/samples/applications_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page AuthorizedCertificatesClient-endpoint-snippet Override AuthorizedCertificatesClient Endpoint Configuration
+
+@snippet google/cloud/appengine/samples/authorized_certificates_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page AuthorizedDomainsClient-endpoint-snippet Override AuthorizedDomainsClient Endpoint Configuration
+
+@snippet google/cloud/appengine/samples/authorized_domains_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page DomainMappingsClient-endpoint-snippet Override DomainMappingsClient Endpoint Configuration
+
+@snippet google/cloud/appengine/samples/domain_mappings_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page FirewallClient-endpoint-snippet Override FirewallClient Endpoint Configuration
+
+@snippet google/cloud/appengine/samples/firewall_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page InstancesClient-endpoint-snippet Override InstancesClient Endpoint Configuration
+
+@snippet google/cloud/appengine/samples/instances_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ServicesClient-endpoint-snippet Override ServicesClient Endpoint Configuration
+
+@snippet google/cloud/appengine/samples/services_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page VersionsClient-endpoint-snippet Override VersionsClient Endpoint Configuration
+
+@snippet google/cloud/appengine/samples/versions_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/artifactregistry/doc/main.dox
+++ b/google/cloud/artifactregistry/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ArtifactRegistryClient`:
+
+@snippet artifact_registry_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ArtifactRegistryClient-endpoint-snippet Override ArtifactRegistryClient Endpoint Configuration
+
+@snippet google/cloud/artifactregistry/samples/artifact_registry_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/asset/doc/main.dox
+++ b/google/cloud/asset/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AssetServiceClient`:
+
+@snippet asset_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AssetServiceClient-endpoint-snippet Override AssetServiceClient Endpoint Configuration
+
+@snippet google/cloud/asset/samples/asset_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AssuredWorkloadsServiceClient`:
+
+@snippet assured_workloads_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AssuredWorkloadsServiceClient-endpoint-snippet Override AssuredWorkloadsServiceClient Endpoint Configuration
+
+@snippet google/cloud/assuredworkloads/samples/assured_workloads_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -97,6 +97,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AutoMlClient`:
+
+@snippet auto_ml_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AutoMlClient](@ref AutoMlClient-endpoint-snippet)
+ [PredictionServiceClient](@ref PredictionServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -115,4 +123,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AutoMlClient-endpoint-snippet Override AutoMlClient Endpoint Configuration
+
+@snippet google/cloud/automl/samples/auto_ml_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page PredictionServiceClient-endpoint-snippet Override PredictionServiceClient Endpoint Configuration
+
+@snippet google/cloud/automl/samples/prediction_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/baremetalsolution/doc/main.dox
+++ b/google/cloud/baremetalsolution/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `BareMetalSolutionClient`:
+
+@snippet bare_metal_solution_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page BareMetalSolutionClient-endpoint-snippet Override BareMetalSolutionClient Endpoint Configuration
+
+@snippet google/cloud/baremetalsolution/samples/bare_metal_solution_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/batch/doc/main.dox
+++ b/google/cloud/batch/doc/main.dox
@@ -91,6 +91,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `BatchServiceClient`:
+
+@snippet batch_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -109,4 +113,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page BatchServiceClient-endpoint-snippet Override BatchServiceClient Endpoint Configuration
+
+@snippet google/cloud/batch/samples/batch_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/beyondcorp/doc/main.dox
+++ b/google/cloud/beyondcorp/doc/main.dox
@@ -112,6 +112,17 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AppConnectionsServiceClient`:
+
+@snippet app_connections_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AppConnectionsServiceClient](@ref AppConnectionsServiceClient-endpoint-snippet)
+ [AppConnectorsServiceClient](@ref AppConnectorsServiceClient-endpoint-snippet)
+ [AppGatewaysServiceClient](@ref AppGatewaysServiceClient-endpoint-snippet)
+ [ClientConnectorServicesServiceClient](@ref ClientConnectorServicesServiceClient-endpoint-snippet)
+ [ClientGatewaysServiceClient](@ref ClientGatewaysServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -130,4 +141,34 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AppConnectionsServiceClient-endpoint-snippet Override AppConnectionsServiceClient Endpoint Configuration
+
+@snippet google/cloud/beyondcorp/samples/app_connections_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page AppConnectorsServiceClient-endpoint-snippet Override AppConnectorsServiceClient Endpoint Configuration
+
+@snippet google/cloud/beyondcorp/samples/app_connectors_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page AppGatewaysServiceClient-endpoint-snippet Override AppGatewaysServiceClient Endpoint Configuration
+
+@snippet google/cloud/beyondcorp/samples/app_gateways_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ClientConnectorServicesServiceClient-endpoint-snippet Override ClientConnectorServicesServiceClient Endpoint Configuration
+
+@snippet google/cloud/beyondcorp/samples/client_connector_services_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ClientGatewaysServiceClient-endpoint-snippet Override ClientGatewaysServiceClient Endpoint Configuration
+
+@snippet google/cloud/beyondcorp/samples/client_gateways_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/bigquery/doc/main.dox
+++ b/google/cloud/bigquery/doc/main.dox
@@ -148,6 +148,20 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AnalyticsHubServiceClient`:
+
+@snippet analytics_hub_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AnalyticsHubServiceClient](@ref AnalyticsHubServiceClient-endpoint-snippet)
+ [BigQueryReadClient](@ref BigQueryReadClient-endpoint-snippet)
+ [BigQueryWriteClient](@ref BigQueryWriteClient-endpoint-snippet)
+ [ConnectionServiceClient](@ref ConnectionServiceClient-endpoint-snippet)
+ [DataTransferServiceClient](@ref DataTransferServiceClient-endpoint-snippet)
+ [MigrationServiceClient](@ref MigrationServiceClient-endpoint-snippet)
+ [ModelServiceClient](@ref ModelServiceClient-endpoint-snippet)
+ [ReservationServiceClient](@ref ReservationServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Next Steps
@@ -166,4 +180,52 @@ library to change this default.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AnalyticsHubServiceClient-endpoint-snippet Override AnalyticsHubServiceClient Endpoint Configuration
+
+@snippet google/cloud/bigquery/samples/analytics_hub_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page BigQueryReadClient-endpoint-snippet Override BigQueryReadClient Endpoint Configuration
+
+@snippet google/cloud/bigquery/samples/bigquery_read_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page BigQueryWriteClient-endpoint-snippet Override BigQueryWriteClient Endpoint Configuration
+
+@snippet google/cloud/bigquery/samples/bigquery_write_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ConnectionServiceClient-endpoint-snippet Override ConnectionServiceClient Endpoint Configuration
+
+@snippet google/cloud/bigquery/samples/connection_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page DataTransferServiceClient-endpoint-snippet Override DataTransferServiceClient Endpoint Configuration
+
+@snippet google/cloud/bigquery/samples/data_transfer_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page MigrationServiceClient-endpoint-snippet Override MigrationServiceClient Endpoint Configuration
+
+@snippet google/cloud/bigquery/samples/migration_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ModelServiceClient-endpoint-snippet Override ModelServiceClient Endpoint Configuration
+
+@snippet google/cloud/bigquery/samples/model_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ReservationServiceClient-endpoint-snippet Override ReservationServiceClient Endpoint Configuration
+
+@snippet google/cloud/bigquery/samples/reservation_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -102,6 +102,15 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `BudgetServiceClient`:
+
+@snippet budget_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [BudgetServiceClient](@ref BudgetServiceClient-endpoint-snippet)
+ [CloudBillingClient](@ref CloudBillingClient-endpoint-snippet)
+ [CloudCatalogClient](@ref CloudCatalogClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -119,4 +128,22 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page BudgetServiceClient-endpoint-snippet Override BudgetServiceClient Endpoint Configuration
+
+@snippet google/cloud/billing/samples/budget_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page CloudBillingClient-endpoint-snippet Override CloudBillingClient Endpoint Configuration
+
+@snippet google/cloud/billing/samples/cloud_billing_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page CloudCatalogClient-endpoint-snippet Override CloudCatalogClient Endpoint Configuration
+
+@snippet google/cloud/billing/samples/cloud_catalog_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/binaryauthorization/doc/main.dox
+++ b/google/cloud/binaryauthorization/doc/main.dox
@@ -101,6 +101,15 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `BinauthzManagementServiceV1Client`:
+
+@snippet binauthz_management_service_v1_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [BinauthzManagementServiceV1Client](@ref BinauthzManagementServiceV1Client-endpoint-snippet)
+ [SystemPolicyV1Client](@ref SystemPolicyV1Client-endpoint-snippet)
+ [ValidationHelperV1Client](@ref ValidationHelperV1Client-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -119,4 +128,22 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page BinauthzManagementServiceV1Client-endpoint-snippet Override BinauthzManagementServiceV1Client Endpoint Configuration
+
+@snippet google/cloud/binaryauthorization/samples/binauthz_management_service_v1_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page SystemPolicyV1Client-endpoint-snippet Override SystemPolicyV1Client Endpoint Configuration
+
+@snippet google/cloud/binaryauthorization/samples/system_policy_v1_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ValidationHelperV1Client-endpoint-snippet Override ValidationHelperV1Client Endpoint Configuration
+
+@snippet google/cloud/binaryauthorization/samples/validation_helper_v1_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/certificatemanager/doc/main.dox
+++ b/google/cloud/certificatemanager/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CertificateManagerClient`:
+
+@snippet certificate_manager_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CertificateManagerClient-endpoint-snippet Override CertificateManagerClient Endpoint Configuration
+
+@snippet google/cloud/certificatemanager/samples/certificate_manager_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/channel/doc/main.dox
+++ b/google/cloud/channel/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudChannelServiceClient`:
+
+@snippet cloud_channel_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudChannelServiceClient-endpoint-snippet Override CloudChannelServiceClient Endpoint Configuration
+
+@snippet google/cloud/channel/samples/cloud_channel_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/cloudbuild/doc/main.dox
+++ b/google/cloud/cloudbuild/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudBuildClient`:
+
+@snippet cloud_build_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudBuildClient-endpoint-snippet Override CloudBuildClient Endpoint Configuration
+
+@snippet google/cloud/cloudbuild/samples/cloud_build_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/composer/doc/main.dox
+++ b/google/cloud/composer/doc/main.dox
@@ -96,6 +96,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `EnvironmentsClient`:
+
+@snippet environments_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [EnvironmentsClient](@ref EnvironmentsClient-endpoint-snippet)
+ [ImageVersionsClient](@ref ImageVersionsClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -114,4 +122,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page EnvironmentsClient-endpoint-snippet Override EnvironmentsClient Endpoint Configuration
+
+@snippet google/cloud/composer/samples/environments_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ImageVersionsClient-endpoint-snippet Override ImageVersionsClient Endpoint Configuration
+
+@snippet google/cloud/composer/samples/image_versions_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/contactcenterinsights/doc/main.dox
+++ b/google/cloud/contactcenterinsights/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ContactCenterInsightsClient`:
+
+@snippet contact_center_insights_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ContactCenterInsightsClient-endpoint-snippet Override ContactCenterInsightsClient Endpoint Configuration
+
+@snippet google/cloud/contactcenterinsights/samples/contact_center_insights_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/container/doc/main.dox
+++ b/google/cloud/container/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ClusterManagerClient`:
+
+@snippet cluster_manager_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ClusterManagerClient-endpoint-snippet Override ClusterManagerClient Endpoint Configuration
+
+@snippet google/cloud/container/samples/cluster_manager_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/containeranalysis/doc/main.dox
+++ b/google/cloud/containeranalysis/doc/main.dox
@@ -98,6 +98,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ContainerAnalysisClient`:
+
+@snippet container_analysis_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [ContainerAnalysisClient](@ref ContainerAnalysisClient-endpoint-snippet)
+ [GrafeasClient](@ref GrafeasClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -116,4 +124,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ContainerAnalysisClient-endpoint-snippet Override ContainerAnalysisClient Endpoint Configuration
+
+@snippet google/cloud/containeranalysis/samples/container_analysis_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page GrafeasClient-endpoint-snippet Override GrafeasClient Endpoint Configuration
+
+@snippet google/cloud/containeranalysis/samples/grafeas_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/datacatalog/doc/main.dox
+++ b/google/cloud/datacatalog/doc/main.dox
@@ -100,6 +100,15 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `DataCatalogClient`:
+
+@snippet data_catalog_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [DataCatalogClient](@ref DataCatalogClient-endpoint-snippet)
+ [PolicyTagManagerClient](@ref PolicyTagManagerClient-endpoint-snippet)
+ [PolicyTagManagerSerializationClient](@ref PolicyTagManagerSerializationClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -118,4 +127,22 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page DataCatalogClient-endpoint-snippet Override DataCatalogClient Endpoint Configuration
+
+@snippet google/cloud/datacatalog/samples/data_catalog_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page PolicyTagManagerClient-endpoint-snippet Override PolicyTagManagerClient Endpoint Configuration
+
+@snippet google/cloud/datacatalog/samples/policy_tag_manager_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page PolicyTagManagerSerializationClient-endpoint-snippet Override PolicyTagManagerSerializationClient Endpoint Configuration
+
+@snippet google/cloud/datacatalog/samples/policy_tag_manager_serialization_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/datamigration/doc/main.dox
+++ b/google/cloud/datamigration/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `DataMigrationServiceClient`:
+
+@snippet data_migration_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page DataMigrationServiceClient-endpoint-snippet Override DataMigrationServiceClient Endpoint Configuration
+
+@snippet google/cloud/datamigration/samples/data_migration_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dataplex/doc/main.dox
+++ b/google/cloud/dataplex/doc/main.dox
@@ -101,6 +101,15 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ContentServiceClient`:
+
+@snippet content_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [ContentServiceClient](@ref ContentServiceClient-endpoint-snippet)
+ [DataplexServiceClient](@ref DataplexServiceClient-endpoint-snippet)
+ [MetadataServiceClient](@ref MetadataServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -119,4 +128,22 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ContentServiceClient-endpoint-snippet Override ContentServiceClient Endpoint Configuration
+
+@snippet google/cloud/dataplex/samples/content_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page DataplexServiceClient-endpoint-snippet Override DataplexServiceClient Endpoint Configuration
+
+@snippet google/cloud/dataplex/samples/dataplex_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page MetadataServiceClient-endpoint-snippet Override MetadataServiceClient Endpoint Configuration
+
+@snippet google/cloud/dataplex/samples/metadata_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -111,6 +111,17 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AutoscalingPolicyServiceClient`:
+
+@snippet autoscaling_policy_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AutoscalingPolicyServiceClient](@ref AutoscalingPolicyServiceClient-endpoint-snippet)
+ [BatchControllerClient](@ref BatchControllerClient-endpoint-snippet)
+ [ClusterControllerClient](@ref ClusterControllerClient-endpoint-snippet)
+ [JobControllerClient](@ref JobControllerClient-endpoint-snippet)
+ [WorkflowTemplateServiceClient](@ref WorkflowTemplateServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -129,4 +140,34 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AutoscalingPolicyServiceClient-endpoint-snippet Override AutoscalingPolicyServiceClient Endpoint Configuration
+
+@snippet google/cloud/dataproc/samples/autoscaling_policy_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page BatchControllerClient-endpoint-snippet Override BatchControllerClient Endpoint Configuration
+
+@snippet google/cloud/dataproc/samples/batch_controller_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ClusterControllerClient-endpoint-snippet Override ClusterControllerClient Endpoint Configuration
+
+@snippet google/cloud/dataproc/samples/cluster_controller_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page JobControllerClient-endpoint-snippet Override JobControllerClient Endpoint Configuration
+
+@snippet google/cloud/dataproc/samples/job_controller_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page WorkflowTemplateServiceClient-endpoint-snippet Override WorkflowTemplateServiceClient Endpoint Configuration
+
+@snippet google/cloud/dataproc/samples/workflow_template_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/datastream/doc/main.dox
+++ b/google/cloud/datastream/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `DatastreamClient`:
+
+@snippet datastream_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -113,4 +117,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page DatastreamClient-endpoint-snippet Override DatastreamClient Endpoint Configuration
+
+@snippet google/cloud/datastream/samples/datastream_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/debugger/doc/main.dox
+++ b/google/cloud/debugger/doc/main.dox
@@ -97,6 +97,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `Controller2Client`:
+
+@snippet controller2_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [Controller2Client](@ref Controller2Client-endpoint-snippet)
+ [Debugger2Client](@ref Debugger2Client-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -115,4 +123,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page Controller2Client-endpoint-snippet Override Controller2Client Endpoint Configuration
+
+@snippet google/cloud/debugger/samples/controller2_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page Debugger2Client-endpoint-snippet Override Debugger2Client Endpoint Configuration
+
+@snippet google/cloud/debugger/samples/debugger2_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/deploy/doc/main.dox
+++ b/google/cloud/deploy/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudDeployClient`:
+
+@snippet cloud_deploy_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudDeployClient-endpoint-snippet Override CloudDeployClient Endpoint Configuration
+
+@snippet google/cloud/deploy/samples/cloud_deploy_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -155,6 +155,28 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AgentsClient`:
+
+@snippet agents_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AgentsClient](@ref AgentsClient-endpoint-snippet)
+ [ChangelogsClient](@ref ChangelogsClient-endpoint-snippet)
+ [DeploymentsClient](@ref DeploymentsClient-endpoint-snippet)
+ [EntityTypesClient](@ref EntityTypesClient-endpoint-snippet)
+ [EnvironmentsClient](@ref EnvironmentsClient-endpoint-snippet)
+ [ExperimentsClient](@ref ExperimentsClient-endpoint-snippet)
+ [FlowsClient](@ref FlowsClient-endpoint-snippet)
+ [IntentsClient](@ref IntentsClient-endpoint-snippet)
+ [PagesClient](@ref PagesClient-endpoint-snippet)
+ [SecuritySettingsServiceClient](@ref SecuritySettingsServiceClient-endpoint-snippet)
+ [SessionEntityTypesClient](@ref SessionEntityTypesClient-endpoint-snippet)
+ [SessionsClient](@ref SessionsClient-endpoint-snippet)
+ [TestCasesClient](@ref TestCasesClient-endpoint-snippet)
+ [TransitionRouteGroupsClient](@ref TransitionRouteGroupsClient-endpoint-snippet)
+ [VersionsClient](@ref VersionsClient-endpoint-snippet)
+ [WebhooksClient](@ref WebhooksClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -173,4 +195,100 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AgentsClient-endpoint-snippet Override AgentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/agents_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ChangelogsClient-endpoint-snippet Override ChangelogsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/changelogs_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page DeploymentsClient-endpoint-snippet Override DeploymentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/deployments_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page EntityTypesClient-endpoint-snippet Override EntityTypesClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/entity_types_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page EnvironmentsClient-endpoint-snippet Override EnvironmentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/environments_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ExperimentsClient-endpoint-snippet Override ExperimentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/experiments_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page FlowsClient-endpoint-snippet Override FlowsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/flows_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page IntentsClient-endpoint-snippet Override IntentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/intents_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page PagesClient-endpoint-snippet Override PagesClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/pages_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page SecuritySettingsServiceClient-endpoint-snippet Override SecuritySettingsServiceClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/security_settings_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page SessionEntityTypesClient-endpoint-snippet Override SessionEntityTypesClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/session_entity_types_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page SessionsClient-endpoint-snippet Override SessionsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/sessions_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page TestCasesClient-endpoint-snippet Override TestCasesClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/test_cases_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page TransitionRouteGroupsClient-endpoint-snippet Override TransitionRouteGroupsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/transition_route_groups_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page VersionsClient-endpoint-snippet Override VersionsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/versions_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page WebhooksClient-endpoint-snippet Override WebhooksClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_cx/samples/webhooks_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -159,6 +159,29 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AgentsClient`:
+
+@snippet agents_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AgentsClient](@ref AgentsClient-endpoint-snippet)
+ [AnswerRecordsClient](@ref AnswerRecordsClient-endpoint-snippet)
+ [ContextsClient](@ref ContextsClient-endpoint-snippet)
+ [ConversationDatasetsClient](@ref ConversationDatasetsClient-endpoint-snippet)
+ [ConversationModelsClient](@ref ConversationModelsClient-endpoint-snippet)
+ [ConversationProfilesClient](@ref ConversationProfilesClient-endpoint-snippet)
+ [ConversationsClient](@ref ConversationsClient-endpoint-snippet)
+ [DocumentsClient](@ref DocumentsClient-endpoint-snippet)
+ [EntityTypesClient](@ref EntityTypesClient-endpoint-snippet)
+ [EnvironmentsClient](@ref EnvironmentsClient-endpoint-snippet)
+ [FulfillmentsClient](@ref FulfillmentsClient-endpoint-snippet)
+ [IntentsClient](@ref IntentsClient-endpoint-snippet)
+ [KnowledgeBasesClient](@ref KnowledgeBasesClient-endpoint-snippet)
+ [ParticipantsClient](@ref ParticipantsClient-endpoint-snippet)
+ [SessionEntityTypesClient](@ref SessionEntityTypesClient-endpoint-snippet)
+ [SessionsClient](@ref SessionsClient-endpoint-snippet)
+ [VersionsClient](@ref VersionsClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -177,4 +200,106 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AgentsClient-endpoint-snippet Override AgentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/agents_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page AnswerRecordsClient-endpoint-snippet Override AnswerRecordsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/answer_records_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ContextsClient-endpoint-snippet Override ContextsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/contexts_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ConversationDatasetsClient-endpoint-snippet Override ConversationDatasetsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/conversation_datasets_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ConversationModelsClient-endpoint-snippet Override ConversationModelsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/conversation_models_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ConversationProfilesClient-endpoint-snippet Override ConversationProfilesClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/conversation_profiles_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ConversationsClient-endpoint-snippet Override ConversationsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/conversations_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page DocumentsClient-endpoint-snippet Override DocumentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/documents_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page EntityTypesClient-endpoint-snippet Override EntityTypesClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/entity_types_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page EnvironmentsClient-endpoint-snippet Override EnvironmentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/environments_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page FulfillmentsClient-endpoint-snippet Override FulfillmentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/fulfillments_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page IntentsClient-endpoint-snippet Override IntentsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/intents_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page KnowledgeBasesClient-endpoint-snippet Override KnowledgeBasesClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/knowledge_bases_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ParticipantsClient-endpoint-snippet Override ParticipantsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/participants_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page SessionEntityTypesClient-endpoint-snippet Override SessionEntityTypesClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/session_entity_types_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page SessionsClient-endpoint-snippet Override SessionsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/sessions_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page VersionsClient-endpoint-snippet Override VersionsClient Endpoint Configuration
+
+@snippet google/cloud/dialogflow_es/samples/versions_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/dlp/doc/main.dox
+++ b/google/cloud/dlp/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `DlpServiceClient`:
+
+@snippet dlp_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -113,4 +117,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page DlpServiceClient-endpoint-snippet Override DlpServiceClient Endpoint Configuration
+
+@snippet google/cloud/dlp/samples/dlp_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/documentai/doc/main.dox
+++ b/google/cloud/documentai/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `DocumentProcessorServiceClient`:
+
+@snippet document_processor_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page DocumentProcessorServiceClient-endpoint-snippet Override DocumentProcessorServiceClient Endpoint Configuration
+
+@snippet google/cloud/documentai/samples/document_processor_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/edgecontainer/doc/main.dox
+++ b/google/cloud/edgecontainer/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `EdgeContainerClient`:
+
+@snippet edge_container_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -113,4 +117,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page EdgeContainerClient-endpoint-snippet Override EdgeContainerClient Endpoint Configuration
+
+@snippet google/cloud/edgecontainer/samples/edge_container_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -96,6 +96,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `EventarcClient`:
+
+@snippet eventarc_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [EventarcClient](@ref EventarcClient-endpoint-snippet)
+ [PublisherClient](@ref PublisherClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -114,4 +122,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page EventarcClient-endpoint-snippet Override EventarcClient Endpoint Configuration
+
+@snippet google/cloud/eventarc/samples/eventarc_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page PublisherClient-endpoint-snippet Override PublisherClient Endpoint Configuration
+
+@snippet google/cloud/eventarc/samples/publisher_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/filestore/doc/main.dox
+++ b/google/cloud/filestore/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudFilestoreManagerClient`:
+
+@snippet cloud_filestore_manager_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudFilestoreManagerClient-endpoint-snippet Override CloudFilestoreManagerClient Endpoint Configuration
+
+@snippet google/cloud/filestore/samples/cloud_filestore_manager_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/functions/doc/main.dox
+++ b/google/cloud/functions/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudFunctionsServiceClient`:
+
+@snippet cloud_functions_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudFunctionsServiceClient-endpoint-snippet Override CloudFunctionsServiceClient Endpoint Configuration
+
+@snippet google/cloud/functions/samples/cloud_functions_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/gameservices/doc/main.dox
+++ b/google/cloud/gameservices/doc/main.dox
@@ -105,6 +105,16 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `GameServerClustersServiceClient`:
+
+@snippet game_server_clusters_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [GameServerClustersServiceClient](@ref GameServerClustersServiceClient-endpoint-snippet)
+ [GameServerConfigsServiceClient](@ref GameServerConfigsServiceClient-endpoint-snippet)
+ [GameServerDeploymentsServiceClient](@ref GameServerDeploymentsServiceClient-endpoint-snippet)
+ [RealmsServiceClient](@ref RealmsServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -123,4 +133,28 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page GameServerClustersServiceClient-endpoint-snippet Override GameServerClustersServiceClient Endpoint Configuration
+
+@snippet google/cloud/gameservices/samples/game_server_clusters_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page GameServerConfigsServiceClient-endpoint-snippet Override GameServerConfigsServiceClient Endpoint Configuration
+
+@snippet google/cloud/gameservices/samples/game_server_configs_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page GameServerDeploymentsServiceClient-endpoint-snippet Override GameServerDeploymentsServiceClient Endpoint Configuration
+
+@snippet google/cloud/gameservices/samples/game_server_deployments_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page RealmsServiceClient-endpoint-snippet Override RealmsServiceClient Endpoint Configuration
+
+@snippet google/cloud/gameservices/samples/realms_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/gkehub/doc/main.dox
+++ b/google/cloud/gkehub/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `GkeHubClient`:
+
+@snippet gke_hub_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page GkeHubClient-endpoint-snippet Override GkeHubClient Endpoint Configuration
+
+@snippet google/cloud/gkehub/samples/gke_hub_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/iam/doc/main.dox
+++ b/google/cloud/iam/doc/main.dox
@@ -128,6 +128,15 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `IAMClient`:
+
+@snippet iam_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [IAMClient](@ref IAMClient-endpoint-snippet)
+ [IAMCredentialsClient](@ref IAMCredentialsClient-endpoint-snippet)
+ [IAMPolicyClient](@ref IAMPolicyClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Next Steps
@@ -147,6 +156,24 @@ library to change this default.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page IAMClient-endpoint-snippet Override IAMClient Endpoint Configuration
+
+@snippet google/cloud/iam/samples/iam_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page IAMCredentialsClient-endpoint-snippet Override IAMCredentialsClient Endpoint Configuration
+
+@snippet google/cloud/iam/samples/iam_credentials_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page IAMPolicyClient-endpoint-snippet Override IAMPolicyClient Endpoint Configuration
+
+@snippet google/cloud/iam/samples/iam_policy_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->
 
 // <!-- inject-endpoint-pages-start -->

--- a/google/cloud/iap/doc/main.dox
+++ b/google/cloud/iap/doc/main.dox
@@ -96,6 +96,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `IdentityAwareProxyAdminServiceClient`:
+
+@snippet identity_aware_proxy_admin_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [IdentityAwareProxyAdminServiceClient](@ref IdentityAwareProxyAdminServiceClient-endpoint-snippet)
+ [IdentityAwareProxyOAuthServiceClient](@ref IdentityAwareProxyOAuthServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -114,4 +122,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page IdentityAwareProxyAdminServiceClient-endpoint-snippet Override IdentityAwareProxyAdminServiceClient Endpoint Configuration
+
+@snippet google/cloud/iap/samples/identity_aware_proxy_admin_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page IdentityAwareProxyOAuthServiceClient-endpoint-snippet Override IdentityAwareProxyOAuthServiceClient Endpoint Configuration
+
+@snippet google/cloud/iap/samples/identity_aware_proxy_o_auth_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/ids/doc/main.dox
+++ b/google/cloud/ids/doc/main.dox
@@ -97,6 +97,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `IDSClient`:
+
+@snippet ids_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -115,4 +119,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page IDSClient-endpoint-snippet Override IDSClient Endpoint Configuration
+
+@snippet google/cloud/ids/samples/ids_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/iot/doc/main.dox
+++ b/google/cloud/iot/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `DeviceManagerClient`:
+
+@snippet device_manager_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page DeviceManagerClient-endpoint-snippet Override DeviceManagerClient Endpoint Configuration
+
+@snippet google/cloud/iot/samples/device_manager_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -100,6 +100,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `EkmServiceClient`:
+
+@snippet ekm_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [EkmServiceClient](@ref EkmServiceClient-endpoint-snippet)
+ [KeyManagementServiceClient](@ref KeyManagementServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -117,4 +125,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page EkmServiceClient-endpoint-snippet Override EkmServiceClient Endpoint Configuration
+
+@snippet google/cloud/kms/samples/ekm_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page KeyManagementServiceClient-endpoint-snippet Override KeyManagementServiceClient Endpoint Configuration
+
+@snippet google/cloud/kms/samples/key_management_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/language/doc/main.dox
+++ b/google/cloud/language/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `LanguageServiceClient`:
+
+@snippet language_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page LanguageServiceClient-endpoint-snippet Override LanguageServiceClient Endpoint Configuration
+
+@snippet google/cloud/language/samples/language_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `LoggingServiceV2Client`:
+
+@snippet logging_service_v2_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page LoggingServiceV2Client-endpoint-snippet Override LoggingServiceV2Client Endpoint Configuration
+
+@snippet google/cloud/logging/samples/logging_service_v2_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/managedidentities/doc/main.dox
+++ b/google/cloud/managedidentities/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ManagedIdentitiesServiceClient`:
+
+@snippet managed_identities_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ManagedIdentitiesServiceClient-endpoint-snippet Override ManagedIdentitiesServiceClient Endpoint Configuration
+
+@snippet google/cloud/managedidentities/samples/managed_identities_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/memcache/doc/main.dox
+++ b/google/cloud/memcache/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudMemcacheClient`:
+
+@snippet cloud_memcache_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudMemcacheClient-endpoint-snippet Override CloudMemcacheClient Endpoint Configuration
+
+@snippet google/cloud/memcache/samples/cloud_memcache_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -127,6 +127,21 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AlertPolicyServiceClient`:
+
+@snippet alert_policy_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AlertPolicyServiceClient](@ref AlertPolicyServiceClient-endpoint-snippet)
+ [DashboardsServiceClient](@ref DashboardsServiceClient-endpoint-snippet)
+ [GroupServiceClient](@ref GroupServiceClient-endpoint-snippet)
+ [MetricServiceClient](@ref MetricServiceClient-endpoint-snippet)
+ [MetricsScopesClient](@ref MetricsScopesClient-endpoint-snippet)
+ [NotificationChannelServiceClient](@ref NotificationChannelServiceClient-endpoint-snippet)
+ [QueryServiceClient](@ref QueryServiceClient-endpoint-snippet)
+ [ServiceMonitoringServiceClient](@ref ServiceMonitoringServiceClient-endpoint-snippet)
+ [UptimeCheckServiceClient](@ref UptimeCheckServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -145,4 +160,58 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AlertPolicyServiceClient-endpoint-snippet Override AlertPolicyServiceClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/alert_policy_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page DashboardsServiceClient-endpoint-snippet Override DashboardsServiceClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/dashboards_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page GroupServiceClient-endpoint-snippet Override GroupServiceClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/group_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page MetricServiceClient-endpoint-snippet Override MetricServiceClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/metric_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page MetricsScopesClient-endpoint-snippet Override MetricsScopesClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/metrics_scopes_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page NotificationChannelServiceClient-endpoint-snippet Override NotificationChannelServiceClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/notification_channel_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page QueryServiceClient-endpoint-snippet Override QueryServiceClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/query_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ServiceMonitoringServiceClient-endpoint-snippet Override ServiceMonitoringServiceClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/service_monitoring_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page UptimeCheckServiceClient-endpoint-snippet Override UptimeCheckServiceClient Endpoint Configuration
+
+@snippet google/cloud/monitoring/samples/uptime_check_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/networkconnectivity/doc/main.dox
+++ b/google/cloud/networkconnectivity/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `HubServiceClient`:
+
+@snippet hub_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -113,4 +117,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page HubServiceClient-endpoint-snippet Override HubServiceClient Endpoint Configuration
+
+@snippet google/cloud/networkconnectivity/samples/hub_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/networkmanagement/doc/main.dox
+++ b/google/cloud/networkmanagement/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ReachabilityServiceClient`:
+
+@snippet reachability_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ReachabilityServiceClient-endpoint-snippet Override ReachabilityServiceClient Endpoint Configuration
+
+@snippet google/cloud/networkmanagement/samples/reachability_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -97,6 +97,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ManagedNotebookServiceClient`:
+
+@snippet managed_notebook_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [ManagedNotebookServiceClient](@ref ManagedNotebookServiceClient-endpoint-snippet)
+ [NotebookServiceClient](@ref NotebookServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -116,4 +124,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ManagedNotebookServiceClient-endpoint-snippet Override ManagedNotebookServiceClient Endpoint Configuration
+
+@snippet google/cloud/notebooks/samples/managed_notebook_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page NotebookServiceClient-endpoint-snippet Override NotebookServiceClient Endpoint Configuration
+
+@snippet google/cloud/notebooks/samples/notebook_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/optimization/doc/main.dox
+++ b/google/cloud/optimization/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `FleetRoutingClient`:
+
+@snippet fleet_routing_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page FleetRoutingClient-endpoint-snippet Override FleetRoutingClient Endpoint Configuration
+
+@snippet google/cloud/optimization/samples/fleet_routing_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/orgpolicy/doc/main.dox
+++ b/google/cloud/orgpolicy/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `OrgPolicyClient`:
+
+@snippet org_policy_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page OrgPolicyClient-endpoint-snippet Override OrgPolicyClient Endpoint Configuration
+
+@snippet google/cloud/orgpolicy/samples/org_policy_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -97,6 +97,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AgentEndpointServiceClient`:
+
+@snippet agent_endpoint_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AgentEndpointServiceClient](@ref AgentEndpointServiceClient-endpoint-snippet)
+ [OsConfigServiceClient](@ref OsConfigServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -115,4 +123,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AgentEndpointServiceClient-endpoint-snippet Override AgentEndpointServiceClient Endpoint Configuration
+
+@snippet google/cloud/osconfig/samples/agent_endpoint_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page OsConfigServiceClient-endpoint-snippet Override OsConfigServiceClient Endpoint Configuration
+
+@snippet google/cloud/osconfig/samples/os_config_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/oslogin/doc/main.dox
+++ b/google/cloud/oslogin/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `OsLoginServiceClient`:
+
+@snippet os_login_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page OsLoginServiceClient-endpoint-snippet Override OsLoginServiceClient Endpoint Configuration
+
+@snippet google/cloud/oslogin/samples/os_login_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/policytroubleshooter/doc/main.dox
+++ b/google/cloud/policytroubleshooter/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `IamCheckerClient`:
+
+@snippet iam_checker_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page IamCheckerClient-endpoint-snippet Override IamCheckerClient Endpoint Configuration
+
+@snippet google/cloud/policytroubleshooter/samples/iam_checker_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/privateca/doc/main.dox
+++ b/google/cloud/privateca/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CertificateAuthorityServiceClient`:
+
+@snippet certificate_authority_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -113,4 +117,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CertificateAuthorityServiceClient-endpoint-snippet Override CertificateAuthorityServiceClient Endpoint Configuration
+
+@snippet google/cloud/privateca/samples/certificate_authority_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/profiler/doc/main.dox
+++ b/google/cloud/profiler/doc/main.dox
@@ -100,6 +100,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ProfilerServiceClient`:
+
+@snippet profiler_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -118,4 +122,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ProfilerServiceClient-endpoint-snippet Override ProfilerServiceClient Endpoint Configuration
+
+@snippet google/cloud/profiler/samples/profiler_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -99,6 +99,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `AdminServiceClient`:
+
+@snippet admin_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [AdminServiceClient](@ref AdminServiceClient-endpoint-snippet)
+ [TopicStatsServiceClient](@ref TopicStatsServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -116,4 +124,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page AdminServiceClient-endpoint-snippet Override AdminServiceClient Endpoint Configuration
+
+@snippet google/cloud/pubsublite/samples/admin_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page TopicStatsServiceClient-endpoint-snippet Override TopicStatsServiceClient Endpoint Configuration
+
+@snippet google/cloud/pubsublite/samples/topic_stats_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/recommender/doc/main.dox
+++ b/google/cloud/recommender/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `RecommenderClient`:
+
+@snippet recommender_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page RecommenderClient-endpoint-snippet Override RecommenderClient Endpoint Configuration
+
+@snippet google/cloud/recommender/samples/recommender_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/redis/doc/main.dox
+++ b/google/cloud/redis/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudRedisClient`:
+
+@snippet cloud_redis_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudRedisClient-endpoint-snippet Override CloudRedisClient Endpoint Configuration
+
+@snippet google/cloud/redis/samples/cloud_redis_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -101,6 +101,15 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `FoldersClient`:
+
+@snippet folders_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [FoldersClient](@ref FoldersClient-endpoint-snippet)
+ [OrganizationsClient](@ref OrganizationsClient-endpoint-snippet)
+ [ProjectsClient](@ref ProjectsClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -119,4 +128,22 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page FoldersClient-endpoint-snippet Override FoldersClient Endpoint Configuration
+
+@snippet google/cloud/resourcemanager/samples/folders_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page OrganizationsClient-endpoint-snippet Override OrganizationsClient Endpoint Configuration
+
+@snippet google/cloud/resourcemanager/samples/organizations_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ProjectsClient-endpoint-snippet Override ProjectsClient Endpoint Configuration
+
+@snippet google/cloud/resourcemanager/samples/projects_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/resourcesettings/doc/main.dox
+++ b/google/cloud/resourcesettings/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ResourceSettingsServiceClient`:
+
+@snippet resource_settings_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ResourceSettingsServiceClient-endpoint-snippet Override ResourceSettingsServiceClient Endpoint Configuration
+
+@snippet google/cloud/resourcesettings/samples/resource_settings_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -114,6 +114,18 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CatalogServiceClient`:
+
+@snippet catalog_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [CatalogServiceClient](@ref CatalogServiceClient-endpoint-snippet)
+ [CompletionServiceClient](@ref CompletionServiceClient-endpoint-snippet)
+ [PredictionServiceClient](@ref PredictionServiceClient-endpoint-snippet)
+ [ProductServiceClient](@ref ProductServiceClient-endpoint-snippet)
+ [SearchServiceClient](@ref SearchServiceClient-endpoint-snippet)
+ [UserEventServiceClient](@ref UserEventServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -132,4 +144,40 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CatalogServiceClient-endpoint-snippet Override CatalogServiceClient Endpoint Configuration
+
+@snippet google/cloud/retail/samples/catalog_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page CompletionServiceClient-endpoint-snippet Override CompletionServiceClient Endpoint Configuration
+
+@snippet google/cloud/retail/samples/completion_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page PredictionServiceClient-endpoint-snippet Override PredictionServiceClient Endpoint Configuration
+
+@snippet google/cloud/retail/samples/prediction_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ProductServiceClient-endpoint-snippet Override ProductServiceClient Endpoint Configuration
+
+@snippet google/cloud/retail/samples/product_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page SearchServiceClient-endpoint-snippet Override SearchServiceClient Endpoint Configuration
+
+@snippet google/cloud/retail/samples/search_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page UserEventServiceClient-endpoint-snippet Override UserEventServiceClient Endpoint Configuration
+
+@snippet google/cloud/retail/samples/user_event_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/run/doc/main.dox
+++ b/google/cloud/run/doc/main.dox
@@ -106,6 +106,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `RevisionsClient`:
+
+@snippet revisions_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [RevisionsClient](@ref RevisionsClient-endpoint-snippet)
+ [ServicesClient](@ref ServicesClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -124,4 +132,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page RevisionsClient-endpoint-snippet Override RevisionsClient Endpoint Configuration
+
+@snippet google/cloud/run/samples/revisions_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ServicesClient-endpoint-snippet Override ServicesClient Endpoint Configuration
+
+@snippet google/cloud/run/samples/services_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudSchedulerClient`:
+
+@snippet cloud_scheduler_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudSchedulerClient-endpoint-snippet Override CloudSchedulerClient Endpoint Configuration
+
+@snippet google/cloud/scheduler/samples/cloud_scheduler_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `SecretManagerServiceClient`:
+
+@snippet secret_manager_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page SecretManagerServiceClient-endpoint-snippet Override SecretManagerServiceClient Endpoint Configuration
+
+@snippet google/cloud/secretmanager/samples/secret_manager_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/securitycenter/doc/main.dox
+++ b/google/cloud/securitycenter/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `SecurityCenterClient`:
+
+@snippet security_center_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page SecurityCenterClient-endpoint-snippet Override SecurityCenterClient Endpoint Configuration
+
+@snippet google/cloud/securitycenter/samples/security_center_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/servicecontrol/doc/main.dox
+++ b/google/cloud/servicecontrol/doc/main.dox
@@ -97,6 +97,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `QuotaControllerClient`:
+
+@snippet quota_controller_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [QuotaControllerClient](@ref QuotaControllerClient-endpoint-snippet)
+ [ServiceControllerClient](@ref ServiceControllerClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -115,4 +123,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page QuotaControllerClient-endpoint-snippet Override QuotaControllerClient Endpoint Configuration
+
+@snippet google/cloud/servicecontrol/samples/quota_controller_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ServiceControllerClient-endpoint-snippet Override ServiceControllerClient Endpoint Configuration
+
+@snippet google/cloud/servicecontrol/samples/service_controller_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/servicedirectory/doc/main.dox
+++ b/google/cloud/servicedirectory/doc/main.dox
@@ -97,6 +97,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `LookupServiceClient`:
+
+@snippet lookup_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [LookupServiceClient](@ref LookupServiceClient-endpoint-snippet)
+ [RegistrationServiceClient](@ref RegistrationServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -115,4 +123,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page LookupServiceClient-endpoint-snippet Override LookupServiceClient Endpoint Configuration
+
+@snippet google/cloud/servicedirectory/samples/lookup_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page RegistrationServiceClient-endpoint-snippet Override RegistrationServiceClient Endpoint Configuration
+
+@snippet google/cloud/servicedirectory/samples/registration_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/servicemanagement/doc/main.dox
+++ b/google/cloud/servicemanagement/doc/main.dox
@@ -91,6 +91,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ServiceManagerClient`:
+
+@snippet service_manager_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -109,4 +113,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ServiceManagerClient-endpoint-snippet Override ServiceManagerClient Endpoint Configuration
+
+@snippet google/cloud/servicemanagement/samples/service_manager_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/serviceusage/doc/main.dox
+++ b/google/cloud/serviceusage/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ServiceUsageClient`:
+
+@snippet service_usage_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ServiceUsageClient-endpoint-snippet Override ServiceUsageClient Endpoint Configuration
+
+@snippet google/cloud/serviceusage/samples/service_usage_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/shell/doc/main.dox
+++ b/google/cloud/shell/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudShellServiceClient`:
+
+@snippet cloud_shell_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudShellServiceClient-endpoint-snippet Override CloudShellServiceClient Endpoint Configuration
+
+@snippet google/cloud/shell/samples/cloud_shell_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `SpeechClient`:
+
+@snippet speech_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page SpeechClient-endpoint-snippet Override SpeechClient Endpoint Configuration
+
+@snippet google/cloud/speech/samples/speech_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/storagetransfer/doc/main.dox
+++ b/google/cloud/storagetransfer/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `StorageTransferServiceClient`:
+
+@snippet storage_transfer_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page StorageTransferServiceClient-endpoint-snippet Override StorageTransferServiceClient Endpoint Configuration
+
+@snippet google/cloud/storagetransfer/samples/storage_transfer_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/talent/doc/main.dox
+++ b/google/cloud/talent/doc/main.dox
@@ -109,6 +109,17 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CompanyServiceClient`:
+
+@snippet company_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [CompanyServiceClient](@ref CompanyServiceClient-endpoint-snippet)
+ [CompletionClient](@ref CompletionClient-endpoint-snippet)
+ [EventServiceClient](@ref EventServiceClient-endpoint-snippet)
+ [JobServiceClient](@ref JobServiceClient-endpoint-snippet)
+ [TenantServiceClient](@ref TenantServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -127,4 +138,34 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CompanyServiceClient-endpoint-snippet Override CompanyServiceClient Endpoint Configuration
+
+@snippet google/cloud/talent/samples/company_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page CompletionClient-endpoint-snippet Override CompletionClient Endpoint Configuration
+
+@snippet google/cloud/talent/samples/completion_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page EventServiceClient-endpoint-snippet Override EventServiceClient Endpoint Configuration
+
+@snippet google/cloud/talent/samples/event_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page JobServiceClient-endpoint-snippet Override JobServiceClient Endpoint Configuration
+
+@snippet google/cloud/talent/samples/job_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page TenantServiceClient-endpoint-snippet Override TenantServiceClient Endpoint Configuration
+
+@snippet google/cloud/talent/samples/tenant_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `CloudTasksClient`:
+
+@snippet cloud_tasks_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page CloudTasksClient-endpoint-snippet Override CloudTasksClient Endpoint Configuration
+
+@snippet google/cloud/tasks/samples/cloud_tasks_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/texttospeech/doc/main.dox
+++ b/google/cloud/texttospeech/doc/main.dox
@@ -93,6 +93,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `TextToSpeechClient`:
+
+@snippet text_to_speech_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page TextToSpeechClient-endpoint-snippet Override TextToSpeechClient Endpoint Configuration
+
+@snippet google/cloud/texttospeech/samples/text_to_speech_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `TpuClient`:
+
+@snippet tpu_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page TpuClient-endpoint-snippet Override TpuClient Endpoint Configuration
+
+@snippet google/cloud/tpu/samples/tpu_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/trace/doc/main.dox
+++ b/google/cloud/trace/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `TraceServiceClient`:
+
+@snippet trace_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -113,4 +117,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page TraceServiceClient-endpoint-snippet Override TraceServiceClient Endpoint Configuration
+
+@snippet google/cloud/trace/samples/trace_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/translate/doc/main.dox
+++ b/google/cloud/translate/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `TranslationServiceClient`:
+
+@snippet translation_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page TranslationServiceClient-endpoint-snippet Override TranslationServiceClient Endpoint Configuration
+
+@snippet google/cloud/translate/samples/translation_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/video/doc/main.dox
+++ b/google/cloud/video/doc/main.dox
@@ -108,6 +108,15 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `LivestreamServiceClient`:
+
+@snippet livestream_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [LivestreamServiceClient](@ref LivestreamServiceClient-endpoint-snippet)
+ [TranscoderServiceClient](@ref TranscoderServiceClient-endpoint-snippet)
+ [VideoStitcherServiceClient](@ref VideoStitcherServiceClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -128,4 +137,22 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page LivestreamServiceClient-endpoint-snippet Override LivestreamServiceClient Endpoint Configuration
+
+@snippet google/cloud/video/samples/livestream_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page TranscoderServiceClient-endpoint-snippet Override TranscoderServiceClient Endpoint Configuration
+
+@snippet google/cloud/video/samples/transcoder_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page VideoStitcherServiceClient-endpoint-snippet Override VideoStitcherServiceClient Endpoint Configuration
+
+@snippet google/cloud/video/samples/video_stitcher_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/videointelligence/doc/main.dox
+++ b/google/cloud/videointelligence/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `VideoIntelligenceServiceClient`:
+
+@snippet video_intelligence_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page VideoIntelligenceServiceClient-endpoint-snippet Override VideoIntelligenceServiceClient Endpoint Configuration
+
+@snippet google/cloud/videointelligence/samples/video_intelligence_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -98,6 +98,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ImageAnnotatorClient`:
+
+@snippet image_annotator_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [ImageAnnotatorClient](@ref ImageAnnotatorClient-endpoint-snippet)
+ [ProductSearchClient](@ref ProductSearchClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -116,4 +124,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ImageAnnotatorClient-endpoint-snippet Override ImageAnnotatorClient Endpoint Configuration
+
+@snippet google/cloud/vision/samples/image_annotator_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page ProductSearchClient-endpoint-snippet Override ProductSearchClient Endpoint Configuration
+
+@snippet google/cloud/vision/samples/product_search_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/vmmigration/doc/main.dox
+++ b/google/cloud/vmmigration/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `VmMigrationClient`:
+
+@snippet vm_migration_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page VmMigrationClient-endpoint-snippet Override VmMigrationClient Endpoint Configuration
+
+@snippet google/cloud/vmmigration/samples/vm_migration_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/vpcaccess/doc/main.dox
+++ b/google/cloud/vpcaccess/doc/main.dox
@@ -92,6 +92,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `VpcAccessServiceClient`:
+
+@snippet vpc_access_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -110,4 +114,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page VpcAccessServiceClient-endpoint-snippet Override VpcAccessServiceClient Endpoint Configuration
+
+@snippet google/cloud/vpcaccess/samples/vpc_access_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -94,6 +94,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `WebRiskServiceClient`:
+
+@snippet web_risk_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -111,4 +115,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page WebRiskServiceClient-endpoint-snippet Override WebRiskServiceClient Endpoint Configuration
+
+@snippet google/cloud/webrisk/samples/web_risk_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -95,6 +95,10 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `WebSecurityScannerClient`:
+
+@snippet web_security_scanner_client_samples.cc set-client-endpoint
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -112,4 +116,10 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page WebSecurityScannerClient-endpoint-snippet Override WebSecurityScannerClient Endpoint Configuration
+
+@snippet google/cloud/websecurityscanner/samples/web_security_scanner_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -98,6 +98,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
+For example, this will override the default endpoint for `ExecutionsClient`:
+
+@snippet executions_client_samples.cc set-client-endpoint
+
+Follow these links to find examples for other \c *Client classes:
+ [ExecutionsClient](@ref ExecutionsClient-endpoint-snippet)
+ [WorkflowsClient](@ref WorkflowsClient-endpoint-snippet)
+
 <!-- inject-endpoint-snippet-end -->
 
 ## Retry, Backoff, and Idempotency Policies.
@@ -115,4 +123,16 @@ can override the default policies.
 */
 
 // <!-- inject-endpoint-pages-start -->
+
+/*! @page ExecutionsClient-endpoint-snippet Override ExecutionsClient Endpoint Configuration
+
+@snippet google/cloud/workflows/samples/executions_client_samples.cc set-client-endpoint
+
+*/
+
+/*! @page WorkflowsClient-endpoint-snippet Override WorkflowsClient Endpoint Configuration
+
+@snippet google/cloud/workflows/samples/workflows_client_samples.cc set-client-endpoint
+
+*/
 // <!-- inject-endpoint-pages-end -->


### PR DESCRIPTION
Modify the landing pages for all the generated libraries to include a
snippet showing how to override the endpoint for the `*Client`.

In libraries where there is more than one `*Client` injecting a
snippet for each `*Client` looked too cluttered. The script injects the
first (in alphabetical order) snippet into the landing page. The
remaining snippets are referenced from that page, but are in
separate pages.

Part of the work for #10114 

The main page for a service now looks like this (click on the image to embiggen):

![image](https://user-images.githubusercontent.com/6241635/198844014-c6544c41-5f97-44a6-816f-1335dc2156b0.png)

While each one of the referenced pages looks like this:

![image](https://user-images.githubusercontent.com/6241635/198844023-16c1e5ab-85ba-4d10-85ea-218f0060c23c.png)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10129)
<!-- Reviewable:end -->
