### PR TITLE
cleanup(generator): better library name parsing for nested services

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -61,7 +61,6 @@ expected_dirs+=(
   ./include/google/appengine/logging/v1
   ./include/google/cloud/bigquery/logging
   ./include/google/cloud/bigquery/logging/v1
-  ./include/google/cloud/bigtable/admin/mocks
   ./include/google/cloud/bigtable/mocks
   # no RPC services in google/cloud/certificatemanager/logging
   ./include/google/cloud/certificatemanager/logging
@@ -89,7 +88,6 @@ expected_dirs+=(
   # no gRPC services in google/cloud/secretmanager/logging
   ./include/google/cloud/secretmanager/logging
   ./include/google/cloud/secretmanager/logging/v1
-  ./include/google/cloud/spanner/admin/mocks
   ./include/google/cloud/spanner/internal
   ./include/google/cloud/spanner/mocks
   ./include/google/cloud/storage/oauth2
@@ -115,7 +113,6 @@ expected_dirs+=(
   ./lib64/cmake/google_cloud_cpp_pubsub_mocks
   ./lib64/cmake/google_cloud_cpp_rest_internal
   ./lib64/cmake/google_cloud_cpp_rest_protobuf_internal
-  ./lib64/cmake/google_cloud_cpp_spanner
   ./lib64/pkgconfig
 )
 

--- a/ci/etc/expected_install_directories
+++ b/ci/etc/expected_install_directories
@@ -93,6 +93,7 @@
 ./include/google/cloud/bigtable
 ./include/google/cloud/bigtable/admin
 ./include/google/cloud/bigtable/admin/internal
+./include/google/cloud/bigtable/admin/mocks
 ./include/google/cloud/bigtable/internal
 ./include/google/cloud/billing
 ./include/google/cloud/billing/budgets
@@ -346,6 +347,7 @@
 ./include/google/cloud/spanner
 ./include/google/cloud/spanner/admin
 ./include/google/cloud/spanner/admin/internal
+./include/google/cloud/spanner/admin/mocks
 ./include/google/cloud/speech
 ./include/google/cloud/speech/internal
 ./include/google/cloud/speech/mocks
@@ -543,6 +545,7 @@
 ./lib64/cmake/google_cloud_cpp_servicemanagement
 ./lib64/cmake/google_cloud_cpp_serviceusage
 ./lib64/cmake/google_cloud_cpp_shell
+./lib64/cmake/google_cloud_cpp_spanner
 ./lib64/cmake/google_cloud_cpp_speech
 ./lib64/cmake/google_cloud_cpp_storage
 ./lib64/cmake/google_cloud_cpp_storagetransfer

--- a/ci/etc/full_feature_list
+++ b/ci/etc/full_feature_list
@@ -75,6 +75,7 @@ servicedirectory
 servicemanagement
 serviceusage
 shell
+spanner
 speech
 storage
 storagetransfer

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -37,8 +37,8 @@ auto constexpr kApiIndexFilename = "api-index-v1.json";
 std::string LibraryName(
     google::cloud::cpp::generator::ServiceConfiguration const& service) {
   std::vector<std::string> v = absl::StrSplit(service.product_path(), '/');
-  // Assume we are given: google/cloud/<library>/...
-  if (v.size() < 2) return {};
+  if (v.size() < 3) return {};
+  if (v[0] != "google" && v[1] != "cloud") return {};
   return v[2];
 }
 

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -36,9 +36,10 @@ auto constexpr kApiIndexFilename = "api-index-v1.json";
 
 std::string LibraryName(
     google::cloud::cpp::generator::ServiceConfiguration const& service) {
-  auto const l = service.product_path().find_last_of('/');
-  if (l == std::string::npos) return {};
-  return service.product_path().substr(l + 1);
+  std::vector<std::string> v = absl::StrSplit(service.product_path(), '/');
+  // Assume we are given: google/cloud/<library>/...
+  if (v.size() < 2) return {};
+  return v[2];
 }
 
 std::string SiteRoot(

--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -31,7 +31,7 @@ namespace generator_internal {
  * In `google-cloud-cpp` libraries called `foo` live in the `google/cloud/foo`
  * directory. The names of CMake targets, Bazel rules, pkg-config modules,
  * features, etc. are based on the library name. This function returns the
- * name give a service configuration.
+ * name given a service configuration.
  *
  * This function assumes the service configuration has already been validated.
  */

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -45,6 +45,20 @@ char const* const kHierarchy[] = {
     "/external/googleapis/protodeps/",
 };
 
+TEST(ScaffoldGeneratorTest, LibraryName) {
+  google::cloud::cpp::generator::ServiceConfiguration service;
+  service.set_product_path("google/cloud/test");
+  EXPECT_EQ("test", LibraryName(service));
+
+  service.set_product_path("google/cloud/test/v1");
+  EXPECT_EQ("test", LibraryName(service));
+
+  // LibraryName() is only called when we are generating scaffolding, or
+  // updating our CI. We do not care much about the error case.
+  service.set_product_path("bad-directory-structure");
+  EXPECT_EQ("", LibraryName(service));
+}
+
 class ScaffoldGenerator : public ::testing::Test {
  protected:
   ~ScaffoldGenerator() override {
@@ -113,10 +127,6 @@ class ScaffoldGenerator : public ::testing::Test {
   std::string path_;
   google::cloud::cpp::generator::ServiceConfiguration service_;
 };
-
-TEST_F(ScaffoldGenerator, LibraryName) {
-  EXPECT_EQ("test", LibraryName(service()));
-}
 
 TEST_F(ScaffoldGenerator, Vars) {
   auto const ga = ScaffoldVars(path(), service(), false);

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -109,8 +109,6 @@ int WriteInstallDirectories(
       install_directories.push_back(p);
     }
     auto const lib = google::cloud::generator_internal::LibraryName(service);
-    // Bigtable and Spanner use a custom path for generated code.
-    if (lib == "admin") continue;
     // Services without a connection do not create mocks.
     if (!service.omit_connection()) {
       install_directories.push_back("./include/" + product_path + "/mocks");
@@ -137,8 +135,6 @@ int WriteFeatureList(
       return 1;
     }
     auto feature = google::cloud::generator_internal::LibraryName(service);
-    // Spanner and Bigtable use a custom directory for generated files
-    if (feature == "admin") continue;
     features.push_back(std::move(feature));
   }
   std::sort(features.begin(), features.end());


### PR DESCRIPTION
Part of the work for #10170 

I would rather assume that the `product_path` matches `google/cloud/service($|/**)` than assume that it matches `**/service`

(I am sure my regex syntax is wrong, but you get the point)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10171)
<!-- Reviewable:end -->
