### PR TITLE
doc: one options group per library

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_options.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_options.h
@@ -34,7 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Use with `google::cloud::Options` to configure the retry policy.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 struct GoldenKitchenSinkRetryPolicyOption {
   using Type = std::shared_ptr<GoldenKitchenSinkRetryPolicy>;
@@ -43,7 +43,7 @@ struct GoldenKitchenSinkRetryPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure the backoff policy.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 struct GoldenKitchenSinkBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
@@ -52,7 +52,7 @@ struct GoldenKitchenSinkBackoffPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure which operations are retried.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 struct GoldenKitchenSinkConnectionIdempotencyPolicyOption {
   using Type = std::shared_ptr<GoldenKitchenSinkConnectionIdempotencyPolicy>;
@@ -61,7 +61,7 @@ struct GoldenKitchenSinkConnectionIdempotencyPolicyOption {
 /**
  * The options applicable to GoldenKitchenSink.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 using GoldenKitchenSinkPolicyOptionList =
     OptionList<GoldenKitchenSinkRetryPolicyOption,

--- a/generator/integration_tests/golden/golden_thing_admin_options.h
+++ b/generator/integration_tests/golden/golden_thing_admin_options.h
@@ -34,7 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Use with `google::cloud::Options` to configure the retry policy.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 struct GoldenThingAdminRetryPolicyOption {
   using Type = std::shared_ptr<GoldenThingAdminRetryPolicy>;
@@ -43,7 +43,7 @@ struct GoldenThingAdminRetryPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure the backoff policy.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 struct GoldenThingAdminBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
@@ -52,7 +52,7 @@ struct GoldenThingAdminBackoffPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure which operations are retried.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 struct GoldenThingAdminConnectionIdempotencyPolicyOption {
   using Type = std::shared_ptr<GoldenThingAdminConnectionIdempotencyPolicy>;
@@ -62,7 +62,7 @@ struct GoldenThingAdminConnectionIdempotencyPolicyOption {
  * Use with `google::cloud::Options` to configure the long-running operations
  * polling policy.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 struct GoldenThingAdminPollingPolicyOption {
   using Type = std::shared_ptr<PollingPolicy>;
@@ -71,7 +71,7 @@ struct GoldenThingAdminPollingPolicyOption {
 /**
  * The options applicable to GoldenThingAdmin.
  *
- * @ingroup generator-integration_tests-golden-options
+ * @ingroup google-cloud-golden-options
  */
 using GoldenThingAdminPolicyOptionList =
     OptionList<GoldenThingAdminRetryPolicyOption,

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -35,6 +35,7 @@
 #include "generator/internal/retry_traits_generator.h"
 #include "generator/internal/round_robin_decorator_generator.h"
 #include "generator/internal/sample_generator.h"
+#include "generator/internal/scaffold_generator.h"
 #include "generator/internal/stub_factory_generator.h"
 #include "generator/internal/stub_generator.h"
 #include "generator/internal/stub_rest_generator.h"
@@ -848,7 +849,7 @@ VarsDictionary CreateServiceVars(
     std::vector<std::pair<std::string, std::string>> const& initial_values) {
   VarsDictionary vars(initial_values.begin(), initial_values.end());
   vars["product_options_page"] = absl::StrCat(
-      absl::StrReplaceAll(vars["product_path"], {{"/", "-"}}), "options");
+      "google-cloud-", LibraryName(vars["product_path"]), "-options");
   vars["additional_pb_header_paths"] = FormatAdditionalPbHeaderPaths(vars);
   vars["class_comment_block"] =
       FormatClassCommentsFromServiceComments(descriptor);

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -212,6 +212,7 @@ TEST_P(CreateServiceVarsTest, KeySetCorrectly) {
 INSTANTIATE_TEST_SUITE_P(
     ServiceVars, CreateServiceVarsTest,
     testing::Values(
+        std::make_pair("product_options_page", "google-cloud-frobber-options"),
         std::make_pair("additional_pb_header_paths",
                        "google/cloud/add1.pb.h,google/cloud/add2.pb.h"),
         std::make_pair("class_comment_block",

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -35,18 +35,17 @@ namespace generator_internal {
 
 auto constexpr kApiIndexFilename = "api-index-v1.json";
 
-std::string LibraryName(
-    google::cloud::cpp::generator::ServiceConfiguration const& service) {
-  std::vector<std::string> v = absl::StrSplit(service.product_path(), '/');
-  if (v.size() < 3) return {};
-  if (v[0] != "google" && v[1] != "cloud") return {};
-  return v[2];
+std::string LibraryName(std::string const& product_path) {
+  std::vector<std::string> v = absl::StrSplit(product_path, '/');
+  if (v.size() > 2 && v[0] == "google" && v[1] == "cloud") return v[2];
+  // This branch is only reached in our golden files.
+  return "golden";
 }
 
 std::string SiteRoot(
     google::cloud::cpp::generator::ServiceConfiguration const& service) {
   // TODO(#7605) - get a configurable source for this
-  return LibraryName(service);
+  return LibraryName(service.product_path());
 }
 
 std::map<std::string, std::string> ScaffoldVars(
@@ -80,11 +79,11 @@ std::map<std::string, std::string> ScaffoldVars(
     vars.emplace("description", api.value("description", ""));
     vars.emplace("directory", api.value("directory", ""));
   }
-  auto const library = LibraryName(service);
+  auto const library = LibraryName(service.product_path());
   vars["copyright_year"] = service.initial_copyright_year();
   vars["library"] = library;
-  vars["product_options_page"] = absl::StrCat(
-      absl::StrReplaceAll(service.product_path(), {{"/", "-"}}), "options");
+  vars["product_options_page"] =
+      absl::StrCat("google-cloud-", library, "-options");
   vars["site_root"] = SiteRoot(service);
   vars["library_prefix"] = experimental ? "experimental-" : "";
   vars["doxygen_version_suffix"] = experimental ? " (Experimental)" : "";

--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -31,12 +31,9 @@ namespace generator_internal {
  * In `google-cloud-cpp` libraries called `foo` live in the `google/cloud/foo`
  * directory. The names of CMake targets, Bazel rules, pkg-config modules,
  * features, etc. are based on the library name. This function returns the
- * name given a service configuration.
- *
- * This function assumes the service configuration has already been validated.
+ * library name given a service configuration's product path.
  */
-std::string LibraryName(
-    google::cloud::cpp::generator::ServiceConfiguration const& service);
+std::string LibraryName(std::string const& product_path);
 
 std::map<std::string, std::string> ScaffoldVars(
     std::string const& googleapis_path,

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -46,17 +46,10 @@ char const* const kHierarchy[] = {
 };
 
 TEST(ScaffoldGeneratorTest, LibraryName) {
-  google::cloud::cpp::generator::ServiceConfiguration service;
-  service.set_product_path("google/cloud/test/");
-  EXPECT_EQ("test", LibraryName(service));
-
-  service.set_product_path("google/cloud/test/v1");
-  EXPECT_EQ("test", LibraryName(service));
-
-  // LibraryName() is only called when we are generating scaffolding, or
-  // updating our CI. We do not care much about the error case.
-  service.set_product_path("bad-directory-structure");
-  EXPECT_EQ("", LibraryName(service));
+  EXPECT_EQ("test", LibraryName("google/cloud/test"));
+  EXPECT_EQ("test", LibraryName("google/cloud/test/"));
+  EXPECT_EQ("test", LibraryName("google/cloud/test/v1"));
+  EXPECT_EQ("golden", LibraryName("blah/golden"));
 }
 
 class ScaffoldGenerator : public ::testing::Test {

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -108,11 +108,12 @@ int WriteInstallDirectories(
          Parents("./include/" + Dirname(service.service_proto_path()))) {
       install_directories.push_back(p);
     }
-    auto const lib = google::cloud::generator_internal::LibraryName(service);
     // Services without a connection do not create mocks.
     if (!service.omit_connection()) {
       install_directories.push_back("./include/" + product_path + "/mocks");
     }
+    auto const lib =
+        google::cloud::generator_internal::LibraryName(product_path);
     install_directories.push_back("./lib64/cmake/google_cloud_cpp_" + lib);
   }
   std::sort(install_directories.begin(), install_directories.end());
@@ -134,8 +135,8 @@ int WriteFeatureList(
                      << service.DebugString() << "\n";
       return 1;
     }
-    auto feature = google::cloud::generator_internal::LibraryName(service);
-    features.push_back(std::move(feature));
+    features.push_back(
+        google::cloud::generator_internal::LibraryName(service.product_path()));
   }
   std::sort(features.begin(), features.end());
   auto const end = std::unique(features.begin(), features.end());

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_options.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_options.h
@@ -34,7 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Use with `google::cloud::Options` to configure the retry policy.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 struct BigtableInstanceAdminRetryPolicyOption {
   using Type = std::shared_ptr<BigtableInstanceAdminRetryPolicy>;
@@ -43,7 +43,7 @@ struct BigtableInstanceAdminRetryPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure the backoff policy.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 struct BigtableInstanceAdminBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
@@ -52,7 +52,7 @@ struct BigtableInstanceAdminBackoffPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure which operations are retried.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 struct BigtableInstanceAdminConnectionIdempotencyPolicyOption {
   using Type =
@@ -63,7 +63,7 @@ struct BigtableInstanceAdminConnectionIdempotencyPolicyOption {
  * Use with `google::cloud::Options` to configure the long-running operations
  * polling policy.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 struct BigtableInstanceAdminPollingPolicyOption {
   using Type = std::shared_ptr<PollingPolicy>;
@@ -72,7 +72,7 @@ struct BigtableInstanceAdminPollingPolicyOption {
 /**
  * The options applicable to BigtableInstanceAdmin.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 using BigtableInstanceAdminPolicyOptionList =
     OptionList<BigtableInstanceAdminRetryPolicyOption,

--- a/google/cloud/bigtable/admin/bigtable_table_admin_options.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_options.h
@@ -34,7 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Use with `google::cloud::Options` to configure the retry policy.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 struct BigtableTableAdminRetryPolicyOption {
   using Type = std::shared_ptr<BigtableTableAdminRetryPolicy>;
@@ -43,7 +43,7 @@ struct BigtableTableAdminRetryPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure the backoff policy.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 struct BigtableTableAdminBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
@@ -52,7 +52,7 @@ struct BigtableTableAdminBackoffPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure which operations are retried.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 struct BigtableTableAdminConnectionIdempotencyPolicyOption {
   using Type = std::shared_ptr<BigtableTableAdminConnectionIdempotencyPolicy>;
@@ -62,7 +62,7 @@ struct BigtableTableAdminConnectionIdempotencyPolicyOption {
  * Use with `google::cloud::Options` to configure the long-running operations
  * polling policy.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 struct BigtableTableAdminPollingPolicyOption {
   using Type = std::shared_ptr<PollingPolicy>;
@@ -71,7 +71,7 @@ struct BigtableTableAdminPollingPolicyOption {
 /**
  * The options applicable to BigtableTableAdmin.
  *
- * @ingroup google-cloud-bigtable-admin-options
+ * @ingroup google-cloud-bigtable-options
  */
 using BigtableTableAdminPolicyOptionList =
     OptionList<BigtableTableAdminRetryPolicyOption,

--- a/google/cloud/spanner/admin/database_admin_options.h
+++ b/google/cloud/spanner/admin/database_admin_options.h
@@ -34,7 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Use with `google::cloud::Options` to configure the retry policy.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 struct DatabaseAdminRetryPolicyOption {
   using Type = std::shared_ptr<DatabaseAdminRetryPolicy>;
@@ -43,7 +43,7 @@ struct DatabaseAdminRetryPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure the backoff policy.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 struct DatabaseAdminBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
@@ -52,7 +52,7 @@ struct DatabaseAdminBackoffPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure which operations are retried.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 struct DatabaseAdminConnectionIdempotencyPolicyOption {
   using Type = std::shared_ptr<DatabaseAdminConnectionIdempotencyPolicy>;
@@ -62,7 +62,7 @@ struct DatabaseAdminConnectionIdempotencyPolicyOption {
  * Use with `google::cloud::Options` to configure the long-running operations
  * polling policy.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 struct DatabaseAdminPollingPolicyOption {
   using Type = std::shared_ptr<PollingPolicy>;
@@ -71,7 +71,7 @@ struct DatabaseAdminPollingPolicyOption {
 /**
  * The options applicable to DatabaseAdmin.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 using DatabaseAdminPolicyOptionList =
     OptionList<DatabaseAdminRetryPolicyOption, DatabaseAdminBackoffPolicyOption,

--- a/google/cloud/spanner/admin/instance_admin_options.h
+++ b/google/cloud/spanner/admin/instance_admin_options.h
@@ -34,7 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Use with `google::cloud::Options` to configure the retry policy.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 struct InstanceAdminRetryPolicyOption {
   using Type = std::shared_ptr<InstanceAdminRetryPolicy>;
@@ -43,7 +43,7 @@ struct InstanceAdminRetryPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure the backoff policy.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 struct InstanceAdminBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
@@ -52,7 +52,7 @@ struct InstanceAdminBackoffPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure which operations are retried.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 struct InstanceAdminConnectionIdempotencyPolicyOption {
   using Type = std::shared_ptr<InstanceAdminConnectionIdempotencyPolicy>;
@@ -62,7 +62,7 @@ struct InstanceAdminConnectionIdempotencyPolicyOption {
  * Use with `google::cloud::Options` to configure the long-running operations
  * polling policy.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 struct InstanceAdminPollingPolicyOption {
   using Type = std::shared_ptr<PollingPolicy>;
@@ -71,7 +71,7 @@ struct InstanceAdminPollingPolicyOption {
 /**
  * The options applicable to InstanceAdmin.
  *
- * @ingroup google-cloud-spanner-admin-options
+ * @ingroup google-cloud-spanner-options
  */
 using InstanceAdminPolicyOptionList =
     OptionList<InstanceAdminRetryPolicyOption, InstanceAdminBackoffPolicyOption,


### PR DESCRIPTION
Part of the work for #10170

Set the options group to `google-cloud-<library>-options`. I think this is a fine assumption, because only libraries in `google/cloud/` have reference docs.

Bigtable and Spanner Admin options are now documented in the options group.

I don't love `LibraryName()` as a long term solution. I think something like #10237 would be cleaner.