### PR TITLE
impl(rest): add user facing RestOptions

### DIFF
--- a/google/cloud/google_cloud_cpp_rest_internal.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for google_cloud_cpp_rest_internal - DO NOT EDIT."""
 
 google_cloud_cpp_rest_internal_hdrs = [
+    "rest_options.h",
     "internal/binary_data_as_debug_string.h",
     "internal/curl_handle.h",
     "internal/curl_handle_factory.h",

--- a/google/cloud/google_cloud_cpp_rest_internal.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal.bzl
@@ -17,7 +17,6 @@
 """Automatically generated source lists for google_cloud_cpp_rest_internal - DO NOT EDIT."""
 
 google_cloud_cpp_rest_internal_hdrs = [
-    "rest_options.h",
     "internal/binary_data_as_debug_string.h",
     "internal/curl_handle.h",
     "internal/curl_handle_factory.h",
@@ -50,6 +49,7 @@ google_cloud_cpp_rest_internal_hdrs = [
     "internal/rest_request.h",
     "internal/rest_response.h",
     "internal/unified_rest_credentials.h",
+    "rest_options.h",
 ]
 
 google_cloud_cpp_rest_internal_srcs = [

--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -79,7 +79,8 @@ add_library(
     internal/rest_response.cc
     internal/rest_response.h
     internal/unified_rest_credentials.cc
-    internal/unified_rest_credentials.h)
+    internal/unified_rest_credentials.h
+    rest_options.h)
 target_link_libraries(
     google_cloud_cpp_rest_internal
     PUBLIC absl::span google-cloud-cpp::common CURL::libcurl

--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -23,7 +23,6 @@
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/curl_rest_response.h"
 #include "google/cloud/internal/oauth2_google_credentials.h"
-#include "google/cloud/internal/rest_options.h"
 #include "google/cloud/internal/unified_rest_credentials.h"
 #include "absl/strings/match.h"
 #include "absl/strings/strip.h"

--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/internal/oauth2_credentials.h"
 #include "google/cloud/internal/rest_client.h"
-#include "google/cloud/internal/rest_options.h"
 #include "google/cloud/internal/rest_request.h"
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/options.h"

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -21,7 +21,6 @@
 #include "google/cloud/internal/oauth2_credentials.h"
 #include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/internal/rest_client.h"
-#include "google/cloud/internal/rest_options.h"
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"

--- a/google/cloud/internal/rest_client.h
+++ b/google/cloud/internal/rest_client.h
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/rest_request.h"
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/options.h"
+#include "google/cloud/rest_options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <string>

--- a/google/cloud/internal/rest_options.h
+++ b/google/cloud/internal/rest_options.h
@@ -28,17 +28,6 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * Configure the UserIp query parameter.
- *
- * This can be used to separate quota usage by source IP address.
- *
- * @deprecated prefer using `google::cloud::QuotaUser`.
- */
-struct UserIpOption {
-  using Type = std::string;
-};
-
-/**
  * Sets the transfer stall timeout.
  *
  * If a transfer (upload, download, or request) *stalls*, i.e., no bytes are
@@ -96,8 +85,8 @@ struct DownloadStallMinimumRateOption {
 };
 
 /// The complete list of options accepted by `CurlRestClient`
-using RestOptionList = ::google::cloud::OptionList<
-    UserIpOption, TransferStallTimeoutOption, TransferStallMinimumRateOption,
+using RestInternalOptionList = ::google::cloud::OptionList<
+    TransferStallTimeoutOption, TransferStallMinimumRateOption,
     DownloadStallTimeoutOption, DownloadStallMinimumRateOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/rest_options.h
+++ b/google/cloud/rest_options.h
@@ -1,0 +1,70 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_REST_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_REST_OPTIONS_H
+
+#include "google/cloud/options.h"
+#include "google/cloud/version.h"
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Configure the QuotaUser system parameter.
+ *
+ * A pseudo user identifier for charging per-user quotas. If not specified, the
+ * authenticated principal is used. If there is no authenticated principal, the
+ * client IP address will be used. When specified, a valid API key with service
+ * restrictions must be used to identify the quota project. Otherwise, this
+ * parameter is ignored.
+ */
+struct QuotaUser {
+  using Type = std::string;
+};
+
+/**
+ * Configure the UserIp query parameter.
+ *
+ * This can be used to separate quota usage by source IP address.
+ *
+ * @deprecated prefer using `google::cloud::QuotaUser`.
+ */
+struct UserIpOption {
+  using Type = std::string;
+};
+
+/**
+ * Timeout (in seconds) for the server to finish processing the request. This
+ * system param only applies to REST APIs for which client-side timeout is not
+ * applicable.
+ */
+struct ServerTimeout {
+  using Type = float;
+};
+
+/// The complete list of options accepted by `CurlRestClient`
+using RestOptionList =
+    ::google::cloud::OptionList<QuotaUser, ServerTimeout, UserIpOption>;
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_REST_OPTIONS_H


### PR DESCRIPTION
This adds a user visible set of RestOptions for use with REST transport. These are based on the system parameters found at https://cloud.google.com/apis/docs/system-parameters. If we need to add additional options from these parameters, we can do so later as they are needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10240)
<!-- Reviewable:end -->
