### PR TITLE
doc(pubsub): samples for endpoint and auth

### DIFF
--- a/google/cloud/pubsub/doc/pubsub-main.dox
+++ b/google/cloud/pubsub/doc/pubsub-main.dox
@@ -50,11 +50,7 @@ the Cloud Pub/Sub C++ client library API.
 @include quickstart.cc
 @endparblock
 
-## API Notes
-
-The following are general notes about using the library.
-
-### Environment Variables
+## Environment Variables
 
 There are several environment variables that can be set to configure certain
 behaviors in the library.
@@ -112,6 +108,40 @@ there is no value.
 @par Example
 @snippet samples.cc example-status-or
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.  For example, this will override the default
+endpoint for `google::cloud::pubsub::Publisher`:
+
+@snippet client_samples.cc publisher-set-endpoint
+
+Follow these links for additional examples
+ [Subscriber](@ref Subscriber-endpoint-snippet)
+ [BlockingPublisher](@ref BlockingPublisher-endpoint-snippet)
+ [TopicAdminClient](@ref TopicAdminClient-endpoint-snippet)
+ [SubscriptionAdminClient](@ref SubscriptionAdminClient-endpoint-snippet)
+ [SchemaAdminClient](@ref SchemaAdminClient-endpoint-snippet)
+ [Publisher](@ref Publisher-endpoint-snippet)
+
+## Override the authentication configuration
+
+In some cases, you may need to override the default authentication credentials
+used by the client library. Use the `google::cloud::UnifiedCredentialsOption`
+when initializing the client library to change the default.  For example, this
+will override the default to use a service account key file:
+
+@snippet client_samples.cc publisher-service-account
+
+Follow these links for additional examples
+ [Subscriber](@ref Subscriber-service-account-snippet)
+ [BlockingPublisher](@ref BlockingPublisher-service-account-snippet)
+ [TopicAdminClient](@ref TopicAdminClient-service-account-snippet)
+ [SubscriptionAdminClient](@ref SubscriptionAdminClient-service-account-snippet)
+ [SchemaAdminClient](@ref SchemaAdminClient-service-account-snippet)
+ [Publisher](@ref Publisher-service-account-snippet)
+
 ## Next Steps
 
 - @ref publisher-mock
