### PR TITLE
ci: split fedora dockerfiles by build system

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -63,8 +63,8 @@
 # Advanced Examples:
 #
 # 1. Runs the ci/cloudbuild/builds/asan.sh script using the
-#    ci/cloudbuild/dockerfiles/fedora-36.Dockerfile distro.
-#    $ build.sh --build asan --distro fedora-36
+#    ci/cloudbuild/dockerfiles/fedora-36-bazel.Dockerfile distro.
+#    $ build.sh --build asan --distro fedora-36-bazel
 #
 # Note: Builds with the `--docker` flag inherit some (but not all) environment
 # variables from the calling process, such as USE_BAZEL_VERSION

--- a/ci/cloudbuild/builds/integration-daily.sh
+++ b/ci/cloudbuild/builds/integration-daily.sh
@@ -23,7 +23,7 @@
 # `ci/cloudbuild/triggers` directory. "Manual" triggers exist only within the
 # GCB UI at the time of this writing. Users with the appropriate access can run
 # this build by hand with:
-#   `ci/cloudbuild/build.sh --distro fedora-36 --build integration-daily --cloud cloud-cpp-testing-resources`
+#   `ci/cloudbuild/build.sh --distro fedora-36-bazel --build integration-daily --cloud cloud-cpp-testing-resources`
 
 set -euo pipefail
 

--- a/ci/cloudbuild/dockerfiles/fedora-36-bazel.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-bazel.Dockerfile
@@ -1,0 +1,51 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM fedora:36
+ARG NCPU=4
+ARG ARCH=amd64
+
+# Install the minimal packages needed to install Bazel, and then compile our
+# code.
+RUN dnf install -y clang diffutils findutils gcc-c++ git lcov libcxx-devel \
+        libcxxabi-devel libasan libubsan libtsan patch python python3 \
+        python-pip tar unzip w3m wget which zip zlib-devel
+
+# Sets root's password to the empty string to enable users to get a root shell
+# inside the container with `su -` and no password. Sudo would not work because
+# we run these containers as the invoking user's uid, which does not exist in
+# the container's /etc/passwd file.
+RUN echo 'root:' | chpasswd
+
+# Install the Python modules needed to run the storage emulator
+RUN pip3 install --upgrade pip
+RUN pip3 install setuptools wheel
+
+WORKDIR /var/tmp/build
+
+# Install the Cloud SDK and some of the emulators. We use the emulators to run
+# integration tests for the client libraries.
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+ENV CLOUDSDK_PYTHON=python3.10
+RUN /var/tmp/ci/install-cloud-sdk.sh
+ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
+ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
+# The Cloud Pub/Sub emulator needs Java, and so does `bazel coverage` :shrug:
+# Bazel needs the '-devel' version with javac.
+RUN dnf makecache && dnf install -y java-latest-openjdk-devel
+
+RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-${ARCH}" && \
+    chmod +x /usr/bin/bazelisk && \
+    ln -s /usr/bin/bazelisk /usr/bin/bazel

--- a/ci/cloudbuild/dockerfiles/fedora-36-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-cmake.Dockerfile
@@ -179,16 +179,8 @@ ENV CLOUDSDK_PYTHON=python3.10
 RUN /var/tmp/ci/install-cloud-sdk.sh
 ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
-# The Cloud Pub/Sub emulator needs Java, and so does `bazel coverage` :shrug:
-# Bazel needs the '-devel' version with javac.
-RUN dnf makecache && dnf install -y java-latest-openjdk-devel
-
-RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-${ARCH}" && \
-    chmod +x /usr/bin/bazelisk && \
-    ln -s /usr/bin/bazelisk /usr/bin/bazel
-
-RUN dnf makecache && dnf install -y "dnf-command(debuginfo-install)"
-RUN dnf makecache && dnf debuginfo-install -y libstdc++
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN dnf makecache && dnf install -y java-latest-openjdk
 
 # Some of the above libraries may have installed in /usr/local, so make sure
 # those library directories will be found.

--- a/ci/cloudbuild/dockerfiles/fedora-36-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-cmake.Dockerfile
@@ -182,6 +182,14 @@ ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
 # The Cloud Pub/Sub emulator needs Java :shrug:
 RUN dnf makecache && dnf install -y java-latest-openjdk
 
