### PR TITLE
impl(pubsub): use the pubsub::PubsubMessageDataType type alias

### DIFF
--- a/google/cloud/pubsub/samples/mock_subscriber.cc
+++ b/google/cloud/pubsub/samples/mock_subscriber.cc
@@ -82,7 +82,7 @@ TEST(MockSubscribeExample, Subscribe) {
   //! [create-client]
 
   //! [client-call]
-  std::vector<std::string> payloads;
+  std::vector<pubsub::PubsubMessageDataType> payloads;
   auto handler = [&](pubsub::Message const& m, pubsub::AckHandler h) {
     payloads.push_back(m.data());
     std::move(h).ack();
@@ -148,7 +148,7 @@ TEST(MockSubscribeExample, ExactlyOnceSubscribe) {
 
   pubsub::Subscriber subscriber(mock);
 
-  std::vector<std::string> payloads;
+  std::vector<pubsub::PubsubMessageDataType> payloads;
   auto callback = [&](pubsub::Message const& m,
                       pubsub::ExactlyOnceAckHandler h) {
     payloads.push_back(m.data());

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/samples/pubsub_samples_common.h"
+#include "google/cloud/pubsub/samples/samples.pb.h"
 #include "google/cloud/pubsub/schema_admin_client.h"
 #include "google/cloud/pubsub/subscriber.h"
 #include "google/cloud/pubsub/subscription_admin_client.h"
@@ -21,7 +22,6 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/example_driver.h"
-#include <google/cloud/pubsub/samples/samples.pb.h>
 #include <condition_variable>
 #include <mutex>
 #include <tuple>
@@ -1149,7 +1149,7 @@ google::cloud::future<google::cloud::Status> SubscribeProtobufRecords(
     auto session = subscriber.Subscribe(
         [](pubsub::Message const& m, pubsub::AckHandler h) {
           google::cloud::pubsub::samples::State state;
-          state.ParseFromString(m.data());
+          state.ParseFromString(std::string{m.data()});
           std::cout << "Message contents: " << state.DebugString() << "\n";
           std::move(h).ack();
         });


### PR DESCRIPTION
Allow for `pubsub::Message::data()` to return a type that isn't exactly `std::string`, but is explicitly convertible to it.

Also tweak the bracketing for a `#include`.

Both of these make it easier for a downstream user of the code to adapt it to a different environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10135)
<!-- Reviewable:end -->
