### PR TITLE
cleanup: eliminate ODR violations in samples

### DIFF
--- a/google/cloud/bigquery/samples/BUILD.bazel
+++ b/google/cloud/bigquery/samples/BUILD.bazel
@@ -31,7 +31,6 @@ load(":bigquery_client_samples.bzl", "bigquery_client_samples")
         "//:bigquery",
         "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-        "@com_google_googletest//:gtest_main",
     ],
 ) for test in bigquery_client_samples]
 

--- a/google/cloud/bigquery/samples/CMakeLists.txt
+++ b/google/cloud/bigquery/samples/CMakeLists.txt
@@ -26,10 +26,8 @@ function (bigquery_client_define_samples)
     foreach (fname ${bigquery_client_samples})
         google_cloud_cpp_add_executable(target "bigquery" "${fname}")
         add_test(NAME ${target} COMMAND ${target})
-        target_link_libraries(
-            ${target}
-            PRIVATE google_cloud_cpp_testing google-cloud-cpp::bigquery
-                    GTest::gmock_main GTest::gmock GTest::gtest)
+        target_link_libraries(${target} PRIVATE google_cloud_cpp_testing
+                                                google-cloud-cpp::bigquery)
         google_cloud_cpp_add_common_options(${target})
     endforeach ()
 

--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -65,6 +65,5 @@ load(":bigtable_examples.bzl", "bigtable_examples")
         "//:grpc_utils",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-        "@com_google_googletest//:gtest_main",
     ],
 ) for test in bigtable_examples]

--- a/google/cloud/iam/samples/BUILD.bazel
+++ b/google/cloud/iam/samples/BUILD.bazel
@@ -31,7 +31,6 @@ load(":iam_client_samples.bzl", "iam_client_samples")
         "//:common",
         "//:iam",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-        "@com_google_googletest//:gtest_main",
     ],
 ) for test in iam_client_samples]
 

--- a/google/cloud/iam/samples/CMakeLists.txt
+++ b/google/cloud/iam/samples/CMakeLists.txt
@@ -26,9 +26,8 @@ function (iam_client_define_samples)
     foreach (fname ${iam_client_samples})
         google_cloud_cpp_add_executable(target "iam" "${fname}")
         add_test(NAME ${target} COMMAND ${target})
-        target_link_libraries(
-            ${target} PRIVATE google_cloud_cpp_testing google-cloud-cpp::iam
-                              GTest::gmock_main GTest::gmock GTest::gtest)
+        target_link_libraries(${target} PRIVATE google_cloud_cpp_testing
+                                                google-cloud-cpp::iam)
         google_cloud_cpp_add_common_options(${target})
     endforeach ()
 

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -48,7 +48,6 @@ load(":pubsub_samples_unit_tests.bzl", "pubsub_samples_unit_tests")
 ) for test in pubsub_samples_unit_tests]
 
 load(":pubsub_client_integration_samples.bzl", "pubsub_client_integration_samples")
-load(":pubsub_client_unit_samples.bzl", "pubsub_client_unit_samples")
 
 proto_library(
     name = "samples_proto",
@@ -77,9 +76,10 @@ cc_proto_library(
         ":samples_cc_proto",
         "//:common",
         "//:pubsub",
-        "@com_google_googletest//:gtest_main",
     ] + (["//:iam"] if test == "iam_samples.cc" else []),
 ) for test in pubsub_client_integration_samples]
+
+load(":pubsub_client_unit_samples.bzl", "pubsub_client_unit_samples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/pubsub/samples/CMakeLists.txt
+++ b/google/cloud/pubsub/samples/CMakeLists.txt
@@ -77,9 +77,18 @@ google_cloud_cpp_proto_library(
     pubsub_samples_protos samples.proto PROTO_PATH_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR} LOCAL_INCLUDE)
 
+# Generate a target for each integration test.
+foreach (fname ${pubsub_client_integration_samples})
+    google_cloud_cpp_add_executable(target "pubsub" "${fname}")
+    add_test(NAME ${target} COMMAND ${target})
+    target_link_libraries(
+        ${target} PRIVATE pubsub_samples_protos pubsub_samples_common
+                          google_cloud_cpp_testing google-cloud-cpp::pubsub)
+    google_cloud_cpp_add_common_options(${target})
+endforeach ()
+
 # Generate a target for each unit test.
-foreach (fname ${pubsub_client_integration_samples}
-               ${pubsub_client_unit_samples})
+foreach (fname ${pubsub_client_unit_samples})
     google_cloud_cpp_add_executable(target "pubsub" "${fname}")
     add_test(NAME ${target} COMMAND ${target})
     target_link_libraries(

--- a/google/cloud/spanner/samples/BUILD.bazel
+++ b/google/cloud/spanner/samples/BUILD.bazel
@@ -19,7 +19,6 @@ package(default_visibility = ["//visibility:private"])
 licenses(["notice"])  # Apache 2.0
 
 load(":spanner_client_integration_samples.bzl", "spanner_client_integration_samples")
-load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
@@ -33,9 +32,10 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
         "//:spanner",
         "//google/cloud/spanner:spanner_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-        "@com_google_googletest//:gtest_main",
     ],
 ) for test in spanner_client_integration_samples]
+
+load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -27,9 +27,18 @@ function (spanner_client_define_samples)
     export_list_to_bazel("spanner_client_unit_samples.bzl"
                          "spanner_client_unit_samples" YEAR "2019")
 
+    # Generate a target for each integration test.
+    foreach (fname ${spanner_client_integration_samples})
+        google_cloud_cpp_add_executable(target "spanner" "${fname}")
+        google_cloud_cpp_add_common_options(${target})
+        add_test(NAME ${target} COMMAND ${target})
+        target_link_libraries(
+            ${target} PRIVATE spanner_client_testing google_cloud_cpp_testing
+                              google-cloud-cpp::spanner)
+    endforeach ()
+
     # Generate a target for each unit test.
-    foreach (fname ${spanner_client_integration_samples}
-                   ${spanner_client_unit_samples})
+    foreach (fname ${spanner_client_unit_samples})
         google_cloud_cpp_add_executable(target "spanner" "${fname}")
         google_cloud_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})

--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -60,6 +60,5 @@ load(":storage_examples.bzl", "storage_examples")
         "//:storage",
         "//google/cloud/storage:google_cloud_cpp_storage_grpc",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-        "@com_google_googletest//:gtest_main",
     ],
 ) for test in storage_examples]


### PR DESCRIPTION
Samples that have their own `main()`, and don't use gtest anyway, should not link with `@com_google_googletest//:gtest_main`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10156)
<!-- Reviewable:end -->
