### PR TITLE
doc(spanner): add `*Client` samples

### DIFF
--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -49,11 +49,7 @@ the Cloud Spanner C++ client library API.
 
 @include quickstart.cc
 
-## API Notes
-
-The following are general notes about using the library.
-
-### Environment Variables
+## Environment Variables
 
 There are several environment variables that can be set to configure certain
 behaviors in the library.
@@ -134,6 +130,36 @@ there is no value.
 
 @snippet samples.cc example-status-or
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.  For example, this will override the default
+endpoint for `google::cloud::pubsub::Publisher`:
+
+@snippet client_samples.cc client-set-endpoint
+
+Follow these links for additional examples
+ [DatabaseAdminClient](@ref DatabaseAdminClient-set-endpoint-snippet)
+ [InstanceAdminClient](@ref InstanceAdminClient-set-endpoint-snippet)
+
+## Override the authentication configuration
+
+Some applications cannot use the default authentication mechanism (known as
+[Application Default Credentials]). You can override this default using
+`google::cloud::UnifiedCredentialsOption`. The following example shows how
+to explicitly load a service account key file.
+
+@snippet client_samples.cc client-with-service-account
+
+Keep in mind that we chose this as an example because it is relatively easy to
+understand. Consult the [Best practices for managing service account keys]
+guide for more details.
+
+Follow these links for additional examples
+ [DatabaseAdminClient](@ref DatabaseAdminClient-with-service-account-snippet)
+ [InstanceAdminClient](@ref InstanceAdminClient-with-service-account-snippet)
+
 ## Retry, Backoff, and Idempotency Policies.
 
 The library automatically retries requests that fail with transient errors, and
