### PR TITLE
fix(common): avoid globals for easier DLLs

### DIFF
--- a/google/cloud/grpc_error_delegate.cc
+++ b/google/cloud/grpc_error_delegate.cc
@@ -121,7 +121,7 @@ google::cloud::Status MakeStatusFromRpcError(google::rpc::Status const& proto) {
   }
   auto status = Status(code, proto.message(), GetErrorInfo(proto));
   google::cloud::internal::SetPayload(
-      status, google::cloud::internal::kStatusPayloadGrpcProto,
+      status, google::cloud::internal::StatusPayloadGrpcProto(),
       proto.SerializeAsString());
   return status;
 }

--- a/google/cloud/grpc_error_delegate_test.cc
+++ b/google/cloud/grpc_error_delegate_test.cc
@@ -118,7 +118,7 @@ TEST(MakeStatusFromRpcError, AllCodesWithPayload) {
 
     auto expected = google::cloud::Status(codes.expected, message);
     google::cloud::internal::SetPayload(
-        expected, google::cloud::internal::kStatusPayloadGrpcProto, payload);
+        expected, google::cloud::internal::StatusPayloadGrpcProto(), payload);
 
     auto const actual = MakeStatusFromRpcError(original);
     EXPECT_EQ(expected, actual);
@@ -127,7 +127,7 @@ TEST(MakeStatusFromRpcError, AllCodesWithPayload) {
 
     // Make sure the actual payload is what we expect.
     auto actual_payload = google::cloud::internal::GetPayload(
-        actual, google::cloud::internal::kStatusPayloadGrpcProto);
+        actual, google::cloud::internal::StatusPayloadGrpcProto());
     EXPECT_TRUE(actual_payload.has_value());
     EXPECT_EQ(payload, actual_payload.value());
   }
@@ -168,7 +168,7 @@ TEST(MakeStatusFromRpcError, AllCodesWithPayloadAndErrorDetails) {
 
     auto expected = google::cloud::Status(codes.expected, message, error_info);
     google::cloud::internal::SetPayload(
-        expected, google::cloud::internal::kStatusPayloadGrpcProto, payload);
+        expected, google::cloud::internal::StatusPayloadGrpcProto(), payload);
 
     auto const actual = MakeStatusFromRpcError(original);
     EXPECT_EQ(expected, actual);
@@ -177,7 +177,7 @@ TEST(MakeStatusFromRpcError, AllCodesWithPayloadAndErrorDetails) {
 
     // Make sure the actual payload is what we expect.
     auto actual_payload = google::cloud::internal::GetPayload(
-        actual, google::cloud::internal::kStatusPayloadGrpcProto);
+        actual, google::cloud::internal::StatusPayloadGrpcProto());
     EXPECT_TRUE(actual_payload.has_value());
     EXPECT_EQ(payload, actual_payload.value());
   }
@@ -217,7 +217,7 @@ TEST(MakeStatusFromRpcError, ProtoValidCode) {
     auto const actual = MakeStatusFromRpcError(original);
     auto expected = google::cloud::Status(codes.expected, message);
     google::cloud::internal::SetPayload(
-        expected, google::cloud::internal::kStatusPayloadGrpcProto,
+        expected, google::cloud::internal::StatusPayloadGrpcProto(),
         MakeErrorDetails(original));
 
     EXPECT_EQ(expected, actual);
@@ -235,7 +235,7 @@ TEST(MakeStatusFromRpcError, ProtoInvalidCode) {
     auto const actual = MakeStatusFromRpcError(original);
     auto expected = google::cloud::Status(StatusCode::kUnknown, message);
     google::cloud::internal::SetPayload(
-        expected, google::cloud::internal::kStatusPayloadGrpcProto,
+        expected, google::cloud::internal::StatusPayloadGrpcProto(),
         MakeErrorDetails(original));
     EXPECT_EQ(expected, actual);
   }

--- a/google/cloud/internal/log_wrapper_helpers.cc
+++ b/google/cloud/internal/log_wrapper_helpers.cc
@@ -103,7 +103,7 @@ std::string DebugString(Status const& status, TracingOptions const& options) {
   std::ostringstream os;
   os << status;
   auto payload =
-      internal::GetPayload(status, internal::kStatusPayloadGrpcProto);
+      internal::GetPayload(status, internal::StatusPayloadGrpcProto());
   google::rpc::Status proto;
   if (payload && proto.ParseFromString(*payload)) {
     // See https://cloud.google.com/apis/design/errors#error_payloads

--- a/google/cloud/internal/status_payload_keys.cc
+++ b/google/cloud/internal/status_payload_keys.cc
@@ -19,8 +19,11 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
-// These keys need to be unique, but there's no other required format.
-char const kStatusPayloadGrpcProto[] = "StatusProtoSerialized";
+char const* StatusPayloadGrpcProto() {
+  // These keys need to be unique, but there's no other required format.
+  static char const kStatusPayloadGrpcProto[] = "StatusProtoSerialized";
+  return kStatusPayloadGrpcProto;
+}
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/status_payload_keys.h
+++ b/google/cloud/internal/status_payload_keys.h
@@ -26,7 +26,7 @@ namespace internal {
 // The key to use when setting/getting a `google::cloud::Status` payload
 // associated with a serialized `google::rpc::Status` protobuf. The value
 // should be serialized with `.SerializeAsString()`.
-extern char const kStatusPayloadGrpcProto[];
+char const* StatusPayloadGrpcProto();
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/status_payload_keys_test.cc
+++ b/google/cloud/internal/status_payload_keys_test.cc
@@ -22,7 +22,7 @@ namespace internal {
 
 TEST(StatusPayloadKeys, Basics) {
   std::string const empty{};
-  EXPECT_NE(empty, kStatusPayloadGrpcProto);
+  EXPECT_NE(empty, StatusPayloadGrpcProto());
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/status_utils.cc
+++ b/google/cloud/spanner/internal/status_utils.cc
@@ -32,7 +32,7 @@ bool IsSessionNotFound(google::cloud::Status const& status) {
   // type from the `ResourceInfo` details in the original gRPC proto.
   google::rpc::Status proto;
   auto payload =
-      internal::GetPayload(status, internal::kStatusPayloadGrpcProto);
+      internal::GetPayload(status, internal::StatusPayloadGrpcProto());
   if (payload && proto.ParseFromString(*payload)) {
     google::rpc::ResourceInfo resource_info;
     for (google::protobuf::Any const& any : proto.details()) {

--- a/google/cloud/spanner/internal/status_utils_test.cc
+++ b/google/cloud/spanner/internal/status_utils_test.cc
@@ -43,7 +43,7 @@ TEST(StatusUtils, SessionNotFoundResourceInfo) {
 
   // A status with the right ResourceInfo doesn't need a particular message.
   Status still_not_found(not_found.code(), "foo bar", not_found.error_info());
-  std::string const key = internal::kStatusPayloadGrpcProto;
+  std::string const key = internal::StatusPayloadGrpcProto();
   auto payload = internal::GetPayload(not_found, key);
   ASSERT_TRUE(payload.has_value());
   internal::SetPayload(still_not_found, key, *std::move(payload));


### PR DESCRIPTION
CMake can automatically create Windows DLLs if we don't use *data* symbols in the library.  This may unblock some folks trying to support DLLs.

Fixes #10205

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10212)
<!-- Reviewable:end -->