+# The check-api build uses bazelisk
+RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-${ARCH}" && \
+    chmod +x /usr/bin/bazelisk && \
+    ln -s /usr/bin/bazelisk /usr/bin/bazel
+
+RUN dnf makecache && dnf install -y "dnf-command(debuginfo-install)"
+RUN dnf makecache && dnf debuginfo-install -y libstdc++
+
 # Some of the above libraries may have installed in /usr/local, so make sure
 # those library directories will be found.
 RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/fedora-36.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36.Dockerfile
@@ -166,7 +166,7 @@ RUN curl -sSL https://github.com/universal-ctags/ctags/archive/refs/tags/p5.9.20
 # https://github.com/lvc/abi-dumper/pull/29. We can switch back to `dnf install
 # abi-dumper` once it has the fix.
 WORKDIR /var/tmp/build
-RUN curl -sSL https://github.com/lvc/abi-dumper/archive/814effec0f20a9613441dfa033aa0a0bc2a96a87.tar.gz | \
+RUN curl -sSL https://github.com/lvc/abi-dumper/archive/16bb467cd7d343dd3a16782b151b56cf15509594.tar.gz | \
     tar -xzf - --strip-components=1 && \
     mv abi-dumper.pl /usr/local/bin/abi-dumper && \
     chmod +x /usr/local/bin/abi-dumper
@@ -190,3 +190,10 @@ RUN ldconfig /usr/local/lib*
 RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-${ARCH}" && \
     chmod +x /usr/bin/bazelisk && \
     ln -s /usr/bin/bazelisk /usr/bin/bazel
+
+RUN dnf makecache && dnf install -y "dnf-command(debuginfo-install)"
+RUN dnf makecache && dnf debuginfo-install -y libstdc++
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/fedora-36.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -166,7 +166,7 @@ RUN curl -sSL https://github.com/universal-ctags/ctags/archive/refs/tags/p5.9.20
 # https://github.com/lvc/abi-dumper/pull/29. We can switch back to `dnf install
 # abi-dumper` once it has the fix.
 WORKDIR /var/tmp/build
-RUN curl -sSL https://github.com/lvc/abi-dumper/archive/16bb467cd7d343dd3a16782b151b56cf15509594.tar.gz | \
+RUN curl -sSL https://github.com/lvc/abi-dumper/archive/814effec0f20a9613441dfa033aa0a0bc2a96a87.tar.gz | \
     tar -xzf - --strip-components=1 && \
     mv abi-dumper.pl /usr/local/bin/abi-dumper && \
     chmod +x /usr/local/bin/abi-dumper
@@ -179,9 +179,14 @@ ENV CLOUDSDK_PYTHON=python3.10
 RUN /var/tmp/ci/install-cloud-sdk.sh
 ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
-# The Cloud Pub/Sub emulator needs Java :shrug:
-RUN dnf makecache && dnf install -y java-latest-openjdk
+# The Cloud Pub/Sub emulator needs Java, and so does `bazel coverage` :shrug:
+# Bazel needs the '-devel' version with javac.
+RUN dnf makecache && dnf install -y java-latest-openjdk-devel
 
 # Some of the above libraries may have installed in /usr/local, so make sure
 # those library directories will be found.
 RUN ldconfig /usr/local/lib*
+
+RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-${ARCH}" && \
+    chmod +x /usr/bin/bazelisk && \
+    ln -s /usr/bin/bazelisk /usr/bin/bazel

