### PR TITLE
test(storage): reduce runtime of ThreadIntegrationTest.Unshared

### DIFF
--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -115,7 +115,7 @@ TEST_F(ThreadIntegrationTest, Unshared) {
   // feature.
   auto const thread_count =
       (std::min)(32U, (std::max)(8U, std::thread::hardware_concurrency()));
-  auto const object_count = 50 * thread_count;
+  auto const object_count = 25 * thread_count;
   std::vector<std::string> objects(object_count);
   std::generate(objects.begin(), objects.end(),
                 [this] { return MakeRandomObjectName(); });


### PR DESCRIPTION
take #9918 a step further, reducing the objects from 50/thread to 25/thread.

Motivated by #9909

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10147)
<!-- Reviewable:end -->