@@ -124,5 +154,79 @@ there is no value.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 [quickstart-link]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/pubsub/quickstart
 [status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
+
+*/
+
+/*! @page Publisher-endpoint-snippet Override @c Publisher Default Endpoint
+
+@snippet google/cloud/pubsub/samples/client_samples.cc publisher-set-endpoint
+
+*/
+
+/*! @page Subscriber-endpoint-snippet Override @c Subscriber Default Endpoint
+
+@snippet google/cloud/pubsub/samples/client_samples.cc subscriber-set-endpoint
+
+*/
+
+/*! @page BlockingPublisher-endpoint-snippet Override @c BlockingPublisher Default Endpoint
+
+@snippet google/cloud/pubsub/samples/client_samples.cc blocking-publisher-set-endpoint
+
+*/
+
+/*! @page TopicAdminClient-endpoint-snippet Override @c TopicAdminClient Default Endpoint
+
+@snippet google/cloud/pubsub/samples/client_samples.cc topic-admin-client-set-endpoint
+
+*/
+
+/*! @page SubscriptionAdminClient-endpoint-snippet Override @c SubscriptionAdminClient Default Endpoint
+
+@snippet google/cloud/pubsub/samples/client_samples.cc schema-admin-client-set-endpoint
+
+*/
+
+/*! @page SchemaAdminClient-endpoint-snippet Override @c SchemaAdminClient Default Endpoint
+
+@snippet google/cloud/pubsub/samples/client_samples.cc schema-admin-client-set-endpoint
+
+*/
+
+
+
+/*! @page Publisher-service-account-snippet Override @c Publisher Default Authentication
+
+@snippet google/cloud/pubsub/samples/client_samples.cc publisher-service-account
+
+*/
+
+/*! @page Subscriber-service-account-snippet Override @c Subscriber Default Authentication
+
+@snippet google/cloud/pubsub/samples/client_samples.cc subscriber-service-account
+
+*/
+
+/*! @page BlockingPublisher-service-account-snippet Override @c BlockingPublisher Default Authentication
+
+@snippet google/cloud/pubsub/samples/client_samples.cc blocking-publisher-service-account
+
+*/
+
+/*! @page TopicAdminClient-service-account-snippet Override @c TopicAdminClient Default Authentication
+
+@snippet google/cloud/pubsub/samples/client_samples.cc topic-admin-client-service-account
+
+*/
+
+/*! @page SubscriptionAdminClient-service-account-snippet Override @c SubscriptionAdminClient Default Authentication
+
+@snippet google/cloud/pubsub/samples/client_samples.cc schema-admin-client-service-account
+
+*/
+
+/*! @page SchemaAdminClient-service-account-snippet Override @c SchemaAdminClient Default Authentication
+
+@snippet google/cloud/pubsub/samples/client_samples.cc schema-admin-client-service-account
 
 */

--- a/google/cloud/pubsub/samples/CMakeLists.txt
+++ b/google/cloud/pubsub/samples/CMakeLists.txt
@@ -57,8 +57,9 @@ endforeach ()
 export_list_to_bazel("pubsub_samples_unit_tests.bzl"
                      "pubsub_samples_unit_tests" YEAR "2020")
 
-set(pubsub_client_integration_samples # cmake-format: sort
-                                      blocking_samples.cc samples.cc)
+set(pubsub_client_integration_samples
+    # cmake-format: sort
+    blocking_samples.cc client_samples.cc samples.cc)
 if (TARGET google-cloud-cpp::iam)
     list(APPEND pubsub_client_integration_samples iam_samples.cc)
 endif ()

--- a/google/cloud/pubsub/samples/client_samples.cc
+++ b/google/cloud/pubsub/samples/client_samples.cc
@@ -39,9 +39,7 @@ void PublisherSetEndpoint(std::vector<std::string> const& argv) {
   }
   //! [publisher-set-endpoint]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   [](std::string project_id, std::string topic_id) {
     auto topic = pubsub::Topic(std::move(project_id), std::move(topic_id));
     return pubsub::Publisher(pubsub::MakePublisherConnection(
@@ -60,9 +58,7 @@ void PublisherServiceAccountKey(std::vector<std::string> const& argv) {
   }
   //! [publisher-service-account]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   [](std::string project_id, std::string topic_id, std::string const& keyfile) {
     auto is = std::ifstream(keyfile);
     is.exceptions(std::ios::badbit);
@@ -85,9 +81,7 @@ void SubscriberSetEndpoint(std::vector<std::string> const& argv) {
   }
   //! [subscriber-set-endpoint]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   [](std::string project_id, std::string subscription_id) {
     auto subscription =
         pubsub::Subscription(std::move(project_id), std::move(subscription_id));
@@ -107,9 +101,7 @@ void SubscriberServiceAccountKey(std::vector<std::string> const& argv) {
   }
   //! [subscriber-service-account]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   [](std::string project_id, std::string subscription_id,
      std::string const& keyfile) {
     auto is = std::ifstream(keyfile);
@@ -133,9 +125,7 @@ void BlockingPublisherSetEndpoint(std::vector<std::string> const& argv) {
   }
   //! [blocking-publisher-set-endpoint]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   []() {
     return pubsub::BlockingPublisher(pubsub::MakeBlockingPublisherConnection(
         Options{}.set<google::cloud::EndpointOption>(
@@ -152,9 +142,7 @@ void BlockingPublisherServiceAccountKey(std::vector<std::string> const& argv) {
   }
   //! [blocking-publisher-service-account]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   [](std::string const& keyfile) {
     auto is = std::ifstream(keyfile);
     is.exceptions(std::ios::badbit);
@@ -174,9 +162,7 @@ void TopicAdminClientSetEndpoint(std::vector<std::string> const& argv) {
   }
   //! [topic-admin-client-set-endpoint]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   []() {
     return pubsub::TopicAdminClient(pubsub::MakeTopicAdminConnection(
         Options{}.set<google::cloud::EndpointOption>(
@@ -193,9 +179,7 @@ void TopicAdminClientServiceAccountKey(std::vector<std::string> const& argv) {
   }
   //! [topic-admin-client-service-account]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   [](std::string const& keyfile) {
     auto is = std::ifstream(keyfile);
     is.exceptions(std::ios::badbit);
@@ -216,9 +200,7 @@ void SubscriptionAdminClientSetEndpoint(std::vector<std::string> const& argv) {
   }
   //! [subscription-admin-client-set-endpoint]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   []() {
     return pubsub::SubscriptionAdminClient(
         pubsub::MakeSubscriptionAdminConnection(
@@ -238,9 +220,7 @@ void SubscriptionAdminClientServiceAccountKey(
   }
   //! [subscription-admin-client-service-account]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   [](std::string const& keyfile) {
     auto is = std::ifstream(keyfile);
     is.exceptions(std::ios::badbit);
@@ -261,9 +241,7 @@ void SchemaAdminClientSetEndpoint(std::vector<std::string> const& argv) {
   }
   //! [schema-admin-client-set-endpoint]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   []() {
     return pubsub::SchemaAdminClient(pubsub::MakeSchemaAdminConnection(
         Options{}.set<google::cloud::EndpointOption>(
@@ -280,9 +258,7 @@ void SchemaAdminClientServiceAccountKey(std::vector<std::string> const& argv) {
   }
   //! [schema-admin-client-service-account]
   namespace pubsub = ::google::cloud::pubsub;
-  using ::google::cloud::future;
   using ::google::cloud::Options;
-  using ::google::cloud::StatusOr;
   [](std::string const& keyfile) {
     auto is = std::ifstream(keyfile);
     is.exceptions(std::ios::badbit);

--- a/google/cloud/pubsub/samples/client_samples.cc
+++ b/google/cloud/pubsub/samples/client_samples.cc
@@ -1,0 +1,375 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/blocking_publisher.h"
+#include "google/cloud/pubsub/samples/pubsub_samples_common.h"
+#include "google/cloud/pubsub/schema_admin_client.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/pubsub/subscription_admin_client.h"
+#include "google/cloud/pubsub/subscription_builder.h"
+#include "google/cloud/pubsub/topic_admin_client.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using ::google::cloud::internal::GetEnv;
+using ::google::cloud::pubsub::examples::RandomSubscriptionId;
+using ::google::cloud::pubsub::examples::RandomTopicId;
+
+void PublisherSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 2) {
+    throw examples::Usage{"publisher-set-endpoint <project-id> <topic-id>"};
+  }
+  //! [publisher-set-endpoint]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  [](std::string project_id, std::string topic_id) {
+    auto topic = pubsub::Topic(std::move(project_id), std::move(topic_id));
+    return pubsub::Publisher(pubsub::MakePublisherConnection(
+        std::move(topic), Options{}.set<google::cloud::EndpointOption>(
+                              "private.googleapis.com")));
+  }
+  //! [publisher-set-endpoint]
+  (argv.at(0), argv.at(1));
+}
+
+void PublisherServiceAccountKey(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 3) {
+    throw examples::Usage{
+        "publisher-service-account <project-id> <topic-id> <keyfile>"};
+  }
+  //! [publisher-service-account]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  [](std::string project_id, std::string topic_id, std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto topic = pubsub::Topic(std::move(project_id), std::move(topic_id));
+    return pubsub::Publisher(pubsub::MakePublisherConnection(
+        std::move(topic),
+        Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents))));
+  }
+  //! [publisher-service-account]
+  (argv.at(0), argv.at(1), argv.at(2));
+}
+
+void SubscriberSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 2) {
+    throw examples::Usage{
+        "subscriber-set-endpoint <project-id> <subscription-id>"};
+  }
+  //! [subscriber-set-endpoint]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  [](std::string project_id, std::string subscription_id) {
+    auto subscription =
+        pubsub::Subscription(std::move(project_id), std::move(subscription_id));
+    return pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+        std::move(subscription), Options{}.set<google::cloud::EndpointOption>(
+                                     "private.googleapis.com")));
+  }
+  //! [subscriber-set-endpoint]
+  (argv.at(0), argv.at(1));
+}
+
+void SubscriberServiceAccountKey(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 3) {
+    throw examples::Usage{
+        "subscriber-service-account <project-id> <subscription-id> <keyfile>"};
+  }
+  //! [subscriber-service-account]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  [](std::string project_id, std::string subscription_id,
+     std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto subscription =
+        pubsub::Subscription(std::move(project_id), std::move(subscription_id));
+    return pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+        std::move(subscription),
+        Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents))));
+  }
+  //! [subscriber-service-account]
+  (argv.at(0), argv.at(1), argv.at(2));
+}
+
+void BlockingPublisherSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (!argv.empty()) {
+    throw examples::Usage{"blocking-publisher-set-endpoint"};
+  }
+  //! [blocking-publisher-set-endpoint]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  []() {
+    return pubsub::BlockingPublisher(pubsub::MakeBlockingPublisherConnection(
+        Options{}.set<google::cloud::EndpointOption>(
+            "private.googleapis.com")));
+  }
+  //! [blocking-publisher-set-endpoint]
+  ();
+}
+
+void BlockingPublisherServiceAccountKey(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw examples::Usage{"blocking-publisher-service-account <keyfile>"};
+  }
+  //! [blocking-publisher-service-account]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    return pubsub::BlockingPublisher(pubsub::MakeBlockingPublisherConnection(
+        Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents))));
+  }
+  //! [blocking-publisher-service-account]
+  (argv.at(0));
+}
+
+void TopicAdminClientSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (!argv.empty()) {
+    throw examples::Usage{"topic-admin-client-set-endpoint"};
+  }
+  //! [topic-admin-client-set-endpoint]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  []() {
+    return pubsub::TopicAdminClient(pubsub::MakeTopicAdminConnection(
+        Options{}.set<google::cloud::EndpointOption>(
+            "private.googleapis.com")));
+  }
+  //! [topic-admin-client-set-endpoint]
+  ();
+}
+
+void TopicAdminClientServiceAccountKey(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw examples::Usage{"topic-admin-client-service-account <keyfile>"};
+  }
+  //! [topic-admin-client-service-account]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    std::cerr << "DEBUG\n" << keyfile << "\nDEBUG\n";
+    return pubsub::TopicAdminClient(pubsub::MakeTopicAdminConnection(
+        Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents))));
+  }
+  //! [topic-admin-client-service-account]
+  (argv.at(0));
+}
+
+void SubscriptionAdminClientSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (!argv.empty()) {
+    throw examples::Usage{"subscription-admin-client-set-endpoint"};
+  }
+  //! [subscription-admin-client-set-endpoint]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  []() {
+    return pubsub::SubscriptionAdminClient(
+        pubsub::MakeSubscriptionAdminConnection(
+            Options{}.set<google::cloud::EndpointOption>(
+                "private.googleapis.com")));
+  }
+  //! [subscription-admin-client-set-endpoint]
+  ();
+}
+
+void SubscriptionAdminClientServiceAccountKey(
+    std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw examples::Usage{
+        "subscription-admin-client-service-account <keyfile>"};
+  }
+  //! [subscription-admin-client-service-account]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    return pubsub::SubscriptionAdminClient(
+        pubsub::MakeSubscriptionAdminConnection(
+            Options{}.set<google::cloud::UnifiedCredentialsOption>(
+                google::cloud::MakeServiceAccountCredentials(contents))));
+  }
+  //! [subscription-admin-client-service-account]
+  (argv.at(0));
+}
+
+void SchemaAdminClientSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (!argv.empty()) {
+    throw examples::Usage{"schema-admin-client-set-endpoint"};
+  }
+  //! [schema-admin-client-set-endpoint]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  []() {
+    return pubsub::SchemaAdminClient(pubsub::MakeSchemaAdminConnection(
+        Options{}.set<google::cloud::EndpointOption>(
+            "private.googleapis.com")));
+  }
+  //! [schema-admin-client-set-endpoint]
+  ();
+}
+
+void SchemaAdminClientServiceAccountKey(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw examples::Usage{"schema-admin-client-service-account <keyfile>"};
+  }
+  //! [schema-admin-client-service-account]
+  namespace pubsub = ::google::cloud::pubsub;
+  using ::google::cloud::future;
+  using ::google::cloud::Options;
+  using ::google::cloud::StatusOr;
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    return pubsub::SchemaAdminClient(pubsub::MakeSchemaAdminConnection(
+        Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents))));
+  }
+  //! [schema-admin-client-service-account]
+  (argv.at(0));
+}
+
+void AutoRun(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE",
+  });
+  auto project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value();
+  auto keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
+
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+  auto const topic_id = RandomTopicId(generator);
+  auto const subscription_id = RandomSubscriptionId(generator);
+
+  std::cout << "\nRunning PublisherSetEndpoint() sample" << std::endl;
+  PublisherSetEndpoint({project_id, topic_id});
+
+  std::cout << "\nRunning PublisherServiceAccountKey() sample" << std::endl;
+  PublisherServiceAccountKey({project_id, topic_id, keyfile});
+
+  std::cout << "\nRunning SubscriberSetEndpoint() sample" << std::endl;
+  SubscriberSetEndpoint({project_id, subscription_id});
+
+  std::cout << "\nRunning SubscriberServiceAccountKey() sample" << std::endl;
+  SubscriberServiceAccountKey({project_id, subscription_id, keyfile});
+
+  std::cout << "\nRunning BlockingPublisherSetEndpoint() sample" << std::endl;
+  BlockingPublisherSetEndpoint({});
+
+  std::cout << "\nRunning BlockingPublisherServiceAccountKey() sample"
+            << std::endl;
+  BlockingPublisherServiceAccountKey({keyfile});
+
+  std::cout << "\nRunning SubscriptionAdminClientSetEndpoint() sample"
+            << std::endl;
+  SubscriptionAdminClientSetEndpoint({});
+
+  std::cout << "\nRunning SubscriptionAdminClientServiceAccountKey() sample"
+            << std::endl;
+  SubscriptionAdminClientServiceAccountKey({keyfile});
+
+  std::cout << "\nRunning SchemaAdminClientSetEndpoint() sample" << std::endl;
+  SchemaAdminClientSetEndpoint({});
+
+  std::cout << "\nRunning SchemaAdminClientServiceAccountKey() sample"
+            << std::endl;
+  SchemaAdminClientServiceAccountKey({keyfile});
+
+  std::cout << "\nAutoRun done" << std::endl;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+  google::cloud::testing_util::Example example({
+      {"publisher-set-endpoint", PublisherSetEndpoint},
+      {"publisher-service-account-key", PublisherServiceAccountKey},
+      {"subscriber-set-endpoint", SubscriberSetEndpoint},
+      {"subscriber-service-account-key", SubscriberServiceAccountKey},
+      {"blocking-publisher-set-endpoint", BlockingPublisherSetEndpoint},
+      {"blocking-publisher-service-account-key",
+       BlockingPublisherServiceAccountKey},
+      {"topic-admin-client-set-endpoint", TopicAdminClientSetEndpoint},
+      {"topic-admin-client-service-account-key",
+       TopicAdminClientServiceAccountKey},
+      {"subscription-admin-client-set-endpoint",
+       SubscriptionAdminClientSetEndpoint},
+      {"subscription-admin-client-service-account-key",
+       SubscriptionAdminClientServiceAccountKey},
+      {"schema-admin-client-set-endpoint", SchemaAdminClientSetEndpoint},
+      {"schema-admin-client-service-account-key",
+       SchemaAdminClientServiceAccountKey},
+      {"auto", AutoRun},
+  });
+  return example.Run(argc, argv);
+}

--- a/google/cloud/pubsub/samples/client_samples.cc
+++ b/google/cloud/pubsub/samples/client_samples.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/example_driver.h"
 #include <fstream>
 #include <string>
 #include <vector>

--- a/google/cloud/pubsub/samples/pubsub_client_integration_samples.bzl
+++ b/google/cloud/pubsub/samples/pubsub_client_integration_samples.bzl
@@ -18,6 +18,7 @@
 
 pubsub_client_integration_samples = [
     "blocking_samples.cc",
+    "client_samples.cc",
     "samples.cc",
     "iam_samples.cc",
 ]


### PR DESCRIPTION
For each `*Client` class add an examples showing how to override the default endpoint and authentication credentials. Reference these examples from the landing page, as this is one of the most common questions for the client libraries.

Fixes #10133 and fixes #10132

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10136)
<!-- Reviewable:end -->