--- a/ci/cloudbuild/triggers/asan-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: asan-ci
 substitutions:
   _BUILD_NAME: asan
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/asan-pr.yaml
+++ b/ci/cloudbuild/triggers/asan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: asan-pr
 substitutions:
   _BUILD_NAME: asan
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/bazel-oldest-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-oldest-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: bazel-oldest-ci
 substitutions:
   _BUILD_NAME: bazel-oldest
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/bazel-oldest-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-oldest-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: bazel-oldest-pr
 substitutions:
   _BUILD_NAME: bazel-oldest
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/bazel-targets-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: bazel-targets-ci
 substitutions:
   _BUILD_NAME: bazel-targets
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/bazel-targets-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: bazel-targets-pr
 substitutions:
   _BUILD_NAME: bazel-targets
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/check-api-ci.yaml
+++ b/ci/cloudbuild/triggers/check-api-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: check-api-ci
 substitutions:
   _BUILD_NAME: check-api
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/check-api-pr.yaml
+++ b/ci/cloudbuild/triggers/check-api-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: check-api-pr
 substitutions:
   _BUILD_NAME: check-api
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: clang-tidy-ci
 substitutions:
   _BUILD_NAME: clang-tidy
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/clang-tidy-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: clang-tidy-pr
 substitutions:
   _BUILD_NAME: clang-tidy
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cmake-gcs-rest-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcs-rest-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-gcs-rest-ci
 substitutions:
   _BUILD_NAME: cmake-gcs-rest
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-gcs-rest-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcs-rest-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-gcs-rest-pr
 substitutions:
   _BUILD_NAME: cmake-gcs-rest
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cmake-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-install-ci
 substitutions:
   _BUILD_NAME: cmake-install
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-install-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-install-pr
 substitutions:
   _BUILD_NAME: cmake-install
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cmake-single-feature-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-single-feature-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-single-feature-ci
 substitutions:
   _BUILD_NAME: cmake-single-feature
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-single-feature-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-single-feature-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-single-feature-pr
 substitutions:
   _BUILD_NAME: cmake-single-feature
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/coverage-ci.yaml
+++ b/ci/cloudbuild/triggers/coverage-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: coverage-ci
 substitutions:
   _BUILD_NAME: coverage
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/coverage-pr.yaml
+++ b/ci/cloudbuild/triggers/coverage-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: coverage-pr
 substitutions:
   _BUILD_NAME: coverage
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: gcs-grpc-ci
 substitutions:
   _BUILD_NAME: gcs-grpc
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: gcs-grpc-pr
 substitutions:
   _BUILD_NAME: gcs-grpc
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/integration-production-ci.yaml
+++ b/ci/cloudbuild/triggers/integration-production-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: integration-production-ci
 substitutions:
   _BUILD_NAME: integration-production
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/integration-production-pr.yaml
+++ b/ci/cloudbuild/triggers/integration-production-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: integration-production-pr
 substitutions:
   _BUILD_NAME: integration-production
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/libcxx-ci.yaml
+++ b/ci/cloudbuild/triggers/libcxx-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: libcxx-ci
 substitutions:
   _BUILD_NAME: libcxx
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/libcxx-pr.yaml
+++ b/ci/cloudbuild/triggers/libcxx-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: libcxx-pr
 substitutions:
   _BUILD_NAME: libcxx
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/noex-ci.yaml
+++ b/ci/cloudbuild/triggers/noex-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: noex-ci
 substitutions:
   _BUILD_NAME: noex
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/noex-pr.yaml
+++ b/ci/cloudbuild/triggers/noex-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: noex-pr
 substitutions:
   _BUILD_NAME: noex
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/publish-docs-ci.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: publish-docs-ci
 substitutions:
   _BUILD_NAME: publish-docs
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/publish-docs-pr.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: publish-docs-pr
 substitutions:
   _BUILD_NAME: publish-docs
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/quickstart-production-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: quickstart-production-ci
 substitutions:
   _BUILD_NAME: quickstart-production
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/quickstart-production-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: quickstart-production-pr
 substitutions:
   _BUILD_NAME: quickstart-production
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/shared-ci.yaml
+++ b/ci/cloudbuild/triggers/shared-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: shared-ci
 substitutions:
   _BUILD_NAME: shared
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/shared-pr.yaml
+++ b/ci/cloudbuild/triggers/shared-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: shared-pr
 substitutions:
   _BUILD_NAME: shared
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-cmake
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: tsan-ci
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/tsan-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: tsan-pr
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/ubsan-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: ubsan-ci
 substitutions:
   _BUILD_NAME: ubsan
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/ubsan-pr.yaml
+++ b/ci/cloudbuild/triggers/ubsan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: ubsan-pr
 substitutions:
   _BUILD_NAME: ubsan
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/xsan-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: xsan-ci
 substitutions:
   _BUILD_NAME: xsan
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/xsan-pr.yaml
+++ b/ci/cloudbuild/triggers/xsan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: xsan-pr
 substitutions:
   _BUILD_NAME: xsan
-  _DISTRO: fedora-36
+  _DISTRO: fedora-36-bazel
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Fixes #10217 

This separates the Fedora 36 Dockerfile into bazel and cmake components. It will speed up bazel builds where we `--docker-clean` a bit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10220)
<!-- Reviewable:end -->
