### PR TITLE
feat(spanner): tests and samples for DML RETURNING

### DIFF
--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -341,11 +341,17 @@ class Client {
    * returned/ignored, and the column order is known. This enables more
    * efficient and simpler code.
    *
+   * Can also execute a DML statement with a returning clause in a read/write
+   * transaction.
+   *
    * @par Example with explicitly selected columns.
    * @snippet samples.cc spanner-query-data
    *
-   * @par Example using SELECT *
+   * @par Example using `SELECT *`.
    * @snippet samples.cc spanner-query-data-select-star
+   *
+   * @par Example using a DML statement with `THEN RETURN`.
+   * @snippet samples.cc spanner_update_dml_returning
    *
    * @param statement The SQL statement to execute.
    * @param opts (optional) The `Options` to use for this call. If given,

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -351,7 +351,7 @@ class Client {
    * @snippet samples.cc spanner-query-data-select-star
    *
    * @par Example using a DML statement with `THEN RETURN`.
-   * @snippet samples.cc spanner_update_dml_returning
+   * @snippet samples.cc spanner-update-dml-returning
    *
    * @param statement The SQL statement to execute.
    * @param opts (optional) The `Options` to use for this call. If given,

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3278,7 +3278,7 @@ void FieldAccessOnNestedStruct(google::cloud::spanner::Client client) {
 }
 //! [END spanner_field_access_on_nested_struct_parameters]
 
-// [START spanner_update_dml_returning]
+// [START spanner_update_dml_returning] [spanner-update-dml-returning]
 void UpdateUsingDmlReturning(google::cloud::spanner::Client client) {
   // Update MarketingBudget column for records satisfying a particular
   // condition and return the modified MarketingBudget column of the
@@ -3308,7 +3308,7 @@ void UpdateUsingDmlReturning(google::cloud::spanner::Client client) {
       });
   if (!commit) throw std::move(commit).status();
 }
-// [END spanner_update_dml_returning]
+// [END spanner_update_dml_returning] [spanner-update-dml-returning]
 
 // [START spanner_insert_dml_returning]
 void InsertUsingDmlReturning(google::cloud::spanner::Client client) {


### PR DESCRIPTION
Add tests and samples for GOOGLE_STANDARD_SQL "THEN RETURN" and POSTGRESQL "RETURNING".

Note that `Client::ExecuteQuery()` can now execute a DML statement with a returning clause.

Previously we added support for `RowStream::RowsModified()` (#10102), which is now used here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10233)
<!-- Reviewable:end -->
