### PR TITLE
feat(generator): generate authentication example

### DIFF
--- a/generator/integration_tests/golden/samples/golden_kitchen_sink_client_samples.cc
+++ b/generator/integration_tests/golden/samples/golden_kitchen_sink_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "generator/integration_tests/golden/golden_kitchen_sink_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: GoldenKitchenSinkClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::golden::GoldenKitchenSinkClient(
       google::cloud::golden::MakeGoldenKitchenSinkConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: GoldenKitchenSinkClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::golden::GoldenKitchenSinkClient(
+        google::cloud::golden::MakeGoldenKitchenSinkConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+    "GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"
+  });
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/generator/integration_tests/golden/samples/golden_thing_admin_client_samples.cc
+++ b/generator/integration_tests/golden/samples/golden_thing_admin_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "generator/integration_tests/golden/golden_thing_admin_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: GoldenThingAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::golden::GoldenThingAdminClient(
       google::cloud::golden::MakeGoldenThingAdminConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: GoldenThingAdminClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::golden::GoldenThingAdminClient(
+        google::cloud::golden::MakeGoldenThingAdminConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+    "GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"
+  });
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/accessapproval/samples/access_approval_client_samples.cc
+++ b/google/cloud/accessapproval/samples/access_approval_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/accessapproval/access_approval_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AccessApprovalClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::accessapproval::AccessApprovalClient(
       google::cloud::accessapproval::MakeAccessApprovalConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AccessApprovalClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::accessapproval::AccessApprovalClient(
+        google::cloud::accessapproval::MakeAccessApprovalConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/accesscontextmanager/samples/access_context_manager_client_samples.cc
+++ b/google/cloud/accesscontextmanager/samples/access_context_manager_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/accesscontextmanager/access_context_manager_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AccessContextManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::accesscontextmanager::AccessContextManagerClient(
       google::cloud::accesscontextmanager::MakeAccessContextManagerConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AccessContextManagerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::accesscontextmanager::AccessContextManagerClient(
+        google::cloud::accesscontextmanager::MakeAccessContextManagerConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/apigateway/samples/api_gateway_client_samples.cc
+++ b/google/cloud/apigateway/samples/api_gateway_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/apigateway/api_gateway_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ApiGatewayServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::apigateway::ApiGatewayServiceClient(
       google::cloud::apigateway::MakeApiGatewayServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ApiGatewayServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::apigateway::ApiGatewayServiceClient(
+        google::cloud::apigateway::MakeApiGatewayServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/apigeeconnect/samples/connection_client_samples.cc
+++ b/google/cloud/apigeeconnect/samples/connection_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/apigeeconnect/connection_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ConnectionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::apigeeconnect::ConnectionServiceClient(
       google::cloud::apigeeconnect::MakeConnectionServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ConnectionServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::apigeeconnect::ConnectionServiceClient(
+        google::cloud::apigeeconnect::MakeConnectionServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/apikeys/samples/api_keys_client_samples.cc
+++ b/google/cloud/apikeys/samples/api_keys_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/apikeys/api_keys_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ApiKeysClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::apikeys::ApiKeysClient(
       google::cloud::apikeys::MakeApiKeysConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ApiKeysClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::apikeys::ApiKeysClient(
+        google::cloud::apikeys::MakeApiKeysConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/appengine/samples/applications_client_samples.cc
+++ b/google/cloud/appengine/samples/applications_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/appengine/applications_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ApplicationsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::appengine::ApplicationsClient(
       google::cloud::appengine::MakeApplicationsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ApplicationsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::appengine::ApplicationsClient(
+        google::cloud::appengine::MakeApplicationsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/appengine/samples/authorized_certificates_client_samples.cc
+++ b/google/cloud/appengine/samples/authorized_certificates_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/appengine/authorized_certificates_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AuthorizedCertificatesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::appengine::AuthorizedCertificatesClient(
       google::cloud::appengine::MakeAuthorizedCertificatesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AuthorizedCertificatesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::appengine::AuthorizedCertificatesClient(
+        google::cloud::appengine::MakeAuthorizedCertificatesConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/appengine/samples/authorized_domains_client_samples.cc
+++ b/google/cloud/appengine/samples/authorized_domains_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/appengine/authorized_domains_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AuthorizedDomainsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::appengine::AuthorizedDomainsClient(
       google::cloud::appengine::MakeAuthorizedDomainsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AuthorizedDomainsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::appengine::AuthorizedDomainsClient(
+        google::cloud::appengine::MakeAuthorizedDomainsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/appengine/samples/domain_mappings_client_samples.cc
+++ b/google/cloud/appengine/samples/domain_mappings_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/appengine/domain_mappings_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DomainMappingsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::appengine::DomainMappingsClient(
       google::cloud::appengine::MakeDomainMappingsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DomainMappingsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::appengine::DomainMappingsClient(
+        google::cloud::appengine::MakeDomainMappingsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/appengine/samples/firewall_client_samples.cc
+++ b/google/cloud/appengine/samples/firewall_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/appengine/firewall_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: FirewallClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::appengine::FirewallClient(
       google::cloud::appengine::MakeFirewallConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: FirewallClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::appengine::FirewallClient(
+        google::cloud::appengine::MakeFirewallConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/appengine/samples/instances_client_samples.cc
+++ b/google/cloud/appengine/samples/instances_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/appengine/instances_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: InstancesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::appengine::InstancesClient(
       google::cloud::appengine::MakeInstancesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: InstancesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::appengine::InstancesClient(
+        google::cloud::appengine::MakeInstancesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/appengine/samples/services_client_samples.cc
+++ b/google/cloud/appengine/samples/services_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/appengine/services_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ServicesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::appengine::ServicesClient(
       google::cloud::appengine::MakeServicesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ServicesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::appengine::ServicesClient(
+        google::cloud::appengine::MakeServicesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/appengine/samples/versions_client_samples.cc
+++ b/google/cloud/appengine/samples/versions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/appengine/versions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: VersionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::appengine::VersionsClient(
       google::cloud::appengine::MakeVersionsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: VersionsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::appengine::VersionsClient(
+        google::cloud::appengine::MakeVersionsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/artifactregistry/samples/artifact_registry_client_samples.cc
+++ b/google/cloud/artifactregistry/samples/artifact_registry_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/artifactregistry/artifact_registry_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ArtifactRegistryClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::artifactregistry::ArtifactRegistryClient(
       google::cloud::artifactregistry::MakeArtifactRegistryConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ArtifactRegistryClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::artifactregistry::ArtifactRegistryClient(
+        google::cloud::artifactregistry::MakeArtifactRegistryConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/asset/samples/asset_client_samples.cc
+++ b/google/cloud/asset/samples/asset_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/asset/asset_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AssetServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::asset::AssetServiceClient(
       google::cloud::asset::MakeAssetServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AssetServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::asset::AssetServiceClient(
+        google::cloud::asset::MakeAssetServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/assuredworkloads/samples/assured_workloads_client_samples.cc
+++ b/google/cloud/assuredworkloads/samples/assured_workloads_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/assuredworkloads/assured_workloads_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AssuredWorkloadsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::assuredworkloads::AssuredWorkloadsServiceClient(
       google::cloud::assuredworkloads::MakeAssuredWorkloadsServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AssuredWorkloadsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::assuredworkloads::AssuredWorkloadsServiceClient(
+        google::cloud::assuredworkloads::MakeAssuredWorkloadsServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/automl/samples/auto_ml_client_samples.cc
+++ b/google/cloud/automl/samples/auto_ml_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/automl/auto_ml_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AutoMlClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::automl::AutoMlClient(
       google::cloud::automl::MakeAutoMlConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AutoMlClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::automl::AutoMlClient(
+        google::cloud::automl::MakeAutoMlConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/automl/samples/prediction_client_samples.cc
+++ b/google/cloud/automl/samples/prediction_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/automl/prediction_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: PredictionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::automl::PredictionServiceClient(
       google::cloud::automl::MakePredictionServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: PredictionServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::automl::PredictionServiceClient(
+        google::cloud::automl::MakePredictionServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/baremetalsolution/samples/bare_metal_solution_client_samples.cc
+++ b/google/cloud/baremetalsolution/samples/bare_metal_solution_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/baremetalsolution/bare_metal_solution_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BareMetalSolutionClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::baremetalsolution::BareMetalSolutionClient(
       google::cloud::baremetalsolution::MakeBareMetalSolutionConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BareMetalSolutionClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::baremetalsolution::BareMetalSolutionClient(
+        google::cloud::baremetalsolution::MakeBareMetalSolutionConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/batch/samples/batch_client_samples.cc
+++ b/google/cloud/batch/samples/batch_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/batch/batch_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BatchServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::batch::BatchServiceClient(
       google::cloud::batch::MakeBatchServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BatchServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::batch::BatchServiceClient(
+        google::cloud::batch::MakeBatchServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/beyondcorp/samples/app_connections_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/app_connections_client_samples.cc
@@ -19,11 +19,15 @@
 
 #include "google/cloud/beyondcorp/app_connections_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AppConnectionsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::beyondcorp::AppConnectionsServiceClient(
       google::cloud::beyondcorp::MakeAppConnectionsServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AppConnectionsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::beyondcorp::AppConnectionsServiceClient(
+        google::cloud::beyondcorp::MakeAppConnectionsServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/beyondcorp/samples/app_connectors_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/app_connectors_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/beyondcorp/app_connectors_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AppConnectorsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::beyondcorp::AppConnectorsServiceClient(
       google::cloud::beyondcorp::MakeAppConnectorsServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AppConnectorsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::beyondcorp::AppConnectorsServiceClient(
+        google::cloud::beyondcorp::MakeAppConnectorsServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/beyondcorp/samples/app_gateways_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/app_gateways_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/beyondcorp/app_gateways_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AppGatewaysServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::beyondcorp::AppGatewaysServiceClient(
       google::cloud::beyondcorp::MakeAppGatewaysServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AppGatewaysServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::beyondcorp::AppGatewaysServiceClient(
+        google::cloud::beyondcorp::MakeAppGatewaysServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/beyondcorp/samples/client_connector_services_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/client_connector_services_client_samples.cc
@@ -19,11 +19,15 @@
 
 #include "google/cloud/beyondcorp/client_connector_services_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ClientConnectorServicesServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -38,16 +42,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::beyondcorp::ClientConnectorServicesServiceClient(
       google::cloud::beyondcorp::MakeClientConnectorServicesServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ClientConnectorServicesServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::beyondcorp::ClientConnectorServicesServiceClient(
+        google::cloud::beyondcorp::MakeClientConnectorServicesServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -55,6 +86,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/beyondcorp/samples/client_gateways_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/client_gateways_client_samples.cc
@@ -19,11 +19,15 @@
 
 #include "google/cloud/beyondcorp/client_gateways_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ClientGatewaysServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::beyondcorp::ClientGatewaysServiceClient(
       google::cloud::beyondcorp::MakeClientGatewaysServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ClientGatewaysServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::beyondcorp::ClientGatewaysServiceClient(
+        google::cloud::beyondcorp::MakeClientGatewaysServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigquery/samples/analytics_hub_client_samples.cc
+++ b/google/cloud/bigquery/samples/analytics_hub_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigquery/analytics_hub_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AnalyticsHubServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigquery::AnalyticsHubServiceClient(
       google::cloud::bigquery::MakeAnalyticsHubServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AnalyticsHubServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigquery::AnalyticsHubServiceClient(
+        google::cloud::bigquery::MakeAnalyticsHubServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigquery/samples/bigquery_read_client_samples.cc
+++ b/google/cloud/bigquery/samples/bigquery_read_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigquery/bigquery_read_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BigQueryReadClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigquery::BigQueryReadClient(
       google::cloud::bigquery::MakeBigQueryReadConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BigQueryReadClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigquery::BigQueryReadClient(
+        google::cloud::bigquery::MakeBigQueryReadConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigquery/samples/bigquery_write_client_samples.cc
+++ b/google/cloud/bigquery/samples/bigquery_write_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigquery/bigquery_write_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BigQueryWriteClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigquery::BigQueryWriteClient(
       google::cloud::bigquery::MakeBigQueryWriteConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BigQueryWriteClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigquery::BigQueryWriteClient(
+        google::cloud::bigquery::MakeBigQueryWriteConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigquery/samples/connection_client_samples.cc
+++ b/google/cloud/bigquery/samples/connection_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigquery/connection_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ConnectionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigquery::ConnectionServiceClient(
       google::cloud::bigquery::MakeConnectionServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ConnectionServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigquery::ConnectionServiceClient(
+        google::cloud::bigquery::MakeConnectionServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigquery/samples/data_transfer_client_samples.cc
+++ b/google/cloud/bigquery/samples/data_transfer_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigquery/data_transfer_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DataTransferServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigquery::DataTransferServiceClient(
       google::cloud::bigquery::MakeDataTransferServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DataTransferServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigquery::DataTransferServiceClient(
+        google::cloud::bigquery::MakeDataTransferServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigquery/samples/migration_client_samples.cc
+++ b/google/cloud/bigquery/samples/migration_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigquery/migration_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: MigrationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigquery::MigrationServiceClient(
       google::cloud::bigquery::MakeMigrationServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: MigrationServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigquery::MigrationServiceClient(
+        google::cloud::bigquery::MakeMigrationServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigquery/samples/model_client_samples.cc
+++ b/google/cloud/bigquery/samples/model_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigquery/model_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ModelServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigquery::ModelServiceClient(
       google::cloud::bigquery::MakeModelServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ModelServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigquery::ModelServiceClient(
+        google::cloud::bigquery::MakeModelServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigquery/samples/reservation_client_samples.cc
+++ b/google/cloud/bigquery/samples/reservation_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigquery/reservation_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ReservationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigquery::ReservationServiceClient(
       google::cloud::bigquery::MakeReservationServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ReservationServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigquery::ReservationServiceClient(
+        google::cloud::bigquery::MakeReservationServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigtable/admin/samples/bigtable_instance_admin_client_samples.cc
+++ b/google/cloud/bigtable/admin/samples/bigtable_instance_admin_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BigtableInstanceAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::bigtable_admin::BigtableInstanceAdminClient(
       google::cloud::bigtable_admin::MakeBigtableInstanceAdminConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BigtableInstanceAdminClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigtable_admin::BigtableInstanceAdminClient(
+        google::cloud::bigtable_admin::MakeBigtableInstanceAdminConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigtable/admin/samples/bigtable_table_admin_client_samples.cc
+++ b/google/cloud/bigtable/admin/samples/bigtable_table_admin_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BigtableTableAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::bigtable_admin::BigtableTableAdminClient(
       google::cloud::bigtable_admin::MakeBigtableTableAdminConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BigtableTableAdminClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::bigtable_admin::BigtableTableAdminClient(
+        google::cloud::bigtable_admin::MakeBigtableTableAdminConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/billing/samples/budget_client_samples.cc
+++ b/google/cloud/billing/samples/budget_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/billing/budget_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BudgetServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::billing::BudgetServiceClient(
       google::cloud::billing::MakeBudgetServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BudgetServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::billing::BudgetServiceClient(
+        google::cloud::billing::MakeBudgetServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/billing/samples/cloud_billing_client_samples.cc
+++ b/google/cloud/billing/samples/cloud_billing_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/billing/cloud_billing_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudBillingClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::billing::CloudBillingClient(
       google::cloud::billing::MakeCloudBillingConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudBillingClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::billing::CloudBillingClient(
+        google::cloud::billing::MakeCloudBillingConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/billing/samples/cloud_catalog_client_samples.cc
+++ b/google/cloud/billing/samples/cloud_catalog_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/billing/cloud_catalog_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudCatalogClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::billing::CloudCatalogClient(
       google::cloud::billing::MakeCloudCatalogConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudCatalogClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::billing::CloudCatalogClient(
+        google::cloud::billing::MakeCloudCatalogConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/binaryauthorization/samples/binauthz_management_service_v1_client_samples.cc
+++ b/google/cloud/binaryauthorization/samples/binauthz_management_service_v1_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/binaryauthorization/binauthz_management_service_v1_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BinauthzManagementServiceV1Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -38,16 +42,44 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       google::cloud::binaryauthorization::BinauthzManagementServiceV1Client(
           google::cloud::binaryauthorization::
               MakeBinauthzManagementServiceV1Connection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BinauthzManagementServiceV1Client
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::binaryauthorization::
+        BinauthzManagementServiceV1Client(
+            google::cloud::binaryauthorization::
+                MakeBinauthzManagementServiceV1Connection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -55,6 +87,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/binaryauthorization/samples/system_policy_v1_client_samples.cc
+++ b/google/cloud/binaryauthorization/samples/system_policy_v1_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/binaryauthorization/system_policy_v1_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SystemPolicyV1Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::binaryauthorization::SystemPolicyV1Client(
       google::cloud::binaryauthorization::MakeSystemPolicyV1Connection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SystemPolicyV1Client
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::binaryauthorization::SystemPolicyV1Client(
+        google::cloud::binaryauthorization::MakeSystemPolicyV1Connection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/binaryauthorization/samples/validation_helper_v1_client_samples.cc
+++ b/google/cloud/binaryauthorization/samples/validation_helper_v1_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/binaryauthorization/validation_helper_v1_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ValidationHelperV1Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::binaryauthorization::ValidationHelperV1Client(
       google::cloud::binaryauthorization::MakeValidationHelperV1Connection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ValidationHelperV1Client
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::binaryauthorization::ValidationHelperV1Client(
+        google::cloud::binaryauthorization::MakeValidationHelperV1Connection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/certificatemanager/samples/certificate_manager_client_samples.cc
+++ b/google/cloud/certificatemanager/samples/certificate_manager_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/certificatemanager/certificate_manager_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CertificateManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::certificatemanager::CertificateManagerClient(
       google::cloud::certificatemanager::MakeCertificateManagerConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CertificateManagerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::certificatemanager::CertificateManagerClient(
+        google::cloud::certificatemanager::MakeCertificateManagerConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/channel/samples/cloud_channel_client_samples.cc
+++ b/google/cloud/channel/samples/cloud_channel_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/channel/cloud_channel_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudChannelServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::channel::CloudChannelServiceClient(
       google::cloud::channel::MakeCloudChannelServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudChannelServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::channel::CloudChannelServiceClient(
+        google::cloud::channel::MakeCloudChannelServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/cloudbuild/samples/cloud_build_client_samples.cc
+++ b/google/cloud/cloudbuild/samples/cloud_build_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/cloudbuild/cloud_build_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudBuildClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::cloudbuild::CloudBuildClient(
       google::cloud::cloudbuild::MakeCloudBuildConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudBuildClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::cloudbuild::CloudBuildClient(
+        google::cloud::cloudbuild::MakeCloudBuildConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/composer/samples/environments_client_samples.cc
+++ b/google/cloud/composer/samples/environments_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/composer/environments_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EnvironmentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::composer::EnvironmentsClient(
       google::cloud::composer::MakeEnvironmentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EnvironmentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::composer::EnvironmentsClient(
+        google::cloud::composer::MakeEnvironmentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/composer/samples/image_versions_client_samples.cc
+++ b/google/cloud/composer/samples/image_versions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/composer/image_versions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ImageVersionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::composer::ImageVersionsClient(
       google::cloud::composer::MakeImageVersionsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ImageVersionsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::composer::ImageVersionsClient(
+        google::cloud::composer::MakeImageVersionsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/contactcenterinsights/samples/contact_center_insights_client_samples.cc
+++ b/google/cloud/contactcenterinsights/samples/contact_center_insights_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/contactcenterinsights/contact_center_insights_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ContactCenterInsightsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -38,16 +42,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       google::cloud::contactcenterinsights::ContactCenterInsightsClient(
           google::cloud::contactcenterinsights::
               MakeContactCenterInsightsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ContactCenterInsightsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::contactcenterinsights::ContactCenterInsightsClient(
+        google::cloud::contactcenterinsights::
+            MakeContactCenterInsightsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -55,6 +86,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/container/samples/cluster_manager_client_samples.cc
+++ b/google/cloud/container/samples/cluster_manager_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/container/cluster_manager_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ClusterManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::container::ClusterManagerClient(
       google::cloud::container::MakeClusterManagerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ClusterManagerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::container::ClusterManagerClient(
+        google::cloud::container::MakeClusterManagerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/containeranalysis/samples/container_analysis_client_samples.cc
+++ b/google/cloud/containeranalysis/samples/container_analysis_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/containeranalysis/container_analysis_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ContainerAnalysisClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::containeranalysis::ContainerAnalysisClient(
       google::cloud::containeranalysis::MakeContainerAnalysisConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ContainerAnalysisClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::containeranalysis::ContainerAnalysisClient(
+        google::cloud::containeranalysis::MakeContainerAnalysisConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/containeranalysis/samples/grafeas_client_samples.cc
+++ b/google/cloud/containeranalysis/samples/grafeas_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/containeranalysis/grafeas_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: GrafeasClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::containeranalysis::GrafeasClient(
       google::cloud::containeranalysis::MakeGrafeasConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: GrafeasClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::containeranalysis::GrafeasClient(
+        google::cloud::containeranalysis::MakeGrafeasConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/datacatalog/samples/data_catalog_client_samples.cc
+++ b/google/cloud/datacatalog/samples/data_catalog_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/datacatalog/data_catalog_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DataCatalogClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::datacatalog::DataCatalogClient(
       google::cloud::datacatalog::MakeDataCatalogConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DataCatalogClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::datacatalog::DataCatalogClient(
+        google::cloud::datacatalog::MakeDataCatalogConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/datacatalog/samples/policy_tag_manager_client_samples.cc
+++ b/google/cloud/datacatalog/samples/policy_tag_manager_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/datacatalog/policy_tag_manager_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: PolicyTagManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::datacatalog::PolicyTagManagerClient(
       google::cloud::datacatalog::MakePolicyTagManagerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: PolicyTagManagerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::datacatalog::PolicyTagManagerClient(
+        google::cloud::datacatalog::MakePolicyTagManagerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/datacatalog/samples/policy_tag_manager_serialization_client_samples.cc
+++ b/google/cloud/datacatalog/samples/policy_tag_manager_serialization_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/datacatalog/policy_tag_manager_serialization_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: PolicyTagManagerSerializationClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::datacatalog::PolicyTagManagerSerializationClient(
       google::cloud::datacatalog::MakePolicyTagManagerSerializationConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: PolicyTagManagerSerializationClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::datacatalog::PolicyTagManagerSerializationClient(
+        google::cloud::datacatalog::MakePolicyTagManagerSerializationConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/datamigration/samples/data_migration_client_samples.cc
+++ b/google/cloud/datamigration/samples/data_migration_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/datamigration/data_migration_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DataMigrationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::datamigration::DataMigrationServiceClient(
       google::cloud::datamigration::MakeDataMigrationServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DataMigrationServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::datamigration::DataMigrationServiceClient(
+        google::cloud::datamigration::MakeDataMigrationServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dataplex/samples/content_client_samples.cc
+++ b/google/cloud/dataplex/samples/content_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dataplex/content_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ContentServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dataplex::ContentServiceClient(
       google::cloud::dataplex::MakeContentServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ContentServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dataplex::ContentServiceClient(
+        google::cloud::dataplex::MakeContentServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dataplex/samples/dataplex_client_samples.cc
+++ b/google/cloud/dataplex/samples/dataplex_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dataplex/dataplex_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DataplexServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dataplex::DataplexServiceClient(
       google::cloud::dataplex::MakeDataplexServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DataplexServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dataplex::DataplexServiceClient(
+        google::cloud::dataplex::MakeDataplexServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dataplex/samples/metadata_client_samples.cc
+++ b/google/cloud/dataplex/samples/metadata_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dataplex/metadata_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: MetadataServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dataplex::MetadataServiceClient(
       google::cloud::dataplex::MakeMetadataServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: MetadataServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dataplex::MetadataServiceClient(
+        google::cloud::dataplex::MakeMetadataServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dataproc/samples/autoscaling_policy_client_samples.cc
+++ b/google/cloud/dataproc/samples/autoscaling_policy_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dataproc/autoscaling_policy_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AutoscalingPolicyServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dataproc::AutoscalingPolicyServiceClient(
       google::cloud::dataproc::MakeAutoscalingPolicyServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AutoscalingPolicyServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dataproc::AutoscalingPolicyServiceClient(
+        google::cloud::dataproc::MakeAutoscalingPolicyServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dataproc/samples/batch_controller_client_samples.cc
+++ b/google/cloud/dataproc/samples/batch_controller_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dataproc/batch_controller_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: BatchControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dataproc::BatchControllerClient(
       google::cloud::dataproc::MakeBatchControllerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: BatchControllerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dataproc::BatchControllerClient(
+        google::cloud::dataproc::MakeBatchControllerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dataproc/samples/cluster_controller_client_samples.cc
+++ b/google/cloud/dataproc/samples/cluster_controller_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dataproc/cluster_controller_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ClusterControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dataproc::ClusterControllerClient(
       google::cloud::dataproc::MakeClusterControllerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ClusterControllerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dataproc::ClusterControllerClient(
+        google::cloud::dataproc::MakeClusterControllerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dataproc/samples/job_controller_client_samples.cc
+++ b/google/cloud/dataproc/samples/job_controller_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dataproc/job_controller_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: JobControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dataproc::JobControllerClient(
       google::cloud::dataproc::MakeJobControllerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: JobControllerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dataproc::JobControllerClient(
+        google::cloud::dataproc::MakeJobControllerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dataproc/samples/workflow_template_client_samples.cc
+++ b/google/cloud/dataproc/samples/workflow_template_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dataproc/workflow_template_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: WorkflowTemplateServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dataproc::WorkflowTemplateServiceClient(
       google::cloud::dataproc::MakeWorkflowTemplateServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: WorkflowTemplateServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dataproc::WorkflowTemplateServiceClient(
+        google::cloud::dataproc::MakeWorkflowTemplateServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/datastream/samples/datastream_client_samples.cc
+++ b/google/cloud/datastream/samples/datastream_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/datastream/datastream_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DatastreamClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::datastream::DatastreamClient(
       google::cloud::datastream::MakeDatastreamConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DatastreamClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::datastream::DatastreamClient(
+        google::cloud::datastream::MakeDatastreamConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/debugger/samples/controller2_client_samples.cc
+++ b/google/cloud/debugger/samples/controller2_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/debugger/controller2_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: Controller2Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::debugger::Controller2Client(
       google::cloud::debugger::MakeController2Connection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: Controller2Client
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::debugger::Controller2Client(
+        google::cloud::debugger::MakeController2Connection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/deploy/samples/cloud_deploy_client_samples.cc
+++ b/google/cloud/deploy/samples/cloud_deploy_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/deploy/cloud_deploy_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudDeployClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::deploy::CloudDeployClient(
       google::cloud::deploy::MakeCloudDeployConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudDeployClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::deploy::CloudDeployClient(
+        google::cloud::deploy::MakeCloudDeployConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/agents_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/agents_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/agents_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AgentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::AgentsClient(
       google::cloud::dialogflow_cx::MakeAgentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AgentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::AgentsClient(
+        google::cloud::dialogflow_cx::MakeAgentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/changelogs_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/changelogs_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/changelogs_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ChangelogsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::ChangelogsClient(
       google::cloud::dialogflow_cx::MakeChangelogsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ChangelogsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::ChangelogsClient(
+        google::cloud::dialogflow_cx::MakeChangelogsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/deployments_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/deployments_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/deployments_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DeploymentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::DeploymentsClient(
       google::cloud::dialogflow_cx::MakeDeploymentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DeploymentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::DeploymentsClient(
+        google::cloud::dialogflow_cx::MakeDeploymentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/entity_types_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/entity_types_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/entity_types_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EntityTypesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::EntityTypesClient(
       google::cloud::dialogflow_cx::MakeEntityTypesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EntityTypesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::EntityTypesClient(
+        google::cloud::dialogflow_cx::MakeEntityTypesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/environments_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/environments_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/environments_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EnvironmentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::EnvironmentsClient(
       google::cloud::dialogflow_cx::MakeEnvironmentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EnvironmentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::EnvironmentsClient(
+        google::cloud::dialogflow_cx::MakeEnvironmentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/experiments_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/experiments_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/experiments_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ExperimentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::ExperimentsClient(
       google::cloud::dialogflow_cx::MakeExperimentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ExperimentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::ExperimentsClient(
+        google::cloud::dialogflow_cx::MakeExperimentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/flows_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/flows_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/flows_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: FlowsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::FlowsClient(
       google::cloud::dialogflow_cx::MakeFlowsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: FlowsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::FlowsClient(
+        google::cloud::dialogflow_cx::MakeFlowsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/intents_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/intents_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/intents_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IntentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::IntentsClient(
       google::cloud::dialogflow_cx::MakeIntentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IntentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::IntentsClient(
+        google::cloud::dialogflow_cx::MakeIntentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/pages_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/pages_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/pages_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: PagesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::PagesClient(
       google::cloud::dialogflow_cx::MakePagesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: PagesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::PagesClient(
+        google::cloud::dialogflow_cx::MakePagesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/security_settings_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/security_settings_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/security_settings_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SecuritySettingsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::dialogflow_cx::SecuritySettingsServiceClient(
       google::cloud::dialogflow_cx::MakeSecuritySettingsServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SecuritySettingsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::SecuritySettingsServiceClient(
+        google::cloud::dialogflow_cx::MakeSecuritySettingsServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/session_entity_types_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/session_entity_types_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/session_entity_types_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SessionEntityTypesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::SessionEntityTypesClient(
       google::cloud::dialogflow_cx::MakeSessionEntityTypesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SessionEntityTypesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::SessionEntityTypesClient(
+        google::cloud::dialogflow_cx::MakeSessionEntityTypesConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/sessions_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/sessions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/sessions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SessionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::SessionsClient(
       google::cloud::dialogflow_cx::MakeSessionsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SessionsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::SessionsClient(
+        google::cloud::dialogflow_cx::MakeSessionsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/test_cases_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/test_cases_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/test_cases_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TestCasesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::TestCasesClient(
       google::cloud::dialogflow_cx::MakeTestCasesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TestCasesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::TestCasesClient(
+        google::cloud::dialogflow_cx::MakeTestCasesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/transition_route_groups_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/transition_route_groups_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/transition_route_groups_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TransitionRouteGroupsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::dialogflow_cx::TransitionRouteGroupsClient(
       google::cloud::dialogflow_cx::MakeTransitionRouteGroupsConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TransitionRouteGroupsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::TransitionRouteGroupsClient(
+        google::cloud::dialogflow_cx::MakeTransitionRouteGroupsConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/versions_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/versions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/versions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: VersionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::VersionsClient(
       google::cloud::dialogflow_cx::MakeVersionsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: VersionsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::VersionsClient(
+        google::cloud::dialogflow_cx::MakeVersionsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_cx/samples/webhooks_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/webhooks_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_cx/webhooks_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: WebhooksClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_cx::WebhooksClient(
       google::cloud::dialogflow_cx::MakeWebhooksConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: WebhooksClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_cx::WebhooksClient(
+        google::cloud::dialogflow_cx::MakeWebhooksConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/agents_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/agents_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/agents_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AgentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::AgentsClient(
       google::cloud::dialogflow_es::MakeAgentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AgentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::AgentsClient(
+        google::cloud::dialogflow_es::MakeAgentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/answer_records_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/answer_records_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/answer_records_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AnswerRecordsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::AnswerRecordsClient(
       google::cloud::dialogflow_es::MakeAnswerRecordsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AnswerRecordsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::AnswerRecordsClient(
+        google::cloud::dialogflow_es::MakeAnswerRecordsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/contexts_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/contexts_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/contexts_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ContextsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::ContextsClient(
       google::cloud::dialogflow_es::MakeContextsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ContextsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::ContextsClient(
+        google::cloud::dialogflow_es::MakeContextsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/conversation_datasets_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/conversation_datasets_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/conversation_datasets_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ConversationDatasetsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::dialogflow_es::ConversationDatasetsClient(
       google::cloud::dialogflow_es::MakeConversationDatasetsConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ConversationDatasetsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::ConversationDatasetsClient(
+        google::cloud::dialogflow_es::MakeConversationDatasetsConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/conversation_models_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/conversation_models_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/conversation_models_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ConversationModelsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::ConversationModelsClient(
       google::cloud::dialogflow_es::MakeConversationModelsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ConversationModelsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::ConversationModelsClient(
+        google::cloud::dialogflow_es::MakeConversationModelsConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/conversation_profiles_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/conversation_profiles_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/conversation_profiles_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ConversationProfilesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::dialogflow_es::ConversationProfilesClient(
       google::cloud::dialogflow_es::MakeConversationProfilesConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ConversationProfilesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::ConversationProfilesClient(
+        google::cloud::dialogflow_es::MakeConversationProfilesConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/conversations_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/conversations_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/conversations_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ConversationsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::ConversationsClient(
       google::cloud::dialogflow_es::MakeConversationsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ConversationsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::ConversationsClient(
+        google::cloud::dialogflow_es::MakeConversationsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/documents_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/documents_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/documents_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DocumentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::DocumentsClient(
       google::cloud::dialogflow_es::MakeDocumentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DocumentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::DocumentsClient(
+        google::cloud::dialogflow_es::MakeDocumentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/entity_types_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/entity_types_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/entity_types_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EntityTypesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::EntityTypesClient(
       google::cloud::dialogflow_es::MakeEntityTypesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EntityTypesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::EntityTypesClient(
+        google::cloud::dialogflow_es::MakeEntityTypesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/environments_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/environments_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/environments_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EnvironmentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::EnvironmentsClient(
       google::cloud::dialogflow_es::MakeEnvironmentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EnvironmentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::EnvironmentsClient(
+        google::cloud::dialogflow_es::MakeEnvironmentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/fulfillments_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/fulfillments_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/fulfillments_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: FulfillmentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::FulfillmentsClient(
       google::cloud::dialogflow_es::MakeFulfillmentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: FulfillmentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::FulfillmentsClient(
+        google::cloud::dialogflow_es::MakeFulfillmentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/intents_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/intents_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/intents_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IntentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::IntentsClient(
       google::cloud::dialogflow_es::MakeIntentsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IntentsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::IntentsClient(
+        google::cloud::dialogflow_es::MakeIntentsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/knowledge_bases_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/knowledge_bases_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/knowledge_bases_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: KnowledgeBasesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::KnowledgeBasesClient(
       google::cloud::dialogflow_es::MakeKnowledgeBasesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: KnowledgeBasesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::KnowledgeBasesClient(
+        google::cloud::dialogflow_es::MakeKnowledgeBasesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/participants_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/participants_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/participants_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ParticipantsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::ParticipantsClient(
       google::cloud::dialogflow_es::MakeParticipantsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ParticipantsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::ParticipantsClient(
+        google::cloud::dialogflow_es::MakeParticipantsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/session_entity_types_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/session_entity_types_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/session_entity_types_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SessionEntityTypesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::SessionEntityTypesClient(
       google::cloud::dialogflow_es::MakeSessionEntityTypesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SessionEntityTypesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::SessionEntityTypesClient(
+        google::cloud::dialogflow_es::MakeSessionEntityTypesConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/sessions_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/sessions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/sessions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SessionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::SessionsClient(
       google::cloud::dialogflow_es::MakeSessionsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SessionsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::SessionsClient(
+        google::cloud::dialogflow_es::MakeSessionsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dialogflow_es/samples/versions_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/versions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dialogflow_es/versions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: VersionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dialogflow_es::VersionsClient(
       google::cloud::dialogflow_es::MakeVersionsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: VersionsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dialogflow_es::VersionsClient(
+        google::cloud::dialogflow_es::MakeVersionsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/dlp/samples/dlp_client_samples.cc
+++ b/google/cloud/dlp/samples/dlp_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/dlp/dlp_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DlpServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::dlp::DlpServiceClient(
       google::cloud::dlp::MakeDlpServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DlpServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::dlp::DlpServiceClient(
+        google::cloud::dlp::MakeDlpServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/documentai/samples/document_processor_client_samples.cc
+++ b/google/cloud/documentai/samples/document_processor_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/documentai/document_processor_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DocumentProcessorServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::documentai::DocumentProcessorServiceClient(
       google::cloud::documentai::MakeDocumentProcessorServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DocumentProcessorServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::documentai::DocumentProcessorServiceClient(
+        google::cloud::documentai::MakeDocumentProcessorServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/edgecontainer/samples/edge_container_client_samples.cc
+++ b/google/cloud/edgecontainer/samples/edge_container_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/edgecontainer/edge_container_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EdgeContainerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::edgecontainer::EdgeContainerClient(
       google::cloud::edgecontainer::MakeEdgeContainerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EdgeContainerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::edgecontainer::EdgeContainerClient(
+        google::cloud::edgecontainer::MakeEdgeContainerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/eventarc/samples/eventarc_client_samples.cc
+++ b/google/cloud/eventarc/samples/eventarc_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/eventarc/eventarc_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EventarcClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::eventarc::EventarcClient(
       google::cloud::eventarc::MakeEventarcConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EventarcClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::eventarc::EventarcClient(
+        google::cloud::eventarc::MakeEventarcConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/eventarc/samples/publisher_client_samples.cc
+++ b/google/cloud/eventarc/samples/publisher_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/eventarc/publisher_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: PublisherClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::eventarc::PublisherClient(
       google::cloud::eventarc::MakePublisherConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: PublisherClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::eventarc::PublisherClient(
+        google::cloud::eventarc::MakePublisherConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/filestore/samples/cloud_filestore_manager_client_samples.cc
+++ b/google/cloud/filestore/samples/cloud_filestore_manager_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/filestore/cloud_filestore_manager_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudFilestoreManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::filestore::CloudFilestoreManagerClient(
       google::cloud::filestore::MakeCloudFilestoreManagerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudFilestoreManagerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::filestore::CloudFilestoreManagerClient(
+        google::cloud::filestore::MakeCloudFilestoreManagerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/functions/samples/cloud_functions_client_samples.cc
+++ b/google/cloud/functions/samples/cloud_functions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/functions/cloud_functions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudFunctionsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::functions::CloudFunctionsServiceClient(
       google::cloud::functions::MakeCloudFunctionsServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudFunctionsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::functions::CloudFunctionsServiceClient(
+        google::cloud::functions::MakeCloudFunctionsServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/gameservices/samples/game_server_clusters_client_samples.cc
+++ b/google/cloud/gameservices/samples/game_server_clusters_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/gameservices/game_server_clusters_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: GameServerClustersServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::gameservices::GameServerClustersServiceClient(
       google::cloud::gameservices::MakeGameServerClustersServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: GameServerClustersServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::gameservices::GameServerClustersServiceClient(
+        google::cloud::gameservices::MakeGameServerClustersServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/gameservices/samples/game_server_configs_client_samples.cc
+++ b/google/cloud/gameservices/samples/game_server_configs_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/gameservices/game_server_configs_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: GameServerConfigsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::gameservices::GameServerConfigsServiceClient(
       google::cloud::gameservices::MakeGameServerConfigsServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: GameServerConfigsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::gameservices::GameServerConfigsServiceClient(
+        google::cloud::gameservices::MakeGameServerConfigsServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/gameservices/samples/game_server_deployments_client_samples.cc
+++ b/google/cloud/gameservices/samples/game_server_deployments_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/gameservices/game_server_deployments_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: GameServerDeploymentsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::gameservices::GameServerDeploymentsServiceClient(
       google::cloud::gameservices::MakeGameServerDeploymentsServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: GameServerDeploymentsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::gameservices::GameServerDeploymentsServiceClient(
+        google::cloud::gameservices::MakeGameServerDeploymentsServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/gameservices/samples/realms_client_samples.cc
+++ b/google/cloud/gameservices/samples/realms_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/gameservices/realms_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: RealmsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::gameservices::RealmsServiceClient(
       google::cloud::gameservices::MakeRealmsServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: RealmsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::gameservices::RealmsServiceClient(
+        google::cloud::gameservices::MakeRealmsServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/gkehub/samples/gke_hub_client_samples.cc
+++ b/google/cloud/gkehub/samples/gke_hub_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/gkehub/gke_hub_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: GkeHubClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::gkehub::GkeHubClient(
       google::cloud::gkehub::MakeGkeHubConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: GkeHubClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::gkehub::GkeHubClient(
+        google::cloud::gkehub::MakeGkeHubConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/iam/samples/iam_client_samples.cc
+++ b/google/cloud/iam/samples/iam_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/iam/iam_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IAMClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::iam::IAMClient(
       google::cloud::iam::MakeIAMConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IAMClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::iam::IAMClient(
+        google::cloud::iam::MakeIAMConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/iam/samples/iam_credentials_client_samples.cc
+++ b/google/cloud/iam/samples/iam_credentials_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/iam/iam_credentials_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IAMCredentialsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::iam::IAMCredentialsClient(
       google::cloud::iam::MakeIAMCredentialsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IAMCredentialsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::iam::IAMCredentialsClient(
+        google::cloud::iam::MakeIAMCredentialsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/iam/samples/iam_policy_client_samples.cc
+++ b/google/cloud/iam/samples/iam_policy_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/iam/iam_policy_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IAMPolicyClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::iam::IAMPolicyClient(
       google::cloud::iam::MakeIAMPolicyConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IAMPolicyClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::iam::IAMPolicyClient(
+        google::cloud::iam::MakeIAMPolicyConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/iap/samples/identity_aware_proxy_admin_client_samples.cc
+++ b/google/cloud/iap/samples/identity_aware_proxy_admin_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/iap/identity_aware_proxy_admin_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IdentityAwareProxyAdminServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::iap::IdentityAwareProxyAdminServiceClient(
       google::cloud::iap::MakeIdentityAwareProxyAdminServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IdentityAwareProxyAdminServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::iap::IdentityAwareProxyAdminServiceClient(
+        google::cloud::iap::MakeIdentityAwareProxyAdminServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/iap/samples/identity_aware_proxy_o_auth_client_samples.cc
+++ b/google/cloud/iap/samples/identity_aware_proxy_o_auth_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/iap/identity_aware_proxy_o_auth_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IdentityAwareProxyOAuthServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::iap::IdentityAwareProxyOAuthServiceClient(
       google::cloud::iap::MakeIdentityAwareProxyOAuthServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IdentityAwareProxyOAuthServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::iap::IdentityAwareProxyOAuthServiceClient(
+        google::cloud::iap::MakeIdentityAwareProxyOAuthServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/ids/samples/ids_client_samples.cc
+++ b/google/cloud/ids/samples/ids_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/ids/ids_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IDSClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::ids::IDSClient(
       google::cloud::ids::MakeIDSConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IDSClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::ids::IDSClient(
+        google::cloud::ids::MakeIDSConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/iot/samples/device_manager_client_samples.cc
+++ b/google/cloud/iot/samples/device_manager_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/iot/device_manager_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DeviceManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::iot::DeviceManagerClient(
       google::cloud::iot::MakeDeviceManagerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DeviceManagerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::iot::DeviceManagerClient(
+        google::cloud::iot::MakeDeviceManagerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/kms/samples/ekm_client_samples.cc
+++ b/google/cloud/kms/samples/ekm_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/kms/ekm_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EkmServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::kms::EkmServiceClient(
       google::cloud::kms::MakeEkmServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EkmServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::kms::EkmServiceClient(
+        google::cloud::kms::MakeEkmServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/kms/samples/key_management_client_samples.cc
+++ b/google/cloud/kms/samples/key_management_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/kms/key_management_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: KeyManagementServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::kms::KeyManagementServiceClient(
       google::cloud::kms::MakeKeyManagementServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: KeyManagementServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::kms::KeyManagementServiceClient(
+        google::cloud::kms::MakeKeyManagementServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/language/samples/language_client_samples.cc
+++ b/google/cloud/language/samples/language_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/language/language_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: LanguageServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::language::LanguageServiceClient(
       google::cloud::language::MakeLanguageServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: LanguageServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::language::LanguageServiceClient(
+        google::cloud::language::MakeLanguageServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/logging/samples/logging_service_v2_client_samples.cc
+++ b/google/cloud/logging/samples/logging_service_v2_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/logging/logging_service_v2_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: LoggingServiceV2Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::logging::LoggingServiceV2Client(
       google::cloud::logging::MakeLoggingServiceV2Connection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: LoggingServiceV2Client
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::logging::LoggingServiceV2Client(
+        google::cloud::logging::MakeLoggingServiceV2Connection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/managedidentities/samples/managed_identities_client_samples.cc
+++ b/google/cloud/managedidentities/samples/managed_identities_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/managedidentities/managed_identities_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ManagedIdentitiesServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -38,16 +42,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       google::cloud::managedidentities::ManagedIdentitiesServiceClient(
           google::cloud::managedidentities::
               MakeManagedIdentitiesServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ManagedIdentitiesServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::managedidentities::ManagedIdentitiesServiceClient(
+        google::cloud::managedidentities::
+            MakeManagedIdentitiesServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -55,6 +86,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/memcache/samples/cloud_memcache_client_samples.cc
+++ b/google/cloud/memcache/samples/cloud_memcache_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/memcache/cloud_memcache_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudMemcacheClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::memcache::CloudMemcacheClient(
       google::cloud::memcache::MakeCloudMemcacheConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudMemcacheClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::memcache::CloudMemcacheClient(
+        google::cloud::memcache::MakeCloudMemcacheConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/alert_policy_client_samples.cc
+++ b/google/cloud/monitoring/samples/alert_policy_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/alert_policy_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AlertPolicyServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::monitoring::AlertPolicyServiceClient(
       google::cloud::monitoring::MakeAlertPolicyServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AlertPolicyServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::AlertPolicyServiceClient(
+        google::cloud::monitoring::MakeAlertPolicyServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/dashboards_client_samples.cc
+++ b/google/cloud/monitoring/samples/dashboards_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/dashboards_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DashboardsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::monitoring::DashboardsServiceClient(
       google::cloud::monitoring::MakeDashboardsServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DashboardsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::DashboardsServiceClient(
+        google::cloud::monitoring::MakeDashboardsServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/group_client_samples.cc
+++ b/google/cloud/monitoring/samples/group_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/group_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: GroupServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::monitoring::GroupServiceClient(
       google::cloud::monitoring::MakeGroupServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: GroupServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::GroupServiceClient(
+        google::cloud::monitoring::MakeGroupServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/metric_client_samples.cc
+++ b/google/cloud/monitoring/samples/metric_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/metric_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: MetricServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::monitoring::MetricServiceClient(
       google::cloud::monitoring::MakeMetricServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: MetricServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::MetricServiceClient(
+        google::cloud::monitoring::MakeMetricServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/metrics_scopes_client_samples.cc
+++ b/google/cloud/monitoring/samples/metrics_scopes_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/metrics_scopes_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: MetricsScopesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::monitoring::MetricsScopesClient(
       google::cloud::monitoring::MakeMetricsScopesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: MetricsScopesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::MetricsScopesClient(
+        google::cloud::monitoring::MakeMetricsScopesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/notification_channel_client_samples.cc
+++ b/google/cloud/monitoring/samples/notification_channel_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/notification_channel_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: NotificationChannelServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::monitoring::NotificationChannelServiceClient(
       google::cloud::monitoring::MakeNotificationChannelServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: NotificationChannelServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::NotificationChannelServiceClient(
+        google::cloud::monitoring::MakeNotificationChannelServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/query_client_samples.cc
+++ b/google/cloud/monitoring/samples/query_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/query_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: QueryServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::monitoring::QueryServiceClient(
       google::cloud::monitoring::MakeQueryServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: QueryServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::QueryServiceClient(
+        google::cloud::monitoring::MakeQueryServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/service_monitoring_client_samples.cc
+++ b/google/cloud/monitoring/samples/service_monitoring_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/service_monitoring_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ServiceMonitoringServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::monitoring::ServiceMonitoringServiceClient(
       google::cloud::monitoring::MakeServiceMonitoringServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ServiceMonitoringServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::ServiceMonitoringServiceClient(
+        google::cloud::monitoring::MakeServiceMonitoringServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/monitoring/samples/uptime_check_client_samples.cc
+++ b/google/cloud/monitoring/samples/uptime_check_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/monitoring/uptime_check_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: UptimeCheckServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::monitoring::UptimeCheckServiceClient(
       google::cloud::monitoring::MakeUptimeCheckServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: UptimeCheckServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::monitoring::UptimeCheckServiceClient(
+        google::cloud::monitoring::MakeUptimeCheckServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/networkconnectivity/samples/hub_client_samples.cc
+++ b/google/cloud/networkconnectivity/samples/hub_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/networkconnectivity/hub_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: HubServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::networkconnectivity::HubServiceClient(
       google::cloud::networkconnectivity::MakeHubServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: HubServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::networkconnectivity::HubServiceClient(
+        google::cloud::networkconnectivity::MakeHubServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/networkmanagement/samples/reachability_client_samples.cc
+++ b/google/cloud/networkmanagement/samples/reachability_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/networkmanagement/reachability_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ReachabilityServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::networkmanagement::ReachabilityServiceClient(
       google::cloud::networkmanagement::MakeReachabilityServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ReachabilityServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::networkmanagement::ReachabilityServiceClient(
+        google::cloud::networkmanagement::MakeReachabilityServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/notebooks/samples/managed_notebook_client_samples.cc
+++ b/google/cloud/notebooks/samples/managed_notebook_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/notebooks/managed_notebook_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ManagedNotebookServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::notebooks::ManagedNotebookServiceClient(
       google::cloud::notebooks::MakeManagedNotebookServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ManagedNotebookServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::notebooks::ManagedNotebookServiceClient(
+        google::cloud::notebooks::MakeManagedNotebookServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/notebooks/samples/notebook_client_samples.cc
+++ b/google/cloud/notebooks/samples/notebook_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/notebooks/notebook_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: NotebookServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::notebooks::NotebookServiceClient(
       google::cloud::notebooks::MakeNotebookServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: NotebookServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::notebooks::NotebookServiceClient(
+        google::cloud::notebooks::MakeNotebookServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/optimization/samples/fleet_routing_client_samples.cc
+++ b/google/cloud/optimization/samples/fleet_routing_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/optimization/fleet_routing_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: FleetRoutingClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::optimization::FleetRoutingClient(
       google::cloud::optimization::MakeFleetRoutingConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: FleetRoutingClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::optimization::FleetRoutingClient(
+        google::cloud::optimization::MakeFleetRoutingConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/orgpolicy/samples/org_policy_client_samples.cc
+++ b/google/cloud/orgpolicy/samples/org_policy_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/orgpolicy/org_policy_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: OrgPolicyClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::orgpolicy::OrgPolicyClient(
       google::cloud::orgpolicy::MakeOrgPolicyConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: OrgPolicyClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::orgpolicy::OrgPolicyClient(
+        google::cloud::orgpolicy::MakeOrgPolicyConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/osconfig/samples/agent_endpoint_client_samples.cc
+++ b/google/cloud/osconfig/samples/agent_endpoint_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/osconfig/agent_endpoint_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AgentEndpointServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::osconfig::AgentEndpointServiceClient(
       google::cloud::osconfig::MakeAgentEndpointServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AgentEndpointServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::osconfig::AgentEndpointServiceClient(
+        google::cloud::osconfig::MakeAgentEndpointServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/osconfig/samples/os_config_client_samples.cc
+++ b/google/cloud/osconfig/samples/os_config_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/osconfig/os_config_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: OsConfigServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::osconfig::OsConfigServiceClient(
       google::cloud::osconfig::MakeOsConfigServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: OsConfigServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::osconfig::OsConfigServiceClient(
+        google::cloud::osconfig::MakeOsConfigServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/oslogin/samples/os_login_client_samples.cc
+++ b/google/cloud/oslogin/samples/os_login_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/oslogin/os_login_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: OsLoginServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::oslogin::OsLoginServiceClient(
       google::cloud::oslogin::MakeOsLoginServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: OsLoginServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::oslogin::OsLoginServiceClient(
+        google::cloud::oslogin::MakeOsLoginServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/policytroubleshooter/samples/iam_checker_client_samples.cc
+++ b/google/cloud/policytroubleshooter/samples/iam_checker_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/policytroubleshooter/iam_checker_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: IamCheckerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::policytroubleshooter::IamCheckerClient(
       google::cloud::policytroubleshooter::MakeIamCheckerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: IamCheckerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::policytroubleshooter::IamCheckerClient(
+        google::cloud::policytroubleshooter::MakeIamCheckerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/privateca/samples/certificate_authority_client_samples.cc
+++ b/google/cloud/privateca/samples/certificate_authority_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/privateca/certificate_authority_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CertificateAuthorityServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::privateca::CertificateAuthorityServiceClient(
       google::cloud::privateca::MakeCertificateAuthorityServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CertificateAuthorityServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::privateca::CertificateAuthorityServiceClient(
+        google::cloud::privateca::MakeCertificateAuthorityServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/profiler/samples/profiler_client_samples.cc
+++ b/google/cloud/profiler/samples/profiler_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/profiler/profiler_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ProfilerServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::profiler::ProfilerServiceClient(
       google::cloud::profiler::MakeProfilerServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ProfilerServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::profiler::ProfilerServiceClient(
+        google::cloud::profiler::MakeProfilerServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/pubsublite/samples/admin_client_samples.cc
+++ b/google/cloud/pubsublite/samples/admin_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/pubsublite/admin_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: AdminServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::pubsublite::AdminServiceClient(
       google::cloud::pubsublite::MakeAdminServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: AdminServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::pubsublite::AdminServiceClient(
+        google::cloud::pubsublite::MakeAdminServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/pubsublite/samples/topic_stats_client_samples.cc
+++ b/google/cloud/pubsublite/samples/topic_stats_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/pubsublite/topic_stats_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TopicStatsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::pubsublite::TopicStatsServiceClient(
       google::cloud::pubsublite::MakeTopicStatsServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TopicStatsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::pubsublite::TopicStatsServiceClient(
+        google::cloud::pubsublite::MakeTopicStatsServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/recommender/samples/recommender_client_samples.cc
+++ b/google/cloud/recommender/samples/recommender_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/recommender/recommender_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: RecommenderClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::recommender::RecommenderClient(
       google::cloud::recommender::MakeRecommenderConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: RecommenderClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::recommender::RecommenderClient(
+        google::cloud::recommender::MakeRecommenderConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/redis/samples/cloud_redis_client_samples.cc
+++ b/google/cloud/redis/samples/cloud_redis_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/redis/cloud_redis_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudRedisClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::redis::CloudRedisClient(
       google::cloud::redis::MakeCloudRedisConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudRedisClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::redis::CloudRedisClient(
+        google::cloud::redis::MakeCloudRedisConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/resourcemanager/samples/folders_client_samples.cc
+++ b/google/cloud/resourcemanager/samples/folders_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/resourcemanager/folders_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: FoldersClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::resourcemanager::FoldersClient(
       google::cloud::resourcemanager::MakeFoldersConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: FoldersClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::resourcemanager::FoldersClient(
+        google::cloud::resourcemanager::MakeFoldersConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/resourcemanager/samples/organizations_client_samples.cc
+++ b/google/cloud/resourcemanager/samples/organizations_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/resourcemanager/organizations_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: OrganizationsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::resourcemanager::OrganizationsClient(
       google::cloud::resourcemanager::MakeOrganizationsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: OrganizationsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::resourcemanager::OrganizationsClient(
+        google::cloud::resourcemanager::MakeOrganizationsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/resourcemanager/samples/projects_client_samples.cc
+++ b/google/cloud/resourcemanager/samples/projects_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/resourcemanager/projects_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ProjectsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::resourcemanager::ProjectsClient(
       google::cloud::resourcemanager::MakeProjectsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ProjectsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::resourcemanager::ProjectsClient(
+        google::cloud::resourcemanager::MakeProjectsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/resourcesettings/samples/resource_settings_client_samples.cc
+++ b/google/cloud/resourcesettings/samples/resource_settings_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/resourcesettings/resource_settings_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ResourceSettingsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::resourcesettings::ResourceSettingsServiceClient(
       google::cloud::resourcesettings::MakeResourceSettingsServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ResourceSettingsServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::resourcesettings::ResourceSettingsServiceClient(
+        google::cloud::resourcesettings::MakeResourceSettingsServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/retail/samples/catalog_client_samples.cc
+++ b/google/cloud/retail/samples/catalog_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/retail/catalog_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CatalogServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::retail::CatalogServiceClient(
       google::cloud::retail::MakeCatalogServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CatalogServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::retail::CatalogServiceClient(
+        google::cloud::retail::MakeCatalogServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/retail/samples/completion_client_samples.cc
+++ b/google/cloud/retail/samples/completion_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/retail/completion_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CompletionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::retail::CompletionServiceClient(
       google::cloud::retail::MakeCompletionServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CompletionServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::retail::CompletionServiceClient(
+        google::cloud::retail::MakeCompletionServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/retail/samples/prediction_client_samples.cc
+++ b/google/cloud/retail/samples/prediction_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/retail/prediction_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: PredictionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::retail::PredictionServiceClient(
       google::cloud::retail::MakePredictionServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: PredictionServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::retail::PredictionServiceClient(
+        google::cloud::retail::MakePredictionServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/retail/samples/product_client_samples.cc
+++ b/google/cloud/retail/samples/product_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/retail/product_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ProductServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::retail::ProductServiceClient(
       google::cloud::retail::MakeProductServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ProductServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::retail::ProductServiceClient(
+        google::cloud::retail::MakeProductServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/retail/samples/search_client_samples.cc
+++ b/google/cloud/retail/samples/search_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/retail/search_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SearchServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::retail::SearchServiceClient(
       google::cloud::retail::MakeSearchServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SearchServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::retail::SearchServiceClient(
+        google::cloud::retail::MakeSearchServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/retail/samples/user_event_client_samples.cc
+++ b/google/cloud/retail/samples/user_event_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/retail/user_event_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: UserEventServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::retail::UserEventServiceClient(
       google::cloud::retail::MakeUserEventServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: UserEventServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::retail::UserEventServiceClient(
+        google::cloud::retail::MakeUserEventServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/run/samples/revisions_client_samples.cc
+++ b/google/cloud/run/samples/revisions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/run/revisions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: RevisionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::run::RevisionsClient(
       google::cloud::run::MakeRevisionsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: RevisionsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::run::RevisionsClient(
+        google::cloud::run::MakeRevisionsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/run/samples/services_client_samples.cc
+++ b/google/cloud/run/samples/services_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/run/services_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ServicesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::run::ServicesClient(
       google::cloud::run::MakeServicesConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ServicesClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::run::ServicesClient(
+        google::cloud::run::MakeServicesConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/scheduler/samples/cloud_scheduler_client_samples.cc
+++ b/google/cloud/scheduler/samples/cloud_scheduler_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/scheduler/cloud_scheduler_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudSchedulerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::scheduler::CloudSchedulerClient(
       google::cloud::scheduler::MakeCloudSchedulerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudSchedulerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::scheduler::CloudSchedulerClient(
+        google::cloud::scheduler::MakeCloudSchedulerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/secretmanager/samples/secret_manager_client_samples.cc
+++ b/google/cloud/secretmanager/samples/secret_manager_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/secretmanager/secret_manager_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SecretManagerServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::secretmanager::SecretManagerServiceClient(
       google::cloud::secretmanager::MakeSecretManagerServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SecretManagerServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::secretmanager::SecretManagerServiceClient(
+        google::cloud::secretmanager::MakeSecretManagerServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/securitycenter/samples/security_center_client_samples.cc
+++ b/google/cloud/securitycenter/samples/security_center_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/securitycenter/security_center_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SecurityCenterClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::securitycenter::SecurityCenterClient(
       google::cloud::securitycenter::MakeSecurityCenterConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SecurityCenterClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::securitycenter::SecurityCenterClient(
+        google::cloud::securitycenter::MakeSecurityCenterConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/servicecontrol/samples/quota_controller_client_samples.cc
+++ b/google/cloud/servicecontrol/samples/quota_controller_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/servicecontrol/quota_controller_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: QuotaControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::servicecontrol::QuotaControllerClient(
       google::cloud::servicecontrol::MakeQuotaControllerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: QuotaControllerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::servicecontrol::QuotaControllerClient(
+        google::cloud::servicecontrol::MakeQuotaControllerConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/servicecontrol/samples/service_controller_client_samples.cc
+++ b/google/cloud/servicecontrol/samples/service_controller_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/servicecontrol/service_controller_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ServiceControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::servicecontrol::ServiceControllerClient(
       google::cloud::servicecontrol::MakeServiceControllerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ServiceControllerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::servicecontrol::ServiceControllerClient(
+        google::cloud::servicecontrol::MakeServiceControllerConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/servicedirectory/samples/lookup_client_samples.cc
+++ b/google/cloud/servicedirectory/samples/lookup_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/servicedirectory/lookup_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: LookupServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::servicedirectory::LookupServiceClient(
       google::cloud::servicedirectory::MakeLookupServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: LookupServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::servicedirectory::LookupServiceClient(
+        google::cloud::servicedirectory::MakeLookupServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/servicedirectory/samples/registration_client_samples.cc
+++ b/google/cloud/servicedirectory/samples/registration_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/servicedirectory/registration_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: RegistrationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::servicedirectory::RegistrationServiceClient(
       google::cloud::servicedirectory::MakeRegistrationServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: RegistrationServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::servicedirectory::RegistrationServiceClient(
+        google::cloud::servicedirectory::MakeRegistrationServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/servicemanagement/samples/service_manager_client_samples.cc
+++ b/google/cloud/servicemanagement/samples/service_manager_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/servicemanagement/service_manager_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ServiceManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::servicemanagement::ServiceManagerClient(
       google::cloud::servicemanagement::MakeServiceManagerConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ServiceManagerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::servicemanagement::ServiceManagerClient(
+        google::cloud::servicemanagement::MakeServiceManagerConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +84,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/serviceusage/samples/service_usage_client_samples.cc
+++ b/google/cloud/serviceusage/samples/service_usage_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/serviceusage/service_usage_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ServiceUsageClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::serviceusage::ServiceUsageClient(
       google::cloud::serviceusage::MakeServiceUsageConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ServiceUsageClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::serviceusage::ServiceUsageClient(
+        google::cloud::serviceusage::MakeServiceUsageConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/shell/samples/cloud_shell_client_samples.cc
+++ b/google/cloud/shell/samples/cloud_shell_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/shell/cloud_shell_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudShellServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::shell::CloudShellServiceClient(
       google::cloud::shell::MakeCloudShellServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudShellServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::shell::CloudShellServiceClient(
+        google::cloud::shell::MakeCloudShellServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/spanner/admin/samples/database_admin_client_samples.cc
+++ b/google/cloud/spanner/admin/samples/database_admin_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/spanner/admin/database_admin_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: DatabaseAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::spanner_admin::DatabaseAdminClient(
       google::cloud::spanner_admin::MakeDatabaseAdminConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: DatabaseAdminClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::spanner_admin::DatabaseAdminClient(
+        google::cloud::spanner_admin::MakeDatabaseAdminConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/spanner/admin/samples/instance_admin_client_samples.cc
+++ b/google/cloud/spanner/admin/samples/instance_admin_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/spanner/admin/instance_admin_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: InstanceAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::spanner_admin::InstanceAdminClient(
       google::cloud::spanner_admin::MakeInstanceAdminConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: InstanceAdminClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::spanner_admin::InstanceAdminClient(
+        google::cloud::spanner_admin::MakeInstanceAdminConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/speech/samples/speech_client_samples.cc
+++ b/google/cloud/speech/samples/speech_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/speech/speech_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: SpeechClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::speech::SpeechClient(
       google::cloud::speech::MakeSpeechConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: SpeechClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::speech::SpeechClient(
+        google::cloud::speech::MakeSpeechConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/storagetransfer/samples/storage_transfer_client_samples.cc
+++ b/google/cloud/storagetransfer/samples/storage_transfer_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/storagetransfer/storage_transfer_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: StorageTransferServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::storagetransfer::StorageTransferServiceClient(
       google::cloud::storagetransfer::MakeStorageTransferServiceConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: StorageTransferServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::storagetransfer::StorageTransferServiceClient(
+        google::cloud::storagetransfer::MakeStorageTransferServiceConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/talent/samples/company_client_samples.cc
+++ b/google/cloud/talent/samples/company_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/talent/company_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CompanyServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::talent::CompanyServiceClient(
       google::cloud::talent::MakeCompanyServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CompanyServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::talent::CompanyServiceClient(
+        google::cloud::talent::MakeCompanyServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/talent/samples/completion_client_samples.cc
+++ b/google/cloud/talent/samples/completion_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/talent/completion_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CompletionClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::talent::CompletionClient(
       google::cloud::talent::MakeCompletionConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CompletionClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::talent::CompletionClient(
+        google::cloud::talent::MakeCompletionConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/talent/samples/event_client_samples.cc
+++ b/google/cloud/talent/samples/event_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/talent/event_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: EventServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::talent::EventServiceClient(
       google::cloud::talent::MakeEventServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: EventServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::talent::EventServiceClient(
+        google::cloud::talent::MakeEventServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/talent/samples/job_client_samples.cc
+++ b/google/cloud/talent/samples/job_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/talent/job_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: JobServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::talent::JobServiceClient(
       google::cloud::talent::MakeJobServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: JobServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::talent::JobServiceClient(
+        google::cloud::talent::MakeJobServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/talent/samples/tenant_client_samples.cc
+++ b/google/cloud/talent/samples/tenant_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/talent/tenant_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TenantServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::talent::TenantServiceClient(
       google::cloud::talent::MakeTenantServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TenantServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::talent::TenantServiceClient(
+        google::cloud::talent::MakeTenantServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/tasks/samples/cloud_tasks_client_samples.cc
+++ b/google/cloud/tasks/samples/cloud_tasks_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/tasks/cloud_tasks_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: CloudTasksClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::tasks::CloudTasksClient(
       google::cloud::tasks::MakeCloudTasksConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: CloudTasksClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::tasks::CloudTasksClient(
+        google::cloud::tasks::MakeCloudTasksConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/texttospeech/samples/text_to_speech_client_samples.cc
+++ b/google/cloud/texttospeech/samples/text_to_speech_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/texttospeech/text_to_speech_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TextToSpeechClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::texttospeech::TextToSpeechClient(
       google::cloud::texttospeech::MakeTextToSpeechConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TextToSpeechClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::texttospeech::TextToSpeechClient(
+        google::cloud::texttospeech::MakeTextToSpeechConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/tpu/samples/tpu_client_samples.cc
+++ b/google/cloud/tpu/samples/tpu_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/tpu/tpu_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TpuClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::tpu::TpuClient(
       google::cloud::tpu::MakeTpuConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TpuClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::tpu::TpuClient(
+        google::cloud::tpu::MakeTpuConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/trace/samples/trace_client_samples.cc
+++ b/google/cloud/trace/samples/trace_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/trace/trace_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TraceServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::trace::TraceServiceClient(
       google::cloud::trace::MakeTraceServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TraceServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::trace::TraceServiceClient(
+        google::cloud::trace::MakeTraceServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/translate/samples/translation_client_samples.cc
+++ b/google/cloud/translate/samples/translation_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/translate/translation_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TranslationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::translate::TranslationServiceClient(
       google::cloud::translate::MakeTranslationServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TranslationServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::translate::TranslationServiceClient(
+        google::cloud::translate::MakeTranslationServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/video/samples/livestream_client_samples.cc
+++ b/google/cloud/video/samples/livestream_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/video/livestream_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: LivestreamServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::video::LivestreamServiceClient(
       google::cloud::video::MakeLivestreamServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: LivestreamServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::video::LivestreamServiceClient(
+        google::cloud::video::MakeLivestreamServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/video/samples/transcoder_client_samples.cc
+++ b/google/cloud/video/samples/transcoder_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/video/transcoder_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: TranscoderServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::video::TranscoderServiceClient(
       google::cloud::video::MakeTranscoderServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: TranscoderServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::video::TranscoderServiceClient(
+        google::cloud::video::MakeTranscoderServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/video/samples/video_stitcher_client_samples.cc
+++ b/google/cloud/video/samples/video_stitcher_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/video/video_stitcher_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: VideoStitcherServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::video::VideoStitcherServiceClient(
       google::cloud::video::MakeVideoStitcherServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: VideoStitcherServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::video::VideoStitcherServiceClient(
+        google::cloud::video::MakeVideoStitcherServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/videointelligence/samples/video_intelligence_client_samples.cc
+++ b/google/cloud/videointelligence/samples/video_intelligence_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/videointelligence/video_intelligence_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: VideoIntelligenceServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -38,16 +42,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       google::cloud::videointelligence::VideoIntelligenceServiceClient(
           google::cloud::videointelligence::
               MakeVideoIntelligenceServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: VideoIntelligenceServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::videointelligence::VideoIntelligenceServiceClient(
+        google::cloud::videointelligence::
+            MakeVideoIntelligenceServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -55,6 +86,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/vision/samples/image_annotator_client_samples.cc
+++ b/google/cloud/vision/samples/image_annotator_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/vision/image_annotator_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ImageAnnotatorClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::vision::ImageAnnotatorClient(
       google::cloud::vision::MakeImageAnnotatorConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ImageAnnotatorClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::vision::ImageAnnotatorClient(
+        google::cloud::vision::MakeImageAnnotatorConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/vision/samples/product_search_client_samples.cc
+++ b/google/cloud/vision/samples/product_search_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/vision/product_search_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ProductSearchClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::vision::ProductSearchClient(
       google::cloud::vision::MakeProductSearchConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ProductSearchClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::vision::ProductSearchClient(
+        google::cloud::vision::MakeProductSearchConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/vmmigration/samples/vm_migration_client_samples.cc
+++ b/google/cloud/vmmigration/samples/vm_migration_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/vmmigration/vm_migration_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: VmMigrationClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::vmmigration::VmMigrationClient(
       google::cloud::vmmigration::MakeVmMigrationConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: VmMigrationClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::vmmigration::VmMigrationClient(
+        google::cloud::vmmigration::MakeVmMigrationConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/vpcaccess/samples/vpc_access_client_samples.cc
+++ b/google/cloud/vpcaccess/samples/vpc_access_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/vpcaccess/vpc_access_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: VpcAccessServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::vpcaccess::VpcAccessServiceClient(
       google::cloud::vpcaccess::MakeVpcAccessServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: VpcAccessServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::vpcaccess::VpcAccessServiceClient(
+        google::cloud::vpcaccess::MakeVpcAccessServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/webrisk/samples/web_risk_client_samples.cc
+++ b/google/cloud/webrisk/samples/web_risk_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/webrisk/web_risk_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: WebRiskServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::webrisk::WebRiskServiceClient(
       google::cloud::webrisk::MakeWebRiskServiceConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: WebRiskServiceClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::webrisk::WebRiskServiceClient(
+        google::cloud::webrisk::MakeWebRiskServiceConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/websecurityscanner/samples/web_security_scanner_client_samples.cc
+++ b/google/cloud/websecurityscanner/samples/web_security_scanner_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/websecurityscanner/web_security_scanner_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: WebSecurityScannerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -37,16 +41,43 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
   auto client = google::cloud::websecurityscanner::WebSecurityScannerClient(
       google::cloud::websecurityscanner::MakeWebSecurityScannerConnection(
           options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: WebSecurityScannerClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::websecurityscanner::WebSecurityScannerClient(
+        google::cloud::websecurityscanner::MakeWebSecurityScannerConnection(
+            options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -54,6 +85,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/workflows/samples/executions_client_samples.cc
+++ b/google/cloud/workflows/samples/executions_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/workflows/executions_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: ExecutionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::workflows::ExecutionsClient(
       google::cloud::workflows::MakeExecutionsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: ExecutionsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::workflows::ExecutionsClient(
+        google::cloud::workflows::MakeExecutionsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/workflows/samples/workflows_client_samples.cc
+++ b/google/cloud/workflows/samples/workflows_client_samples.cc
@@ -18,11 +18,15 @@
 
 #include "google/cloud/workflows/workflows_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
+// main-dox-marker: WorkflowsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {
@@ -36,16 +40,42 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
       "private.googleapis.com");
   auto client = google::cloud::workflows::WorkflowsClient(
       google::cloud::workflows::MakeWorkflowsConnection(options));
-  // Use the `client` object as usual
   //! [set-client-endpoint]
 }
 
-// main-dox-marker: WorkflowsClient
+void WithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
+  }
+  //! [with-service-account]
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);  // Minimal error handling in examples
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return google::cloud::workflows::WorkflowsClient(
+        google::cloud::workflows::MakeWorkflowsConnection(options));
+  }
+  //! [with-service-account]
+  (argv.at(0));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::testing_util::Usage{"auto"};
+  namespace examples = ::google::cloud::testing_util;
+  using ::google::cloud::internal::GetEnv;
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet(
+      {"GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE"});
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({});
+
+  std::cout << "\nRunning WithServiceAccount() example" << std::endl;
+  WithServiceAccount({keyfile});
 }
 
 }  // namespace
@@ -53,6 +83,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
+      {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);


### PR DESCRIPTION
Create a minimal examples showing how to use service account
credentials for each `*Client` class.

Part of the work for #10114

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10138)
<!-- Reviewable:end -->
