### PR TITLE
test(spanner): relax environment requirement under emulator

### DIFF
--- a/google/cloud/spanner/samples/client_samples.cc
+++ b/google/cloud/spanner/samples/client_samples.cc
@@ -75,7 +75,6 @@ void AutoRun(std::vector<std::string> const& argv) {
   if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
-      "GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE",
   });
   auto const emulator = GetEnv("SPANNER_EMULATOR_HOST").has_value();
   auto const project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value();
@@ -84,8 +83,6 @@ void AutoRun(std::vector<std::string> const& argv) {
       google::cloud::spanner_testing::RandomInstanceName(generator);
   auto const database_id =
       google::cloud::spanner_testing::RandomDatabaseName(generator);
-  auto const keyfile =
-      GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
 
   std::cout << "\nRunning SetClientEndpoint() example" << std::endl;
   SetClientEndpoint({project_id, instance_id, database_id});
@@ -93,6 +90,11 @@ void AutoRun(std::vector<std::string> const& argv) {
   if (!emulator) {
     // On the emulator this blocks, as the emulator does not support credentials
     // that require SSL.
+    examples::CheckEnvironmentVariablesAreSet({
+        "GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE",
+    });
+    auto const keyfile =
+        GetEnv("GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE").value();
     std::cout << "\nRunning WithServiceAccount() example" << std::endl;
     WithServiceAccount({project_id, instance_id, database_id, keyfile});
   }


### PR DESCRIPTION
Do not demand that `${GOOGLE_CLOUD_CPP_TEST_SERVICE_ACCOUNT_KEYFILE}` is set when we're running the Spanner client samples against the emulator, as it's value is not used in that case.  This allows the test to be used by the emulator dev team without unnecessary extra requirements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10163)
<!-- Reviewable:end -->
