### PR TITLE
impl(generator): add predicate for http annotation

### DIFF
--- a/generator/internal/predicate_utils.cc
+++ b/generator/internal/predicate_utils.cc
@@ -134,6 +134,12 @@ bool HasRoutingHeader(MethodDescriptor const& method) {
   return absl::holds_alternative<HttpExtensionInfo>(result);
 }
 
+bool HasHttpAnnotation(google::protobuf::MethodDescriptor const& method) {
+  auto result = ParseHttpExtension(method);
+  return absl::holds_alternative<HttpExtensionInfo>(result) ||
+         absl::holds_alternative<HttpSimpleInfo>(result);
+}
+
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/internal/predicate_utils.h
+++ b/generator/internal/predicate_utils.h
@@ -84,6 +84,12 @@ bool IsLongrunningMetadataTypeUsedAsResponse(
 bool HasRoutingHeader(google::protobuf::MethodDescriptor const& method);
 
 /**
+ * Determines if the method contains a google.api.http annotation necessary for
+ * supporting REST transport.
+ */
+bool HasHttpAnnotation(google::protobuf::MethodDescriptor const& method);
+
+/**
  * If method meets pagination criteria, provides paginated field type and field
  * name.
  *

--- a/generator/internal/predicate_utils_test.cc
+++ b/generator/internal/predicate_utils_test.cc
@@ -829,7 +829,7 @@ TEST_F(StreamingReadTest, IsStreamingRead) {
       IsStreamingRead(*service_file_descriptor->service(0)->method(3)));
 }
 
-TEST(PredicateUtilsTest, HasRoutingHeaderSuccess) {
+TEST(PredicateUtilsTest, HasHttpAnnotationRoutingHeaderSuccess) {
   google::protobuf::FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -858,6 +858,37 @@ TEST(PredicateUtilsTest, HasRoutingHeaderSuccess) {
   FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
   EXPECT_TRUE(
       HasRoutingHeader(*service_file_descriptor->service(0)->method(0)));
+  EXPECT_TRUE(
+      HasHttpAnnotation(*service_file_descriptor->service(0)->method(0)));
+}
+
+TEST(PredicateUtilsTest, HasSimpleHttpAnnotationSuccess) {
+  google::protobuf::FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Bar" }
+    message_type { name: "Empty" }
+    service {
+      name: "Service"
+      method {
+        name: "Method0"
+        input_type: "google.protobuf.Bar"
+        output_type: "google.protobuf.Empty"
+        options {
+          [google.api.http] { patch: "/v1/databases" }
+        }
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  EXPECT_TRUE(
+      HasHttpAnnotation(*service_file_descriptor->service(0)->method(0)));
 }
 
 TEST(PredicateUtilsTest, HasRoutingHeaderWrongUrlFormat) {
@@ -889,7 +920,7 @@ TEST(PredicateUtilsTest, HasRoutingHeaderWrongUrlFormat) {
       HasRoutingHeader(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, HasRoutingHeaderAnnotationMissing) {
+TEST(PredicateUtilsTest, HasHttpAnnotationRoutingHeaderAnnotationMissing) {
   google::protobuf::FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -913,6 +944,8 @@ TEST(PredicateUtilsTest, HasRoutingHeaderAnnotationMissing) {
   FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
   EXPECT_FALSE(
       HasRoutingHeader(*service_file_descriptor->service(0)->method(0)));
+  EXPECT_FALSE(
+      HasHttpAnnotation(*service_file_descriptor->service(0)->method(0)));
 }
 
 TEST(PredicateUtilsTest, PredicatedFragmentTrueString) {


### PR DESCRIPTION
Necessary to determine if an rpc can be used with REST transport.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10160)
<!-- Reviewable:end -->