@@ -167,5 +193,41 @@ period between retries.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 [quickstart-link]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/spanner/quickstart
 [status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
+
+*/
+
+/*! @page Client-set-endpoint-snippet Override Client Default Endpoint
+
+@snippet google/cloud/spanner/samples/client_samples.cc client-set-endpoint
+
+*/
+
+/*! @page Client-with-service-account-snippet Override Client Default Authentication
+
+@snippet google/cloud/spanner/samples/client_samples.cc client-with-service-account
+
+*/
+
+/*! @page DatabaseAdminClient-set-endpoint-snippet Override DatabaseAdminClient Default Endpoint
+
+@snippet google/cloud/spanner/samples/client_samples.cc database-admin-client-set-endpoint
+
+*/
+
+/*! @page DatabaseAdminClient-with-service-account-snippet Override DatabaseAdminClient Default Authentication
+
+@snippet google/cloud/spanner/samples/client_samples.cc database-admin-client-with-service-account
+
+*/
+
+/*! @page InstanceAdminClient-set-endpoint-snippet Override InstanceAdminClient Default Endpoint
+
+@snippet google/cloud/spanner/samples/client_samples.cc instance-admin-client-set-endpoint
+
+*/
+
+/*! @page InstanceAdminClient-with-service-account-snippet Override InstanceAdminClient Default Authentication
+
+@snippet google/cloud/spanner/samples/client_samples.cc instance-admin-client-with-service-account
 
 */

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -15,8 +15,9 @@
 # ~~~
 
 function (spanner_client_define_samples)
-    set(spanner_client_integration_samples # cmake-format: sort
-                                           postgresql_samples.cc samples.cc)
+    set(spanner_client_integration_samples
+        # cmake-format: sort
+        client_samples.cc postgresql_samples.cc samples.cc)
     set(spanner_client_unit_samples # cmake-format: sort
                                     mock_execute_query.cc)
 

--- a/google/cloud/spanner/samples/client_samples.cc
+++ b/google/cloud/spanner/samples/client_samples.cc
@@ -1,0 +1,212 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/admin/database_admin_client.h"
+#include "google/cloud/spanner/admin/instance_admin_client.h"
+#include "google/cloud/spanner/client.h"
+#include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/spanner/testing/random_instance_name.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+void ClientSetEndpoint(std::vector<std::string> const& argv) {
+  if (argv.size() != 3) {
+    throw google::cloud::testing_util::Usage{
+        "client-set-endpoint <project-id> <instance-id> <database-id>"};
+  }
+  //! [client-set-endpoint]
+  namespace spanner = ::google::cloud::spanner;
+  [](std::string const& project_id, std::string const& instance_id,
+     std::string const& database_id) {
+    auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
+        "private.googleapis.com");
+    return spanner::Client(spanner::MakeConnection(
+        spanner::Database(project_id, instance_id, database_id), options));
+  }
+  //! [client-set-endpoint]
+  (argv.at(0), argv.at(1), argv.at(2));
+}
+
+void ClientWithServiceAccount(std::vector<std::string> const& argv) {
+  if (argv.size() != 4) {
+    throw google::cloud::testing_util::Usage{
+        "client-with-service-account <project-id> <instance-id> <database-id> "
+        "<keyfile>"};
+  }
+  //! [client-with-service-account]
+  namespace spanner = ::google::cloud::spanner;
+  [](std::string const& project_id, std::string const& instance_id,
+     std::string const& database_id, std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return spanner::Client(spanner::MakeConnection(
+        spanner::Database(project_id, instance_id, database_id), options));
+  }
+  //! [client-with-service-account]
+  (argv.at(0), argv.at(1), argv.at(2), argv.at(3));
+}
+
+void DatabaseAdminClientSetEndpoint(std::vector<std::string> const& argv) {
+  if (!argv.empty()) {
+    throw google::cloud::testing_util::Usage{
+        "database-admin-client-set-endpoint"};
+  }
+  //! [database-admin-client-set-endpoint]
+  namespace admin = ::google::cloud::spanner_admin;
+  []() {
+    auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
+        "private.googleapis.com");
+    return admin::DatabaseAdminClient(
+        admin::MakeDatabaseAdminConnection(options));
+  }
+  //! [database-admin-client-set-endpoint]
+  ();
+}
+
+void DatabaseAdminClientWithServiceAccount(
+    std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{
+        "database-admin-client-with-service-account <keyfile>"};
+  }
+  //! [database-admin-client-with-service-account]
+  namespace admin = ::google::cloud::spanner_admin;
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return admin::DatabaseAdminClient(
+        admin::MakeDatabaseAdminConnection(options));
+  }
+  //! [database-admin-client-with-service-account]
+  (argv.at(0));
+}
+
+void InstanceAdminClientSetEndpoint(std::vector<std::string> const& argv) {
+  if (!argv.empty()) {
+    throw google::cloud::testing_util::Usage{
+        "instance-admin-client-set-endpoint"};
+  }
+  //! [instance-admin-client-set-endpoint]
+  namespace admin = ::google::cloud::spanner_admin;
+  []() {
+    auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
+        "private.googleapis.com");
+    return admin::InstanceAdminClient(
+        admin::MakeInstanceAdminConnection(options));
+  }
+  //! [instance-admin-client-set-endpoint]
+  ();
+}
+
+void InstanceAdminClientWithServiceAccount(
+    std::vector<std::string> const& argv) {
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw google::cloud::testing_util::Usage{
+        "instance-admin-client-with-service-account <keyfile>"};
+  }
+  //! [instance-admin-client-with-service-account]
+  namespace admin = ::google::cloud::spanner_admin;
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return admin::InstanceAdminClient(
+        admin::MakeInstanceAdminConnection(options));
+  }
+  //! [instance-admin-client-with-service-account]
+  (argv.at(0));
+}
+
+void AutoRun(std::vector<std::string> const& argv) {
+  using ::google::cloud::internal::GetEnv;
+  namespace examples = ::google::cloud::testing_util;
+
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE",
+  });
+  auto const emulator = GetEnv("SPANNER_EMULATOR_HOST").has_value();
+  auto const project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value();
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const instance_id =
+      google::cloud::spanner_testing::RandomInstanceName(generator);
+  auto const database_id =
+      google::cloud::spanner_testing::RandomDatabaseName(generator);
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
+
+  std::cout << "\nRunning ClientSetEndpoint() example" << std::endl;
+  ClientSetEndpoint({project_id, instance_id, database_id});
+
+  if (!emulator) {
+    // On the emulator this blocks, as the emulator does not support credentials
+    // that require SSL.
+    std::cout << "\nRunning ClientWithServiceAccount() example" << std::endl;
+    ClientWithServiceAccount({project_id, instance_id, database_id, keyfile});
+  }
+
+  std::cout << "\nRunning DatabaseAdminClientSetEndpoint() example"
+            << std::endl;
+  DatabaseAdminClientSetEndpoint({});
+
+  std::cout << "\nRunning DatabaseAdminClientWithServiceAccount() example"
+            << std::endl;
+  DatabaseAdminClientWithServiceAccount({keyfile});
+
+  std::cout << "\nRunning InstanceAdminClientSetEndpoint() example"
+            << std::endl;
+  InstanceAdminClientSetEndpoint({});
+
+  std::cout << "\nRunning InstanceAdminClientWithServiceAccount() example"
+            << std::endl;
+  InstanceAdminClientWithServiceAccount({keyfile});
+
+  std::cout << "\nAutoRun done" << std::endl;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+  google::cloud::testing_util::Example example({
+      {"client-set-endpoint", ClientSetEndpoint},
+      {"client-with-service-account", ClientWithServiceAccount},
+      {"database-admin-client-set-endpoint", DatabaseAdminClientSetEndpoint},
+      {"database-admin-client-with-service-account",
+       DatabaseAdminClientWithServiceAccount},
+      {"database-admin-client-set-endpoint", DatabaseAdminClientSetEndpoint},
+      {"database-admin-client-with-service-account",
+       DatabaseAdminClientWithServiceAccount},
+      {"auto", AutoRun},
+  });
+  return example.Run(argc, argv);
+}

--- a/google/cloud/spanner/samples/spanner_client_integration_samples.bzl
+++ b/google/cloud/spanner/samples/spanner_client_integration_samples.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 spanner_client_integration_samples = [
+    "client_samples.cc",
     "postgresql_samples.cc",
     "samples.cc",
 ]


### PR DESCRIPTION
Add examples showing how to override the default endpoint and default authentication.

Fixes #10141 and fixes @10142