### PR TITLE
Add storage_mocks library to Google Cloud Storage

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -265,6 +265,14 @@ cc_library(
 )
 
 cc_library(
+    name = "storage_mocks",
+    testonly = True,
+    deps = [
+        "//google/cloud/storage:storage_client_testing",
+    ],
+)
+
+cc_library(
     name = "experimental-storage-grpc",
     tags = ["manual"],
     deps = [


### PR DESCRIPTION
I'm not sure why the mock client wasn't already exposed, but I'm adding it here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10175)
<!-- Reviewable:end -->
