### PR TITLE
impl(generator): correct http verb for test rpc

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -55,7 +55,7 @@ Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::ListServiceAccountKeys
 }
 
 Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::DoNothing(google::protobuf::Empty const&) {
-  return Idempotency::kIdempotent;
+  return Idempotency::kNonIdempotent;
 }
 
 Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const&) {

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -838,7 +838,7 @@ service GoldenKitchenSink {
   // Does Nothing.
   rpc DoNothing(google.protobuf.Empty) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      get: "/v1/doNothing"
+      post: "/v1/doNothing"
     };
     option (google.api.method_signature) = "";
   }


### PR DESCRIPTION
In order for the test method to "do nothing", it should not be a Get. Post is a better option for a no-op.