### PR TITLE
doc(bigtable): add `*Client` samples

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -18,8 +18,10 @@ include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Google Cloud Bigtable C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Bigtable")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
-set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
-                         "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
+set(DOXYGEN_EXAMPLE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/examples"
+    "${CMAKE_CURRENT_SOURCE_DIR}/admin/samples"
+    "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
 set(DOXYGEN_EXCLUDE_SYMBOLS "benchmarks" "bigtable_admin_internal"
                             "bigtable_internal" "internal" "testing" "examples")
 

--- a/google/cloud/bigtable/doc/bigtable-main.dox
+++ b/google/cloud/bigtable/doc/bigtable-main.dox
@@ -168,20 +168,20 @@ guide for more details.
 
 /*! @page BigtableTableAdminClient-set-endpoint-snippet Override @c BigtableTableAdminClient Default Endpoint
 
-@snippet google/cloud/bigtable/examples/client_samples.cc table-admin-client-set-endpoint
+@snippet google/cloud/bigtable/admin/samples/bigtable_table_admin_client_samples.cc set-client-endpoint
 */
 
 /*! @page BigtableTableAdminClient-with-service-account-snippet Override @c BigtableTableAdminClient Default Authentication
 
-@snippet google/cloud/bigtable/examples/client_samples.cc table-admin-client-with-service-account
+@snippet google/cloud/bigtable/admin/samples/bigtable_table_admin_client_samples.cc with-service-account
 */
 
 /*! @page BigtableInstanceAdminClient-set-endpoint-snippet Override @c BigtableInstanceAdminClient Default Endpoint
 
-@snippet google/cloud/bigtable/examples/client_samples.cc instance-admin-client-set-endpoint
+@snippet google/cloud/bigtable/admin/samples/bigtable_instance_admin_client_samples.cc set-client-endpoint
 */
 
 /*! @page BigtableInstanceAdminClient-with-service-account-snippet Override @c BigtableInstanceAdminClient Default Authentication
 
-@snippet google/cloud/bigtable/examples/client_samples.cc instance-admin-client-with-service-account
+@snippet google/cloud/bigtable/admin/samples/bigtable_instance_admin_client_samples.cc with-service-account
 */

--- a/google/cloud/bigtable/doc/bigtable-main.dox
+++ b/google/cloud/bigtable/doc/bigtable-main.dox
@@ -78,6 +78,46 @@ which should give you a taste of the Cloud Bigtable C++ client library API.
   actually print anything until the application sets a backend or they set this
   environment variable.
 
+## Override the default endpoint
+
+In some cases, you may need to override the default endpoint used by the client
+library. Use the `google::cloud::EndpointOption` when initializing the client
+library to change this default.  For example, this will override the default
+endpoint for `google::cloud::bigtable::Table`:
+
+@snippet client_samples.cc table-set-endpoint
+
+Follow these links for additional examples
+ [BigtableTableAdminClient](@ref BigtableTableAdminClient-set-endpoint-snippet)
+ [InstanceTableAdminClient](@ref BigtableInstanceAdminClient-set-endpoint-snippet)
+
+## Override the authentication configuration
+
+Some applications cannot use the default authentication mechanism (known as
+[Application Default Credentials]). You can override this default using
+`google::cloud::UnifiedCredentialsOption`. The following example shows how
+to explicitly load a service account key file.
+
+@snippet client_samples.cc table-with-service-account
+
+Keep in mind that we chose this as an example because it is relatively easy to
+understand. Consult the [Best practices for managing service account keys]
+guide for more details.
+
+Follow these links for additional examples
+ [BigtableTableAdminClient](@ref BigtableTableAdminClient-with-service-account-snippet)
+ [InstanceTableAdminClient](@ref BigtableInstanceAdminClient-with-service-account-snippet)
+
+Keep in mind that we chose this as an example because it is relatively easy to
+understand. Consult the [Best practices for managing service account keys]
+guide for more details.
+
+@see @ref guac - for more information on the factory functions to create
+`google::cloud::Credentials` objects.
+
+[Best practices for managing service account keys]: https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys
+[Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
+
 ## Next Steps
 
 - @ref bigtable-hello-world "Hello World Example"
@@ -114,4 +154,34 @@ which should give you a taste of the Cloud Bigtable C++ client library API.
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/INSTALL%2Emd
 
+*/
+
+/*! @page Table-set-endpoint Override @c Table Default Endpoint
+
+@snippet google/cloud/bigtable/examples/client_samples.cc table-set-endpoint
+*/
+
+/*! @page Table-with-service-account-snippet Override @c Table Default Authentication
+
+@snippet google/cloud/bigtable/examples/client_samples.cc table-with-service-account
+*/
+
+/*! @page BigtableTableAdminClient-set-endpoint-snippet Override @c BigtableTableAdminClient Default Endpoint
+
+@snippet google/cloud/bigtable/examples/client_samples.cc table-admin-client-set-endpoint
+*/
+
+/*! @page BigtableTableAdminClient-with-service-account-snippet Override @c BigtableTableAdminClient Default Authentication
+
+@snippet google/cloud/bigtable/examples/client_samples.cc table-admin-client-with-service-account
+*/
+
+/*! @page BigtableInstanceAdminClient-set-endpoint-snippet Override @c BigtableInstanceAdminClient Default Endpoint
+
+@snippet google/cloud/bigtable/examples/client_samples.cc instance-admin-client-set-endpoint
+*/
+
+/*! @page BigtableInstanceAdminClient-with-service-account-snippet Override @c BigtableInstanceAdminClient Default Authentication
+
+@snippet google/cloud/bigtable/examples/client_samples.cc instance-admin-client-with-service-account
 */

--- a/google/cloud/bigtable/examples/CMakeLists.txt
+++ b/google/cloud/bigtable/examples/CMakeLists.txt
@@ -40,6 +40,7 @@ if (BUILD_TESTING)
         bigtable_hello_world.cc
         bigtable_instance_admin_snippets.cc
         bigtable_table_admin_backup_snippets.cc
+        client_samples.cc
         data_async_snippets.cc
         data_filter_snippets.cc
         data_snippets.cc

--- a/google/cloud/bigtable/examples/bigtable_examples.bzl
+++ b/google/cloud/bigtable/examples/bigtable_examples.bzl
@@ -24,6 +24,7 @@ bigtable_examples = [
     "bigtable_hello_world.cc",
     "bigtable_instance_admin_snippets.cc",
     "bigtable_table_admin_backup_snippets.cc",
+    "client_samples.cc",
     "data_async_snippets.cc",
     "data_filter_snippets.cc",
     "data_snippets.cc",

--- a/google/cloud/bigtable/examples/client_samples.cc
+++ b/google/cloud/bigtable/examples/client_samples.cc
@@ -69,83 +69,6 @@ void TableWithServiceAccount(std::vector<std::string> const& argv) {
   (argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
-void TableAdminClientSetEndpoint(std::vector<std::string> const& argv) {
-  namespace examples = ::google::cloud::testing_util;
-  if (!argv.empty()) {
-    throw examples::Usage{"table-admin-client-set-endpoint"};
-  }
-  //! [table-admin-client-set-endpoint]
-  namespace admin = ::google::cloud::bigtable_admin;
-  []() {
-    auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
-        "private.googleapis.com");
-    return admin::BigtableTableAdminClient(
-        admin::MakeBigtableTableAdminConnection(options));
-  }
-  //! [table-admin-client-set-endpoint]
-  ();
-}
-
-void TableAdminClientWithServiceAccount(std::vector<std::string> const& argv) {
-  namespace examples = ::google::cloud::testing_util;
-  if (argv.size() != 1 || argv[0] == "--help") {
-    throw examples::Usage{"table-admin-client-with-service-account"};
-  }
-  //! [table-admin-client-with-service-account]
-  namespace admin = ::google::cloud::bigtable_admin;
-  [](std::string const& keyfile) {
-    auto is = std::ifstream(keyfile);
-    is.exceptions(std::ios::badbit);
-    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
-    auto options =
-        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
-            google::cloud::MakeServiceAccountCredentials(contents));
-    return admin::BigtableTableAdminClient(
-        admin::MakeBigtableTableAdminConnection(options));
-  }
-  //! [table-admin-client-with-service-account]
-  (argv.at(0));
-}
-
-void InstanceAdminClientSetEndpoint(std::vector<std::string> const& argv) {
-  namespace examples = ::google::cloud::testing_util;
-  if (!argv.empty()) {
-    throw examples::Usage{"instance-admin-client-set-endpoint"};
-  }
-  //! [instance-admin-client-set-endpoint]
-  namespace admin = ::google::cloud::bigtable_admin;
-  []() {
-    auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
-        "private.googleapis.com");
-    return admin::BigtableInstanceAdminClient(
-        admin::MakeBigtableInstanceAdminConnection(options));
-  }
-  //! [instance-admin-client-set-endpoint]
-  ();
-}
-
-void InstanceAdminClientWithServiceAccount(
-    std::vector<std::string> const& argv) {
-  namespace examples = ::google::cloud::testing_util;
-  if (argv.size() != 1 || argv[0] == "--help") {
-    throw examples::Usage{"instance-admin-client-with-service-account"};
-  }
-  //! [instance-admin-client-with-service-account]
-  namespace admin = ::google::cloud::bigtable_admin;
-  [](std::string const& keyfile) {
-    auto is = std::ifstream(keyfile);
-    is.exceptions(std::ios::badbit);
-    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
-    auto options =
-        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
-            google::cloud::MakeServiceAccountCredentials(contents));
-    return admin::BigtableInstanceAdminClient(
-        admin::MakeBigtableInstanceAdminConnection(options));
-  }
-  //! [instance-admin-client-with-service-account]
-  (argv.at(0));
-}
-
 void AutoRun(std::vector<std::string> const& argv) {
   using ::google::cloud::internal::GetEnv;
   namespace examples = ::google::cloud::testing_util;
@@ -171,20 +94,6 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning TableWithServiceAccount() sample" << std::endl;
   TableWithServiceAccount({project_id, instance_id, table_id, keyfile});
 
-  std::cout << "\nRunning TableAdminClientSetEndpoint() sample" << std::endl;
-  TableAdminClientSetEndpoint({});
-
-  std::cout << "\nRunning TableAdminClientWithServiceAccount() sample"
-            << std::endl;
-  TableAdminClientWithServiceAccount({keyfile});
-
-  std::cout << "\nRunning InstanceAdminClientSetEndpoint() sample" << std::endl;
-  InstanceAdminClientSetEndpoint({});
-
-  std::cout << "\nRunning InstanceAdminClientWithServiceAccount() sample"
-            << std::endl;
-  InstanceAdminClientWithServiceAccount({keyfile});
-
   std::cout << "\nAutoRun done" << std::endl;
 }
 
@@ -194,12 +103,6 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"table-set-endpoint", TableSetEndpoint},
       {"table-with-service-account", TableWithServiceAccount},
