### PR TITLE
cleanup: remove workarounds for older CMake versions

### DIFF
--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -383,12 +383,7 @@ function (google_cloud_cpp_proto_library libname)
         ${libname} SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                                  $<INSTALL_INTERFACE:include>)
     google_cloud_cpp_silence_warnings_in_deps(${libname})
-    # Disable clang-tidy for generated code, note that the CXX_CLANG_TIDY
-    # property was introduced in 3.6, and we do not use clang-tidy with older
-    # versions
-    if (NOT ("${CMAKE_VERSION}" VERSION_LESS 3.6))
-        set_target_properties(${libname} PROPERTIES CXX_CLANG_TIDY "")
-    endif ()
+    set_target_properties(${libname} PROPERTIES CXX_CLANG_TIDY "")
     if (MSVC)
         # The protobuf-generated files have warnings under the default MSVC
         # settings. We are not interested in these warnings, because we cannot

--- a/cmake/EnableWerror.cmake
+++ b/cmake/EnableWerror.cmake
@@ -40,25 +40,10 @@ endfunction ()
 
 function (google_cloud_cpp_add_common_options target)
     google_cloud_cpp_silence_warnings_in_deps(${target})
-    # Require C++ >= 14.  Unfortunately CMake can only express such requirements
-    # starting with CMake == 3.8.0. Note that this is a *minimum* requirement.
-    # It is still possible to compile the library (and its dependencies) with
-    # C++17 or higher.
-    if (NOT ("${CMAKE_VERSION}" VERSION_LESS 3.8))
-        target_compile_features(${target} PUBLIC cxx_std_14)
-    elseif (NOT CMAKE_CXX_STANDARD)
-        # CMake < 3.8 does not have a feature to express "requires C++ >= 14",
-        # but it has a way to express "I need generalized lambda captures", so
-        # we do that.  This may seem unnecessary, as the default C++ version is
-        # 14 for all the compilers we support. Unfortunately nlohmann::json
-        # sneakily adds a requirement for "ranged for loops". CMake interprets
-        # this requirement as "add the -std=c++11 flag", which disables the
-        # C++14 features.  Sigh.
-        # ~~~
-        # TODO(#9343) - remove this workaround once CMake < 3.8 is not needed
-        # ~~~
-        target_compile_features(${target} PUBLIC cxx_lambda_init_captures)
-    endif ()
+    # Require C++ >= 14.  Note that this is a *minimum* requirement. It is still
+    # possible to compile the library (and its dependencies) with C++17 or
+    # higher.
+    target_compile_features(${target} PUBLIC cxx_std_14)
     if (MSVC)
         target_compile_options(${target} PRIVATE "/W3")
         if (GOOGLE_CLOUD_CPP_ENABLE_WERROR)

--- a/cmake/FindgRPC.cmake
+++ b/cmake/FindgRPC.cmake
@@ -269,35 +269,12 @@ if (_gRPC_grpc++_LIBRARY)
             APPEND
             PROPERTY INTERFACE_LINK_LIBRARIES gRPC::grpc protobuf::libprotobuf
                      Threads::Threads)
-        if (CMAKE_VERSION VERSION_GREATER 3.8)
-            # gRPC++ requires C++14 (soon), but only CMake-3.8 introduced a
-            # compiler feature to meet that requirement.
-            set_property(
-                TARGET gRPC::grpc++
-                APPEND
-                PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
-        elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-            # CMake 3.5 is still alive and kicking in some older distros, use
-            # the compiler-specific versions in these cases.
-            set_property(
-                TARGET gRPC::grpc++
-                APPEND
-                PROPERTY INTERFACE_COMPILE_OPTIONS "-std=c++14")
-        elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-            set_property(
-                TARGET gRPC::grpc++
-                APPEND
-                PROPERTY INTERFACE_COMPILE_OPTIONS "-std=c++14")
-        else ()
-            message(
-                WARNING
-                    "gRPC::grpc++ requires C++14, but this module"
-                    " (${CMAKE_CURRENT_LIST_FILE})"
-                    " cannot enable it for the library target in your CMake and"
-                    " compiler versions. You need to enable C++14 in the"
-                    " CMakeLists.txt for your project. Consider filing a bug"
-                    " so we can fix this problem.")
-        endif ()
+        # gRPC++ requires C++14. It does not yet define the compile features, so
+        # we define the feature ourselves.
+        set_property(
+            TARGET gRPC::grpc++
+            APPEND
+            PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
     endif ()
 endif ()
 


### PR DESCRIPTION
We require CMake >= 3.10, any workarounds for CMake < 3.10 are no longer needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10216)
<!-- Reviewable:end -->
