### PR TITLE
doc: workaround Doxygen formatting quirk

### DIFF
--- a/google/cloud/baremetalsolution/doc/main.dox
+++ b/google/cloud/baremetalsolution/doc/main.dox
@@ -6,8 +6,7 @@ An idiomatic C++ client library for the [Bare Metal Solution API][cloud-service-
 a service that provides ways to manage Bare Metal Solution hardware installed in
 a regional extension located near a Google Cloud data center.
 
-While this library is **GA**, please note Google Cloud C++ client libraries do
-**not** follow [Semantic Versioning](https://semver.org/).
+While this library is **GA**, please note Google Cloud C++ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 This library requires a C++14 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The [README][github-readme]

--- a/google/cloud/beyondcorp/doc/main.dox
+++ b/google/cloud/beyondcorp/doc/main.dox
@@ -8,8 +8,7 @@ resources and enables zero-trust access. Using the BeyondCorp Enterprise APIs,
 enterprises can set up multi-cloud and on-prem connectivity using the App
 Connector hybrid connectivity solution.
 
-While this library is **GA**, please note Google Cloud C++ client libraries do
-**not** follow [Semantic Versioning](https://semver.org/).
+While this library is **GA**, please note Google Cloud C++ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 This library requires a C++14 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The [README][github-readme]

--- a/google/cloud/optimization/doc/main.dox
+++ b/google/cloud/optimization/doc/main.dox
@@ -6,8 +6,7 @@ This directory contains an idiomatic C++ client library for the
 [Cloud Optimization API][cloud-service-docs], a service that provides a
 portfolio of solvers to address common optimization use cases.
 
-While this library is **GA**, please note Google Cloud C++ client libraries do
-**not** follow [Semantic Versioning](https://semver.org/).
+While this library is **GA**, please note Google Cloud C++ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 This library requires a C++14 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The [README][github-readme]

--- a/google/cloud/run/doc/main.dox
+++ b/google/cloud/run/doc/main.dox
@@ -14,8 +14,7 @@ actually deploy a C++ function to Cloud Run, see the
 [hello-world]: https://github.com/GoogleCloudPlatform/cpp-samples/tree/main/cloud-run-hello-world
 [functions-framework]: https://github.com/GoogleCloudPlatform/functions-framework-cpp
 
-While this library is **GA**, please note Google Cloud C++ client libraries do
-**not** follow [Semantic Versioning](https://semver.org/).
+While this library is **GA**, please note Google Cloud C++ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 This library requires a C++14 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The [README][github-readme]

--- a/google/cloud/video/doc/main.dox
+++ b/google/cloud/video/doc/main.dox
@@ -12,8 +12,7 @@ An idiomatic C++ client library for video services, including:
   servers to dynamically insert ads into video-on-demand and live streams for
   your users.
 
-While this library is **GA**, please note Google Cloud C++ client libraries do
-**not** follow [Semantic Versioning](https://semver.org/).
+While this library is **GA**, please note Google Cloud C++ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 This library requires a C++14 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The [README][github-readme]


### PR DESCRIPTION
Doxygen interprets `**` at the beginning of the line as part of a Doxygen comment block.  In these cases we wanted to interpret this as a `**not**`, i.e., bold the word. There may be better solutions, but this is a quick fix to get the formatting right.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10137)
<!-- Reviewable:end -->