-      {"table-admin-client-set-endpoint", TableAdminClientSetEndpoint},
-      {"table-admin-client-with-service-account",
-       TableAdminClientWithServiceAccount},
-      {"instance-admin-client-set-endpoint", InstanceAdminClientSetEndpoint},
-      {"instance-admin-client-with-service-account",
-       InstanceAdminClientWithServiceAccount},
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigtable/examples/client_samples.cc
+++ b/google/cloud/bigtable/examples/client_samples.cc
@@ -1,0 +1,206 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
+#include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
+#include "google/cloud/bigtable/table.h"
+#include "google/cloud/bigtable/testing/random_names.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/example_driver.h"
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+void TableSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 3) {
+    throw examples::Usage{
+        "table-set-endpoint <project-id> <instance-id> <table-id>"};
+  }
+  //! [table-set-endpoint]
+  namespace bigtable = ::google::cloud::bigtable;
+  [](std::string const& project_id, std::string const& instance_id,
+     std::string const& table_id) {
+    auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
+        "private.googleapis.com");
+    auto resource = bigtable::TableResource(project_id, instance_id, table_id);
+    return bigtable::Table(bigtable::MakeDataConnection(options), resource);
+  }
+  //! [table-set-endpoint]
+  (argv.at(0), argv.at(1), argv.at(2));
+}
+
+void TableWithServiceAccount(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 4) {
+    throw examples::Usage{
+        "table-with-service-account <project-id> <instance-id> <table-id> "
+        "<keyfile>"};
+  }
+  //! [table-with-service-account]
+  namespace bigtable = ::google::cloud::bigtable;
+  [](std::string const& project_id, std::string const& instance_id,
+     std::string const& table_id, std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    auto resource = bigtable::TableResource(project_id, instance_id, table_id);
+    return bigtable::Table(bigtable::MakeDataConnection(options), resource);
+  }
+  //! [table-with-service-account]
+  (argv.at(0), argv.at(1), argv.at(2), argv.at(3));
+}
+
+void TableAdminClientSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (!argv.empty()) {
+    throw examples::Usage{"table-admin-client-set-endpoint"};
+  }
+  //! [table-admin-client-set-endpoint]
+  namespace admin = ::google::cloud::bigtable_admin;
+  []() {
+    auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
+        "private.googleapis.com");
+    return admin::BigtableTableAdminClient(
+        admin::MakeBigtableTableAdminConnection(options));
+  }
+  //! [table-admin-client-set-endpoint]
+  ();
+}
+
+void TableAdminClientWithServiceAccount(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw examples::Usage{"table-admin-client-with-service-account"};
+  }
+  //! [table-admin-client-with-service-account]
+  namespace admin = ::google::cloud::bigtable_admin;
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return admin::BigtableTableAdminClient(
+        admin::MakeBigtableTableAdminConnection(options));
+  }
+  //! [table-admin-client-with-service-account]
+  (argv.at(0));
+}
+
+void InstanceAdminClientSetEndpoint(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (!argv.empty()) {
+    throw examples::Usage{"instance-admin-client-set-endpoint"};
+  }
+  //! [instance-admin-client-set-endpoint]
+  namespace admin = ::google::cloud::bigtable_admin;
+  []() {
+    auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
+        "private.googleapis.com");
+    return admin::BigtableInstanceAdminClient(
+        admin::MakeBigtableInstanceAdminConnection(options));
+  }
+  //! [instance-admin-client-set-endpoint]
+  ();
+}
+
+void InstanceAdminClientWithServiceAccount(
+    std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 1 || argv[0] == "--help") {
+    throw examples::Usage{"instance-admin-client-with-service-account"};
+  }
+  //! [instance-admin-client-with-service-account]
+  namespace admin = ::google::cloud::bigtable_admin;
+  [](std::string const& keyfile) {
+    auto is = std::ifstream(keyfile);
+    is.exceptions(std::ios::badbit);
+    auto contents = std::string(std::istreambuf_iterator<char>(is.rdbuf()), {});
+    auto options =
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeServiceAccountCredentials(contents));
+    return admin::BigtableInstanceAdminClient(
+        admin::MakeBigtableInstanceAdminConnection(options));
+  }
+  //! [instance-admin-client-with-service-account]
+  (argv.at(0));
+}
+
+void AutoRun(std::vector<std::string> const& argv) {
+  using ::google::cloud::internal::GetEnv;
+  namespace examples = ::google::cloud::testing_util;
+
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE",
+  });
+  auto const project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value();
+  auto const keyfile =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
+
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const instance_id =
+      google::cloud::bigtable::testing::RandomInstanceId(generator);
+  auto const table_id =
+      google::cloud::bigtable::testing::RandomTableId(generator);
+
+  std::cout << "\nRunning TableSetEndpoint() sample" << std::endl;
+  TableSetEndpoint({project_id, instance_id, table_id});
+
+  std::cout << "\nRunning TableWithServiceAccount() sample" << std::endl;
+  TableWithServiceAccount({project_id, instance_id, table_id, keyfile});
+
+  std::cout << "\nRunning TableAdminClientSetEndpoint() sample" << std::endl;
+  TableAdminClientSetEndpoint({});
+
+  std::cout << "\nRunning TableAdminClientWithServiceAccount() sample"
+            << std::endl;
+  TableAdminClientWithServiceAccount({keyfile});
+
+  std::cout << "\nRunning InstanceAdminClientSetEndpoint() sample" << std::endl;
+  InstanceAdminClientSetEndpoint({});
+
+  std::cout << "\nRunning InstanceAdminClientWithServiceAccount() sample"
+            << std::endl;
+  InstanceAdminClientWithServiceAccount({keyfile});
+
+  std::cout << "\nAutoRun done" << std::endl;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+  google::cloud::testing_util::Example example({
+      {"table-set-endpoint", TableSetEndpoint},
+      {"table-with-service-account", TableWithServiceAccount},
+      {"table-admin-client-set-endpoint", TableAdminClientSetEndpoint},
+      {"table-admin-client-with-service-account",
+       TableAdminClientWithServiceAccount},
+      {"instance-admin-client-set-endpoint", InstanceAdminClientSetEndpoint},
+      {"instance-admin-client-with-service-account",
+       InstanceAdminClientWithServiceAccount},
+      {"auto", AutoRun},
+  });
+  return example.Run(argc, argv);
+}


### PR DESCRIPTION
Add examples showing how to override the default endpoint and default authentication.

Fixes #10143 and fixes #10144

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10149)
<!-- Reviewable:end -->
