### PR TITLE
cleanup(bigtable): use implicit default ctor

### DIFF
--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -560,8 +560,6 @@ class TableAdmin {
    * Parameters for `ListBackups`.
    */
   struct ListBackupsParams {
-    ListBackupsParams() = default;
-
     /**
      * Sets the cluster_id.
      *


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10179)
<!-- Reviewable:end -->
