### PR TITLE
doc: use qualified client name in samples

### DIFF
--- a/generator/integration_tests/golden/samples/golden_kitchen_sink_client_samples.cc
+++ b/generator/integration_tests/golden/samples/golden_kitchen_sink_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: GoldenKitchenSinkClient
+// main-dox-marker: golden::GoldenKitchenSinkClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/generator/integration_tests/golden/samples/golden_thing_admin_client_samples.cc
+++ b/generator/integration_tests/golden/samples/golden_thing_admin_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: GoldenThingAdminClient
+// main-dox-marker: golden::GoldenThingAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/generator/internal/sample_generator.cc
+++ b/generator/internal/sample_generator.cc
@@ -48,7 +48,7 @@ Status SampleGenerator::GenerateHeader() {
   HeaderSystemIncludes({"iostream", "fstream", "string", "vector"});
 
   HeaderPrint(R"""(
-// main-dox-marker: $client_class_name$
+// main-dox-marker: $product_namespace$::$client_class_name$
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AccessApprovalClient`:
+For example, this will override the default endpoint for `accessapproval::AccessApprovalClient`:
 
 @snippet access_approval_client_samples.cc set-client-endpoint
 
@@ -144,13 +144,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AccessApprovalClient-endpoint-snippet Override AccessApprovalClient Endpoint Configuration
+/*! @page accessapproval::AccessApprovalClient-endpoint-snippet Override accessapproval::AccessApprovalClient Endpoint Configuration
 
 @snippet google/cloud/accessapproval/samples/access_approval_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AccessApprovalClient-service-account-snippet Override AccessApprovalClient Authentication Defaults
+/*! @page accessapproval::AccessApprovalClient-service-account-snippet Override accessapproval::AccessApprovalClient Authentication Defaults
 
 @snippet google/cloud/accessapproval/samples/access_approval_client_samples.cc with-service-account
 

--- a/google/cloud/accessapproval/samples/access_approval_client_samples.cc
+++ b/google/cloud/accessapproval/samples/access_approval_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AccessApprovalClient
+// main-dox-marker: accessapproval::AccessApprovalClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/accesscontextmanager/doc/main.dox
+++ b/google/cloud/accesscontextmanager/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AccessContextManagerClient`:
+For example, this will override the default endpoint for `accesscontextmanager::AccessContextManagerClient`:
 
 @snippet access_context_manager_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AccessContextManagerClient-endpoint-snippet Override AccessContextManagerClient Endpoint Configuration
+/*! @page accesscontextmanager::AccessContextManagerClient-endpoint-snippet Override accesscontextmanager::AccessContextManagerClient Endpoint Configuration
 
 @snippet google/cloud/accesscontextmanager/samples/access_context_manager_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AccessContextManagerClient-service-account-snippet Override AccessContextManagerClient Authentication Defaults
+/*! @page accesscontextmanager::AccessContextManagerClient-service-account-snippet Override accesscontextmanager::AccessContextManagerClient Authentication Defaults
 
 @snippet google/cloud/accesscontextmanager/samples/access_context_manager_client_samples.cc with-service-account
 

--- a/google/cloud/accesscontextmanager/samples/access_context_manager_client_samples.cc
+++ b/google/cloud/accesscontextmanager/samples/access_context_manager_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AccessContextManagerClient
+// main-dox-marker: accesscontextmanager::AccessContextManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/apigateway/doc/main.dox
+++ b/google/cloud/apigateway/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ApiGatewayServiceClient`:
+For example, this will override the default endpoint for `apigateway::ApiGatewayServiceClient`:
 
 @snippet api_gateway_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ApiGatewayServiceClient-endpoint-snippet Override ApiGatewayServiceClient Endpoint Configuration
+/*! @page apigateway::ApiGatewayServiceClient-endpoint-snippet Override apigateway::ApiGatewayServiceClient Endpoint Configuration
 
 @snippet google/cloud/apigateway/samples/api_gateway_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ApiGatewayServiceClient-service-account-snippet Override ApiGatewayServiceClient Authentication Defaults
+/*! @page apigateway::ApiGatewayServiceClient-service-account-snippet Override apigateway::ApiGatewayServiceClient Authentication Defaults
 
 @snippet google/cloud/apigateway/samples/api_gateway_client_samples.cc with-service-account
 

--- a/google/cloud/apigateway/samples/api_gateway_client_samples.cc
+++ b/google/cloud/apigateway/samples/api_gateway_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ApiGatewayServiceClient
+// main-dox-marker: apigateway::ApiGatewayServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/apigeeconnect/doc/main.dox
+++ b/google/cloud/apigeeconnect/doc/main.dox
@@ -96,7 +96,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ConnectionServiceClient`:
+For example, this will override the default endpoint for `apigeeconnect::ConnectionServiceClient`:
 
 @snippet connection_client_samples.cc set-client-endpoint
 
@@ -141,13 +141,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ConnectionServiceClient-endpoint-snippet Override ConnectionServiceClient Endpoint Configuration
+/*! @page apigeeconnect::ConnectionServiceClient-endpoint-snippet Override apigeeconnect::ConnectionServiceClient Endpoint Configuration
 
 @snippet google/cloud/apigeeconnect/samples/connection_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ConnectionServiceClient-service-account-snippet Override ConnectionServiceClient Authentication Defaults
+/*! @page apigeeconnect::ConnectionServiceClient-service-account-snippet Override apigeeconnect::ConnectionServiceClient Authentication Defaults
 
 @snippet google/cloud/apigeeconnect/samples/connection_client_samples.cc with-service-account
 

--- a/google/cloud/apigeeconnect/samples/connection_client_samples.cc
+++ b/google/cloud/apigeeconnect/samples/connection_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ConnectionServiceClient
+// main-dox-marker: apigeeconnect::ConnectionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/apikeys/doc/main.dox
+++ b/google/cloud/apikeys/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ApiKeysClient`:
+For example, this will override the default endpoint for `apikeys::ApiKeysClient`:
 
 @snippet api_keys_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ApiKeysClient-endpoint-snippet Override ApiKeysClient Endpoint Configuration
+/*! @page apikeys::ApiKeysClient-endpoint-snippet Override apikeys::ApiKeysClient Endpoint Configuration
 
 @snippet google/cloud/apikeys/samples/api_keys_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ApiKeysClient-service-account-snippet Override ApiKeysClient Authentication Defaults
+/*! @page apikeys::ApiKeysClient-service-account-snippet Override apikeys::ApiKeysClient Authentication Defaults
 
 @snippet google/cloud/apikeys/samples/api_keys_client_samples.cc with-service-account
 

--- a/google/cloud/apikeys/samples/api_keys_client_samples.cc
+++ b/google/cloud/apikeys/samples/api_keys_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ApiKeysClient
+// main-dox-marker: apikeys::ApiKeysClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/appengine/doc/main.dox
+++ b/google/cloud/appengine/doc/main.dox
@@ -120,19 +120,19 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ApplicationsClient`:
+For example, this will override the default endpoint for `appengine::ApplicationsClient`:
 
 @snippet applications_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [ApplicationsClient](@ref ApplicationsClient-endpoint-snippet)
- [AuthorizedCertificatesClient](@ref AuthorizedCertificatesClient-endpoint-snippet)
- [AuthorizedDomainsClient](@ref AuthorizedDomainsClient-endpoint-snippet)
- [DomainMappingsClient](@ref DomainMappingsClient-endpoint-snippet)
- [FirewallClient](@ref FirewallClient-endpoint-snippet)
- [InstancesClient](@ref InstancesClient-endpoint-snippet)
- [ServicesClient](@ref ServicesClient-endpoint-snippet)
- [VersionsClient](@ref VersionsClient-endpoint-snippet)
+ [appengine::ApplicationsClient](@ref appengine::ApplicationsClient-endpoint-snippet)
+ [appengine::AuthorizedCertificatesClient](@ref appengine::AuthorizedCertificatesClient-endpoint-snippet)
+ [appengine::AuthorizedDomainsClient](@ref appengine::AuthorizedDomainsClient-endpoint-snippet)
+ [appengine::DomainMappingsClient](@ref appengine::DomainMappingsClient-endpoint-snippet)
+ [appengine::FirewallClient](@ref appengine::FirewallClient-endpoint-snippet)
+ [appengine::InstancesClient](@ref appengine::InstancesClient-endpoint-snippet)
+ [appengine::ServicesClient](@ref appengine::ServicesClient-endpoint-snippet)
+ [appengine::VersionsClient](@ref appengine::VersionsClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -147,14 +147,14 @@ to explicitly load a service account key file.
 @snippet applications_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [ApplicationsClient](@ref ApplicationsClient-service-account-snippet)
- [AuthorizedCertificatesClient](@ref AuthorizedCertificatesClient-service-account-snippet)
- [AuthorizedDomainsClient](@ref AuthorizedDomainsClient-service-account-snippet)
- [DomainMappingsClient](@ref DomainMappingsClient-service-account-snippet)
- [FirewallClient](@ref FirewallClient-service-account-snippet)
- [InstancesClient](@ref InstancesClient-service-account-snippet)
- [ServicesClient](@ref ServicesClient-service-account-snippet)
- [VersionsClient](@ref VersionsClient-service-account-snippet)
+ [appengine::ApplicationsClient](@ref appengine::ApplicationsClient-service-account-snippet)
+ [appengine::AuthorizedCertificatesClient](@ref appengine::AuthorizedCertificatesClient-service-account-snippet)
+ [appengine::AuthorizedDomainsClient](@ref appengine::AuthorizedDomainsClient-service-account-snippet)
+ [appengine::DomainMappingsClient](@ref appengine::DomainMappingsClient-service-account-snippet)
+ [appengine::FirewallClient](@ref appengine::FirewallClient-service-account-snippet)
+ [appengine::InstancesClient](@ref appengine::InstancesClient-service-account-snippet)
+ [appengine::ServicesClient](@ref appengine::ServicesClient-service-account-snippet)
+ [appengine::VersionsClient](@ref appengine::VersionsClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -185,97 +185,97 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ApplicationsClient-endpoint-snippet Override ApplicationsClient Endpoint Configuration
+/*! @page appengine::ApplicationsClient-endpoint-snippet Override appengine::ApplicationsClient Endpoint Configuration
 
 @snippet google/cloud/appengine/samples/applications_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ApplicationsClient-service-account-snippet Override ApplicationsClient Authentication Defaults
+/*! @page appengine::ApplicationsClient-service-account-snippet Override appengine::ApplicationsClient Authentication Defaults
 
 @snippet google/cloud/appengine/samples/applications_client_samples.cc with-service-account
 
 */
 
-/*! @page AuthorizedCertificatesClient-endpoint-snippet Override AuthorizedCertificatesClient Endpoint Configuration
+/*! @page appengine::AuthorizedCertificatesClient-endpoint-snippet Override appengine::AuthorizedCertificatesClient Endpoint Configuration
 
 @snippet google/cloud/appengine/samples/authorized_certificates_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AuthorizedCertificatesClient-service-account-snippet Override AuthorizedCertificatesClient Authentication Defaults
+/*! @page appengine::AuthorizedCertificatesClient-service-account-snippet Override appengine::AuthorizedCertificatesClient Authentication Defaults
 
 @snippet google/cloud/appengine/samples/authorized_certificates_client_samples.cc with-service-account
 
 */
 
-/*! @page AuthorizedDomainsClient-endpoint-snippet Override AuthorizedDomainsClient Endpoint Configuration
+/*! @page appengine::AuthorizedDomainsClient-endpoint-snippet Override appengine::AuthorizedDomainsClient Endpoint Configuration
 
 @snippet google/cloud/appengine/samples/authorized_domains_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AuthorizedDomainsClient-service-account-snippet Override AuthorizedDomainsClient Authentication Defaults
+/*! @page appengine::AuthorizedDomainsClient-service-account-snippet Override appengine::AuthorizedDomainsClient Authentication Defaults
 
 @snippet google/cloud/appengine/samples/authorized_domains_client_samples.cc with-service-account
 
 */
 
-/*! @page DomainMappingsClient-endpoint-snippet Override DomainMappingsClient Endpoint Configuration
+/*! @page appengine::DomainMappingsClient-endpoint-snippet Override appengine::DomainMappingsClient Endpoint Configuration
 
 @snippet google/cloud/appengine/samples/domain_mappings_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DomainMappingsClient-service-account-snippet Override DomainMappingsClient Authentication Defaults
+/*! @page appengine::DomainMappingsClient-service-account-snippet Override appengine::DomainMappingsClient Authentication Defaults
 
 @snippet google/cloud/appengine/samples/domain_mappings_client_samples.cc with-service-account
 
 */
 
-/*! @page FirewallClient-endpoint-snippet Override FirewallClient Endpoint Configuration
+/*! @page appengine::FirewallClient-endpoint-snippet Override appengine::FirewallClient Endpoint Configuration
 
 @snippet google/cloud/appengine/samples/firewall_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page FirewallClient-service-account-snippet Override FirewallClient Authentication Defaults
+/*! @page appengine::FirewallClient-service-account-snippet Override appengine::FirewallClient Authentication Defaults
 
 @snippet google/cloud/appengine/samples/firewall_client_samples.cc with-service-account
 
 */
 
-/*! @page InstancesClient-endpoint-snippet Override InstancesClient Endpoint Configuration
+/*! @page appengine::InstancesClient-endpoint-snippet Override appengine::InstancesClient Endpoint Configuration
 
 @snippet google/cloud/appengine/samples/instances_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page InstancesClient-service-account-snippet Override InstancesClient Authentication Defaults
+/*! @page appengine::InstancesClient-service-account-snippet Override appengine::InstancesClient Authentication Defaults
 
 @snippet google/cloud/appengine/samples/instances_client_samples.cc with-service-account
 
 */
 
-/*! @page ServicesClient-endpoint-snippet Override ServicesClient Endpoint Configuration
+/*! @page appengine::ServicesClient-endpoint-snippet Override appengine::ServicesClient Endpoint Configuration
 
 @snippet google/cloud/appengine/samples/services_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ServicesClient-service-account-snippet Override ServicesClient Authentication Defaults
+/*! @page appengine::ServicesClient-service-account-snippet Override appengine::ServicesClient Authentication Defaults
 
 @snippet google/cloud/appengine/samples/services_client_samples.cc with-service-account
 
 */
 
-/*! @page VersionsClient-endpoint-snippet Override VersionsClient Endpoint Configuration
+/*! @page appengine::VersionsClient-endpoint-snippet Override appengine::VersionsClient Endpoint Configuration
 
 @snippet google/cloud/appengine/samples/versions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page VersionsClient-service-account-snippet Override VersionsClient Authentication Defaults
+/*! @page appengine::VersionsClient-service-account-snippet Override appengine::VersionsClient Authentication Defaults
 
 @snippet google/cloud/appengine/samples/versions_client_samples.cc with-service-account
 

--- a/google/cloud/appengine/samples/applications_client_samples.cc
+++ b/google/cloud/appengine/samples/applications_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ApplicationsClient
+// main-dox-marker: appengine::ApplicationsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/appengine/samples/authorized_certificates_client_samples.cc
+++ b/google/cloud/appengine/samples/authorized_certificates_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AuthorizedCertificatesClient
+// main-dox-marker: appengine::AuthorizedCertificatesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/appengine/samples/authorized_domains_client_samples.cc
+++ b/google/cloud/appengine/samples/authorized_domains_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AuthorizedDomainsClient
+// main-dox-marker: appengine::AuthorizedDomainsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/appengine/samples/domain_mappings_client_samples.cc
+++ b/google/cloud/appengine/samples/domain_mappings_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DomainMappingsClient
+// main-dox-marker: appengine::DomainMappingsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/appengine/samples/firewall_client_samples.cc
+++ b/google/cloud/appengine/samples/firewall_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: FirewallClient
+// main-dox-marker: appengine::FirewallClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/appengine/samples/instances_client_samples.cc
+++ b/google/cloud/appengine/samples/instances_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: InstancesClient
+// main-dox-marker: appengine::InstancesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/appengine/samples/services_client_samples.cc
+++ b/google/cloud/appengine/samples/services_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ServicesClient
+// main-dox-marker: appengine::ServicesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/appengine/samples/versions_client_samples.cc
+++ b/google/cloud/appengine/samples/versions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: VersionsClient
+// main-dox-marker: appengine::VersionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/artifactregistry/doc/main.dox
+++ b/google/cloud/artifactregistry/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ArtifactRegistryClient`:
+For example, this will override the default endpoint for `artifactregistry::ArtifactRegistryClient`:
 
 @snippet artifact_registry_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ArtifactRegistryClient-endpoint-snippet Override ArtifactRegistryClient Endpoint Configuration
+/*! @page artifactregistry::ArtifactRegistryClient-endpoint-snippet Override artifactregistry::ArtifactRegistryClient Endpoint Configuration
 
 @snippet google/cloud/artifactregistry/samples/artifact_registry_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ArtifactRegistryClient-service-account-snippet Override ArtifactRegistryClient Authentication Defaults
+/*! @page artifactregistry::ArtifactRegistryClient-service-account-snippet Override artifactregistry::ArtifactRegistryClient Authentication Defaults
 
 @snippet google/cloud/artifactregistry/samples/artifact_registry_client_samples.cc with-service-account
 

--- a/google/cloud/artifactregistry/samples/artifact_registry_client_samples.cc
+++ b/google/cloud/artifactregistry/samples/artifact_registry_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ArtifactRegistryClient
+// main-dox-marker: artifactregistry::ArtifactRegistryClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/asset/doc/main.dox
+++ b/google/cloud/asset/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AssetServiceClient`:
+For example, this will override the default endpoint for `asset::AssetServiceClient`:
 
 @snippet asset_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AssetServiceClient-endpoint-snippet Override AssetServiceClient Endpoint Configuration
+/*! @page asset::AssetServiceClient-endpoint-snippet Override asset::AssetServiceClient Endpoint Configuration
 
 @snippet google/cloud/asset/samples/asset_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AssetServiceClient-service-account-snippet Override AssetServiceClient Authentication Defaults
+/*! @page asset::AssetServiceClient-service-account-snippet Override asset::AssetServiceClient Authentication Defaults
 
 @snippet google/cloud/asset/samples/asset_client_samples.cc with-service-account
 

--- a/google/cloud/asset/samples/asset_client_samples.cc
+++ b/google/cloud/asset/samples/asset_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AssetServiceClient
+// main-dox-marker: asset::AssetServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AssuredWorkloadsServiceClient`:
+For example, this will override the default endpoint for `assuredworkloads::AssuredWorkloadsServiceClient`:
 
 @snippet assured_workloads_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AssuredWorkloadsServiceClient-endpoint-snippet Override AssuredWorkloadsServiceClient Endpoint Configuration
+/*! @page assuredworkloads::AssuredWorkloadsServiceClient-endpoint-snippet Override assuredworkloads::AssuredWorkloadsServiceClient Endpoint Configuration
 
 @snippet google/cloud/assuredworkloads/samples/assured_workloads_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AssuredWorkloadsServiceClient-service-account-snippet Override AssuredWorkloadsServiceClient Authentication Defaults
+/*! @page assuredworkloads::AssuredWorkloadsServiceClient-service-account-snippet Override assuredworkloads::AssuredWorkloadsServiceClient Authentication Defaults
 
 @snippet google/cloud/assuredworkloads/samples/assured_workloads_client_samples.cc with-service-account
 

--- a/google/cloud/assuredworkloads/samples/assured_workloads_client_samples.cc
+++ b/google/cloud/assuredworkloads/samples/assured_workloads_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AssuredWorkloadsServiceClient
+// main-dox-marker: assuredworkloads::AssuredWorkloadsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -97,13 +97,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AutoMlClient`:
+For example, this will override the default endpoint for `automl::AutoMlClient`:
 
 @snippet auto_ml_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AutoMlClient](@ref AutoMlClient-endpoint-snippet)
- [PredictionServiceClient](@ref PredictionServiceClient-endpoint-snippet)
+ [automl::AutoMlClient](@ref automl::AutoMlClient-endpoint-snippet)
+ [automl::PredictionServiceClient](@ref automl::PredictionServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -118,8 +118,8 @@ to explicitly load a service account key file.
 @snippet auto_ml_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AutoMlClient](@ref AutoMlClient-service-account-snippet)
- [PredictionServiceClient](@ref PredictionServiceClient-service-account-snippet)
+ [automl::AutoMlClient](@ref automl::AutoMlClient-service-account-snippet)
+ [automl::PredictionServiceClient](@ref automl::PredictionServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -150,25 +150,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AutoMlClient-endpoint-snippet Override AutoMlClient Endpoint Configuration
+/*! @page automl::AutoMlClient-endpoint-snippet Override automl::AutoMlClient Endpoint Configuration
 
 @snippet google/cloud/automl/samples/auto_ml_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AutoMlClient-service-account-snippet Override AutoMlClient Authentication Defaults
+/*! @page automl::AutoMlClient-service-account-snippet Override automl::AutoMlClient Authentication Defaults
 
 @snippet google/cloud/automl/samples/auto_ml_client_samples.cc with-service-account
 
 */
 
-/*! @page PredictionServiceClient-endpoint-snippet Override PredictionServiceClient Endpoint Configuration
+/*! @page automl::PredictionServiceClient-endpoint-snippet Override automl::PredictionServiceClient Endpoint Configuration
 
 @snippet google/cloud/automl/samples/prediction_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page PredictionServiceClient-service-account-snippet Override PredictionServiceClient Authentication Defaults
+/*! @page automl::PredictionServiceClient-service-account-snippet Override automl::PredictionServiceClient Authentication Defaults
 
 @snippet google/cloud/automl/samples/prediction_client_samples.cc with-service-account
 

--- a/google/cloud/automl/samples/auto_ml_client_samples.cc
+++ b/google/cloud/automl/samples/auto_ml_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AutoMlClient
+// main-dox-marker: automl::AutoMlClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/automl/samples/prediction_client_samples.cc
+++ b/google/cloud/automl/samples/prediction_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: PredictionServiceClient
+// main-dox-marker: automl::PredictionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/baremetalsolution/doc/main.dox
+++ b/google/cloud/baremetalsolution/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `BareMetalSolutionClient`:
+For example, this will override the default endpoint for `baremetalsolution::BareMetalSolutionClient`:
 
 @snippet bare_metal_solution_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page BareMetalSolutionClient-endpoint-snippet Override BareMetalSolutionClient Endpoint Configuration
+/*! @page baremetalsolution::BareMetalSolutionClient-endpoint-snippet Override baremetalsolution::BareMetalSolutionClient Endpoint Configuration
 
 @snippet google/cloud/baremetalsolution/samples/bare_metal_solution_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page BareMetalSolutionClient-service-account-snippet Override BareMetalSolutionClient Authentication Defaults
+/*! @page baremetalsolution::BareMetalSolutionClient-service-account-snippet Override baremetalsolution::BareMetalSolutionClient Authentication Defaults
 
 @snippet google/cloud/baremetalsolution/samples/bare_metal_solution_client_samples.cc with-service-account
 

--- a/google/cloud/baremetalsolution/samples/bare_metal_solution_client_samples.cc
+++ b/google/cloud/baremetalsolution/samples/bare_metal_solution_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BareMetalSolutionClient
+// main-dox-marker: baremetalsolution::BareMetalSolutionClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/batch/doc/main.dox
+++ b/google/cloud/batch/doc/main.dox
@@ -91,7 +91,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `BatchServiceClient`:
+For example, this will override the default endpoint for `batch::BatchServiceClient`:
 
 @snippet batch_client_samples.cc set-client-endpoint
 
@@ -136,13 +136,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page BatchServiceClient-endpoint-snippet Override BatchServiceClient Endpoint Configuration
+/*! @page batch::BatchServiceClient-endpoint-snippet Override batch::BatchServiceClient Endpoint Configuration
 
 @snippet google/cloud/batch/samples/batch_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page BatchServiceClient-service-account-snippet Override BatchServiceClient Authentication Defaults
+/*! @page batch::BatchServiceClient-service-account-snippet Override batch::BatchServiceClient Authentication Defaults
 
 @snippet google/cloud/batch/samples/batch_client_samples.cc with-service-account
 

--- a/google/cloud/batch/samples/batch_client_samples.cc
+++ b/google/cloud/batch/samples/batch_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BatchServiceClient
+// main-dox-marker: batch::BatchServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/beyondcorp/doc/main.dox
+++ b/google/cloud/beyondcorp/doc/main.dox
@@ -111,16 +111,16 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AppConnectionsServiceClient`:
+For example, this will override the default endpoint for `beyondcorp::AppConnectionsServiceClient`:
 
 @snippet app_connections_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AppConnectionsServiceClient](@ref AppConnectionsServiceClient-endpoint-snippet)
- [AppConnectorsServiceClient](@ref AppConnectorsServiceClient-endpoint-snippet)
- [AppGatewaysServiceClient](@ref AppGatewaysServiceClient-endpoint-snippet)
- [ClientConnectorServicesServiceClient](@ref ClientConnectorServicesServiceClient-endpoint-snippet)
- [ClientGatewaysServiceClient](@ref ClientGatewaysServiceClient-endpoint-snippet)
+ [beyondcorp::AppConnectionsServiceClient](@ref beyondcorp::AppConnectionsServiceClient-endpoint-snippet)
+ [beyondcorp::AppConnectorsServiceClient](@ref beyondcorp::AppConnectorsServiceClient-endpoint-snippet)
+ [beyondcorp::AppGatewaysServiceClient](@ref beyondcorp::AppGatewaysServiceClient-endpoint-snippet)
+ [beyondcorp::ClientConnectorServicesServiceClient](@ref beyondcorp::ClientConnectorServicesServiceClient-endpoint-snippet)
+ [beyondcorp::ClientGatewaysServiceClient](@ref beyondcorp::ClientGatewaysServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -135,11 +135,11 @@ to explicitly load a service account key file.
 @snippet app_connections_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AppConnectionsServiceClient](@ref AppConnectionsServiceClient-service-account-snippet)
- [AppConnectorsServiceClient](@ref AppConnectorsServiceClient-service-account-snippet)
- [AppGatewaysServiceClient](@ref AppGatewaysServiceClient-service-account-snippet)
- [ClientConnectorServicesServiceClient](@ref ClientConnectorServicesServiceClient-service-account-snippet)
- [ClientGatewaysServiceClient](@ref ClientGatewaysServiceClient-service-account-snippet)
+ [beyondcorp::AppConnectionsServiceClient](@ref beyondcorp::AppConnectionsServiceClient-service-account-snippet)
+ [beyondcorp::AppConnectorsServiceClient](@ref beyondcorp::AppConnectorsServiceClient-service-account-snippet)
+ [beyondcorp::AppGatewaysServiceClient](@ref beyondcorp::AppGatewaysServiceClient-service-account-snippet)
+ [beyondcorp::ClientConnectorServicesServiceClient](@ref beyondcorp::ClientConnectorServicesServiceClient-service-account-snippet)
+ [beyondcorp::ClientGatewaysServiceClient](@ref beyondcorp::ClientGatewaysServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -170,61 +170,61 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AppConnectionsServiceClient-endpoint-snippet Override AppConnectionsServiceClient Endpoint Configuration
+/*! @page beyondcorp::AppConnectionsServiceClient-endpoint-snippet Override beyondcorp::AppConnectionsServiceClient Endpoint Configuration
 
 @snippet google/cloud/beyondcorp/samples/app_connections_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AppConnectionsServiceClient-service-account-snippet Override AppConnectionsServiceClient Authentication Defaults
+/*! @page beyondcorp::AppConnectionsServiceClient-service-account-snippet Override beyondcorp::AppConnectionsServiceClient Authentication Defaults
 
 @snippet google/cloud/beyondcorp/samples/app_connections_client_samples.cc with-service-account
 
 */
 
-/*! @page AppConnectorsServiceClient-endpoint-snippet Override AppConnectorsServiceClient Endpoint Configuration
+/*! @page beyondcorp::AppConnectorsServiceClient-endpoint-snippet Override beyondcorp::AppConnectorsServiceClient Endpoint Configuration
 
 @snippet google/cloud/beyondcorp/samples/app_connectors_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AppConnectorsServiceClient-service-account-snippet Override AppConnectorsServiceClient Authentication Defaults
+/*! @page beyondcorp::AppConnectorsServiceClient-service-account-snippet Override beyondcorp::AppConnectorsServiceClient Authentication Defaults
 
 @snippet google/cloud/beyondcorp/samples/app_connectors_client_samples.cc with-service-account
 
 */
 
-/*! @page AppGatewaysServiceClient-endpoint-snippet Override AppGatewaysServiceClient Endpoint Configuration
+/*! @page beyondcorp::AppGatewaysServiceClient-endpoint-snippet Override beyondcorp::AppGatewaysServiceClient Endpoint Configuration
 
 @snippet google/cloud/beyondcorp/samples/app_gateways_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AppGatewaysServiceClient-service-account-snippet Override AppGatewaysServiceClient Authentication Defaults
+/*! @page beyondcorp::AppGatewaysServiceClient-service-account-snippet Override beyondcorp::AppGatewaysServiceClient Authentication Defaults
 
 @snippet google/cloud/beyondcorp/samples/app_gateways_client_samples.cc with-service-account
 
 */
 
-/*! @page ClientConnectorServicesServiceClient-endpoint-snippet Override ClientConnectorServicesServiceClient Endpoint Configuration
+/*! @page beyondcorp::ClientConnectorServicesServiceClient-endpoint-snippet Override beyondcorp::ClientConnectorServicesServiceClient Endpoint Configuration
 
 @snippet google/cloud/beyondcorp/samples/client_connector_services_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ClientConnectorServicesServiceClient-service-account-snippet Override ClientConnectorServicesServiceClient Authentication Defaults
+/*! @page beyondcorp::ClientConnectorServicesServiceClient-service-account-snippet Override beyondcorp::ClientConnectorServicesServiceClient Authentication Defaults
 
 @snippet google/cloud/beyondcorp/samples/client_connector_services_client_samples.cc with-service-account
 
 */
 
-/*! @page ClientGatewaysServiceClient-endpoint-snippet Override ClientGatewaysServiceClient Endpoint Configuration
+/*! @page beyondcorp::ClientGatewaysServiceClient-endpoint-snippet Override beyondcorp::ClientGatewaysServiceClient Endpoint Configuration
 
 @snippet google/cloud/beyondcorp/samples/client_gateways_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ClientGatewaysServiceClient-service-account-snippet Override ClientGatewaysServiceClient Authentication Defaults
+/*! @page beyondcorp::ClientGatewaysServiceClient-service-account-snippet Override beyondcorp::ClientGatewaysServiceClient Authentication Defaults
 
 @snippet google/cloud/beyondcorp/samples/client_gateways_client_samples.cc with-service-account
 

--- a/google/cloud/beyondcorp/samples/app_connections_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/app_connections_client_samples.cc
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AppConnectionsServiceClient
+// main-dox-marker: beyondcorp::AppConnectionsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/beyondcorp/samples/app_connectors_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/app_connectors_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AppConnectorsServiceClient
+// main-dox-marker: beyondcorp::AppConnectorsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/beyondcorp/samples/app_gateways_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/app_gateways_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AppGatewaysServiceClient
+// main-dox-marker: beyondcorp::AppGatewaysServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/beyondcorp/samples/client_connector_services_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/client_connector_services_client_samples.cc
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ClientConnectorServicesServiceClient
+// main-dox-marker: beyondcorp::ClientConnectorServicesServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/beyondcorp/samples/client_gateways_client_samples.cc
+++ b/google/cloud/beyondcorp/samples/client_gateways_client_samples.cc
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ClientGatewaysServiceClient
+// main-dox-marker: beyondcorp::ClientGatewaysServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigquery/doc/main.dox
+++ b/google/cloud/bigquery/doc/main.dox
@@ -148,19 +148,19 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AnalyticsHubServiceClient`:
+For example, this will override the default endpoint for `bigquery::AnalyticsHubServiceClient`:
 
 @snippet analytics_hub_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AnalyticsHubServiceClient](@ref AnalyticsHubServiceClient-endpoint-snippet)
- [BigQueryReadClient](@ref BigQueryReadClient-endpoint-snippet)
- [BigQueryWriteClient](@ref BigQueryWriteClient-endpoint-snippet)
- [ConnectionServiceClient](@ref ConnectionServiceClient-endpoint-snippet)
- [DataTransferServiceClient](@ref DataTransferServiceClient-endpoint-snippet)
- [MigrationServiceClient](@ref MigrationServiceClient-endpoint-snippet)
- [ModelServiceClient](@ref ModelServiceClient-endpoint-snippet)
- [ReservationServiceClient](@ref ReservationServiceClient-endpoint-snippet)
+ [bigquery::AnalyticsHubServiceClient](@ref bigquery::AnalyticsHubServiceClient-endpoint-snippet)
+ [bigquery::BigQueryReadClient](@ref bigquery::BigQueryReadClient-endpoint-snippet)
+ [bigquery::BigQueryWriteClient](@ref bigquery::BigQueryWriteClient-endpoint-snippet)
+ [bigquery::ConnectionServiceClient](@ref bigquery::ConnectionServiceClient-endpoint-snippet)
+ [bigquery::DataTransferServiceClient](@ref bigquery::DataTransferServiceClient-endpoint-snippet)
+ [bigquery::MigrationServiceClient](@ref bigquery::MigrationServiceClient-endpoint-snippet)
+ [bigquery::ModelServiceClient](@ref bigquery::ModelServiceClient-endpoint-snippet)
+ [bigquery::ReservationServiceClient](@ref bigquery::ReservationServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -175,14 +175,14 @@ to explicitly load a service account key file.
 @snippet analytics_hub_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AnalyticsHubServiceClient](@ref AnalyticsHubServiceClient-service-account-snippet)
- [BigQueryReadClient](@ref BigQueryReadClient-service-account-snippet)
- [BigQueryWriteClient](@ref BigQueryWriteClient-service-account-snippet)
- [ConnectionServiceClient](@ref ConnectionServiceClient-service-account-snippet)
- [DataTransferServiceClient](@ref DataTransferServiceClient-service-account-snippet)
- [MigrationServiceClient](@ref MigrationServiceClient-service-account-snippet)
- [ModelServiceClient](@ref ModelServiceClient-service-account-snippet)
- [ReservationServiceClient](@ref ReservationServiceClient-service-account-snippet)
+ [bigquery::AnalyticsHubServiceClient](@ref bigquery::AnalyticsHubServiceClient-service-account-snippet)
+ [bigquery::BigQueryReadClient](@ref bigquery::BigQueryReadClient-service-account-snippet)
+ [bigquery::BigQueryWriteClient](@ref bigquery::BigQueryWriteClient-service-account-snippet)
+ [bigquery::ConnectionServiceClient](@ref bigquery::ConnectionServiceClient-service-account-snippet)
+ [bigquery::DataTransferServiceClient](@ref bigquery::DataTransferServiceClient-service-account-snippet)
+ [bigquery::MigrationServiceClient](@ref bigquery::MigrationServiceClient-service-account-snippet)
+ [bigquery::ModelServiceClient](@ref bigquery::ModelServiceClient-service-account-snippet)
+ [bigquery::ReservationServiceClient](@ref bigquery::ReservationServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -213,97 +213,97 @@ guide for more details.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AnalyticsHubServiceClient-endpoint-snippet Override AnalyticsHubServiceClient Endpoint Configuration
+/*! @page bigquery::AnalyticsHubServiceClient-endpoint-snippet Override bigquery::AnalyticsHubServiceClient Endpoint Configuration
 
 @snippet google/cloud/bigquery/samples/analytics_hub_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AnalyticsHubServiceClient-service-account-snippet Override AnalyticsHubServiceClient Authentication Defaults
+/*! @page bigquery::AnalyticsHubServiceClient-service-account-snippet Override bigquery::AnalyticsHubServiceClient Authentication Defaults
 
 @snippet google/cloud/bigquery/samples/analytics_hub_client_samples.cc with-service-account
 
 */
 
-/*! @page BigQueryReadClient-endpoint-snippet Override BigQueryReadClient Endpoint Configuration
+/*! @page bigquery::BigQueryReadClient-endpoint-snippet Override bigquery::BigQueryReadClient Endpoint Configuration
 
 @snippet google/cloud/bigquery/samples/bigquery_read_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page BigQueryReadClient-service-account-snippet Override BigQueryReadClient Authentication Defaults
+/*! @page bigquery::BigQueryReadClient-service-account-snippet Override bigquery::BigQueryReadClient Authentication Defaults
 
 @snippet google/cloud/bigquery/samples/bigquery_read_client_samples.cc with-service-account
 
 */
 
-/*! @page BigQueryWriteClient-endpoint-snippet Override BigQueryWriteClient Endpoint Configuration
+/*! @page bigquery::BigQueryWriteClient-endpoint-snippet Override bigquery::BigQueryWriteClient Endpoint Configuration
 
 @snippet google/cloud/bigquery/samples/bigquery_write_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page BigQueryWriteClient-service-account-snippet Override BigQueryWriteClient Authentication Defaults
+/*! @page bigquery::BigQueryWriteClient-service-account-snippet Override bigquery::BigQueryWriteClient Authentication Defaults
 
 @snippet google/cloud/bigquery/samples/bigquery_write_client_samples.cc with-service-account
 
 */
 
-/*! @page ConnectionServiceClient-endpoint-snippet Override ConnectionServiceClient Endpoint Configuration
+/*! @page bigquery::ConnectionServiceClient-endpoint-snippet Override bigquery::ConnectionServiceClient Endpoint Configuration
 
 @snippet google/cloud/bigquery/samples/connection_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ConnectionServiceClient-service-account-snippet Override ConnectionServiceClient Authentication Defaults
+/*! @page bigquery::ConnectionServiceClient-service-account-snippet Override bigquery::ConnectionServiceClient Authentication Defaults
 
 @snippet google/cloud/bigquery/samples/connection_client_samples.cc with-service-account
 
 */
 
-/*! @page DataTransferServiceClient-endpoint-snippet Override DataTransferServiceClient Endpoint Configuration
+/*! @page bigquery::DataTransferServiceClient-endpoint-snippet Override bigquery::DataTransferServiceClient Endpoint Configuration
 
 @snippet google/cloud/bigquery/samples/data_transfer_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DataTransferServiceClient-service-account-snippet Override DataTransferServiceClient Authentication Defaults
+/*! @page bigquery::DataTransferServiceClient-service-account-snippet Override bigquery::DataTransferServiceClient Authentication Defaults
 
 @snippet google/cloud/bigquery/samples/data_transfer_client_samples.cc with-service-account
 
 */
 
-/*! @page MigrationServiceClient-endpoint-snippet Override MigrationServiceClient Endpoint Configuration
+/*! @page bigquery::MigrationServiceClient-endpoint-snippet Override bigquery::MigrationServiceClient Endpoint Configuration
 
 @snippet google/cloud/bigquery/samples/migration_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page MigrationServiceClient-service-account-snippet Override MigrationServiceClient Authentication Defaults
+/*! @page bigquery::MigrationServiceClient-service-account-snippet Override bigquery::MigrationServiceClient Authentication Defaults
 
 @snippet google/cloud/bigquery/samples/migration_client_samples.cc with-service-account
 
 */
 
-/*! @page ModelServiceClient-endpoint-snippet Override ModelServiceClient Endpoint Configuration
+/*! @page bigquery::ModelServiceClient-endpoint-snippet Override bigquery::ModelServiceClient Endpoint Configuration
 
 @snippet google/cloud/bigquery/samples/model_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ModelServiceClient-service-account-snippet Override ModelServiceClient Authentication Defaults
+/*! @page bigquery::ModelServiceClient-service-account-snippet Override bigquery::ModelServiceClient Authentication Defaults
 
 @snippet google/cloud/bigquery/samples/model_client_samples.cc with-service-account
 
 */
 
-/*! @page ReservationServiceClient-endpoint-snippet Override ReservationServiceClient Endpoint Configuration
+/*! @page bigquery::ReservationServiceClient-endpoint-snippet Override bigquery::ReservationServiceClient Endpoint Configuration
 
 @snippet google/cloud/bigquery/samples/reservation_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ReservationServiceClient-service-account-snippet Override ReservationServiceClient Authentication Defaults
+/*! @page bigquery::ReservationServiceClient-service-account-snippet Override bigquery::ReservationServiceClient Authentication Defaults
 
 @snippet google/cloud/bigquery/samples/reservation_client_samples.cc with-service-account
 

--- a/google/cloud/bigquery/samples/analytics_hub_client_samples.cc
+++ b/google/cloud/bigquery/samples/analytics_hub_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AnalyticsHubServiceClient
+// main-dox-marker: bigquery::AnalyticsHubServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigquery/samples/bigquery_read_client_samples.cc
+++ b/google/cloud/bigquery/samples/bigquery_read_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BigQueryReadClient
+// main-dox-marker: bigquery::BigQueryReadClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigquery/samples/bigquery_write_client_samples.cc
+++ b/google/cloud/bigquery/samples/bigquery_write_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BigQueryWriteClient
+// main-dox-marker: bigquery::BigQueryWriteClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigquery/samples/connection_client_samples.cc
+++ b/google/cloud/bigquery/samples/connection_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ConnectionServiceClient
+// main-dox-marker: bigquery::ConnectionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigquery/samples/data_transfer_client_samples.cc
+++ b/google/cloud/bigquery/samples/data_transfer_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DataTransferServiceClient
+// main-dox-marker: bigquery::DataTransferServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigquery/samples/migration_client_samples.cc
+++ b/google/cloud/bigquery/samples/migration_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: MigrationServiceClient
+// main-dox-marker: bigquery::MigrationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigquery/samples/model_client_samples.cc
+++ b/google/cloud/bigquery/samples/model_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ModelServiceClient
+// main-dox-marker: bigquery::ModelServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigquery/samples/reservation_client_samples.cc
+++ b/google/cloud/bigquery/samples/reservation_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ReservationServiceClient
+// main-dox-marker: bigquery::ReservationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigtable/admin/samples/bigtable_instance_admin_client_samples.cc
+++ b/google/cloud/bigtable/admin/samples/bigtable_instance_admin_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BigtableInstanceAdminClient
+// main-dox-marker: bigtable_admin::BigtableInstanceAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/bigtable/admin/samples/bigtable_table_admin_client_samples.cc
+++ b/google/cloud/bigtable/admin/samples/bigtable_table_admin_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BigtableTableAdminClient
+// main-dox-marker: bigtable_admin::BigtableTableAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -102,14 +102,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `BudgetServiceClient`:
+For example, this will override the default endpoint for `billing::BudgetServiceClient`:
 
 @snippet budget_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [BudgetServiceClient](@ref BudgetServiceClient-endpoint-snippet)
- [CloudBillingClient](@ref CloudBillingClient-endpoint-snippet)
- [CloudCatalogClient](@ref CloudCatalogClient-endpoint-snippet)
+ [billing::BudgetServiceClient](@ref billing::BudgetServiceClient-endpoint-snippet)
+ [billing::CloudBillingClient](@ref billing::CloudBillingClient-endpoint-snippet)
+ [billing::CloudCatalogClient](@ref billing::CloudCatalogClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -124,9 +124,9 @@ to explicitly load a service account key file.
 @snippet budget_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [BudgetServiceClient](@ref BudgetServiceClient-service-account-snippet)
- [CloudBillingClient](@ref CloudBillingClient-service-account-snippet)
- [CloudCatalogClient](@ref CloudCatalogClient-service-account-snippet)
+ [billing::BudgetServiceClient](@ref billing::BudgetServiceClient-service-account-snippet)
+ [billing::CloudBillingClient](@ref billing::CloudBillingClient-service-account-snippet)
+ [billing::CloudCatalogClient](@ref billing::CloudCatalogClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -156,37 +156,37 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page BudgetServiceClient-endpoint-snippet Override BudgetServiceClient Endpoint Configuration
+/*! @page billing::BudgetServiceClient-endpoint-snippet Override billing::BudgetServiceClient Endpoint Configuration
 
 @snippet google/cloud/billing/samples/budget_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page BudgetServiceClient-service-account-snippet Override BudgetServiceClient Authentication Defaults
+/*! @page billing::BudgetServiceClient-service-account-snippet Override billing::BudgetServiceClient Authentication Defaults
 
 @snippet google/cloud/billing/samples/budget_client_samples.cc with-service-account
 
 */
 
-/*! @page CloudBillingClient-endpoint-snippet Override CloudBillingClient Endpoint Configuration
+/*! @page billing::CloudBillingClient-endpoint-snippet Override billing::CloudBillingClient Endpoint Configuration
 
 @snippet google/cloud/billing/samples/cloud_billing_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudBillingClient-service-account-snippet Override CloudBillingClient Authentication Defaults
+/*! @page billing::CloudBillingClient-service-account-snippet Override billing::CloudBillingClient Authentication Defaults
 
 @snippet google/cloud/billing/samples/cloud_billing_client_samples.cc with-service-account
 
 */
 
-/*! @page CloudCatalogClient-endpoint-snippet Override CloudCatalogClient Endpoint Configuration
+/*! @page billing::CloudCatalogClient-endpoint-snippet Override billing::CloudCatalogClient Endpoint Configuration
 
 @snippet google/cloud/billing/samples/cloud_catalog_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudCatalogClient-service-account-snippet Override CloudCatalogClient Authentication Defaults
+/*! @page billing::CloudCatalogClient-service-account-snippet Override billing::CloudCatalogClient Authentication Defaults
 
 @snippet google/cloud/billing/samples/cloud_catalog_client_samples.cc with-service-account
 

--- a/google/cloud/billing/samples/budget_client_samples.cc
+++ b/google/cloud/billing/samples/budget_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BudgetServiceClient
+// main-dox-marker: billing::BudgetServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/billing/samples/cloud_billing_client_samples.cc
+++ b/google/cloud/billing/samples/cloud_billing_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudBillingClient
+// main-dox-marker: billing::CloudBillingClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/billing/samples/cloud_catalog_client_samples.cc
+++ b/google/cloud/billing/samples/cloud_catalog_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudCatalogClient
+// main-dox-marker: billing::CloudCatalogClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/binaryauthorization/doc/main.dox
+++ b/google/cloud/binaryauthorization/doc/main.dox
@@ -101,14 +101,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `BinauthzManagementServiceV1Client`:
+For example, this will override the default endpoint for `binaryauthorization::BinauthzManagementServiceV1Client`:
 
 @snippet binauthz_management_service_v1_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [BinauthzManagementServiceV1Client](@ref BinauthzManagementServiceV1Client-endpoint-snippet)
- [SystemPolicyV1Client](@ref SystemPolicyV1Client-endpoint-snippet)
- [ValidationHelperV1Client](@ref ValidationHelperV1Client-endpoint-snippet)
+ [binaryauthorization::BinauthzManagementServiceV1Client](@ref binaryauthorization::BinauthzManagementServiceV1Client-endpoint-snippet)
+ [binaryauthorization::SystemPolicyV1Client](@ref binaryauthorization::SystemPolicyV1Client-endpoint-snippet)
+ [binaryauthorization::ValidationHelperV1Client](@ref binaryauthorization::ValidationHelperV1Client-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -123,9 +123,9 @@ to explicitly load a service account key file.
 @snippet binauthz_management_service_v1_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [BinauthzManagementServiceV1Client](@ref BinauthzManagementServiceV1Client-service-account-snippet)
- [SystemPolicyV1Client](@ref SystemPolicyV1Client-service-account-snippet)
- [ValidationHelperV1Client](@ref ValidationHelperV1Client-service-account-snippet)
+ [binaryauthorization::BinauthzManagementServiceV1Client](@ref binaryauthorization::BinauthzManagementServiceV1Client-service-account-snippet)
+ [binaryauthorization::SystemPolicyV1Client](@ref binaryauthorization::SystemPolicyV1Client-service-account-snippet)
+ [binaryauthorization::ValidationHelperV1Client](@ref binaryauthorization::ValidationHelperV1Client-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -156,37 +156,37 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page BinauthzManagementServiceV1Client-endpoint-snippet Override BinauthzManagementServiceV1Client Endpoint Configuration
+/*! @page binaryauthorization::BinauthzManagementServiceV1Client-endpoint-snippet Override binaryauthorization::BinauthzManagementServiceV1Client Endpoint Configuration
 
 @snippet google/cloud/binaryauthorization/samples/binauthz_management_service_v1_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page BinauthzManagementServiceV1Client-service-account-snippet Override BinauthzManagementServiceV1Client Authentication Defaults
+/*! @page binaryauthorization::BinauthzManagementServiceV1Client-service-account-snippet Override binaryauthorization::BinauthzManagementServiceV1Client Authentication Defaults
 
 @snippet google/cloud/binaryauthorization/samples/binauthz_management_service_v1_client_samples.cc with-service-account
 
 */
 
-/*! @page SystemPolicyV1Client-endpoint-snippet Override SystemPolicyV1Client Endpoint Configuration
+/*! @page binaryauthorization::SystemPolicyV1Client-endpoint-snippet Override binaryauthorization::SystemPolicyV1Client Endpoint Configuration
 
 @snippet google/cloud/binaryauthorization/samples/system_policy_v1_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SystemPolicyV1Client-service-account-snippet Override SystemPolicyV1Client Authentication Defaults
+/*! @page binaryauthorization::SystemPolicyV1Client-service-account-snippet Override binaryauthorization::SystemPolicyV1Client Authentication Defaults
 
 @snippet google/cloud/binaryauthorization/samples/system_policy_v1_client_samples.cc with-service-account
 
 */
 
-/*! @page ValidationHelperV1Client-endpoint-snippet Override ValidationHelperV1Client Endpoint Configuration
+/*! @page binaryauthorization::ValidationHelperV1Client-endpoint-snippet Override binaryauthorization::ValidationHelperV1Client Endpoint Configuration
 
 @snippet google/cloud/binaryauthorization/samples/validation_helper_v1_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ValidationHelperV1Client-service-account-snippet Override ValidationHelperV1Client Authentication Defaults
+/*! @page binaryauthorization::ValidationHelperV1Client-service-account-snippet Override binaryauthorization::ValidationHelperV1Client Authentication Defaults
 
 @snippet google/cloud/binaryauthorization/samples/validation_helper_v1_client_samples.cc with-service-account
 

--- a/google/cloud/binaryauthorization/samples/binauthz_management_service_v1_client_samples.cc
+++ b/google/cloud/binaryauthorization/samples/binauthz_management_service_v1_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BinauthzManagementServiceV1Client
+// main-dox-marker: binaryauthorization::BinauthzManagementServiceV1Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/binaryauthorization/samples/system_policy_v1_client_samples.cc
+++ b/google/cloud/binaryauthorization/samples/system_policy_v1_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SystemPolicyV1Client
+// main-dox-marker: binaryauthorization::SystemPolicyV1Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/binaryauthorization/samples/validation_helper_v1_client_samples.cc
+++ b/google/cloud/binaryauthorization/samples/validation_helper_v1_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ValidationHelperV1Client
+// main-dox-marker: binaryauthorization::ValidationHelperV1Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/certificatemanager/doc/main.dox
+++ b/google/cloud/certificatemanager/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CertificateManagerClient`:
+For example, this will override the default endpoint for `certificatemanager::CertificateManagerClient`:
 
 @snippet certificate_manager_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CertificateManagerClient-endpoint-snippet Override CertificateManagerClient Endpoint Configuration
+/*! @page certificatemanager::CertificateManagerClient-endpoint-snippet Override certificatemanager::CertificateManagerClient Endpoint Configuration
 
 @snippet google/cloud/certificatemanager/samples/certificate_manager_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CertificateManagerClient-service-account-snippet Override CertificateManagerClient Authentication Defaults
+/*! @page certificatemanager::CertificateManagerClient-service-account-snippet Override certificatemanager::CertificateManagerClient Authentication Defaults
 
 @snippet google/cloud/certificatemanager/samples/certificate_manager_client_samples.cc with-service-account
 

--- a/google/cloud/certificatemanager/samples/certificate_manager_client_samples.cc
+++ b/google/cloud/certificatemanager/samples/certificate_manager_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CertificateManagerClient
+// main-dox-marker: certificatemanager::CertificateManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/channel/doc/main.dox
+++ b/google/cloud/channel/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudChannelServiceClient`:
+For example, this will override the default endpoint for `channel::CloudChannelServiceClient`:
 
 @snippet cloud_channel_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudChannelServiceClient-endpoint-snippet Override CloudChannelServiceClient Endpoint Configuration
+/*! @page channel::CloudChannelServiceClient-endpoint-snippet Override channel::CloudChannelServiceClient Endpoint Configuration
 
 @snippet google/cloud/channel/samples/cloud_channel_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudChannelServiceClient-service-account-snippet Override CloudChannelServiceClient Authentication Defaults
+/*! @page channel::CloudChannelServiceClient-service-account-snippet Override channel::CloudChannelServiceClient Authentication Defaults
 
 @snippet google/cloud/channel/samples/cloud_channel_client_samples.cc with-service-account
 

--- a/google/cloud/channel/samples/cloud_channel_client_samples.cc
+++ b/google/cloud/channel/samples/cloud_channel_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudChannelServiceClient
+// main-dox-marker: channel::CloudChannelServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/cloudbuild/doc/main.dox
+++ b/google/cloud/cloudbuild/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudBuildClient`:
+For example, this will override the default endpoint for `cloudbuild::CloudBuildClient`:
 
 @snippet cloud_build_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudBuildClient-endpoint-snippet Override CloudBuildClient Endpoint Configuration
+/*! @page cloudbuild::CloudBuildClient-endpoint-snippet Override cloudbuild::CloudBuildClient Endpoint Configuration
 
 @snippet google/cloud/cloudbuild/samples/cloud_build_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudBuildClient-service-account-snippet Override CloudBuildClient Authentication Defaults
+/*! @page cloudbuild::CloudBuildClient-service-account-snippet Override cloudbuild::CloudBuildClient Authentication Defaults
 
 @snippet google/cloud/cloudbuild/samples/cloud_build_client_samples.cc with-service-account
 

--- a/google/cloud/cloudbuild/samples/cloud_build_client_samples.cc
+++ b/google/cloud/cloudbuild/samples/cloud_build_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudBuildClient
+// main-dox-marker: cloudbuild::CloudBuildClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/composer/doc/main.dox
+++ b/google/cloud/composer/doc/main.dox
@@ -96,13 +96,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `EnvironmentsClient`:
+For example, this will override the default endpoint for `composer::EnvironmentsClient`:
 
 @snippet environments_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [EnvironmentsClient](@ref EnvironmentsClient-endpoint-snippet)
- [ImageVersionsClient](@ref ImageVersionsClient-endpoint-snippet)
+ [composer::EnvironmentsClient](@ref composer::EnvironmentsClient-endpoint-snippet)
+ [composer::ImageVersionsClient](@ref composer::ImageVersionsClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -117,8 +117,8 @@ to explicitly load a service account key file.
 @snippet environments_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [EnvironmentsClient](@ref EnvironmentsClient-service-account-snippet)
- [ImageVersionsClient](@ref ImageVersionsClient-service-account-snippet)
+ [composer::EnvironmentsClient](@ref composer::EnvironmentsClient-service-account-snippet)
+ [composer::ImageVersionsClient](@ref composer::ImageVersionsClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -149,25 +149,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page EnvironmentsClient-endpoint-snippet Override EnvironmentsClient Endpoint Configuration
+/*! @page composer::EnvironmentsClient-endpoint-snippet Override composer::EnvironmentsClient Endpoint Configuration
 
 @snippet google/cloud/composer/samples/environments_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EnvironmentsClient-service-account-snippet Override EnvironmentsClient Authentication Defaults
+/*! @page composer::EnvironmentsClient-service-account-snippet Override composer::EnvironmentsClient Authentication Defaults
 
 @snippet google/cloud/composer/samples/environments_client_samples.cc with-service-account
 
 */
 
-/*! @page ImageVersionsClient-endpoint-snippet Override ImageVersionsClient Endpoint Configuration
+/*! @page composer::ImageVersionsClient-endpoint-snippet Override composer::ImageVersionsClient Endpoint Configuration
 
 @snippet google/cloud/composer/samples/image_versions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ImageVersionsClient-service-account-snippet Override ImageVersionsClient Authentication Defaults
+/*! @page composer::ImageVersionsClient-service-account-snippet Override composer::ImageVersionsClient Authentication Defaults
 
 @snippet google/cloud/composer/samples/image_versions_client_samples.cc with-service-account
 

--- a/google/cloud/composer/samples/environments_client_samples.cc
+++ b/google/cloud/composer/samples/environments_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EnvironmentsClient
+// main-dox-marker: composer::EnvironmentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/composer/samples/image_versions_client_samples.cc
+++ b/google/cloud/composer/samples/image_versions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ImageVersionsClient
+// main-dox-marker: composer::ImageVersionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/connectors/doc/main.dox
+++ b/google/cloud/connectors/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ConnectorsClient`:
+For example, this will override the default endpoint for `connectors::ConnectorsClient`:
 
 @snippet connectors_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ConnectorsClient-endpoint-snippet Override ConnectorsClient Endpoint Configuration
+/*! @page connectors::ConnectorsClient-endpoint-snippet Override connectors::ConnectorsClient Endpoint Configuration
 
 @snippet google/cloud/connectors/samples/connectors_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ConnectorsClient-service-account-snippet Override ConnectorsClient Authentication Defaults
+/*! @page connectors::ConnectorsClient-service-account-snippet Override connectors::ConnectorsClient Authentication Defaults
 
 @snippet google/cloud/connectors/samples/connectors_client_samples.cc with-service-account
 

--- a/google/cloud/connectors/samples/connectors_client_samples.cc
+++ b/google/cloud/connectors/samples/connectors_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ConnectorsClient
+// main-dox-marker: connectors::ConnectorsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/contactcenterinsights/doc/main.dox
+++ b/google/cloud/contactcenterinsights/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ContactCenterInsightsClient`:
+For example, this will override the default endpoint for `contactcenterinsights::ContactCenterInsightsClient`:
 
 @snippet contact_center_insights_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ContactCenterInsightsClient-endpoint-snippet Override ContactCenterInsightsClient Endpoint Configuration
+/*! @page contactcenterinsights::ContactCenterInsightsClient-endpoint-snippet Override contactcenterinsights::ContactCenterInsightsClient Endpoint Configuration
 
 @snippet google/cloud/contactcenterinsights/samples/contact_center_insights_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ContactCenterInsightsClient-service-account-snippet Override ContactCenterInsightsClient Authentication Defaults
+/*! @page contactcenterinsights::ContactCenterInsightsClient-service-account-snippet Override contactcenterinsights::ContactCenterInsightsClient Authentication Defaults
 
 @snippet google/cloud/contactcenterinsights/samples/contact_center_insights_client_samples.cc with-service-account
 

--- a/google/cloud/contactcenterinsights/samples/contact_center_insights_client_samples.cc
+++ b/google/cloud/contactcenterinsights/samples/contact_center_insights_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ContactCenterInsightsClient
+// main-dox-marker: contactcenterinsights::ContactCenterInsightsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/container/doc/main.dox
+++ b/google/cloud/container/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ClusterManagerClient`:
+For example, this will override the default endpoint for `container::ClusterManagerClient`:
 
 @snippet cluster_manager_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ClusterManagerClient-endpoint-snippet Override ClusterManagerClient Endpoint Configuration
+/*! @page container::ClusterManagerClient-endpoint-snippet Override container::ClusterManagerClient Endpoint Configuration
 
 @snippet google/cloud/container/samples/cluster_manager_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ClusterManagerClient-service-account-snippet Override ClusterManagerClient Authentication Defaults
+/*! @page container::ClusterManagerClient-service-account-snippet Override container::ClusterManagerClient Authentication Defaults
 
 @snippet google/cloud/container/samples/cluster_manager_client_samples.cc with-service-account
 

--- a/google/cloud/container/samples/cluster_manager_client_samples.cc
+++ b/google/cloud/container/samples/cluster_manager_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ClusterManagerClient
+// main-dox-marker: container::ClusterManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/containeranalysis/doc/main.dox
+++ b/google/cloud/containeranalysis/doc/main.dox
@@ -98,13 +98,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ContainerAnalysisClient`:
+For example, this will override the default endpoint for `containeranalysis::ContainerAnalysisClient`:
 
 @snippet container_analysis_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [ContainerAnalysisClient](@ref ContainerAnalysisClient-endpoint-snippet)
- [GrafeasClient](@ref GrafeasClient-endpoint-snippet)
+ [containeranalysis::ContainerAnalysisClient](@ref containeranalysis::ContainerAnalysisClient-endpoint-snippet)
+ [containeranalysis::GrafeasClient](@ref containeranalysis::GrafeasClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -119,8 +119,8 @@ to explicitly load a service account key file.
 @snippet container_analysis_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [ContainerAnalysisClient](@ref ContainerAnalysisClient-service-account-snippet)
- [GrafeasClient](@ref GrafeasClient-service-account-snippet)
+ [containeranalysis::ContainerAnalysisClient](@ref containeranalysis::ContainerAnalysisClient-service-account-snippet)
+ [containeranalysis::GrafeasClient](@ref containeranalysis::GrafeasClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -151,25 +151,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ContainerAnalysisClient-endpoint-snippet Override ContainerAnalysisClient Endpoint Configuration
+/*! @page containeranalysis::ContainerAnalysisClient-endpoint-snippet Override containeranalysis::ContainerAnalysisClient Endpoint Configuration
 
 @snippet google/cloud/containeranalysis/samples/container_analysis_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ContainerAnalysisClient-service-account-snippet Override ContainerAnalysisClient Authentication Defaults
+/*! @page containeranalysis::ContainerAnalysisClient-service-account-snippet Override containeranalysis::ContainerAnalysisClient Authentication Defaults
 
 @snippet google/cloud/containeranalysis/samples/container_analysis_client_samples.cc with-service-account
 
 */
 
-/*! @page GrafeasClient-endpoint-snippet Override GrafeasClient Endpoint Configuration
+/*! @page containeranalysis::GrafeasClient-endpoint-snippet Override containeranalysis::GrafeasClient Endpoint Configuration
 
 @snippet google/cloud/containeranalysis/samples/grafeas_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page GrafeasClient-service-account-snippet Override GrafeasClient Authentication Defaults
+/*! @page containeranalysis::GrafeasClient-service-account-snippet Override containeranalysis::GrafeasClient Authentication Defaults
 
 @snippet google/cloud/containeranalysis/samples/grafeas_client_samples.cc with-service-account
 

--- a/google/cloud/containeranalysis/samples/container_analysis_client_samples.cc
+++ b/google/cloud/containeranalysis/samples/container_analysis_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ContainerAnalysisClient
+// main-dox-marker: containeranalysis::ContainerAnalysisClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/containeranalysis/samples/grafeas_client_samples.cc
+++ b/google/cloud/containeranalysis/samples/grafeas_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: GrafeasClient
+// main-dox-marker: containeranalysis::GrafeasClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/datacatalog/doc/main.dox
+++ b/google/cloud/datacatalog/doc/main.dox
@@ -100,14 +100,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `DataCatalogClient`:
+For example, this will override the default endpoint for `datacatalog::DataCatalogClient`:
 
 @snippet data_catalog_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [DataCatalogClient](@ref DataCatalogClient-endpoint-snippet)
- [PolicyTagManagerClient](@ref PolicyTagManagerClient-endpoint-snippet)
- [PolicyTagManagerSerializationClient](@ref PolicyTagManagerSerializationClient-endpoint-snippet)
+ [datacatalog::DataCatalogClient](@ref datacatalog::DataCatalogClient-endpoint-snippet)
+ [datacatalog::PolicyTagManagerClient](@ref datacatalog::PolicyTagManagerClient-endpoint-snippet)
+ [datacatalog::PolicyTagManagerSerializationClient](@ref datacatalog::PolicyTagManagerSerializationClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -122,9 +122,9 @@ to explicitly load a service account key file.
 @snippet data_catalog_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [DataCatalogClient](@ref DataCatalogClient-service-account-snippet)
- [PolicyTagManagerClient](@ref PolicyTagManagerClient-service-account-snippet)
- [PolicyTagManagerSerializationClient](@ref PolicyTagManagerSerializationClient-service-account-snippet)
+ [datacatalog::DataCatalogClient](@ref datacatalog::DataCatalogClient-service-account-snippet)
+ [datacatalog::PolicyTagManagerClient](@ref datacatalog::PolicyTagManagerClient-service-account-snippet)
+ [datacatalog::PolicyTagManagerSerializationClient](@ref datacatalog::PolicyTagManagerSerializationClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -155,37 +155,37 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page DataCatalogClient-endpoint-snippet Override DataCatalogClient Endpoint Configuration
+/*! @page datacatalog::DataCatalogClient-endpoint-snippet Override datacatalog::DataCatalogClient Endpoint Configuration
 
 @snippet google/cloud/datacatalog/samples/data_catalog_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DataCatalogClient-service-account-snippet Override DataCatalogClient Authentication Defaults
+/*! @page datacatalog::DataCatalogClient-service-account-snippet Override datacatalog::DataCatalogClient Authentication Defaults
 
 @snippet google/cloud/datacatalog/samples/data_catalog_client_samples.cc with-service-account
 
 */
 
-/*! @page PolicyTagManagerClient-endpoint-snippet Override PolicyTagManagerClient Endpoint Configuration
+/*! @page datacatalog::PolicyTagManagerClient-endpoint-snippet Override datacatalog::PolicyTagManagerClient Endpoint Configuration
 
 @snippet google/cloud/datacatalog/samples/policy_tag_manager_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page PolicyTagManagerClient-service-account-snippet Override PolicyTagManagerClient Authentication Defaults
+/*! @page datacatalog::PolicyTagManagerClient-service-account-snippet Override datacatalog::PolicyTagManagerClient Authentication Defaults
 
 @snippet google/cloud/datacatalog/samples/policy_tag_manager_client_samples.cc with-service-account
 
 */
 
-/*! @page PolicyTagManagerSerializationClient-endpoint-snippet Override PolicyTagManagerSerializationClient Endpoint Configuration
+/*! @page datacatalog::PolicyTagManagerSerializationClient-endpoint-snippet Override datacatalog::PolicyTagManagerSerializationClient Endpoint Configuration
 
 @snippet google/cloud/datacatalog/samples/policy_tag_manager_serialization_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page PolicyTagManagerSerializationClient-service-account-snippet Override PolicyTagManagerSerializationClient Authentication Defaults
+/*! @page datacatalog::PolicyTagManagerSerializationClient-service-account-snippet Override datacatalog::PolicyTagManagerSerializationClient Authentication Defaults
 
 @snippet google/cloud/datacatalog/samples/policy_tag_manager_serialization_client_samples.cc with-service-account
 

--- a/google/cloud/datacatalog/samples/data_catalog_client_samples.cc
+++ b/google/cloud/datacatalog/samples/data_catalog_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DataCatalogClient
+// main-dox-marker: datacatalog::DataCatalogClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/datacatalog/samples/policy_tag_manager_client_samples.cc
+++ b/google/cloud/datacatalog/samples/policy_tag_manager_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: PolicyTagManagerClient
+// main-dox-marker: datacatalog::PolicyTagManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/datacatalog/samples/policy_tag_manager_serialization_client_samples.cc
+++ b/google/cloud/datacatalog/samples/policy_tag_manager_serialization_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: PolicyTagManagerSerializationClient
+// main-dox-marker: datacatalog::PolicyTagManagerSerializationClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/datamigration/doc/main.dox
+++ b/google/cloud/datamigration/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `DataMigrationServiceClient`:
+For example, this will override the default endpoint for `datamigration::DataMigrationServiceClient`:
 
 @snippet data_migration_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page DataMigrationServiceClient-endpoint-snippet Override DataMigrationServiceClient Endpoint Configuration
+/*! @page datamigration::DataMigrationServiceClient-endpoint-snippet Override datamigration::DataMigrationServiceClient Endpoint Configuration
 
 @snippet google/cloud/datamigration/samples/data_migration_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DataMigrationServiceClient-service-account-snippet Override DataMigrationServiceClient Authentication Defaults
+/*! @page datamigration::DataMigrationServiceClient-service-account-snippet Override datamigration::DataMigrationServiceClient Authentication Defaults
 
 @snippet google/cloud/datamigration/samples/data_migration_client_samples.cc with-service-account
 

--- a/google/cloud/datamigration/samples/data_migration_client_samples.cc
+++ b/google/cloud/datamigration/samples/data_migration_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DataMigrationServiceClient
+// main-dox-marker: datamigration::DataMigrationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dataplex/doc/main.dox
+++ b/google/cloud/dataplex/doc/main.dox
@@ -101,14 +101,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ContentServiceClient`:
+For example, this will override the default endpoint for `dataplex::ContentServiceClient`:
 
 @snippet content_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [ContentServiceClient](@ref ContentServiceClient-endpoint-snippet)
- [DataplexServiceClient](@ref DataplexServiceClient-endpoint-snippet)
- [MetadataServiceClient](@ref MetadataServiceClient-endpoint-snippet)
+ [dataplex::ContentServiceClient](@ref dataplex::ContentServiceClient-endpoint-snippet)
+ [dataplex::DataplexServiceClient](@ref dataplex::DataplexServiceClient-endpoint-snippet)
+ [dataplex::MetadataServiceClient](@ref dataplex::MetadataServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -123,9 +123,9 @@ to explicitly load a service account key file.
 @snippet content_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [ContentServiceClient](@ref ContentServiceClient-service-account-snippet)
- [DataplexServiceClient](@ref DataplexServiceClient-service-account-snippet)
- [MetadataServiceClient](@ref MetadataServiceClient-service-account-snippet)
+ [dataplex::ContentServiceClient](@ref dataplex::ContentServiceClient-service-account-snippet)
+ [dataplex::DataplexServiceClient](@ref dataplex::DataplexServiceClient-service-account-snippet)
+ [dataplex::MetadataServiceClient](@ref dataplex::MetadataServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -156,37 +156,37 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ContentServiceClient-endpoint-snippet Override ContentServiceClient Endpoint Configuration
+/*! @page dataplex::ContentServiceClient-endpoint-snippet Override dataplex::ContentServiceClient Endpoint Configuration
 
 @snippet google/cloud/dataplex/samples/content_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ContentServiceClient-service-account-snippet Override ContentServiceClient Authentication Defaults
+/*! @page dataplex::ContentServiceClient-service-account-snippet Override dataplex::ContentServiceClient Authentication Defaults
 
 @snippet google/cloud/dataplex/samples/content_client_samples.cc with-service-account
 
 */
 
-/*! @page DataplexServiceClient-endpoint-snippet Override DataplexServiceClient Endpoint Configuration
+/*! @page dataplex::DataplexServiceClient-endpoint-snippet Override dataplex::DataplexServiceClient Endpoint Configuration
 
 @snippet google/cloud/dataplex/samples/dataplex_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DataplexServiceClient-service-account-snippet Override DataplexServiceClient Authentication Defaults
+/*! @page dataplex::DataplexServiceClient-service-account-snippet Override dataplex::DataplexServiceClient Authentication Defaults
 
 @snippet google/cloud/dataplex/samples/dataplex_client_samples.cc with-service-account
 
 */
 
-/*! @page MetadataServiceClient-endpoint-snippet Override MetadataServiceClient Endpoint Configuration
+/*! @page dataplex::MetadataServiceClient-endpoint-snippet Override dataplex::MetadataServiceClient Endpoint Configuration
 
 @snippet google/cloud/dataplex/samples/metadata_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page MetadataServiceClient-service-account-snippet Override MetadataServiceClient Authentication Defaults
+/*! @page dataplex::MetadataServiceClient-service-account-snippet Override dataplex::MetadataServiceClient Authentication Defaults
 
 @snippet google/cloud/dataplex/samples/metadata_client_samples.cc with-service-account
 

--- a/google/cloud/dataplex/samples/content_client_samples.cc
+++ b/google/cloud/dataplex/samples/content_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ContentServiceClient
+// main-dox-marker: dataplex::ContentServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dataplex/samples/dataplex_client_samples.cc
+++ b/google/cloud/dataplex/samples/dataplex_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DataplexServiceClient
+// main-dox-marker: dataplex::DataplexServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dataplex/samples/metadata_client_samples.cc
+++ b/google/cloud/dataplex/samples/metadata_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: MetadataServiceClient
+// main-dox-marker: dataplex::MetadataServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -111,16 +111,16 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AutoscalingPolicyServiceClient`:
+For example, this will override the default endpoint for `dataproc::AutoscalingPolicyServiceClient`:
 
 @snippet autoscaling_policy_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AutoscalingPolicyServiceClient](@ref AutoscalingPolicyServiceClient-endpoint-snippet)
- [BatchControllerClient](@ref BatchControllerClient-endpoint-snippet)
- [ClusterControllerClient](@ref ClusterControllerClient-endpoint-snippet)
- [JobControllerClient](@ref JobControllerClient-endpoint-snippet)
- [WorkflowTemplateServiceClient](@ref WorkflowTemplateServiceClient-endpoint-snippet)
+ [dataproc::AutoscalingPolicyServiceClient](@ref dataproc::AutoscalingPolicyServiceClient-endpoint-snippet)
+ [dataproc::BatchControllerClient](@ref dataproc::BatchControllerClient-endpoint-snippet)
+ [dataproc::ClusterControllerClient](@ref dataproc::ClusterControllerClient-endpoint-snippet)
+ [dataproc::JobControllerClient](@ref dataproc::JobControllerClient-endpoint-snippet)
+ [dataproc::WorkflowTemplateServiceClient](@ref dataproc::WorkflowTemplateServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -135,11 +135,11 @@ to explicitly load a service account key file.
 @snippet autoscaling_policy_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AutoscalingPolicyServiceClient](@ref AutoscalingPolicyServiceClient-service-account-snippet)
- [BatchControllerClient](@ref BatchControllerClient-service-account-snippet)
- [ClusterControllerClient](@ref ClusterControllerClient-service-account-snippet)
- [JobControllerClient](@ref JobControllerClient-service-account-snippet)
- [WorkflowTemplateServiceClient](@ref WorkflowTemplateServiceClient-service-account-snippet)
+ [dataproc::AutoscalingPolicyServiceClient](@ref dataproc::AutoscalingPolicyServiceClient-service-account-snippet)
+ [dataproc::BatchControllerClient](@ref dataproc::BatchControllerClient-service-account-snippet)
+ [dataproc::ClusterControllerClient](@ref dataproc::ClusterControllerClient-service-account-snippet)
+ [dataproc::JobControllerClient](@ref dataproc::JobControllerClient-service-account-snippet)
+ [dataproc::WorkflowTemplateServiceClient](@ref dataproc::WorkflowTemplateServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -170,61 +170,61 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AutoscalingPolicyServiceClient-endpoint-snippet Override AutoscalingPolicyServiceClient Endpoint Configuration
+/*! @page dataproc::AutoscalingPolicyServiceClient-endpoint-snippet Override dataproc::AutoscalingPolicyServiceClient Endpoint Configuration
 
 @snippet google/cloud/dataproc/samples/autoscaling_policy_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AutoscalingPolicyServiceClient-service-account-snippet Override AutoscalingPolicyServiceClient Authentication Defaults
+/*! @page dataproc::AutoscalingPolicyServiceClient-service-account-snippet Override dataproc::AutoscalingPolicyServiceClient Authentication Defaults
 
 @snippet google/cloud/dataproc/samples/autoscaling_policy_client_samples.cc with-service-account
 
 */
 
-/*! @page BatchControllerClient-endpoint-snippet Override BatchControllerClient Endpoint Configuration
+/*! @page dataproc::BatchControllerClient-endpoint-snippet Override dataproc::BatchControllerClient Endpoint Configuration
 
 @snippet google/cloud/dataproc/samples/batch_controller_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page BatchControllerClient-service-account-snippet Override BatchControllerClient Authentication Defaults
+/*! @page dataproc::BatchControllerClient-service-account-snippet Override dataproc::BatchControllerClient Authentication Defaults
 
 @snippet google/cloud/dataproc/samples/batch_controller_client_samples.cc with-service-account
 
 */
 
-/*! @page ClusterControllerClient-endpoint-snippet Override ClusterControllerClient Endpoint Configuration
+/*! @page dataproc::ClusterControllerClient-endpoint-snippet Override dataproc::ClusterControllerClient Endpoint Configuration
 
 @snippet google/cloud/dataproc/samples/cluster_controller_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ClusterControllerClient-service-account-snippet Override ClusterControllerClient Authentication Defaults
+/*! @page dataproc::ClusterControllerClient-service-account-snippet Override dataproc::ClusterControllerClient Authentication Defaults
 
 @snippet google/cloud/dataproc/samples/cluster_controller_client_samples.cc with-service-account
 
 */
 
-/*! @page JobControllerClient-endpoint-snippet Override JobControllerClient Endpoint Configuration
+/*! @page dataproc::JobControllerClient-endpoint-snippet Override dataproc::JobControllerClient Endpoint Configuration
 
 @snippet google/cloud/dataproc/samples/job_controller_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page JobControllerClient-service-account-snippet Override JobControllerClient Authentication Defaults
+/*! @page dataproc::JobControllerClient-service-account-snippet Override dataproc::JobControllerClient Authentication Defaults
 
 @snippet google/cloud/dataproc/samples/job_controller_client_samples.cc with-service-account
 
 */
 
-/*! @page WorkflowTemplateServiceClient-endpoint-snippet Override WorkflowTemplateServiceClient Endpoint Configuration
+/*! @page dataproc::WorkflowTemplateServiceClient-endpoint-snippet Override dataproc::WorkflowTemplateServiceClient Endpoint Configuration
 
 @snippet google/cloud/dataproc/samples/workflow_template_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page WorkflowTemplateServiceClient-service-account-snippet Override WorkflowTemplateServiceClient Authentication Defaults
+/*! @page dataproc::WorkflowTemplateServiceClient-service-account-snippet Override dataproc::WorkflowTemplateServiceClient Authentication Defaults
 
 @snippet google/cloud/dataproc/samples/workflow_template_client_samples.cc with-service-account
 

--- a/google/cloud/dataproc/samples/autoscaling_policy_client_samples.cc
+++ b/google/cloud/dataproc/samples/autoscaling_policy_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AutoscalingPolicyServiceClient
+// main-dox-marker: dataproc::AutoscalingPolicyServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dataproc/samples/batch_controller_client_samples.cc
+++ b/google/cloud/dataproc/samples/batch_controller_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: BatchControllerClient
+// main-dox-marker: dataproc::BatchControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dataproc/samples/cluster_controller_client_samples.cc
+++ b/google/cloud/dataproc/samples/cluster_controller_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ClusterControllerClient
+// main-dox-marker: dataproc::ClusterControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dataproc/samples/job_controller_client_samples.cc
+++ b/google/cloud/dataproc/samples/job_controller_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: JobControllerClient
+// main-dox-marker: dataproc::JobControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dataproc/samples/workflow_template_client_samples.cc
+++ b/google/cloud/dataproc/samples/workflow_template_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: WorkflowTemplateServiceClient
+// main-dox-marker: dataproc::WorkflowTemplateServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/datastream/doc/main.dox
+++ b/google/cloud/datastream/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `DatastreamClient`:
+For example, this will override the default endpoint for `datastream::DatastreamClient`:
 
 @snippet datastream_client_samples.cc set-client-endpoint
 
@@ -140,13 +140,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page DatastreamClient-endpoint-snippet Override DatastreamClient Endpoint Configuration
+/*! @page datastream::DatastreamClient-endpoint-snippet Override datastream::DatastreamClient Endpoint Configuration
 
 @snippet google/cloud/datastream/samples/datastream_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DatastreamClient-service-account-snippet Override DatastreamClient Authentication Defaults
+/*! @page datastream::DatastreamClient-service-account-snippet Override datastream::DatastreamClient Authentication Defaults
 
 @snippet google/cloud/datastream/samples/datastream_client_samples.cc with-service-account
 

--- a/google/cloud/datastream/samples/datastream_client_samples.cc
+++ b/google/cloud/datastream/samples/datastream_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DatastreamClient
+// main-dox-marker: datastream::DatastreamClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/debugger/doc/main.dox
+++ b/google/cloud/debugger/doc/main.dox
@@ -97,13 +97,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `Controller2Client`:
+For example, this will override the default endpoint for `debugger::Controller2Client`:
 
 @snippet controller2_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [Controller2Client](@ref Controller2Client-endpoint-snippet)
- [Debugger2Client](@ref Debugger2Client-endpoint-snippet)
+ [debugger::Controller2Client](@ref debugger::Controller2Client-endpoint-snippet)
+ [debugger::Debugger2Client](@ref debugger::Debugger2Client-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -118,8 +118,8 @@ to explicitly load a service account key file.
 @snippet controller2_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [Controller2Client](@ref Controller2Client-service-account-snippet)
- [Debugger2Client](@ref Debugger2Client-service-account-snippet)
+ [debugger::Controller2Client](@ref debugger::Controller2Client-service-account-snippet)
+ [debugger::Debugger2Client](@ref debugger::Debugger2Client-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -150,25 +150,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page Controller2Client-endpoint-snippet Override Controller2Client Endpoint Configuration
+/*! @page debugger::Controller2Client-endpoint-snippet Override debugger::Controller2Client Endpoint Configuration
 
 @snippet google/cloud/debugger/samples/controller2_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page Controller2Client-service-account-snippet Override Controller2Client Authentication Defaults
+/*! @page debugger::Controller2Client-service-account-snippet Override debugger::Controller2Client Authentication Defaults
 
 @snippet google/cloud/debugger/samples/controller2_client_samples.cc with-service-account
 
 */
 
-/*! @page Debugger2Client-endpoint-snippet Override Debugger2Client Endpoint Configuration
+/*! @page debugger::Debugger2Client-endpoint-snippet Override debugger::Debugger2Client Endpoint Configuration
 
 @snippet google/cloud/debugger/samples/debugger2_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page Debugger2Client-service-account-snippet Override Debugger2Client Authentication Defaults
+/*! @page debugger::Debugger2Client-service-account-snippet Override debugger::Debugger2Client Authentication Defaults
 
 @snippet google/cloud/debugger/samples/debugger2_client_samples.cc with-service-account
 

--- a/google/cloud/debugger/samples/controller2_client_samples.cc
+++ b/google/cloud/debugger/samples/controller2_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: Controller2Client
+// main-dox-marker: debugger::Controller2Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/debugger/samples/debugger2_client_samples.cc
+++ b/google/cloud/debugger/samples/debugger2_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: Debugger2Client
+// main-dox-marker: debugger::Debugger2Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/deploy/doc/main.dox
+++ b/google/cloud/deploy/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudDeployClient`:
+For example, this will override the default endpoint for `deploy::CloudDeployClient`:
 
 @snippet cloud_deploy_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudDeployClient-endpoint-snippet Override CloudDeployClient Endpoint Configuration
+/*! @page deploy::CloudDeployClient-endpoint-snippet Override deploy::CloudDeployClient Endpoint Configuration
 
 @snippet google/cloud/deploy/samples/cloud_deploy_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudDeployClient-service-account-snippet Override CloudDeployClient Authentication Defaults
+/*! @page deploy::CloudDeployClient-service-account-snippet Override deploy::CloudDeployClient Authentication Defaults
 
 @snippet google/cloud/deploy/samples/cloud_deploy_client_samples.cc with-service-account
 

--- a/google/cloud/deploy/samples/cloud_deploy_client_samples.cc
+++ b/google/cloud/deploy/samples/cloud_deploy_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudDeployClient
+// main-dox-marker: deploy::CloudDeployClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -155,27 +155,27 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AgentsClient`:
+For example, this will override the default endpoint for `dialogflow_cx::AgentsClient`:
 
 @snippet agents_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AgentsClient](@ref AgentsClient-endpoint-snippet)
- [ChangelogsClient](@ref ChangelogsClient-endpoint-snippet)
- [DeploymentsClient](@ref DeploymentsClient-endpoint-snippet)
- [EntityTypesClient](@ref EntityTypesClient-endpoint-snippet)
- [EnvironmentsClient](@ref EnvironmentsClient-endpoint-snippet)
- [ExperimentsClient](@ref ExperimentsClient-endpoint-snippet)
- [FlowsClient](@ref FlowsClient-endpoint-snippet)
- [IntentsClient](@ref IntentsClient-endpoint-snippet)
- [PagesClient](@ref PagesClient-endpoint-snippet)
- [SecuritySettingsServiceClient](@ref SecuritySettingsServiceClient-endpoint-snippet)
- [SessionEntityTypesClient](@ref SessionEntityTypesClient-endpoint-snippet)
- [SessionsClient](@ref SessionsClient-endpoint-snippet)
- [TestCasesClient](@ref TestCasesClient-endpoint-snippet)
- [TransitionRouteGroupsClient](@ref TransitionRouteGroupsClient-endpoint-snippet)
- [VersionsClient](@ref VersionsClient-endpoint-snippet)
- [WebhooksClient](@ref WebhooksClient-endpoint-snippet)
+ [dialogflow_cx::AgentsClient](@ref dialogflow_cx::AgentsClient-endpoint-snippet)
+ [dialogflow_cx::ChangelogsClient](@ref dialogflow_cx::ChangelogsClient-endpoint-snippet)
+ [dialogflow_cx::DeploymentsClient](@ref dialogflow_cx::DeploymentsClient-endpoint-snippet)
+ [dialogflow_cx::EntityTypesClient](@ref dialogflow_cx::EntityTypesClient-endpoint-snippet)
+ [dialogflow_cx::EnvironmentsClient](@ref dialogflow_cx::EnvironmentsClient-endpoint-snippet)
+ [dialogflow_cx::ExperimentsClient](@ref dialogflow_cx::ExperimentsClient-endpoint-snippet)
+ [dialogflow_cx::FlowsClient](@ref dialogflow_cx::FlowsClient-endpoint-snippet)
+ [dialogflow_cx::IntentsClient](@ref dialogflow_cx::IntentsClient-endpoint-snippet)
+ [dialogflow_cx::PagesClient](@ref dialogflow_cx::PagesClient-endpoint-snippet)
+ [dialogflow_cx::SecuritySettingsServiceClient](@ref dialogflow_cx::SecuritySettingsServiceClient-endpoint-snippet)
+ [dialogflow_cx::SessionEntityTypesClient](@ref dialogflow_cx::SessionEntityTypesClient-endpoint-snippet)
+ [dialogflow_cx::SessionsClient](@ref dialogflow_cx::SessionsClient-endpoint-snippet)
+ [dialogflow_cx::TestCasesClient](@ref dialogflow_cx::TestCasesClient-endpoint-snippet)
+ [dialogflow_cx::TransitionRouteGroupsClient](@ref dialogflow_cx::TransitionRouteGroupsClient-endpoint-snippet)
+ [dialogflow_cx::VersionsClient](@ref dialogflow_cx::VersionsClient-endpoint-snippet)
+ [dialogflow_cx::WebhooksClient](@ref dialogflow_cx::WebhooksClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -190,22 +190,22 @@ to explicitly load a service account key file.
 @snippet agents_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AgentsClient](@ref AgentsClient-service-account-snippet)
- [ChangelogsClient](@ref ChangelogsClient-service-account-snippet)
- [DeploymentsClient](@ref DeploymentsClient-service-account-snippet)
- [EntityTypesClient](@ref EntityTypesClient-service-account-snippet)
- [EnvironmentsClient](@ref EnvironmentsClient-service-account-snippet)
- [ExperimentsClient](@ref ExperimentsClient-service-account-snippet)
- [FlowsClient](@ref FlowsClient-service-account-snippet)
- [IntentsClient](@ref IntentsClient-service-account-snippet)
- [PagesClient](@ref PagesClient-service-account-snippet)
- [SecuritySettingsServiceClient](@ref SecuritySettingsServiceClient-service-account-snippet)
- [SessionEntityTypesClient](@ref SessionEntityTypesClient-service-account-snippet)
- [SessionsClient](@ref SessionsClient-service-account-snippet)
- [TestCasesClient](@ref TestCasesClient-service-account-snippet)
- [TransitionRouteGroupsClient](@ref TransitionRouteGroupsClient-service-account-snippet)
- [VersionsClient](@ref VersionsClient-service-account-snippet)
- [WebhooksClient](@ref WebhooksClient-service-account-snippet)
+ [dialogflow_cx::AgentsClient](@ref dialogflow_cx::AgentsClient-service-account-snippet)
+ [dialogflow_cx::ChangelogsClient](@ref dialogflow_cx::ChangelogsClient-service-account-snippet)
+ [dialogflow_cx::DeploymentsClient](@ref dialogflow_cx::DeploymentsClient-service-account-snippet)
+ [dialogflow_cx::EntityTypesClient](@ref dialogflow_cx::EntityTypesClient-service-account-snippet)
+ [dialogflow_cx::EnvironmentsClient](@ref dialogflow_cx::EnvironmentsClient-service-account-snippet)
+ [dialogflow_cx::ExperimentsClient](@ref dialogflow_cx::ExperimentsClient-service-account-snippet)
+ [dialogflow_cx::FlowsClient](@ref dialogflow_cx::FlowsClient-service-account-snippet)
+ [dialogflow_cx::IntentsClient](@ref dialogflow_cx::IntentsClient-service-account-snippet)
+ [dialogflow_cx::PagesClient](@ref dialogflow_cx::PagesClient-service-account-snippet)
+ [dialogflow_cx::SecuritySettingsServiceClient](@ref dialogflow_cx::SecuritySettingsServiceClient-service-account-snippet)
+ [dialogflow_cx::SessionEntityTypesClient](@ref dialogflow_cx::SessionEntityTypesClient-service-account-snippet)
+ [dialogflow_cx::SessionsClient](@ref dialogflow_cx::SessionsClient-service-account-snippet)
+ [dialogflow_cx::TestCasesClient](@ref dialogflow_cx::TestCasesClient-service-account-snippet)
+ [dialogflow_cx::TransitionRouteGroupsClient](@ref dialogflow_cx::TransitionRouteGroupsClient-service-account-snippet)
+ [dialogflow_cx::VersionsClient](@ref dialogflow_cx::VersionsClient-service-account-snippet)
+ [dialogflow_cx::WebhooksClient](@ref dialogflow_cx::WebhooksClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -236,193 +236,193 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AgentsClient-endpoint-snippet Override AgentsClient Endpoint Configuration
+/*! @page dialogflow_cx::AgentsClient-endpoint-snippet Override dialogflow_cx::AgentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/agents_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AgentsClient-service-account-snippet Override AgentsClient Authentication Defaults
+/*! @page dialogflow_cx::AgentsClient-service-account-snippet Override dialogflow_cx::AgentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/agents_client_samples.cc with-service-account
 
 */
 
-/*! @page ChangelogsClient-endpoint-snippet Override ChangelogsClient Endpoint Configuration
+/*! @page dialogflow_cx::ChangelogsClient-endpoint-snippet Override dialogflow_cx::ChangelogsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/changelogs_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ChangelogsClient-service-account-snippet Override ChangelogsClient Authentication Defaults
+/*! @page dialogflow_cx::ChangelogsClient-service-account-snippet Override dialogflow_cx::ChangelogsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/changelogs_client_samples.cc with-service-account
 
 */
 
-/*! @page DeploymentsClient-endpoint-snippet Override DeploymentsClient Endpoint Configuration
+/*! @page dialogflow_cx::DeploymentsClient-endpoint-snippet Override dialogflow_cx::DeploymentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/deployments_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DeploymentsClient-service-account-snippet Override DeploymentsClient Authentication Defaults
+/*! @page dialogflow_cx::DeploymentsClient-service-account-snippet Override dialogflow_cx::DeploymentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/deployments_client_samples.cc with-service-account
 
 */
 
-/*! @page EntityTypesClient-endpoint-snippet Override EntityTypesClient Endpoint Configuration
+/*! @page dialogflow_cx::EntityTypesClient-endpoint-snippet Override dialogflow_cx::EntityTypesClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/entity_types_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EntityTypesClient-service-account-snippet Override EntityTypesClient Authentication Defaults
+/*! @page dialogflow_cx::EntityTypesClient-service-account-snippet Override dialogflow_cx::EntityTypesClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/entity_types_client_samples.cc with-service-account
 
 */
 
-/*! @page EnvironmentsClient-endpoint-snippet Override EnvironmentsClient Endpoint Configuration
+/*! @page dialogflow_cx::EnvironmentsClient-endpoint-snippet Override dialogflow_cx::EnvironmentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/environments_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EnvironmentsClient-service-account-snippet Override EnvironmentsClient Authentication Defaults
+/*! @page dialogflow_cx::EnvironmentsClient-service-account-snippet Override dialogflow_cx::EnvironmentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/environments_client_samples.cc with-service-account
 
 */
 
-/*! @page ExperimentsClient-endpoint-snippet Override ExperimentsClient Endpoint Configuration
+/*! @page dialogflow_cx::ExperimentsClient-endpoint-snippet Override dialogflow_cx::ExperimentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/experiments_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ExperimentsClient-service-account-snippet Override ExperimentsClient Authentication Defaults
+/*! @page dialogflow_cx::ExperimentsClient-service-account-snippet Override dialogflow_cx::ExperimentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/experiments_client_samples.cc with-service-account
 
 */
 
-/*! @page FlowsClient-endpoint-snippet Override FlowsClient Endpoint Configuration
+/*! @page dialogflow_cx::FlowsClient-endpoint-snippet Override dialogflow_cx::FlowsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/flows_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page FlowsClient-service-account-snippet Override FlowsClient Authentication Defaults
+/*! @page dialogflow_cx::FlowsClient-service-account-snippet Override dialogflow_cx::FlowsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/flows_client_samples.cc with-service-account
 
 */
 
-/*! @page IntentsClient-endpoint-snippet Override IntentsClient Endpoint Configuration
+/*! @page dialogflow_cx::IntentsClient-endpoint-snippet Override dialogflow_cx::IntentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/intents_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IntentsClient-service-account-snippet Override IntentsClient Authentication Defaults
+/*! @page dialogflow_cx::IntentsClient-service-account-snippet Override dialogflow_cx::IntentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/intents_client_samples.cc with-service-account
 
 */
 
-/*! @page PagesClient-endpoint-snippet Override PagesClient Endpoint Configuration
+/*! @page dialogflow_cx::PagesClient-endpoint-snippet Override dialogflow_cx::PagesClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/pages_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page PagesClient-service-account-snippet Override PagesClient Authentication Defaults
+/*! @page dialogflow_cx::PagesClient-service-account-snippet Override dialogflow_cx::PagesClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/pages_client_samples.cc with-service-account
 
 */
 
-/*! @page SecuritySettingsServiceClient-endpoint-snippet Override SecuritySettingsServiceClient Endpoint Configuration
+/*! @page dialogflow_cx::SecuritySettingsServiceClient-endpoint-snippet Override dialogflow_cx::SecuritySettingsServiceClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/security_settings_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SecuritySettingsServiceClient-service-account-snippet Override SecuritySettingsServiceClient Authentication Defaults
+/*! @page dialogflow_cx::SecuritySettingsServiceClient-service-account-snippet Override dialogflow_cx::SecuritySettingsServiceClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/security_settings_client_samples.cc with-service-account
 
 */
 
-/*! @page SessionEntityTypesClient-endpoint-snippet Override SessionEntityTypesClient Endpoint Configuration
+/*! @page dialogflow_cx::SessionEntityTypesClient-endpoint-snippet Override dialogflow_cx::SessionEntityTypesClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/session_entity_types_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SessionEntityTypesClient-service-account-snippet Override SessionEntityTypesClient Authentication Defaults
+/*! @page dialogflow_cx::SessionEntityTypesClient-service-account-snippet Override dialogflow_cx::SessionEntityTypesClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/session_entity_types_client_samples.cc with-service-account
 
 */
 
-/*! @page SessionsClient-endpoint-snippet Override SessionsClient Endpoint Configuration
+/*! @page dialogflow_cx::SessionsClient-endpoint-snippet Override dialogflow_cx::SessionsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/sessions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SessionsClient-service-account-snippet Override SessionsClient Authentication Defaults
+/*! @page dialogflow_cx::SessionsClient-service-account-snippet Override dialogflow_cx::SessionsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/sessions_client_samples.cc with-service-account
 
 */
 
-/*! @page TestCasesClient-endpoint-snippet Override TestCasesClient Endpoint Configuration
+/*! @page dialogflow_cx::TestCasesClient-endpoint-snippet Override dialogflow_cx::TestCasesClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/test_cases_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TestCasesClient-service-account-snippet Override TestCasesClient Authentication Defaults
+/*! @page dialogflow_cx::TestCasesClient-service-account-snippet Override dialogflow_cx::TestCasesClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/test_cases_client_samples.cc with-service-account
 
 */
 
-/*! @page TransitionRouteGroupsClient-endpoint-snippet Override TransitionRouteGroupsClient Endpoint Configuration
+/*! @page dialogflow_cx::TransitionRouteGroupsClient-endpoint-snippet Override dialogflow_cx::TransitionRouteGroupsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/transition_route_groups_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TransitionRouteGroupsClient-service-account-snippet Override TransitionRouteGroupsClient Authentication Defaults
+/*! @page dialogflow_cx::TransitionRouteGroupsClient-service-account-snippet Override dialogflow_cx::TransitionRouteGroupsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/transition_route_groups_client_samples.cc with-service-account
 
 */
 
-/*! @page VersionsClient-endpoint-snippet Override VersionsClient Endpoint Configuration
+/*! @page dialogflow_cx::VersionsClient-endpoint-snippet Override dialogflow_cx::VersionsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/versions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page VersionsClient-service-account-snippet Override VersionsClient Authentication Defaults
+/*! @page dialogflow_cx::VersionsClient-service-account-snippet Override dialogflow_cx::VersionsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/versions_client_samples.cc with-service-account
 
 */
 
-/*! @page WebhooksClient-endpoint-snippet Override WebhooksClient Endpoint Configuration
+/*! @page dialogflow_cx::WebhooksClient-endpoint-snippet Override dialogflow_cx::WebhooksClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_cx/samples/webhooks_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page WebhooksClient-service-account-snippet Override WebhooksClient Authentication Defaults
+/*! @page dialogflow_cx::WebhooksClient-service-account-snippet Override dialogflow_cx::WebhooksClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_cx/samples/webhooks_client_samples.cc with-service-account
 

--- a/google/cloud/dialogflow_cx/samples/agents_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/agents_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AgentsClient
+// main-dox-marker: dialogflow_cx::AgentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/changelogs_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/changelogs_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ChangelogsClient
+// main-dox-marker: dialogflow_cx::ChangelogsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/deployments_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/deployments_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DeploymentsClient
+// main-dox-marker: dialogflow_cx::DeploymentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/entity_types_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/entity_types_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EntityTypesClient
+// main-dox-marker: dialogflow_cx::EntityTypesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/environments_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/environments_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EnvironmentsClient
+// main-dox-marker: dialogflow_cx::EnvironmentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/experiments_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/experiments_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ExperimentsClient
+// main-dox-marker: dialogflow_cx::ExperimentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/flows_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/flows_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: FlowsClient
+// main-dox-marker: dialogflow_cx::FlowsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/intents_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/intents_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IntentsClient
+// main-dox-marker: dialogflow_cx::IntentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/pages_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/pages_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: PagesClient
+// main-dox-marker: dialogflow_cx::PagesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/security_settings_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/security_settings_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SecuritySettingsServiceClient
+// main-dox-marker: dialogflow_cx::SecuritySettingsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/session_entity_types_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/session_entity_types_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SessionEntityTypesClient
+// main-dox-marker: dialogflow_cx::SessionEntityTypesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/sessions_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/sessions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SessionsClient
+// main-dox-marker: dialogflow_cx::SessionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/test_cases_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/test_cases_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TestCasesClient
+// main-dox-marker: dialogflow_cx::TestCasesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/transition_route_groups_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/transition_route_groups_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TransitionRouteGroupsClient
+// main-dox-marker: dialogflow_cx::TransitionRouteGroupsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/versions_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/versions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: VersionsClient
+// main-dox-marker: dialogflow_cx::VersionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_cx/samples/webhooks_client_samples.cc
+++ b/google/cloud/dialogflow_cx/samples/webhooks_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: WebhooksClient
+// main-dox-marker: dialogflow_cx::WebhooksClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -159,28 +159,28 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AgentsClient`:
+For example, this will override the default endpoint for `dialogflow_es::AgentsClient`:
 
 @snippet agents_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AgentsClient](@ref AgentsClient-endpoint-snippet)
- [AnswerRecordsClient](@ref AnswerRecordsClient-endpoint-snippet)
- [ContextsClient](@ref ContextsClient-endpoint-snippet)
- [ConversationDatasetsClient](@ref ConversationDatasetsClient-endpoint-snippet)
- [ConversationModelsClient](@ref ConversationModelsClient-endpoint-snippet)
- [ConversationProfilesClient](@ref ConversationProfilesClient-endpoint-snippet)
- [ConversationsClient](@ref ConversationsClient-endpoint-snippet)
- [DocumentsClient](@ref DocumentsClient-endpoint-snippet)
- [EntityTypesClient](@ref EntityTypesClient-endpoint-snippet)
- [EnvironmentsClient](@ref EnvironmentsClient-endpoint-snippet)
- [FulfillmentsClient](@ref FulfillmentsClient-endpoint-snippet)
- [IntentsClient](@ref IntentsClient-endpoint-snippet)
- [KnowledgeBasesClient](@ref KnowledgeBasesClient-endpoint-snippet)
- [ParticipantsClient](@ref ParticipantsClient-endpoint-snippet)
- [SessionEntityTypesClient](@ref SessionEntityTypesClient-endpoint-snippet)
- [SessionsClient](@ref SessionsClient-endpoint-snippet)
- [VersionsClient](@ref VersionsClient-endpoint-snippet)
+ [dialogflow_es::AgentsClient](@ref dialogflow_es::AgentsClient-endpoint-snippet)
+ [dialogflow_es::AnswerRecordsClient](@ref dialogflow_es::AnswerRecordsClient-endpoint-snippet)
+ [dialogflow_es::ContextsClient](@ref dialogflow_es::ContextsClient-endpoint-snippet)
+ [dialogflow_es::ConversationDatasetsClient](@ref dialogflow_es::ConversationDatasetsClient-endpoint-snippet)
+ [dialogflow_es::ConversationModelsClient](@ref dialogflow_es::ConversationModelsClient-endpoint-snippet)
+ [dialogflow_es::ConversationProfilesClient](@ref dialogflow_es::ConversationProfilesClient-endpoint-snippet)
+ [dialogflow_es::ConversationsClient](@ref dialogflow_es::ConversationsClient-endpoint-snippet)
+ [dialogflow_es::DocumentsClient](@ref dialogflow_es::DocumentsClient-endpoint-snippet)
+ [dialogflow_es::EntityTypesClient](@ref dialogflow_es::EntityTypesClient-endpoint-snippet)
+ [dialogflow_es::EnvironmentsClient](@ref dialogflow_es::EnvironmentsClient-endpoint-snippet)
+ [dialogflow_es::FulfillmentsClient](@ref dialogflow_es::FulfillmentsClient-endpoint-snippet)
+ [dialogflow_es::IntentsClient](@ref dialogflow_es::IntentsClient-endpoint-snippet)
+ [dialogflow_es::KnowledgeBasesClient](@ref dialogflow_es::KnowledgeBasesClient-endpoint-snippet)
+ [dialogflow_es::ParticipantsClient](@ref dialogflow_es::ParticipantsClient-endpoint-snippet)
+ [dialogflow_es::SessionEntityTypesClient](@ref dialogflow_es::SessionEntityTypesClient-endpoint-snippet)
+ [dialogflow_es::SessionsClient](@ref dialogflow_es::SessionsClient-endpoint-snippet)
+ [dialogflow_es::VersionsClient](@ref dialogflow_es::VersionsClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -195,23 +195,23 @@ to explicitly load a service account key file.
 @snippet agents_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AgentsClient](@ref AgentsClient-service-account-snippet)
- [AnswerRecordsClient](@ref AnswerRecordsClient-service-account-snippet)
- [ContextsClient](@ref ContextsClient-service-account-snippet)
- [ConversationDatasetsClient](@ref ConversationDatasetsClient-service-account-snippet)
- [ConversationModelsClient](@ref ConversationModelsClient-service-account-snippet)
- [ConversationProfilesClient](@ref ConversationProfilesClient-service-account-snippet)
- [ConversationsClient](@ref ConversationsClient-service-account-snippet)
- [DocumentsClient](@ref DocumentsClient-service-account-snippet)
- [EntityTypesClient](@ref EntityTypesClient-service-account-snippet)
- [EnvironmentsClient](@ref EnvironmentsClient-service-account-snippet)
- [FulfillmentsClient](@ref FulfillmentsClient-service-account-snippet)
- [IntentsClient](@ref IntentsClient-service-account-snippet)
- [KnowledgeBasesClient](@ref KnowledgeBasesClient-service-account-snippet)
- [ParticipantsClient](@ref ParticipantsClient-service-account-snippet)
- [SessionEntityTypesClient](@ref SessionEntityTypesClient-service-account-snippet)
- [SessionsClient](@ref SessionsClient-service-account-snippet)
- [VersionsClient](@ref VersionsClient-service-account-snippet)
+ [dialogflow_es::AgentsClient](@ref dialogflow_es::AgentsClient-service-account-snippet)
+ [dialogflow_es::AnswerRecordsClient](@ref dialogflow_es::AnswerRecordsClient-service-account-snippet)
+ [dialogflow_es::ContextsClient](@ref dialogflow_es::ContextsClient-service-account-snippet)
+ [dialogflow_es::ConversationDatasetsClient](@ref dialogflow_es::ConversationDatasetsClient-service-account-snippet)
+ [dialogflow_es::ConversationModelsClient](@ref dialogflow_es::ConversationModelsClient-service-account-snippet)
+ [dialogflow_es::ConversationProfilesClient](@ref dialogflow_es::ConversationProfilesClient-service-account-snippet)
+ [dialogflow_es::ConversationsClient](@ref dialogflow_es::ConversationsClient-service-account-snippet)
+ [dialogflow_es::DocumentsClient](@ref dialogflow_es::DocumentsClient-service-account-snippet)
+ [dialogflow_es::EntityTypesClient](@ref dialogflow_es::EntityTypesClient-service-account-snippet)
+ [dialogflow_es::EnvironmentsClient](@ref dialogflow_es::EnvironmentsClient-service-account-snippet)
+ [dialogflow_es::FulfillmentsClient](@ref dialogflow_es::FulfillmentsClient-service-account-snippet)
+ [dialogflow_es::IntentsClient](@ref dialogflow_es::IntentsClient-service-account-snippet)
+ [dialogflow_es::KnowledgeBasesClient](@ref dialogflow_es::KnowledgeBasesClient-service-account-snippet)
+ [dialogflow_es::ParticipantsClient](@ref dialogflow_es::ParticipantsClient-service-account-snippet)
+ [dialogflow_es::SessionEntityTypesClient](@ref dialogflow_es::SessionEntityTypesClient-service-account-snippet)
+ [dialogflow_es::SessionsClient](@ref dialogflow_es::SessionsClient-service-account-snippet)
+ [dialogflow_es::VersionsClient](@ref dialogflow_es::VersionsClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -242,205 +242,205 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AgentsClient-endpoint-snippet Override AgentsClient Endpoint Configuration
+/*! @page dialogflow_es::AgentsClient-endpoint-snippet Override dialogflow_es::AgentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/agents_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AgentsClient-service-account-snippet Override AgentsClient Authentication Defaults
+/*! @page dialogflow_es::AgentsClient-service-account-snippet Override dialogflow_es::AgentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/agents_client_samples.cc with-service-account
 
 */
 
-/*! @page AnswerRecordsClient-endpoint-snippet Override AnswerRecordsClient Endpoint Configuration
+/*! @page dialogflow_es::AnswerRecordsClient-endpoint-snippet Override dialogflow_es::AnswerRecordsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/answer_records_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AnswerRecordsClient-service-account-snippet Override AnswerRecordsClient Authentication Defaults
+/*! @page dialogflow_es::AnswerRecordsClient-service-account-snippet Override dialogflow_es::AnswerRecordsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/answer_records_client_samples.cc with-service-account
 
 */
 
-/*! @page ContextsClient-endpoint-snippet Override ContextsClient Endpoint Configuration
+/*! @page dialogflow_es::ContextsClient-endpoint-snippet Override dialogflow_es::ContextsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/contexts_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ContextsClient-service-account-snippet Override ContextsClient Authentication Defaults
+/*! @page dialogflow_es::ContextsClient-service-account-snippet Override dialogflow_es::ContextsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/contexts_client_samples.cc with-service-account
 
 */
 
-/*! @page ConversationDatasetsClient-endpoint-snippet Override ConversationDatasetsClient Endpoint Configuration
+/*! @page dialogflow_es::ConversationDatasetsClient-endpoint-snippet Override dialogflow_es::ConversationDatasetsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/conversation_datasets_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ConversationDatasetsClient-service-account-snippet Override ConversationDatasetsClient Authentication Defaults
+/*! @page dialogflow_es::ConversationDatasetsClient-service-account-snippet Override dialogflow_es::ConversationDatasetsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/conversation_datasets_client_samples.cc with-service-account
 
 */
 
-/*! @page ConversationModelsClient-endpoint-snippet Override ConversationModelsClient Endpoint Configuration
+/*! @page dialogflow_es::ConversationModelsClient-endpoint-snippet Override dialogflow_es::ConversationModelsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/conversation_models_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ConversationModelsClient-service-account-snippet Override ConversationModelsClient Authentication Defaults
+/*! @page dialogflow_es::ConversationModelsClient-service-account-snippet Override dialogflow_es::ConversationModelsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/conversation_models_client_samples.cc with-service-account
 
 */
 
-/*! @page ConversationProfilesClient-endpoint-snippet Override ConversationProfilesClient Endpoint Configuration
+/*! @page dialogflow_es::ConversationProfilesClient-endpoint-snippet Override dialogflow_es::ConversationProfilesClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/conversation_profiles_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ConversationProfilesClient-service-account-snippet Override ConversationProfilesClient Authentication Defaults
+/*! @page dialogflow_es::ConversationProfilesClient-service-account-snippet Override dialogflow_es::ConversationProfilesClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/conversation_profiles_client_samples.cc with-service-account
 
 */
 
-/*! @page ConversationsClient-endpoint-snippet Override ConversationsClient Endpoint Configuration
+/*! @page dialogflow_es::ConversationsClient-endpoint-snippet Override dialogflow_es::ConversationsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/conversations_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ConversationsClient-service-account-snippet Override ConversationsClient Authentication Defaults
+/*! @page dialogflow_es::ConversationsClient-service-account-snippet Override dialogflow_es::ConversationsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/conversations_client_samples.cc with-service-account
 
 */
 
-/*! @page DocumentsClient-endpoint-snippet Override DocumentsClient Endpoint Configuration
+/*! @page dialogflow_es::DocumentsClient-endpoint-snippet Override dialogflow_es::DocumentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/documents_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DocumentsClient-service-account-snippet Override DocumentsClient Authentication Defaults
+/*! @page dialogflow_es::DocumentsClient-service-account-snippet Override dialogflow_es::DocumentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/documents_client_samples.cc with-service-account
 
 */
 
-/*! @page EntityTypesClient-endpoint-snippet Override EntityTypesClient Endpoint Configuration
+/*! @page dialogflow_es::EntityTypesClient-endpoint-snippet Override dialogflow_es::EntityTypesClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/entity_types_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EntityTypesClient-service-account-snippet Override EntityTypesClient Authentication Defaults
+/*! @page dialogflow_es::EntityTypesClient-service-account-snippet Override dialogflow_es::EntityTypesClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/entity_types_client_samples.cc with-service-account
 
 */
 
-/*! @page EnvironmentsClient-endpoint-snippet Override EnvironmentsClient Endpoint Configuration
+/*! @page dialogflow_es::EnvironmentsClient-endpoint-snippet Override dialogflow_es::EnvironmentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/environments_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EnvironmentsClient-service-account-snippet Override EnvironmentsClient Authentication Defaults
+/*! @page dialogflow_es::EnvironmentsClient-service-account-snippet Override dialogflow_es::EnvironmentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/environments_client_samples.cc with-service-account
 
 */
 
-/*! @page FulfillmentsClient-endpoint-snippet Override FulfillmentsClient Endpoint Configuration
+/*! @page dialogflow_es::FulfillmentsClient-endpoint-snippet Override dialogflow_es::FulfillmentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/fulfillments_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page FulfillmentsClient-service-account-snippet Override FulfillmentsClient Authentication Defaults
+/*! @page dialogflow_es::FulfillmentsClient-service-account-snippet Override dialogflow_es::FulfillmentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/fulfillments_client_samples.cc with-service-account
 
 */
 
-/*! @page IntentsClient-endpoint-snippet Override IntentsClient Endpoint Configuration
+/*! @page dialogflow_es::IntentsClient-endpoint-snippet Override dialogflow_es::IntentsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/intents_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IntentsClient-service-account-snippet Override IntentsClient Authentication Defaults
+/*! @page dialogflow_es::IntentsClient-service-account-snippet Override dialogflow_es::IntentsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/intents_client_samples.cc with-service-account
 
 */
 
-/*! @page KnowledgeBasesClient-endpoint-snippet Override KnowledgeBasesClient Endpoint Configuration
+/*! @page dialogflow_es::KnowledgeBasesClient-endpoint-snippet Override dialogflow_es::KnowledgeBasesClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/knowledge_bases_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page KnowledgeBasesClient-service-account-snippet Override KnowledgeBasesClient Authentication Defaults
+/*! @page dialogflow_es::KnowledgeBasesClient-service-account-snippet Override dialogflow_es::KnowledgeBasesClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/knowledge_bases_client_samples.cc with-service-account
 
 */
 
-/*! @page ParticipantsClient-endpoint-snippet Override ParticipantsClient Endpoint Configuration
+/*! @page dialogflow_es::ParticipantsClient-endpoint-snippet Override dialogflow_es::ParticipantsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/participants_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ParticipantsClient-service-account-snippet Override ParticipantsClient Authentication Defaults
+/*! @page dialogflow_es::ParticipantsClient-service-account-snippet Override dialogflow_es::ParticipantsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/participants_client_samples.cc with-service-account
 
 */
 
-/*! @page SessionEntityTypesClient-endpoint-snippet Override SessionEntityTypesClient Endpoint Configuration
+/*! @page dialogflow_es::SessionEntityTypesClient-endpoint-snippet Override dialogflow_es::SessionEntityTypesClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/session_entity_types_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SessionEntityTypesClient-service-account-snippet Override SessionEntityTypesClient Authentication Defaults
+/*! @page dialogflow_es::SessionEntityTypesClient-service-account-snippet Override dialogflow_es::SessionEntityTypesClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/session_entity_types_client_samples.cc with-service-account
 
 */
 
-/*! @page SessionsClient-endpoint-snippet Override SessionsClient Endpoint Configuration
+/*! @page dialogflow_es::SessionsClient-endpoint-snippet Override dialogflow_es::SessionsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/sessions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SessionsClient-service-account-snippet Override SessionsClient Authentication Defaults
+/*! @page dialogflow_es::SessionsClient-service-account-snippet Override dialogflow_es::SessionsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/sessions_client_samples.cc with-service-account
 
 */
 
-/*! @page VersionsClient-endpoint-snippet Override VersionsClient Endpoint Configuration
+/*! @page dialogflow_es::VersionsClient-endpoint-snippet Override dialogflow_es::VersionsClient Endpoint Configuration
 
 @snippet google/cloud/dialogflow_es/samples/versions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page VersionsClient-service-account-snippet Override VersionsClient Authentication Defaults
+/*! @page dialogflow_es::VersionsClient-service-account-snippet Override dialogflow_es::VersionsClient Authentication Defaults
 
 @snippet google/cloud/dialogflow_es/samples/versions_client_samples.cc with-service-account
 

--- a/google/cloud/dialogflow_es/samples/agents_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/agents_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AgentsClient
+// main-dox-marker: dialogflow_es::AgentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/answer_records_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/answer_records_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AnswerRecordsClient
+// main-dox-marker: dialogflow_es::AnswerRecordsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/contexts_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/contexts_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ContextsClient
+// main-dox-marker: dialogflow_es::ContextsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/conversation_datasets_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/conversation_datasets_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ConversationDatasetsClient
+// main-dox-marker: dialogflow_es::ConversationDatasetsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/conversation_models_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/conversation_models_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ConversationModelsClient
+// main-dox-marker: dialogflow_es::ConversationModelsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/conversation_profiles_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/conversation_profiles_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ConversationProfilesClient
+// main-dox-marker: dialogflow_es::ConversationProfilesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/conversations_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/conversations_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ConversationsClient
+// main-dox-marker: dialogflow_es::ConversationsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/documents_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/documents_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DocumentsClient
+// main-dox-marker: dialogflow_es::DocumentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/entity_types_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/entity_types_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EntityTypesClient
+// main-dox-marker: dialogflow_es::EntityTypesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/environments_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/environments_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EnvironmentsClient
+// main-dox-marker: dialogflow_es::EnvironmentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/fulfillments_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/fulfillments_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: FulfillmentsClient
+// main-dox-marker: dialogflow_es::FulfillmentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/intents_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/intents_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IntentsClient
+// main-dox-marker: dialogflow_es::IntentsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/knowledge_bases_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/knowledge_bases_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: KnowledgeBasesClient
+// main-dox-marker: dialogflow_es::KnowledgeBasesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/participants_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/participants_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ParticipantsClient
+// main-dox-marker: dialogflow_es::ParticipantsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/session_entity_types_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/session_entity_types_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SessionEntityTypesClient
+// main-dox-marker: dialogflow_es::SessionEntityTypesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/sessions_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/sessions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SessionsClient
+// main-dox-marker: dialogflow_es::SessionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dialogflow_es/samples/versions_client_samples.cc
+++ b/google/cloud/dialogflow_es/samples/versions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: VersionsClient
+// main-dox-marker: dialogflow_es::VersionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/dlp/doc/main.dox
+++ b/google/cloud/dlp/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `DlpServiceClient`:
+For example, this will override the default endpoint for `dlp::DlpServiceClient`:
 
 @snippet dlp_client_samples.cc set-client-endpoint
 
@@ -140,13 +140,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page DlpServiceClient-endpoint-snippet Override DlpServiceClient Endpoint Configuration
+/*! @page dlp::DlpServiceClient-endpoint-snippet Override dlp::DlpServiceClient Endpoint Configuration
 
 @snippet google/cloud/dlp/samples/dlp_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DlpServiceClient-service-account-snippet Override DlpServiceClient Authentication Defaults
+/*! @page dlp::DlpServiceClient-service-account-snippet Override dlp::DlpServiceClient Authentication Defaults
 
 @snippet google/cloud/dlp/samples/dlp_client_samples.cc with-service-account
 

--- a/google/cloud/dlp/samples/dlp_client_samples.cc
+++ b/google/cloud/dlp/samples/dlp_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DlpServiceClient
+// main-dox-marker: dlp::DlpServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/documentai/doc/main.dox
+++ b/google/cloud/documentai/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `DocumentProcessorServiceClient`:
+For example, this will override the default endpoint for `documentai::DocumentProcessorServiceClient`:
 
 @snippet document_processor_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page DocumentProcessorServiceClient-endpoint-snippet Override DocumentProcessorServiceClient Endpoint Configuration
+/*! @page documentai::DocumentProcessorServiceClient-endpoint-snippet Override documentai::DocumentProcessorServiceClient Endpoint Configuration
 
 @snippet google/cloud/documentai/samples/document_processor_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DocumentProcessorServiceClient-service-account-snippet Override DocumentProcessorServiceClient Authentication Defaults
+/*! @page documentai::DocumentProcessorServiceClient-service-account-snippet Override documentai::DocumentProcessorServiceClient Authentication Defaults
 
 @snippet google/cloud/documentai/samples/document_processor_client_samples.cc with-service-account
 

--- a/google/cloud/documentai/samples/document_processor_client_samples.cc
+++ b/google/cloud/documentai/samples/document_processor_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DocumentProcessorServiceClient
+// main-dox-marker: documentai::DocumentProcessorServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/edgecontainer/doc/main.dox
+++ b/google/cloud/edgecontainer/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `EdgeContainerClient`:
+For example, this will override the default endpoint for `edgecontainer::EdgeContainerClient`:
 
 @snippet edge_container_client_samples.cc set-client-endpoint
 
@@ -140,13 +140,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page EdgeContainerClient-endpoint-snippet Override EdgeContainerClient Endpoint Configuration
+/*! @page edgecontainer::EdgeContainerClient-endpoint-snippet Override edgecontainer::EdgeContainerClient Endpoint Configuration
 
 @snippet google/cloud/edgecontainer/samples/edge_container_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EdgeContainerClient-service-account-snippet Override EdgeContainerClient Authentication Defaults
+/*! @page edgecontainer::EdgeContainerClient-service-account-snippet Override edgecontainer::EdgeContainerClient Authentication Defaults
 
 @snippet google/cloud/edgecontainer/samples/edge_container_client_samples.cc with-service-account
 

--- a/google/cloud/edgecontainer/samples/edge_container_client_samples.cc
+++ b/google/cloud/edgecontainer/samples/edge_container_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EdgeContainerClient
+// main-dox-marker: edgecontainer::EdgeContainerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -96,13 +96,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `EventarcClient`:
+For example, this will override the default endpoint for `eventarc::EventarcClient`:
 
 @snippet eventarc_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [EventarcClient](@ref EventarcClient-endpoint-snippet)
- [PublisherClient](@ref PublisherClient-endpoint-snippet)
+ [eventarc::EventarcClient](@ref eventarc::EventarcClient-endpoint-snippet)
+ [eventarc::PublisherClient](@ref eventarc::PublisherClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -117,8 +117,8 @@ to explicitly load a service account key file.
 @snippet eventarc_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [EventarcClient](@ref EventarcClient-service-account-snippet)
- [PublisherClient](@ref PublisherClient-service-account-snippet)
+ [eventarc::EventarcClient](@ref eventarc::EventarcClient-service-account-snippet)
+ [eventarc::PublisherClient](@ref eventarc::PublisherClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -149,25 +149,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page EventarcClient-endpoint-snippet Override EventarcClient Endpoint Configuration
+/*! @page eventarc::EventarcClient-endpoint-snippet Override eventarc::EventarcClient Endpoint Configuration
 
 @snippet google/cloud/eventarc/samples/eventarc_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EventarcClient-service-account-snippet Override EventarcClient Authentication Defaults
+/*! @page eventarc::EventarcClient-service-account-snippet Override eventarc::EventarcClient Authentication Defaults
 
 @snippet google/cloud/eventarc/samples/eventarc_client_samples.cc with-service-account
 
 */
 
-/*! @page PublisherClient-endpoint-snippet Override PublisherClient Endpoint Configuration
+/*! @page eventarc::PublisherClient-endpoint-snippet Override eventarc::PublisherClient Endpoint Configuration
 
 @snippet google/cloud/eventarc/samples/publisher_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page PublisherClient-service-account-snippet Override PublisherClient Authentication Defaults
+/*! @page eventarc::PublisherClient-service-account-snippet Override eventarc::PublisherClient Authentication Defaults
 
 @snippet google/cloud/eventarc/samples/publisher_client_samples.cc with-service-account
 

--- a/google/cloud/eventarc/samples/eventarc_client_samples.cc
+++ b/google/cloud/eventarc/samples/eventarc_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EventarcClient
+// main-dox-marker: eventarc::EventarcClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/eventarc/samples/publisher_client_samples.cc
+++ b/google/cloud/eventarc/samples/publisher_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: PublisherClient
+// main-dox-marker: eventarc::PublisherClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/filestore/doc/main.dox
+++ b/google/cloud/filestore/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudFilestoreManagerClient`:
+For example, this will override the default endpoint for `filestore::CloudFilestoreManagerClient`:
 
 @snippet cloud_filestore_manager_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudFilestoreManagerClient-endpoint-snippet Override CloudFilestoreManagerClient Endpoint Configuration
+/*! @page filestore::CloudFilestoreManagerClient-endpoint-snippet Override filestore::CloudFilestoreManagerClient Endpoint Configuration
 
 @snippet google/cloud/filestore/samples/cloud_filestore_manager_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudFilestoreManagerClient-service-account-snippet Override CloudFilestoreManagerClient Authentication Defaults
+/*! @page filestore::CloudFilestoreManagerClient-service-account-snippet Override filestore::CloudFilestoreManagerClient Authentication Defaults
 
 @snippet google/cloud/filestore/samples/cloud_filestore_manager_client_samples.cc with-service-account
 

--- a/google/cloud/filestore/samples/cloud_filestore_manager_client_samples.cc
+++ b/google/cloud/filestore/samples/cloud_filestore_manager_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudFilestoreManagerClient
+// main-dox-marker: filestore::CloudFilestoreManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/functions/doc/main.dox
+++ b/google/cloud/functions/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudFunctionsServiceClient`:
+For example, this will override the default endpoint for `functions::CloudFunctionsServiceClient`:
 
 @snippet cloud_functions_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudFunctionsServiceClient-endpoint-snippet Override CloudFunctionsServiceClient Endpoint Configuration
+/*! @page functions::CloudFunctionsServiceClient-endpoint-snippet Override functions::CloudFunctionsServiceClient Endpoint Configuration
 
 @snippet google/cloud/functions/samples/cloud_functions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudFunctionsServiceClient-service-account-snippet Override CloudFunctionsServiceClient Authentication Defaults
+/*! @page functions::CloudFunctionsServiceClient-service-account-snippet Override functions::CloudFunctionsServiceClient Authentication Defaults
 
 @snippet google/cloud/functions/samples/cloud_functions_client_samples.cc with-service-account
 

--- a/google/cloud/functions/samples/cloud_functions_client_samples.cc
+++ b/google/cloud/functions/samples/cloud_functions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudFunctionsServiceClient
+// main-dox-marker: functions::CloudFunctionsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/gameservices/doc/main.dox
+++ b/google/cloud/gameservices/doc/main.dox
@@ -105,15 +105,15 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `GameServerClustersServiceClient`:
+For example, this will override the default endpoint for `gameservices::GameServerClustersServiceClient`:
 
 @snippet game_server_clusters_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [GameServerClustersServiceClient](@ref GameServerClustersServiceClient-endpoint-snippet)
- [GameServerConfigsServiceClient](@ref GameServerConfigsServiceClient-endpoint-snippet)
- [GameServerDeploymentsServiceClient](@ref GameServerDeploymentsServiceClient-endpoint-snippet)
- [RealmsServiceClient](@ref RealmsServiceClient-endpoint-snippet)
+ [gameservices::GameServerClustersServiceClient](@ref gameservices::GameServerClustersServiceClient-endpoint-snippet)
+ [gameservices::GameServerConfigsServiceClient](@ref gameservices::GameServerConfigsServiceClient-endpoint-snippet)
+ [gameservices::GameServerDeploymentsServiceClient](@ref gameservices::GameServerDeploymentsServiceClient-endpoint-snippet)
+ [gameservices::RealmsServiceClient](@ref gameservices::RealmsServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -128,10 +128,10 @@ to explicitly load a service account key file.
 @snippet game_server_clusters_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [GameServerClustersServiceClient](@ref GameServerClustersServiceClient-service-account-snippet)
- [GameServerConfigsServiceClient](@ref GameServerConfigsServiceClient-service-account-snippet)
- [GameServerDeploymentsServiceClient](@ref GameServerDeploymentsServiceClient-service-account-snippet)
- [RealmsServiceClient](@ref RealmsServiceClient-service-account-snippet)
+ [gameservices::GameServerClustersServiceClient](@ref gameservices::GameServerClustersServiceClient-service-account-snippet)
+ [gameservices::GameServerConfigsServiceClient](@ref gameservices::GameServerConfigsServiceClient-service-account-snippet)
+ [gameservices::GameServerDeploymentsServiceClient](@ref gameservices::GameServerDeploymentsServiceClient-service-account-snippet)
+ [gameservices::RealmsServiceClient](@ref gameservices::RealmsServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -162,49 +162,49 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page GameServerClustersServiceClient-endpoint-snippet Override GameServerClustersServiceClient Endpoint Configuration
+/*! @page gameservices::GameServerClustersServiceClient-endpoint-snippet Override gameservices::GameServerClustersServiceClient Endpoint Configuration
 
 @snippet google/cloud/gameservices/samples/game_server_clusters_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page GameServerClustersServiceClient-service-account-snippet Override GameServerClustersServiceClient Authentication Defaults
+/*! @page gameservices::GameServerClustersServiceClient-service-account-snippet Override gameservices::GameServerClustersServiceClient Authentication Defaults
 
 @snippet google/cloud/gameservices/samples/game_server_clusters_client_samples.cc with-service-account
 
 */
 
-/*! @page GameServerConfigsServiceClient-endpoint-snippet Override GameServerConfigsServiceClient Endpoint Configuration
+/*! @page gameservices::GameServerConfigsServiceClient-endpoint-snippet Override gameservices::GameServerConfigsServiceClient Endpoint Configuration
 
 @snippet google/cloud/gameservices/samples/game_server_configs_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page GameServerConfigsServiceClient-service-account-snippet Override GameServerConfigsServiceClient Authentication Defaults
+/*! @page gameservices::GameServerConfigsServiceClient-service-account-snippet Override gameservices::GameServerConfigsServiceClient Authentication Defaults
 
 @snippet google/cloud/gameservices/samples/game_server_configs_client_samples.cc with-service-account
 
 */
 
-/*! @page GameServerDeploymentsServiceClient-endpoint-snippet Override GameServerDeploymentsServiceClient Endpoint Configuration
+/*! @page gameservices::GameServerDeploymentsServiceClient-endpoint-snippet Override gameservices::GameServerDeploymentsServiceClient Endpoint Configuration
 
 @snippet google/cloud/gameservices/samples/game_server_deployments_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page GameServerDeploymentsServiceClient-service-account-snippet Override GameServerDeploymentsServiceClient Authentication Defaults
+/*! @page gameservices::GameServerDeploymentsServiceClient-service-account-snippet Override gameservices::GameServerDeploymentsServiceClient Authentication Defaults
 
 @snippet google/cloud/gameservices/samples/game_server_deployments_client_samples.cc with-service-account
 
 */
 
-/*! @page RealmsServiceClient-endpoint-snippet Override RealmsServiceClient Endpoint Configuration
+/*! @page gameservices::RealmsServiceClient-endpoint-snippet Override gameservices::RealmsServiceClient Endpoint Configuration
 
 @snippet google/cloud/gameservices/samples/realms_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page RealmsServiceClient-service-account-snippet Override RealmsServiceClient Authentication Defaults
+/*! @page gameservices::RealmsServiceClient-service-account-snippet Override gameservices::RealmsServiceClient Authentication Defaults
 
 @snippet google/cloud/gameservices/samples/realms_client_samples.cc with-service-account
 

--- a/google/cloud/gameservices/samples/game_server_clusters_client_samples.cc
+++ b/google/cloud/gameservices/samples/game_server_clusters_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: GameServerClustersServiceClient
+// main-dox-marker: gameservices::GameServerClustersServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/gameservices/samples/game_server_configs_client_samples.cc
+++ b/google/cloud/gameservices/samples/game_server_configs_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: GameServerConfigsServiceClient
+// main-dox-marker: gameservices::GameServerConfigsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/gameservices/samples/game_server_deployments_client_samples.cc
+++ b/google/cloud/gameservices/samples/game_server_deployments_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: GameServerDeploymentsServiceClient
+// main-dox-marker: gameservices::GameServerDeploymentsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/gameservices/samples/realms_client_samples.cc
+++ b/google/cloud/gameservices/samples/realms_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: RealmsServiceClient
+// main-dox-marker: gameservices::RealmsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/gkehub/doc/main.dox
+++ b/google/cloud/gkehub/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `GkeHubClient`:
+For example, this will override the default endpoint for `gkehub::GkeHubClient`:
 
 @snippet gke_hub_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page GkeHubClient-endpoint-snippet Override GkeHubClient Endpoint Configuration
+/*! @page gkehub::GkeHubClient-endpoint-snippet Override gkehub::GkeHubClient Endpoint Configuration
 
 @snippet google/cloud/gkehub/samples/gke_hub_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page GkeHubClient-service-account-snippet Override GkeHubClient Authentication Defaults
+/*! @page gkehub::GkeHubClient-service-account-snippet Override gkehub::GkeHubClient Authentication Defaults
 
 @snippet google/cloud/gkehub/samples/gke_hub_client_samples.cc with-service-account
 

--- a/google/cloud/gkehub/samples/gke_hub_client_samples.cc
+++ b/google/cloud/gkehub/samples/gke_hub_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: GkeHubClient
+// main-dox-marker: gkehub::GkeHubClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/iam/doc/main.dox
+++ b/google/cloud/iam/doc/main.dox
@@ -128,14 +128,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `IAMClient`:
+For example, this will override the default endpoint for `iam::IAMClient`:
 
 @snippet iam_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [IAMClient](@ref IAMClient-endpoint-snippet)
- [IAMCredentialsClient](@ref IAMCredentialsClient-endpoint-snippet)
- [IAMPolicyClient](@ref IAMPolicyClient-endpoint-snippet)
+ [iam::IAMClient](@ref iam::IAMClient-endpoint-snippet)
+ [iam::IAMCredentialsClient](@ref iam::IAMCredentialsClient-endpoint-snippet)
+ [iam::IAMPolicyClient](@ref iam::IAMPolicyClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -150,9 +150,9 @@ to explicitly load a service account key file.
 @snippet iam_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [IAMClient](@ref IAMClient-service-account-snippet)
- [IAMCredentialsClient](@ref IAMCredentialsClient-service-account-snippet)
- [IAMPolicyClient](@ref IAMPolicyClient-service-account-snippet)
+ [iam::IAMClient](@ref iam::IAMClient-service-account-snippet)
+ [iam::IAMCredentialsClient](@ref iam::IAMCredentialsClient-service-account-snippet)
+ [iam::IAMPolicyClient](@ref iam::IAMPolicyClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -184,37 +184,37 @@ guide for more details.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page IAMClient-endpoint-snippet Override IAMClient Endpoint Configuration
+/*! @page iam::IAMClient-endpoint-snippet Override iam::IAMClient Endpoint Configuration
 
 @snippet google/cloud/iam/samples/iam_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IAMClient-service-account-snippet Override IAMClient Authentication Defaults
+/*! @page iam::IAMClient-service-account-snippet Override iam::IAMClient Authentication Defaults
 
 @snippet google/cloud/iam/samples/iam_client_samples.cc with-service-account
 
 */
 
-/*! @page IAMCredentialsClient-endpoint-snippet Override IAMCredentialsClient Endpoint Configuration
+/*! @page iam::IAMCredentialsClient-endpoint-snippet Override iam::IAMCredentialsClient Endpoint Configuration
 
 @snippet google/cloud/iam/samples/iam_credentials_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IAMCredentialsClient-service-account-snippet Override IAMCredentialsClient Authentication Defaults
+/*! @page iam::IAMCredentialsClient-service-account-snippet Override iam::IAMCredentialsClient Authentication Defaults
 
 @snippet google/cloud/iam/samples/iam_credentials_client_samples.cc with-service-account
 
 */
 
-/*! @page IAMPolicyClient-endpoint-snippet Override IAMPolicyClient Endpoint Configuration
+/*! @page iam::IAMPolicyClient-endpoint-snippet Override iam::IAMPolicyClient Endpoint Configuration
 
 @snippet google/cloud/iam/samples/iam_policy_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IAMPolicyClient-service-account-snippet Override IAMPolicyClient Authentication Defaults
+/*! @page iam::IAMPolicyClient-service-account-snippet Override iam::IAMPolicyClient Authentication Defaults
 
 @snippet google/cloud/iam/samples/iam_policy_client_samples.cc with-service-account
 

--- a/google/cloud/iam/samples/iam_client_samples.cc
+++ b/google/cloud/iam/samples/iam_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IAMClient
+// main-dox-marker: iam::IAMClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/iam/samples/iam_credentials_client_samples.cc
+++ b/google/cloud/iam/samples/iam_credentials_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IAMCredentialsClient
+// main-dox-marker: iam::IAMCredentialsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/iam/samples/iam_policy_client_samples.cc
+++ b/google/cloud/iam/samples/iam_policy_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IAMPolicyClient
+// main-dox-marker: iam::IAMPolicyClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/iap/doc/main.dox
+++ b/google/cloud/iap/doc/main.dox
@@ -96,13 +96,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `IdentityAwareProxyAdminServiceClient`:
+For example, this will override the default endpoint for `iap::IdentityAwareProxyAdminServiceClient`:
 
 @snippet identity_aware_proxy_admin_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [IdentityAwareProxyAdminServiceClient](@ref IdentityAwareProxyAdminServiceClient-endpoint-snippet)
- [IdentityAwareProxyOAuthServiceClient](@ref IdentityAwareProxyOAuthServiceClient-endpoint-snippet)
+ [iap::IdentityAwareProxyAdminServiceClient](@ref iap::IdentityAwareProxyAdminServiceClient-endpoint-snippet)
+ [iap::IdentityAwareProxyOAuthServiceClient](@ref iap::IdentityAwareProxyOAuthServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -117,8 +117,8 @@ to explicitly load a service account key file.
 @snippet identity_aware_proxy_admin_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [IdentityAwareProxyAdminServiceClient](@ref IdentityAwareProxyAdminServiceClient-service-account-snippet)
- [IdentityAwareProxyOAuthServiceClient](@ref IdentityAwareProxyOAuthServiceClient-service-account-snippet)
+ [iap::IdentityAwareProxyAdminServiceClient](@ref iap::IdentityAwareProxyAdminServiceClient-service-account-snippet)
+ [iap::IdentityAwareProxyOAuthServiceClient](@ref iap::IdentityAwareProxyOAuthServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -149,25 +149,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page IdentityAwareProxyAdminServiceClient-endpoint-snippet Override IdentityAwareProxyAdminServiceClient Endpoint Configuration
+/*! @page iap::IdentityAwareProxyAdminServiceClient-endpoint-snippet Override iap::IdentityAwareProxyAdminServiceClient Endpoint Configuration
 
 @snippet google/cloud/iap/samples/identity_aware_proxy_admin_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IdentityAwareProxyAdminServiceClient-service-account-snippet Override IdentityAwareProxyAdminServiceClient Authentication Defaults
+/*! @page iap::IdentityAwareProxyAdminServiceClient-service-account-snippet Override iap::IdentityAwareProxyAdminServiceClient Authentication Defaults
 
 @snippet google/cloud/iap/samples/identity_aware_proxy_admin_client_samples.cc with-service-account
 
 */
 
-/*! @page IdentityAwareProxyOAuthServiceClient-endpoint-snippet Override IdentityAwareProxyOAuthServiceClient Endpoint Configuration
+/*! @page iap::IdentityAwareProxyOAuthServiceClient-endpoint-snippet Override iap::IdentityAwareProxyOAuthServiceClient Endpoint Configuration
 
 @snippet google/cloud/iap/samples/identity_aware_proxy_o_auth_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IdentityAwareProxyOAuthServiceClient-service-account-snippet Override IdentityAwareProxyOAuthServiceClient Authentication Defaults
+/*! @page iap::IdentityAwareProxyOAuthServiceClient-service-account-snippet Override iap::IdentityAwareProxyOAuthServiceClient Authentication Defaults
 
 @snippet google/cloud/iap/samples/identity_aware_proxy_o_auth_client_samples.cc with-service-account
 

--- a/google/cloud/iap/samples/identity_aware_proxy_admin_client_samples.cc
+++ b/google/cloud/iap/samples/identity_aware_proxy_admin_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IdentityAwareProxyAdminServiceClient
+// main-dox-marker: iap::IdentityAwareProxyAdminServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/iap/samples/identity_aware_proxy_o_auth_client_samples.cc
+++ b/google/cloud/iap/samples/identity_aware_proxy_o_auth_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IdentityAwareProxyOAuthServiceClient
+// main-dox-marker: iap::IdentityAwareProxyOAuthServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/ids/doc/main.dox
+++ b/google/cloud/ids/doc/main.dox
@@ -97,7 +97,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `IDSClient`:
+For example, this will override the default endpoint for `ids::IDSClient`:
 
 @snippet ids_client_samples.cc set-client-endpoint
 
@@ -142,13 +142,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page IDSClient-endpoint-snippet Override IDSClient Endpoint Configuration
+/*! @page ids::IDSClient-endpoint-snippet Override ids::IDSClient Endpoint Configuration
 
 @snippet google/cloud/ids/samples/ids_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IDSClient-service-account-snippet Override IDSClient Authentication Defaults
+/*! @page ids::IDSClient-service-account-snippet Override ids::IDSClient Authentication Defaults
 
 @snippet google/cloud/ids/samples/ids_client_samples.cc with-service-account
 

--- a/google/cloud/ids/samples/ids_client_samples.cc
+++ b/google/cloud/ids/samples/ids_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IDSClient
+// main-dox-marker: ids::IDSClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/iot/doc/main.dox
+++ b/google/cloud/iot/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `DeviceManagerClient`:
+For example, this will override the default endpoint for `iot::DeviceManagerClient`:
 
 @snippet device_manager_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page DeviceManagerClient-endpoint-snippet Override DeviceManagerClient Endpoint Configuration
+/*! @page iot::DeviceManagerClient-endpoint-snippet Override iot::DeviceManagerClient Endpoint Configuration
 
 @snippet google/cloud/iot/samples/device_manager_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DeviceManagerClient-service-account-snippet Override DeviceManagerClient Authentication Defaults
+/*! @page iot::DeviceManagerClient-service-account-snippet Override iot::DeviceManagerClient Authentication Defaults
 
 @snippet google/cloud/iot/samples/device_manager_client_samples.cc with-service-account
 

--- a/google/cloud/iot/samples/device_manager_client_samples.cc
+++ b/google/cloud/iot/samples/device_manager_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DeviceManagerClient
+// main-dox-marker: iot::DeviceManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -100,13 +100,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `EkmServiceClient`:
+For example, this will override the default endpoint for `kms::EkmServiceClient`:
 
 @snippet ekm_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [EkmServiceClient](@ref EkmServiceClient-endpoint-snippet)
- [KeyManagementServiceClient](@ref KeyManagementServiceClient-endpoint-snippet)
+ [kms::EkmServiceClient](@ref kms::EkmServiceClient-endpoint-snippet)
+ [kms::KeyManagementServiceClient](@ref kms::KeyManagementServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -121,8 +121,8 @@ to explicitly load a service account key file.
 @snippet ekm_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [EkmServiceClient](@ref EkmServiceClient-service-account-snippet)
- [KeyManagementServiceClient](@ref KeyManagementServiceClient-service-account-snippet)
+ [kms::EkmServiceClient](@ref kms::EkmServiceClient-service-account-snippet)
+ [kms::KeyManagementServiceClient](@ref kms::KeyManagementServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -152,25 +152,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page EkmServiceClient-endpoint-snippet Override EkmServiceClient Endpoint Configuration
+/*! @page kms::EkmServiceClient-endpoint-snippet Override kms::EkmServiceClient Endpoint Configuration
 
 @snippet google/cloud/kms/samples/ekm_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EkmServiceClient-service-account-snippet Override EkmServiceClient Authentication Defaults
+/*! @page kms::EkmServiceClient-service-account-snippet Override kms::EkmServiceClient Authentication Defaults
 
 @snippet google/cloud/kms/samples/ekm_client_samples.cc with-service-account
 
 */
 
-/*! @page KeyManagementServiceClient-endpoint-snippet Override KeyManagementServiceClient Endpoint Configuration
+/*! @page kms::KeyManagementServiceClient-endpoint-snippet Override kms::KeyManagementServiceClient Endpoint Configuration
 
 @snippet google/cloud/kms/samples/key_management_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page KeyManagementServiceClient-service-account-snippet Override KeyManagementServiceClient Authentication Defaults
+/*! @page kms::KeyManagementServiceClient-service-account-snippet Override kms::KeyManagementServiceClient Authentication Defaults
 
 @snippet google/cloud/kms/samples/key_management_client_samples.cc with-service-account
 

--- a/google/cloud/kms/samples/ekm_client_samples.cc
+++ b/google/cloud/kms/samples/ekm_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EkmServiceClient
+// main-dox-marker: kms::EkmServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/kms/samples/key_management_client_samples.cc
+++ b/google/cloud/kms/samples/key_management_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: KeyManagementServiceClient
+// main-dox-marker: kms::KeyManagementServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/language/doc/main.dox
+++ b/google/cloud/language/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `LanguageServiceClient`:
+For example, this will override the default endpoint for `language::LanguageServiceClient`:
 
 @snippet language_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page LanguageServiceClient-endpoint-snippet Override LanguageServiceClient Endpoint Configuration
+/*! @page language::LanguageServiceClient-endpoint-snippet Override language::LanguageServiceClient Endpoint Configuration
 
 @snippet google/cloud/language/samples/language_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page LanguageServiceClient-service-account-snippet Override LanguageServiceClient Authentication Defaults
+/*! @page language::LanguageServiceClient-service-account-snippet Override language::LanguageServiceClient Authentication Defaults
 
 @snippet google/cloud/language/samples/language_client_samples.cc with-service-account
 

--- a/google/cloud/language/samples/language_client_samples.cc
+++ b/google/cloud/language/samples/language_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: LanguageServiceClient
+// main-dox-marker: language::LanguageServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `LoggingServiceV2Client`:
+For example, this will override the default endpoint for `logging::LoggingServiceV2Client`:
 
 @snippet logging_service_v2_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page LoggingServiceV2Client-endpoint-snippet Override LoggingServiceV2Client Endpoint Configuration
+/*! @page logging::LoggingServiceV2Client-endpoint-snippet Override logging::LoggingServiceV2Client Endpoint Configuration
 
 @snippet google/cloud/logging/samples/logging_service_v2_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page LoggingServiceV2Client-service-account-snippet Override LoggingServiceV2Client Authentication Defaults
+/*! @page logging::LoggingServiceV2Client-service-account-snippet Override logging::LoggingServiceV2Client Authentication Defaults
 
 @snippet google/cloud/logging/samples/logging_service_v2_client_samples.cc with-service-account
 

--- a/google/cloud/logging/samples/logging_service_v2_client_samples.cc
+++ b/google/cloud/logging/samples/logging_service_v2_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: LoggingServiceV2Client
+// main-dox-marker: logging::LoggingServiceV2Client
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/managedidentities/doc/main.dox
+++ b/google/cloud/managedidentities/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ManagedIdentitiesServiceClient`:
+For example, this will override the default endpoint for `managedidentities::ManagedIdentitiesServiceClient`:
 
 @snippet managed_identities_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ManagedIdentitiesServiceClient-endpoint-snippet Override ManagedIdentitiesServiceClient Endpoint Configuration
+/*! @page managedidentities::ManagedIdentitiesServiceClient-endpoint-snippet Override managedidentities::ManagedIdentitiesServiceClient Endpoint Configuration
 
 @snippet google/cloud/managedidentities/samples/managed_identities_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ManagedIdentitiesServiceClient-service-account-snippet Override ManagedIdentitiesServiceClient Authentication Defaults
+/*! @page managedidentities::ManagedIdentitiesServiceClient-service-account-snippet Override managedidentities::ManagedIdentitiesServiceClient Authentication Defaults
 
 @snippet google/cloud/managedidentities/samples/managed_identities_client_samples.cc with-service-account
 

--- a/google/cloud/managedidentities/samples/managed_identities_client_samples.cc
+++ b/google/cloud/managedidentities/samples/managed_identities_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ManagedIdentitiesServiceClient
+// main-dox-marker: managedidentities::ManagedIdentitiesServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/memcache/doc/main.dox
+++ b/google/cloud/memcache/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudMemcacheClient`:
+For example, this will override the default endpoint for `memcache::CloudMemcacheClient`:
 
 @snippet cloud_memcache_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudMemcacheClient-endpoint-snippet Override CloudMemcacheClient Endpoint Configuration
+/*! @page memcache::CloudMemcacheClient-endpoint-snippet Override memcache::CloudMemcacheClient Endpoint Configuration
 
 @snippet google/cloud/memcache/samples/cloud_memcache_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudMemcacheClient-service-account-snippet Override CloudMemcacheClient Authentication Defaults
+/*! @page memcache::CloudMemcacheClient-service-account-snippet Override memcache::CloudMemcacheClient Authentication Defaults
 
 @snippet google/cloud/memcache/samples/cloud_memcache_client_samples.cc with-service-account
 

--- a/google/cloud/memcache/samples/cloud_memcache_client_samples.cc
+++ b/google/cloud/memcache/samples/cloud_memcache_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudMemcacheClient
+// main-dox-marker: memcache::CloudMemcacheClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -127,20 +127,20 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AlertPolicyServiceClient`:
+For example, this will override the default endpoint for `monitoring::AlertPolicyServiceClient`:
 
 @snippet alert_policy_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AlertPolicyServiceClient](@ref AlertPolicyServiceClient-endpoint-snippet)
- [DashboardsServiceClient](@ref DashboardsServiceClient-endpoint-snippet)
- [GroupServiceClient](@ref GroupServiceClient-endpoint-snippet)
- [MetricServiceClient](@ref MetricServiceClient-endpoint-snippet)
- [MetricsScopesClient](@ref MetricsScopesClient-endpoint-snippet)
- [NotificationChannelServiceClient](@ref NotificationChannelServiceClient-endpoint-snippet)
- [QueryServiceClient](@ref QueryServiceClient-endpoint-snippet)
- [ServiceMonitoringServiceClient](@ref ServiceMonitoringServiceClient-endpoint-snippet)
- [UptimeCheckServiceClient](@ref UptimeCheckServiceClient-endpoint-snippet)
+ [monitoring::AlertPolicyServiceClient](@ref monitoring::AlertPolicyServiceClient-endpoint-snippet)
+ [monitoring::DashboardsServiceClient](@ref monitoring::DashboardsServiceClient-endpoint-snippet)
+ [monitoring::GroupServiceClient](@ref monitoring::GroupServiceClient-endpoint-snippet)
+ [monitoring::MetricServiceClient](@ref monitoring::MetricServiceClient-endpoint-snippet)
+ [monitoring::MetricsScopesClient](@ref monitoring::MetricsScopesClient-endpoint-snippet)
+ [monitoring::NotificationChannelServiceClient](@ref monitoring::NotificationChannelServiceClient-endpoint-snippet)
+ [monitoring::QueryServiceClient](@ref monitoring::QueryServiceClient-endpoint-snippet)
+ [monitoring::ServiceMonitoringServiceClient](@ref monitoring::ServiceMonitoringServiceClient-endpoint-snippet)
+ [monitoring::UptimeCheckServiceClient](@ref monitoring::UptimeCheckServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -155,15 +155,15 @@ to explicitly load a service account key file.
 @snippet alert_policy_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AlertPolicyServiceClient](@ref AlertPolicyServiceClient-service-account-snippet)
- [DashboardsServiceClient](@ref DashboardsServiceClient-service-account-snippet)
- [GroupServiceClient](@ref GroupServiceClient-service-account-snippet)
- [MetricServiceClient](@ref MetricServiceClient-service-account-snippet)
- [MetricsScopesClient](@ref MetricsScopesClient-service-account-snippet)
- [NotificationChannelServiceClient](@ref NotificationChannelServiceClient-service-account-snippet)
- [QueryServiceClient](@ref QueryServiceClient-service-account-snippet)
- [ServiceMonitoringServiceClient](@ref ServiceMonitoringServiceClient-service-account-snippet)
- [UptimeCheckServiceClient](@ref UptimeCheckServiceClient-service-account-snippet)
+ [monitoring::AlertPolicyServiceClient](@ref monitoring::AlertPolicyServiceClient-service-account-snippet)
+ [monitoring::DashboardsServiceClient](@ref monitoring::DashboardsServiceClient-service-account-snippet)
+ [monitoring::GroupServiceClient](@ref monitoring::GroupServiceClient-service-account-snippet)
+ [monitoring::MetricServiceClient](@ref monitoring::MetricServiceClient-service-account-snippet)
+ [monitoring::MetricsScopesClient](@ref monitoring::MetricsScopesClient-service-account-snippet)
+ [monitoring::NotificationChannelServiceClient](@ref monitoring::NotificationChannelServiceClient-service-account-snippet)
+ [monitoring::QueryServiceClient](@ref monitoring::QueryServiceClient-service-account-snippet)
+ [monitoring::ServiceMonitoringServiceClient](@ref monitoring::ServiceMonitoringServiceClient-service-account-snippet)
+ [monitoring::UptimeCheckServiceClient](@ref monitoring::UptimeCheckServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -194,109 +194,109 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AlertPolicyServiceClient-endpoint-snippet Override AlertPolicyServiceClient Endpoint Configuration
+/*! @page monitoring::AlertPolicyServiceClient-endpoint-snippet Override monitoring::AlertPolicyServiceClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/alert_policy_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AlertPolicyServiceClient-service-account-snippet Override AlertPolicyServiceClient Authentication Defaults
+/*! @page monitoring::AlertPolicyServiceClient-service-account-snippet Override monitoring::AlertPolicyServiceClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/alert_policy_client_samples.cc with-service-account
 
 */
 
-/*! @page DashboardsServiceClient-endpoint-snippet Override DashboardsServiceClient Endpoint Configuration
+/*! @page monitoring::DashboardsServiceClient-endpoint-snippet Override monitoring::DashboardsServiceClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/dashboards_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page DashboardsServiceClient-service-account-snippet Override DashboardsServiceClient Authentication Defaults
+/*! @page monitoring::DashboardsServiceClient-service-account-snippet Override monitoring::DashboardsServiceClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/dashboards_client_samples.cc with-service-account
 
 */
 
-/*! @page GroupServiceClient-endpoint-snippet Override GroupServiceClient Endpoint Configuration
+/*! @page monitoring::GroupServiceClient-endpoint-snippet Override monitoring::GroupServiceClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/group_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page GroupServiceClient-service-account-snippet Override GroupServiceClient Authentication Defaults
+/*! @page monitoring::GroupServiceClient-service-account-snippet Override monitoring::GroupServiceClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/group_client_samples.cc with-service-account
 
 */
 
-/*! @page MetricServiceClient-endpoint-snippet Override MetricServiceClient Endpoint Configuration
+/*! @page monitoring::MetricServiceClient-endpoint-snippet Override monitoring::MetricServiceClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/metric_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page MetricServiceClient-service-account-snippet Override MetricServiceClient Authentication Defaults
+/*! @page monitoring::MetricServiceClient-service-account-snippet Override monitoring::MetricServiceClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/metric_client_samples.cc with-service-account
 
 */
 
-/*! @page MetricsScopesClient-endpoint-snippet Override MetricsScopesClient Endpoint Configuration
+/*! @page monitoring::MetricsScopesClient-endpoint-snippet Override monitoring::MetricsScopesClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/metrics_scopes_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page MetricsScopesClient-service-account-snippet Override MetricsScopesClient Authentication Defaults
+/*! @page monitoring::MetricsScopesClient-service-account-snippet Override monitoring::MetricsScopesClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/metrics_scopes_client_samples.cc with-service-account
 
 */
 
-/*! @page NotificationChannelServiceClient-endpoint-snippet Override NotificationChannelServiceClient Endpoint Configuration
+/*! @page monitoring::NotificationChannelServiceClient-endpoint-snippet Override monitoring::NotificationChannelServiceClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/notification_channel_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page NotificationChannelServiceClient-service-account-snippet Override NotificationChannelServiceClient Authentication Defaults
+/*! @page monitoring::NotificationChannelServiceClient-service-account-snippet Override monitoring::NotificationChannelServiceClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/notification_channel_client_samples.cc with-service-account
 
 */
 
-/*! @page QueryServiceClient-endpoint-snippet Override QueryServiceClient Endpoint Configuration
+/*! @page monitoring::QueryServiceClient-endpoint-snippet Override monitoring::QueryServiceClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/query_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page QueryServiceClient-service-account-snippet Override QueryServiceClient Authentication Defaults
+/*! @page monitoring::QueryServiceClient-service-account-snippet Override monitoring::QueryServiceClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/query_client_samples.cc with-service-account
 
 */
 
-/*! @page ServiceMonitoringServiceClient-endpoint-snippet Override ServiceMonitoringServiceClient Endpoint Configuration
+/*! @page monitoring::ServiceMonitoringServiceClient-endpoint-snippet Override monitoring::ServiceMonitoringServiceClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/service_monitoring_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ServiceMonitoringServiceClient-service-account-snippet Override ServiceMonitoringServiceClient Authentication Defaults
+/*! @page monitoring::ServiceMonitoringServiceClient-service-account-snippet Override monitoring::ServiceMonitoringServiceClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/service_monitoring_client_samples.cc with-service-account
 
 */
 
-/*! @page UptimeCheckServiceClient-endpoint-snippet Override UptimeCheckServiceClient Endpoint Configuration
+/*! @page monitoring::UptimeCheckServiceClient-endpoint-snippet Override monitoring::UptimeCheckServiceClient Endpoint Configuration
 
 @snippet google/cloud/monitoring/samples/uptime_check_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page UptimeCheckServiceClient-service-account-snippet Override UptimeCheckServiceClient Authentication Defaults
+/*! @page monitoring::UptimeCheckServiceClient-service-account-snippet Override monitoring::UptimeCheckServiceClient Authentication Defaults
 
 @snippet google/cloud/monitoring/samples/uptime_check_client_samples.cc with-service-account
 

--- a/google/cloud/monitoring/samples/alert_policy_client_samples.cc
+++ b/google/cloud/monitoring/samples/alert_policy_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AlertPolicyServiceClient
+// main-dox-marker: monitoring::AlertPolicyServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/samples/dashboards_client_samples.cc
+++ b/google/cloud/monitoring/samples/dashboards_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DashboardsServiceClient
+// main-dox-marker: monitoring::DashboardsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/samples/group_client_samples.cc
+++ b/google/cloud/monitoring/samples/group_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: GroupServiceClient
+// main-dox-marker: monitoring::GroupServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/samples/metric_client_samples.cc
+++ b/google/cloud/monitoring/samples/metric_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: MetricServiceClient
+// main-dox-marker: monitoring::MetricServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/samples/metrics_scopes_client_samples.cc
+++ b/google/cloud/monitoring/samples/metrics_scopes_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: MetricsScopesClient
+// main-dox-marker: monitoring::MetricsScopesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/samples/notification_channel_client_samples.cc
+++ b/google/cloud/monitoring/samples/notification_channel_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: NotificationChannelServiceClient
+// main-dox-marker: monitoring::NotificationChannelServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/samples/query_client_samples.cc
+++ b/google/cloud/monitoring/samples/query_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: QueryServiceClient
+// main-dox-marker: monitoring::QueryServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/samples/service_monitoring_client_samples.cc
+++ b/google/cloud/monitoring/samples/service_monitoring_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ServiceMonitoringServiceClient
+// main-dox-marker: monitoring::ServiceMonitoringServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/monitoring/samples/uptime_check_client_samples.cc
+++ b/google/cloud/monitoring/samples/uptime_check_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: UptimeCheckServiceClient
+// main-dox-marker: monitoring::UptimeCheckServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/networkconnectivity/doc/main.dox
+++ b/google/cloud/networkconnectivity/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `HubServiceClient`:
+For example, this will override the default endpoint for `networkconnectivity::HubServiceClient`:
 
 @snippet hub_client_samples.cc set-client-endpoint
 
@@ -140,13 +140,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page HubServiceClient-endpoint-snippet Override HubServiceClient Endpoint Configuration
+/*! @page networkconnectivity::HubServiceClient-endpoint-snippet Override networkconnectivity::HubServiceClient Endpoint Configuration
 
 @snippet google/cloud/networkconnectivity/samples/hub_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page HubServiceClient-service-account-snippet Override HubServiceClient Authentication Defaults
+/*! @page networkconnectivity::HubServiceClient-service-account-snippet Override networkconnectivity::HubServiceClient Authentication Defaults
 
 @snippet google/cloud/networkconnectivity/samples/hub_client_samples.cc with-service-account
 

--- a/google/cloud/networkconnectivity/samples/hub_client_samples.cc
+++ b/google/cloud/networkconnectivity/samples/hub_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: HubServiceClient
+// main-dox-marker: networkconnectivity::HubServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/networkmanagement/doc/main.dox
+++ b/google/cloud/networkmanagement/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ReachabilityServiceClient`:
+For example, this will override the default endpoint for `networkmanagement::ReachabilityServiceClient`:
 
 @snippet reachability_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ReachabilityServiceClient-endpoint-snippet Override ReachabilityServiceClient Endpoint Configuration
+/*! @page networkmanagement::ReachabilityServiceClient-endpoint-snippet Override networkmanagement::ReachabilityServiceClient Endpoint Configuration
 
 @snippet google/cloud/networkmanagement/samples/reachability_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ReachabilityServiceClient-service-account-snippet Override ReachabilityServiceClient Authentication Defaults
+/*! @page networkmanagement::ReachabilityServiceClient-service-account-snippet Override networkmanagement::ReachabilityServiceClient Authentication Defaults
 
 @snippet google/cloud/networkmanagement/samples/reachability_client_samples.cc with-service-account
 

--- a/google/cloud/networkmanagement/samples/reachability_client_samples.cc
+++ b/google/cloud/networkmanagement/samples/reachability_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ReachabilityServiceClient
+// main-dox-marker: networkmanagement::ReachabilityServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -97,13 +97,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ManagedNotebookServiceClient`:
+For example, this will override the default endpoint for `notebooks::ManagedNotebookServiceClient`:
 
 @snippet managed_notebook_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [ManagedNotebookServiceClient](@ref ManagedNotebookServiceClient-endpoint-snippet)
- [NotebookServiceClient](@ref NotebookServiceClient-endpoint-snippet)
+ [notebooks::ManagedNotebookServiceClient](@ref notebooks::ManagedNotebookServiceClient-endpoint-snippet)
+ [notebooks::NotebookServiceClient](@ref notebooks::NotebookServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -118,8 +118,8 @@ to explicitly load a service account key file.
 @snippet managed_notebook_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [ManagedNotebookServiceClient](@ref ManagedNotebookServiceClient-service-account-snippet)
- [NotebookServiceClient](@ref NotebookServiceClient-service-account-snippet)
+ [notebooks::ManagedNotebookServiceClient](@ref notebooks::ManagedNotebookServiceClient-service-account-snippet)
+ [notebooks::NotebookServiceClient](@ref notebooks::NotebookServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -151,25 +151,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ManagedNotebookServiceClient-endpoint-snippet Override ManagedNotebookServiceClient Endpoint Configuration
+/*! @page notebooks::ManagedNotebookServiceClient-endpoint-snippet Override notebooks::ManagedNotebookServiceClient Endpoint Configuration
 
 @snippet google/cloud/notebooks/samples/managed_notebook_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ManagedNotebookServiceClient-service-account-snippet Override ManagedNotebookServiceClient Authentication Defaults
+/*! @page notebooks::ManagedNotebookServiceClient-service-account-snippet Override notebooks::ManagedNotebookServiceClient Authentication Defaults
 
 @snippet google/cloud/notebooks/samples/managed_notebook_client_samples.cc with-service-account
 
 */
 
-/*! @page NotebookServiceClient-endpoint-snippet Override NotebookServiceClient Endpoint Configuration
+/*! @page notebooks::NotebookServiceClient-endpoint-snippet Override notebooks::NotebookServiceClient Endpoint Configuration
 
 @snippet google/cloud/notebooks/samples/notebook_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page NotebookServiceClient-service-account-snippet Override NotebookServiceClient Authentication Defaults
+/*! @page notebooks::NotebookServiceClient-service-account-snippet Override notebooks::NotebookServiceClient Authentication Defaults
 
 @snippet google/cloud/notebooks/samples/notebook_client_samples.cc with-service-account
 

--- a/google/cloud/notebooks/samples/managed_notebook_client_samples.cc
+++ b/google/cloud/notebooks/samples/managed_notebook_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ManagedNotebookServiceClient
+// main-dox-marker: notebooks::ManagedNotebookServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/notebooks/samples/notebook_client_samples.cc
+++ b/google/cloud/notebooks/samples/notebook_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: NotebookServiceClient
+// main-dox-marker: notebooks::NotebookServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/optimization/doc/main.dox
+++ b/google/cloud/optimization/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `FleetRoutingClient`:
+For example, this will override the default endpoint for `optimization::FleetRoutingClient`:
 
 @snippet fleet_routing_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page FleetRoutingClient-endpoint-snippet Override FleetRoutingClient Endpoint Configuration
+/*! @page optimization::FleetRoutingClient-endpoint-snippet Override optimization::FleetRoutingClient Endpoint Configuration
 
 @snippet google/cloud/optimization/samples/fleet_routing_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page FleetRoutingClient-service-account-snippet Override FleetRoutingClient Authentication Defaults
+/*! @page optimization::FleetRoutingClient-service-account-snippet Override optimization::FleetRoutingClient Authentication Defaults
 
 @snippet google/cloud/optimization/samples/fleet_routing_client_samples.cc with-service-account
 

--- a/google/cloud/optimization/samples/fleet_routing_client_samples.cc
+++ b/google/cloud/optimization/samples/fleet_routing_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: FleetRoutingClient
+// main-dox-marker: optimization::FleetRoutingClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/orgpolicy/doc/main.dox
+++ b/google/cloud/orgpolicy/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `OrgPolicyClient`:
+For example, this will override the default endpoint for `orgpolicy::OrgPolicyClient`:
 
 @snippet org_policy_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page OrgPolicyClient-endpoint-snippet Override OrgPolicyClient Endpoint Configuration
+/*! @page orgpolicy::OrgPolicyClient-endpoint-snippet Override orgpolicy::OrgPolicyClient Endpoint Configuration
 
 @snippet google/cloud/orgpolicy/samples/org_policy_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page OrgPolicyClient-service-account-snippet Override OrgPolicyClient Authentication Defaults
+/*! @page orgpolicy::OrgPolicyClient-service-account-snippet Override orgpolicy::OrgPolicyClient Authentication Defaults
 
 @snippet google/cloud/orgpolicy/samples/org_policy_client_samples.cc with-service-account
 

--- a/google/cloud/orgpolicy/samples/org_policy_client_samples.cc
+++ b/google/cloud/orgpolicy/samples/org_policy_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: OrgPolicyClient
+// main-dox-marker: orgpolicy::OrgPolicyClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -97,13 +97,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AgentEndpointServiceClient`:
+For example, this will override the default endpoint for `osconfig::AgentEndpointServiceClient`:
 
 @snippet agent_endpoint_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AgentEndpointServiceClient](@ref AgentEndpointServiceClient-endpoint-snippet)
- [OsConfigServiceClient](@ref OsConfigServiceClient-endpoint-snippet)
+ [osconfig::AgentEndpointServiceClient](@ref osconfig::AgentEndpointServiceClient-endpoint-snippet)
+ [osconfig::OsConfigServiceClient](@ref osconfig::OsConfigServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -118,8 +118,8 @@ to explicitly load a service account key file.
 @snippet agent_endpoint_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AgentEndpointServiceClient](@ref AgentEndpointServiceClient-service-account-snippet)
- [OsConfigServiceClient](@ref OsConfigServiceClient-service-account-snippet)
+ [osconfig::AgentEndpointServiceClient](@ref osconfig::AgentEndpointServiceClient-service-account-snippet)
+ [osconfig::OsConfigServiceClient](@ref osconfig::OsConfigServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -150,25 +150,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AgentEndpointServiceClient-endpoint-snippet Override AgentEndpointServiceClient Endpoint Configuration
+/*! @page osconfig::AgentEndpointServiceClient-endpoint-snippet Override osconfig::AgentEndpointServiceClient Endpoint Configuration
 
 @snippet google/cloud/osconfig/samples/agent_endpoint_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AgentEndpointServiceClient-service-account-snippet Override AgentEndpointServiceClient Authentication Defaults
+/*! @page osconfig::AgentEndpointServiceClient-service-account-snippet Override osconfig::AgentEndpointServiceClient Authentication Defaults
 
 @snippet google/cloud/osconfig/samples/agent_endpoint_client_samples.cc with-service-account
 
 */
 
-/*! @page OsConfigServiceClient-endpoint-snippet Override OsConfigServiceClient Endpoint Configuration
+/*! @page osconfig::OsConfigServiceClient-endpoint-snippet Override osconfig::OsConfigServiceClient Endpoint Configuration
 
 @snippet google/cloud/osconfig/samples/os_config_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page OsConfigServiceClient-service-account-snippet Override OsConfigServiceClient Authentication Defaults
+/*! @page osconfig::OsConfigServiceClient-service-account-snippet Override osconfig::OsConfigServiceClient Authentication Defaults
 
 @snippet google/cloud/osconfig/samples/os_config_client_samples.cc with-service-account
 

--- a/google/cloud/osconfig/samples/agent_endpoint_client_samples.cc
+++ b/google/cloud/osconfig/samples/agent_endpoint_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AgentEndpointServiceClient
+// main-dox-marker: osconfig::AgentEndpointServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/osconfig/samples/os_config_client_samples.cc
+++ b/google/cloud/osconfig/samples/os_config_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: OsConfigServiceClient
+// main-dox-marker: osconfig::OsConfigServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/oslogin/doc/main.dox
+++ b/google/cloud/oslogin/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `OsLoginServiceClient`:
+For example, this will override the default endpoint for `oslogin::OsLoginServiceClient`:
 
 @snippet os_login_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page OsLoginServiceClient-endpoint-snippet Override OsLoginServiceClient Endpoint Configuration
+/*! @page oslogin::OsLoginServiceClient-endpoint-snippet Override oslogin::OsLoginServiceClient Endpoint Configuration
 
 @snippet google/cloud/oslogin/samples/os_login_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page OsLoginServiceClient-service-account-snippet Override OsLoginServiceClient Authentication Defaults
+/*! @page oslogin::OsLoginServiceClient-service-account-snippet Override oslogin::OsLoginServiceClient Authentication Defaults
 
 @snippet google/cloud/oslogin/samples/os_login_client_samples.cc with-service-account
 

--- a/google/cloud/oslogin/samples/os_login_client_samples.cc
+++ b/google/cloud/oslogin/samples/os_login_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: OsLoginServiceClient
+// main-dox-marker: oslogin::OsLoginServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/policytroubleshooter/doc/main.dox
+++ b/google/cloud/policytroubleshooter/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `IamCheckerClient`:
+For example, this will override the default endpoint for `policytroubleshooter::IamCheckerClient`:
 
 @snippet iam_checker_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page IamCheckerClient-endpoint-snippet Override IamCheckerClient Endpoint Configuration
+/*! @page policytroubleshooter::IamCheckerClient-endpoint-snippet Override policytroubleshooter::IamCheckerClient Endpoint Configuration
 
 @snippet google/cloud/policytroubleshooter/samples/iam_checker_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page IamCheckerClient-service-account-snippet Override IamCheckerClient Authentication Defaults
+/*! @page policytroubleshooter::IamCheckerClient-service-account-snippet Override policytroubleshooter::IamCheckerClient Authentication Defaults
 
 @snippet google/cloud/policytroubleshooter/samples/iam_checker_client_samples.cc with-service-account
 

--- a/google/cloud/policytroubleshooter/samples/iam_checker_client_samples.cc
+++ b/google/cloud/policytroubleshooter/samples/iam_checker_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: IamCheckerClient
+// main-dox-marker: policytroubleshooter::IamCheckerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/privateca/doc/main.dox
+++ b/google/cloud/privateca/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CertificateAuthorityServiceClient`:
+For example, this will override the default endpoint for `privateca::CertificateAuthorityServiceClient`:
 
 @snippet certificate_authority_client_samples.cc set-client-endpoint
 
@@ -140,13 +140,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CertificateAuthorityServiceClient-endpoint-snippet Override CertificateAuthorityServiceClient Endpoint Configuration
+/*! @page privateca::CertificateAuthorityServiceClient-endpoint-snippet Override privateca::CertificateAuthorityServiceClient Endpoint Configuration
 
 @snippet google/cloud/privateca/samples/certificate_authority_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CertificateAuthorityServiceClient-service-account-snippet Override CertificateAuthorityServiceClient Authentication Defaults
+/*! @page privateca::CertificateAuthorityServiceClient-service-account-snippet Override privateca::CertificateAuthorityServiceClient Authentication Defaults
 
 @snippet google/cloud/privateca/samples/certificate_authority_client_samples.cc with-service-account
 

--- a/google/cloud/privateca/samples/certificate_authority_client_samples.cc
+++ b/google/cloud/privateca/samples/certificate_authority_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CertificateAuthorityServiceClient
+// main-dox-marker: privateca::CertificateAuthorityServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/profiler/doc/main.dox
+++ b/google/cloud/profiler/doc/main.dox
@@ -100,7 +100,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ProfilerServiceClient`:
+For example, this will override the default endpoint for `profiler::ProfilerServiceClient`:
 
 @snippet profiler_client_samples.cc set-client-endpoint
 
@@ -145,13 +145,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ProfilerServiceClient-endpoint-snippet Override ProfilerServiceClient Endpoint Configuration
+/*! @page profiler::ProfilerServiceClient-endpoint-snippet Override profiler::ProfilerServiceClient Endpoint Configuration
 
 @snippet google/cloud/profiler/samples/profiler_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ProfilerServiceClient-service-account-snippet Override ProfilerServiceClient Authentication Defaults
+/*! @page profiler::ProfilerServiceClient-service-account-snippet Override profiler::ProfilerServiceClient Authentication Defaults
 
 @snippet google/cloud/profiler/samples/profiler_client_samples.cc with-service-account
 

--- a/google/cloud/profiler/samples/profiler_client_samples.cc
+++ b/google/cloud/profiler/samples/profiler_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ProfilerServiceClient
+// main-dox-marker: profiler::ProfilerServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -99,13 +99,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `AdminServiceClient`:
+For example, this will override the default endpoint for `pubsublite::AdminServiceClient`:
 
 @snippet admin_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [AdminServiceClient](@ref AdminServiceClient-endpoint-snippet)
- [TopicStatsServiceClient](@ref TopicStatsServiceClient-endpoint-snippet)
+ [pubsublite::AdminServiceClient](@ref pubsublite::AdminServiceClient-endpoint-snippet)
+ [pubsublite::TopicStatsServiceClient](@ref pubsublite::TopicStatsServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -120,8 +120,8 @@ to explicitly load a service account key file.
 @snippet admin_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [AdminServiceClient](@ref AdminServiceClient-service-account-snippet)
- [TopicStatsServiceClient](@ref TopicStatsServiceClient-service-account-snippet)
+ [pubsublite::AdminServiceClient](@ref pubsublite::AdminServiceClient-service-account-snippet)
+ [pubsublite::TopicStatsServiceClient](@ref pubsublite::TopicStatsServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -151,25 +151,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page AdminServiceClient-endpoint-snippet Override AdminServiceClient Endpoint Configuration
+/*! @page pubsublite::AdminServiceClient-endpoint-snippet Override pubsublite::AdminServiceClient Endpoint Configuration
 
 @snippet google/cloud/pubsublite/samples/admin_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page AdminServiceClient-service-account-snippet Override AdminServiceClient Authentication Defaults
+/*! @page pubsublite::AdminServiceClient-service-account-snippet Override pubsublite::AdminServiceClient Authentication Defaults
 
 @snippet google/cloud/pubsublite/samples/admin_client_samples.cc with-service-account
 
 */
 
-/*! @page TopicStatsServiceClient-endpoint-snippet Override TopicStatsServiceClient Endpoint Configuration
+/*! @page pubsublite::TopicStatsServiceClient-endpoint-snippet Override pubsublite::TopicStatsServiceClient Endpoint Configuration
 
 @snippet google/cloud/pubsublite/samples/topic_stats_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TopicStatsServiceClient-service-account-snippet Override TopicStatsServiceClient Authentication Defaults
+/*! @page pubsublite::TopicStatsServiceClient-service-account-snippet Override pubsublite::TopicStatsServiceClient Authentication Defaults
 
 @snippet google/cloud/pubsublite/samples/topic_stats_client_samples.cc with-service-account
 

--- a/google/cloud/pubsublite/samples/admin_client_samples.cc
+++ b/google/cloud/pubsublite/samples/admin_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: AdminServiceClient
+// main-dox-marker: pubsublite::AdminServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/pubsublite/samples/topic_stats_client_samples.cc
+++ b/google/cloud/pubsublite/samples/topic_stats_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TopicStatsServiceClient
+// main-dox-marker: pubsublite::TopicStatsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/recommender/doc/main.dox
+++ b/google/cloud/recommender/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `RecommenderClient`:
+For example, this will override the default endpoint for `recommender::RecommenderClient`:
 
 @snippet recommender_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page RecommenderClient-endpoint-snippet Override RecommenderClient Endpoint Configuration
+/*! @page recommender::RecommenderClient-endpoint-snippet Override recommender::RecommenderClient Endpoint Configuration
 
 @snippet google/cloud/recommender/samples/recommender_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page RecommenderClient-service-account-snippet Override RecommenderClient Authentication Defaults
+/*! @page recommender::RecommenderClient-service-account-snippet Override recommender::RecommenderClient Authentication Defaults
 
 @snippet google/cloud/recommender/samples/recommender_client_samples.cc with-service-account
 

--- a/google/cloud/recommender/samples/recommender_client_samples.cc
+++ b/google/cloud/recommender/samples/recommender_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: RecommenderClient
+// main-dox-marker: recommender::RecommenderClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/redis/doc/main.dox
+++ b/google/cloud/redis/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudRedisClient`:
+For example, this will override the default endpoint for `redis::CloudRedisClient`:
 
 @snippet cloud_redis_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudRedisClient-endpoint-snippet Override CloudRedisClient Endpoint Configuration
+/*! @page redis::CloudRedisClient-endpoint-snippet Override redis::CloudRedisClient Endpoint Configuration
 
 @snippet google/cloud/redis/samples/cloud_redis_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudRedisClient-service-account-snippet Override CloudRedisClient Authentication Defaults
+/*! @page redis::CloudRedisClient-service-account-snippet Override redis::CloudRedisClient Authentication Defaults
 
 @snippet google/cloud/redis/samples/cloud_redis_client_samples.cc with-service-account
 

--- a/google/cloud/redis/samples/cloud_redis_client_samples.cc
+++ b/google/cloud/redis/samples/cloud_redis_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudRedisClient
+// main-dox-marker: redis::CloudRedisClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -101,14 +101,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `FoldersClient`:
+For example, this will override the default endpoint for `resourcemanager::FoldersClient`:
 
 @snippet folders_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [FoldersClient](@ref FoldersClient-endpoint-snippet)
- [OrganizationsClient](@ref OrganizationsClient-endpoint-snippet)
- [ProjectsClient](@ref ProjectsClient-endpoint-snippet)
+ [resourcemanager::FoldersClient](@ref resourcemanager::FoldersClient-endpoint-snippet)
+ [resourcemanager::OrganizationsClient](@ref resourcemanager::OrganizationsClient-endpoint-snippet)
+ [resourcemanager::ProjectsClient](@ref resourcemanager::ProjectsClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -123,9 +123,9 @@ to explicitly load a service account key file.
 @snippet folders_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [FoldersClient](@ref FoldersClient-service-account-snippet)
- [OrganizationsClient](@ref OrganizationsClient-service-account-snippet)
- [ProjectsClient](@ref ProjectsClient-service-account-snippet)
+ [resourcemanager::FoldersClient](@ref resourcemanager::FoldersClient-service-account-snippet)
+ [resourcemanager::OrganizationsClient](@ref resourcemanager::OrganizationsClient-service-account-snippet)
+ [resourcemanager::ProjectsClient](@ref resourcemanager::ProjectsClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -156,37 +156,37 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page FoldersClient-endpoint-snippet Override FoldersClient Endpoint Configuration
+/*! @page resourcemanager::FoldersClient-endpoint-snippet Override resourcemanager::FoldersClient Endpoint Configuration
 
 @snippet google/cloud/resourcemanager/samples/folders_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page FoldersClient-service-account-snippet Override FoldersClient Authentication Defaults
+/*! @page resourcemanager::FoldersClient-service-account-snippet Override resourcemanager::FoldersClient Authentication Defaults
 
 @snippet google/cloud/resourcemanager/samples/folders_client_samples.cc with-service-account
 
 */
 
-/*! @page OrganizationsClient-endpoint-snippet Override OrganizationsClient Endpoint Configuration
+/*! @page resourcemanager::OrganizationsClient-endpoint-snippet Override resourcemanager::OrganizationsClient Endpoint Configuration
 
 @snippet google/cloud/resourcemanager/samples/organizations_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page OrganizationsClient-service-account-snippet Override OrganizationsClient Authentication Defaults
+/*! @page resourcemanager::OrganizationsClient-service-account-snippet Override resourcemanager::OrganizationsClient Authentication Defaults
 
 @snippet google/cloud/resourcemanager/samples/organizations_client_samples.cc with-service-account
 
 */
 
-/*! @page ProjectsClient-endpoint-snippet Override ProjectsClient Endpoint Configuration
+/*! @page resourcemanager::ProjectsClient-endpoint-snippet Override resourcemanager::ProjectsClient Endpoint Configuration
 
 @snippet google/cloud/resourcemanager/samples/projects_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ProjectsClient-service-account-snippet Override ProjectsClient Authentication Defaults
+/*! @page resourcemanager::ProjectsClient-service-account-snippet Override resourcemanager::ProjectsClient Authentication Defaults
 
 @snippet google/cloud/resourcemanager/samples/projects_client_samples.cc with-service-account
 

--- a/google/cloud/resourcemanager/samples/folders_client_samples.cc
+++ b/google/cloud/resourcemanager/samples/folders_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: FoldersClient
+// main-dox-marker: resourcemanager::FoldersClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/resourcemanager/samples/organizations_client_samples.cc
+++ b/google/cloud/resourcemanager/samples/organizations_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: OrganizationsClient
+// main-dox-marker: resourcemanager::OrganizationsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/resourcemanager/samples/projects_client_samples.cc
+++ b/google/cloud/resourcemanager/samples/projects_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ProjectsClient
+// main-dox-marker: resourcemanager::ProjectsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/resourcesettings/doc/main.dox
+++ b/google/cloud/resourcesettings/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ResourceSettingsServiceClient`:
+For example, this will override the default endpoint for `resourcesettings::ResourceSettingsServiceClient`:
 
 @snippet resource_settings_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ResourceSettingsServiceClient-endpoint-snippet Override ResourceSettingsServiceClient Endpoint Configuration
+/*! @page resourcesettings::ResourceSettingsServiceClient-endpoint-snippet Override resourcesettings::ResourceSettingsServiceClient Endpoint Configuration
 
 @snippet google/cloud/resourcesettings/samples/resource_settings_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ResourceSettingsServiceClient-service-account-snippet Override ResourceSettingsServiceClient Authentication Defaults
+/*! @page resourcesettings::ResourceSettingsServiceClient-service-account-snippet Override resourcesettings::ResourceSettingsServiceClient Authentication Defaults
 
 @snippet google/cloud/resourcesettings/samples/resource_settings_client_samples.cc with-service-account
 

--- a/google/cloud/resourcesettings/samples/resource_settings_client_samples.cc
+++ b/google/cloud/resourcesettings/samples/resource_settings_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ResourceSettingsServiceClient
+// main-dox-marker: resourcesettings::ResourceSettingsServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -114,17 +114,17 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CatalogServiceClient`:
+For example, this will override the default endpoint for `retail::CatalogServiceClient`:
 
 @snippet catalog_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [CatalogServiceClient](@ref CatalogServiceClient-endpoint-snippet)
- [CompletionServiceClient](@ref CompletionServiceClient-endpoint-snippet)
- [PredictionServiceClient](@ref PredictionServiceClient-endpoint-snippet)
- [ProductServiceClient](@ref ProductServiceClient-endpoint-snippet)
- [SearchServiceClient](@ref SearchServiceClient-endpoint-snippet)
- [UserEventServiceClient](@ref UserEventServiceClient-endpoint-snippet)
+ [retail::CatalogServiceClient](@ref retail::CatalogServiceClient-endpoint-snippet)
+ [retail::CompletionServiceClient](@ref retail::CompletionServiceClient-endpoint-snippet)
+ [retail::PredictionServiceClient](@ref retail::PredictionServiceClient-endpoint-snippet)
+ [retail::ProductServiceClient](@ref retail::ProductServiceClient-endpoint-snippet)
+ [retail::SearchServiceClient](@ref retail::SearchServiceClient-endpoint-snippet)
+ [retail::UserEventServiceClient](@ref retail::UserEventServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -139,12 +139,12 @@ to explicitly load a service account key file.
 @snippet catalog_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [CatalogServiceClient](@ref CatalogServiceClient-service-account-snippet)
- [CompletionServiceClient](@ref CompletionServiceClient-service-account-snippet)
- [PredictionServiceClient](@ref PredictionServiceClient-service-account-snippet)
- [ProductServiceClient](@ref ProductServiceClient-service-account-snippet)
- [SearchServiceClient](@ref SearchServiceClient-service-account-snippet)
- [UserEventServiceClient](@ref UserEventServiceClient-service-account-snippet)
+ [retail::CatalogServiceClient](@ref retail::CatalogServiceClient-service-account-snippet)
+ [retail::CompletionServiceClient](@ref retail::CompletionServiceClient-service-account-snippet)
+ [retail::PredictionServiceClient](@ref retail::PredictionServiceClient-service-account-snippet)
+ [retail::ProductServiceClient](@ref retail::ProductServiceClient-service-account-snippet)
+ [retail::SearchServiceClient](@ref retail::SearchServiceClient-service-account-snippet)
+ [retail::UserEventServiceClient](@ref retail::UserEventServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -175,73 +175,73 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CatalogServiceClient-endpoint-snippet Override CatalogServiceClient Endpoint Configuration
+/*! @page retail::CatalogServiceClient-endpoint-snippet Override retail::CatalogServiceClient Endpoint Configuration
 
 @snippet google/cloud/retail/samples/catalog_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CatalogServiceClient-service-account-snippet Override CatalogServiceClient Authentication Defaults
+/*! @page retail::CatalogServiceClient-service-account-snippet Override retail::CatalogServiceClient Authentication Defaults
 
 @snippet google/cloud/retail/samples/catalog_client_samples.cc with-service-account
 
 */
 
-/*! @page CompletionServiceClient-endpoint-snippet Override CompletionServiceClient Endpoint Configuration
+/*! @page retail::CompletionServiceClient-endpoint-snippet Override retail::CompletionServiceClient Endpoint Configuration
 
 @snippet google/cloud/retail/samples/completion_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CompletionServiceClient-service-account-snippet Override CompletionServiceClient Authentication Defaults
+/*! @page retail::CompletionServiceClient-service-account-snippet Override retail::CompletionServiceClient Authentication Defaults
 
 @snippet google/cloud/retail/samples/completion_client_samples.cc with-service-account
 
 */
 
-/*! @page PredictionServiceClient-endpoint-snippet Override PredictionServiceClient Endpoint Configuration
+/*! @page retail::PredictionServiceClient-endpoint-snippet Override retail::PredictionServiceClient Endpoint Configuration
 
 @snippet google/cloud/retail/samples/prediction_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page PredictionServiceClient-service-account-snippet Override PredictionServiceClient Authentication Defaults
+/*! @page retail::PredictionServiceClient-service-account-snippet Override retail::PredictionServiceClient Authentication Defaults
 
 @snippet google/cloud/retail/samples/prediction_client_samples.cc with-service-account
 
 */
 
-/*! @page ProductServiceClient-endpoint-snippet Override ProductServiceClient Endpoint Configuration
+/*! @page retail::ProductServiceClient-endpoint-snippet Override retail::ProductServiceClient Endpoint Configuration
 
 @snippet google/cloud/retail/samples/product_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ProductServiceClient-service-account-snippet Override ProductServiceClient Authentication Defaults
+/*! @page retail::ProductServiceClient-service-account-snippet Override retail::ProductServiceClient Authentication Defaults
 
 @snippet google/cloud/retail/samples/product_client_samples.cc with-service-account
 
 */
 
-/*! @page SearchServiceClient-endpoint-snippet Override SearchServiceClient Endpoint Configuration
+/*! @page retail::SearchServiceClient-endpoint-snippet Override retail::SearchServiceClient Endpoint Configuration
 
 @snippet google/cloud/retail/samples/search_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SearchServiceClient-service-account-snippet Override SearchServiceClient Authentication Defaults
+/*! @page retail::SearchServiceClient-service-account-snippet Override retail::SearchServiceClient Authentication Defaults
 
 @snippet google/cloud/retail/samples/search_client_samples.cc with-service-account
 
 */
 
-/*! @page UserEventServiceClient-endpoint-snippet Override UserEventServiceClient Endpoint Configuration
+/*! @page retail::UserEventServiceClient-endpoint-snippet Override retail::UserEventServiceClient Endpoint Configuration
 
 @snippet google/cloud/retail/samples/user_event_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page UserEventServiceClient-service-account-snippet Override UserEventServiceClient Authentication Defaults
+/*! @page retail::UserEventServiceClient-service-account-snippet Override retail::UserEventServiceClient Authentication Defaults
 
 @snippet google/cloud/retail/samples/user_event_client_samples.cc with-service-account
 

--- a/google/cloud/retail/samples/catalog_client_samples.cc
+++ b/google/cloud/retail/samples/catalog_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CatalogServiceClient
+// main-dox-marker: retail::CatalogServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/retail/samples/completion_client_samples.cc
+++ b/google/cloud/retail/samples/completion_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CompletionServiceClient
+// main-dox-marker: retail::CompletionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/retail/samples/prediction_client_samples.cc
+++ b/google/cloud/retail/samples/prediction_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: PredictionServiceClient
+// main-dox-marker: retail::PredictionServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/retail/samples/product_client_samples.cc
+++ b/google/cloud/retail/samples/product_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ProductServiceClient
+// main-dox-marker: retail::ProductServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/retail/samples/search_client_samples.cc
+++ b/google/cloud/retail/samples/search_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SearchServiceClient
+// main-dox-marker: retail::SearchServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/retail/samples/user_event_client_samples.cc
+++ b/google/cloud/retail/samples/user_event_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: UserEventServiceClient
+// main-dox-marker: retail::UserEventServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/run/doc/main.dox
+++ b/google/cloud/run/doc/main.dox
@@ -105,13 +105,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `RevisionsClient`:
+For example, this will override the default endpoint for `run::RevisionsClient`:
 
 @snippet revisions_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [RevisionsClient](@ref RevisionsClient-endpoint-snippet)
- [ServicesClient](@ref ServicesClient-endpoint-snippet)
+ [run::RevisionsClient](@ref run::RevisionsClient-endpoint-snippet)
+ [run::ServicesClient](@ref run::ServicesClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -126,8 +126,8 @@ to explicitly load a service account key file.
 @snippet revisions_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [RevisionsClient](@ref RevisionsClient-service-account-snippet)
- [ServicesClient](@ref ServicesClient-service-account-snippet)
+ [run::RevisionsClient](@ref run::RevisionsClient-service-account-snippet)
+ [run::ServicesClient](@ref run::ServicesClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -158,25 +158,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page RevisionsClient-endpoint-snippet Override RevisionsClient Endpoint Configuration
+/*! @page run::RevisionsClient-endpoint-snippet Override run::RevisionsClient Endpoint Configuration
 
 @snippet google/cloud/run/samples/revisions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page RevisionsClient-service-account-snippet Override RevisionsClient Authentication Defaults
+/*! @page run::RevisionsClient-service-account-snippet Override run::RevisionsClient Authentication Defaults
 
 @snippet google/cloud/run/samples/revisions_client_samples.cc with-service-account
 
 */
 
-/*! @page ServicesClient-endpoint-snippet Override ServicesClient Endpoint Configuration
+/*! @page run::ServicesClient-endpoint-snippet Override run::ServicesClient Endpoint Configuration
 
 @snippet google/cloud/run/samples/services_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ServicesClient-service-account-snippet Override ServicesClient Authentication Defaults
+/*! @page run::ServicesClient-service-account-snippet Override run::ServicesClient Authentication Defaults
 
 @snippet google/cloud/run/samples/services_client_samples.cc with-service-account
 

--- a/google/cloud/run/samples/revisions_client_samples.cc
+++ b/google/cloud/run/samples/revisions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: RevisionsClient
+// main-dox-marker: run::RevisionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/run/samples/services_client_samples.cc
+++ b/google/cloud/run/samples/services_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ServicesClient
+// main-dox-marker: run::ServicesClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudSchedulerClient`:
+For example, this will override the default endpoint for `scheduler::CloudSchedulerClient`:
 
 @snippet cloud_scheduler_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudSchedulerClient-endpoint-snippet Override CloudSchedulerClient Endpoint Configuration
+/*! @page scheduler::CloudSchedulerClient-endpoint-snippet Override scheduler::CloudSchedulerClient Endpoint Configuration
 
 @snippet google/cloud/scheduler/samples/cloud_scheduler_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudSchedulerClient-service-account-snippet Override CloudSchedulerClient Authentication Defaults
+/*! @page scheduler::CloudSchedulerClient-service-account-snippet Override scheduler::CloudSchedulerClient Authentication Defaults
 
 @snippet google/cloud/scheduler/samples/cloud_scheduler_client_samples.cc with-service-account
 

--- a/google/cloud/scheduler/samples/cloud_scheduler_client_samples.cc
+++ b/google/cloud/scheduler/samples/cloud_scheduler_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudSchedulerClient
+// main-dox-marker: scheduler::CloudSchedulerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `SecretManagerServiceClient`:
+For example, this will override the default endpoint for `secretmanager::SecretManagerServiceClient`:
 
 @snippet secret_manager_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page SecretManagerServiceClient-endpoint-snippet Override SecretManagerServiceClient Endpoint Configuration
+/*! @page secretmanager::SecretManagerServiceClient-endpoint-snippet Override secretmanager::SecretManagerServiceClient Endpoint Configuration
 
 @snippet google/cloud/secretmanager/samples/secret_manager_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SecretManagerServiceClient-service-account-snippet Override SecretManagerServiceClient Authentication Defaults
+/*! @page secretmanager::SecretManagerServiceClient-service-account-snippet Override secretmanager::SecretManagerServiceClient Authentication Defaults
 
 @snippet google/cloud/secretmanager/samples/secret_manager_client_samples.cc with-service-account
 

--- a/google/cloud/secretmanager/samples/secret_manager_client_samples.cc
+++ b/google/cloud/secretmanager/samples/secret_manager_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SecretManagerServiceClient
+// main-dox-marker: secretmanager::SecretManagerServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/securitycenter/doc/main.dox
+++ b/google/cloud/securitycenter/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `SecurityCenterClient`:
+For example, this will override the default endpoint for `securitycenter::SecurityCenterClient`:
 
 @snippet security_center_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page SecurityCenterClient-endpoint-snippet Override SecurityCenterClient Endpoint Configuration
+/*! @page securitycenter::SecurityCenterClient-endpoint-snippet Override securitycenter::SecurityCenterClient Endpoint Configuration
 
 @snippet google/cloud/securitycenter/samples/security_center_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SecurityCenterClient-service-account-snippet Override SecurityCenterClient Authentication Defaults
+/*! @page securitycenter::SecurityCenterClient-service-account-snippet Override securitycenter::SecurityCenterClient Authentication Defaults
 
 @snippet google/cloud/securitycenter/samples/security_center_client_samples.cc with-service-account
 

--- a/google/cloud/securitycenter/samples/security_center_client_samples.cc
+++ b/google/cloud/securitycenter/samples/security_center_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SecurityCenterClient
+// main-dox-marker: securitycenter::SecurityCenterClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/servicecontrol/doc/main.dox
+++ b/google/cloud/servicecontrol/doc/main.dox
@@ -97,13 +97,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `QuotaControllerClient`:
+For example, this will override the default endpoint for `servicecontrol::QuotaControllerClient`:
 
 @snippet quota_controller_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [QuotaControllerClient](@ref QuotaControllerClient-endpoint-snippet)
- [ServiceControllerClient](@ref ServiceControllerClient-endpoint-snippet)
+ [servicecontrol::QuotaControllerClient](@ref servicecontrol::QuotaControllerClient-endpoint-snippet)
+ [servicecontrol::ServiceControllerClient](@ref servicecontrol::ServiceControllerClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -118,8 +118,8 @@ to explicitly load a service account key file.
 @snippet quota_controller_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [QuotaControllerClient](@ref QuotaControllerClient-service-account-snippet)
- [ServiceControllerClient](@ref ServiceControllerClient-service-account-snippet)
+ [servicecontrol::QuotaControllerClient](@ref servicecontrol::QuotaControllerClient-service-account-snippet)
+ [servicecontrol::ServiceControllerClient](@ref servicecontrol::ServiceControllerClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -150,25 +150,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page QuotaControllerClient-endpoint-snippet Override QuotaControllerClient Endpoint Configuration
+/*! @page servicecontrol::QuotaControllerClient-endpoint-snippet Override servicecontrol::QuotaControllerClient Endpoint Configuration
 
 @snippet google/cloud/servicecontrol/samples/quota_controller_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page QuotaControllerClient-service-account-snippet Override QuotaControllerClient Authentication Defaults
+/*! @page servicecontrol::QuotaControllerClient-service-account-snippet Override servicecontrol::QuotaControllerClient Authentication Defaults
 
 @snippet google/cloud/servicecontrol/samples/quota_controller_client_samples.cc with-service-account
 
 */
 
-/*! @page ServiceControllerClient-endpoint-snippet Override ServiceControllerClient Endpoint Configuration
+/*! @page servicecontrol::ServiceControllerClient-endpoint-snippet Override servicecontrol::ServiceControllerClient Endpoint Configuration
 
 @snippet google/cloud/servicecontrol/samples/service_controller_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ServiceControllerClient-service-account-snippet Override ServiceControllerClient Authentication Defaults
+/*! @page servicecontrol::ServiceControllerClient-service-account-snippet Override servicecontrol::ServiceControllerClient Authentication Defaults
 
 @snippet google/cloud/servicecontrol/samples/service_controller_client_samples.cc with-service-account
 

--- a/google/cloud/servicecontrol/samples/quota_controller_client_samples.cc
+++ b/google/cloud/servicecontrol/samples/quota_controller_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: QuotaControllerClient
+// main-dox-marker: servicecontrol::QuotaControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/servicecontrol/samples/service_controller_client_samples.cc
+++ b/google/cloud/servicecontrol/samples/service_controller_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ServiceControllerClient
+// main-dox-marker: servicecontrol::ServiceControllerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/servicedirectory/doc/main.dox
+++ b/google/cloud/servicedirectory/doc/main.dox
@@ -97,13 +97,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `LookupServiceClient`:
+For example, this will override the default endpoint for `servicedirectory::LookupServiceClient`:
 
 @snippet lookup_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [LookupServiceClient](@ref LookupServiceClient-endpoint-snippet)
- [RegistrationServiceClient](@ref RegistrationServiceClient-endpoint-snippet)
+ [servicedirectory::LookupServiceClient](@ref servicedirectory::LookupServiceClient-endpoint-snippet)
+ [servicedirectory::RegistrationServiceClient](@ref servicedirectory::RegistrationServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -118,8 +118,8 @@ to explicitly load a service account key file.
 @snippet lookup_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [LookupServiceClient](@ref LookupServiceClient-service-account-snippet)
- [RegistrationServiceClient](@ref RegistrationServiceClient-service-account-snippet)
+ [servicedirectory::LookupServiceClient](@ref servicedirectory::LookupServiceClient-service-account-snippet)
+ [servicedirectory::RegistrationServiceClient](@ref servicedirectory::RegistrationServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -150,25 +150,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page LookupServiceClient-endpoint-snippet Override LookupServiceClient Endpoint Configuration
+/*! @page servicedirectory::LookupServiceClient-endpoint-snippet Override servicedirectory::LookupServiceClient Endpoint Configuration
 
 @snippet google/cloud/servicedirectory/samples/lookup_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page LookupServiceClient-service-account-snippet Override LookupServiceClient Authentication Defaults
+/*! @page servicedirectory::LookupServiceClient-service-account-snippet Override servicedirectory::LookupServiceClient Authentication Defaults
 
 @snippet google/cloud/servicedirectory/samples/lookup_client_samples.cc with-service-account
 
 */
 
-/*! @page RegistrationServiceClient-endpoint-snippet Override RegistrationServiceClient Endpoint Configuration
+/*! @page servicedirectory::RegistrationServiceClient-endpoint-snippet Override servicedirectory::RegistrationServiceClient Endpoint Configuration
 
 @snippet google/cloud/servicedirectory/samples/registration_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page RegistrationServiceClient-service-account-snippet Override RegistrationServiceClient Authentication Defaults
+/*! @page servicedirectory::RegistrationServiceClient-service-account-snippet Override servicedirectory::RegistrationServiceClient Authentication Defaults
 
 @snippet google/cloud/servicedirectory/samples/registration_client_samples.cc with-service-account
 

--- a/google/cloud/servicedirectory/samples/lookup_client_samples.cc
+++ b/google/cloud/servicedirectory/samples/lookup_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: LookupServiceClient
+// main-dox-marker: servicedirectory::LookupServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/servicedirectory/samples/registration_client_samples.cc
+++ b/google/cloud/servicedirectory/samples/registration_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: RegistrationServiceClient
+// main-dox-marker: servicedirectory::RegistrationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/servicemanagement/doc/main.dox
+++ b/google/cloud/servicemanagement/doc/main.dox
@@ -91,7 +91,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ServiceManagerClient`:
+For example, this will override the default endpoint for `servicemanagement::ServiceManagerClient`:
 
 @snippet service_manager_client_samples.cc set-client-endpoint
 
@@ -136,13 +136,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ServiceManagerClient-endpoint-snippet Override ServiceManagerClient Endpoint Configuration
+/*! @page servicemanagement::ServiceManagerClient-endpoint-snippet Override servicemanagement::ServiceManagerClient Endpoint Configuration
 
 @snippet google/cloud/servicemanagement/samples/service_manager_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ServiceManagerClient-service-account-snippet Override ServiceManagerClient Authentication Defaults
+/*! @page servicemanagement::ServiceManagerClient-service-account-snippet Override servicemanagement::ServiceManagerClient Authentication Defaults
 
 @snippet google/cloud/servicemanagement/samples/service_manager_client_samples.cc with-service-account
 

--- a/google/cloud/servicemanagement/samples/service_manager_client_samples.cc
+++ b/google/cloud/servicemanagement/samples/service_manager_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ServiceManagerClient
+// main-dox-marker: servicemanagement::ServiceManagerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/serviceusage/doc/main.dox
+++ b/google/cloud/serviceusage/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ServiceUsageClient`:
+For example, this will override the default endpoint for `serviceusage::ServiceUsageClient`:
 
 @snippet service_usage_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ServiceUsageClient-endpoint-snippet Override ServiceUsageClient Endpoint Configuration
+/*! @page serviceusage::ServiceUsageClient-endpoint-snippet Override serviceusage::ServiceUsageClient Endpoint Configuration
 
 @snippet google/cloud/serviceusage/samples/service_usage_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ServiceUsageClient-service-account-snippet Override ServiceUsageClient Authentication Defaults
+/*! @page serviceusage::ServiceUsageClient-service-account-snippet Override serviceusage::ServiceUsageClient Authentication Defaults
 
 @snippet google/cloud/serviceusage/samples/service_usage_client_samples.cc with-service-account
 

--- a/google/cloud/serviceusage/samples/service_usage_client_samples.cc
+++ b/google/cloud/serviceusage/samples/service_usage_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ServiceUsageClient
+// main-dox-marker: serviceusage::ServiceUsageClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/shell/doc/main.dox
+++ b/google/cloud/shell/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudShellServiceClient`:
+For example, this will override the default endpoint for `shell::CloudShellServiceClient`:
 
 @snippet cloud_shell_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudShellServiceClient-endpoint-snippet Override CloudShellServiceClient Endpoint Configuration
+/*! @page shell::CloudShellServiceClient-endpoint-snippet Override shell::CloudShellServiceClient Endpoint Configuration
 
 @snippet google/cloud/shell/samples/cloud_shell_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudShellServiceClient-service-account-snippet Override CloudShellServiceClient Authentication Defaults
+/*! @page shell::CloudShellServiceClient-service-account-snippet Override shell::CloudShellServiceClient Authentication Defaults
 
 @snippet google/cloud/shell/samples/cloud_shell_client_samples.cc with-service-account
 

--- a/google/cloud/shell/samples/cloud_shell_client_samples.cc
+++ b/google/cloud/shell/samples/cloud_shell_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudShellServiceClient
+// main-dox-marker: shell::CloudShellServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/spanner/admin/samples/database_admin_client_samples.cc
+++ b/google/cloud/spanner/admin/samples/database_admin_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: DatabaseAdminClient
+// main-dox-marker: spanner_admin::DatabaseAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/spanner/admin/samples/instance_admin_client_samples.cc
+++ b/google/cloud/spanner/admin/samples/instance_admin_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: InstanceAdminClient
+// main-dox-marker: spanner_admin::InstanceAdminClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `SpeechClient`:
+For example, this will override the default endpoint for `speech::SpeechClient`:
 
 @snippet speech_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page SpeechClient-endpoint-snippet Override SpeechClient Endpoint Configuration
+/*! @page speech::SpeechClient-endpoint-snippet Override speech::SpeechClient Endpoint Configuration
 
 @snippet google/cloud/speech/samples/speech_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page SpeechClient-service-account-snippet Override SpeechClient Authentication Defaults
+/*! @page speech::SpeechClient-service-account-snippet Override speech::SpeechClient Authentication Defaults
 
 @snippet google/cloud/speech/samples/speech_client_samples.cc with-service-account
 

--- a/google/cloud/speech/samples/speech_client_samples.cc
+++ b/google/cloud/speech/samples/speech_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: SpeechClient
+// main-dox-marker: speech::SpeechClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/storagetransfer/doc/main.dox
+++ b/google/cloud/storagetransfer/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `StorageTransferServiceClient`:
+For example, this will override the default endpoint for `storagetransfer::StorageTransferServiceClient`:
 
 @snippet storage_transfer_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page StorageTransferServiceClient-endpoint-snippet Override StorageTransferServiceClient Endpoint Configuration
+/*! @page storagetransfer::StorageTransferServiceClient-endpoint-snippet Override storagetransfer::StorageTransferServiceClient Endpoint Configuration
 
 @snippet google/cloud/storagetransfer/samples/storage_transfer_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page StorageTransferServiceClient-service-account-snippet Override StorageTransferServiceClient Authentication Defaults
+/*! @page storagetransfer::StorageTransferServiceClient-service-account-snippet Override storagetransfer::StorageTransferServiceClient Authentication Defaults
 
 @snippet google/cloud/storagetransfer/samples/storage_transfer_client_samples.cc with-service-account
 

--- a/google/cloud/storagetransfer/samples/storage_transfer_client_samples.cc
+++ b/google/cloud/storagetransfer/samples/storage_transfer_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: StorageTransferServiceClient
+// main-dox-marker: storagetransfer::StorageTransferServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/talent/doc/main.dox
+++ b/google/cloud/talent/doc/main.dox
@@ -109,16 +109,16 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CompanyServiceClient`:
+For example, this will override the default endpoint for `talent::CompanyServiceClient`:
 
 @snippet company_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [CompanyServiceClient](@ref CompanyServiceClient-endpoint-snippet)
- [CompletionClient](@ref CompletionClient-endpoint-snippet)
- [EventServiceClient](@ref EventServiceClient-endpoint-snippet)
- [JobServiceClient](@ref JobServiceClient-endpoint-snippet)
- [TenantServiceClient](@ref TenantServiceClient-endpoint-snippet)
+ [talent::CompanyServiceClient](@ref talent::CompanyServiceClient-endpoint-snippet)
+ [talent::CompletionClient](@ref talent::CompletionClient-endpoint-snippet)
+ [talent::EventServiceClient](@ref talent::EventServiceClient-endpoint-snippet)
+ [talent::JobServiceClient](@ref talent::JobServiceClient-endpoint-snippet)
+ [talent::TenantServiceClient](@ref talent::TenantServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -133,11 +133,11 @@ to explicitly load a service account key file.
 @snippet company_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [CompanyServiceClient](@ref CompanyServiceClient-service-account-snippet)
- [CompletionClient](@ref CompletionClient-service-account-snippet)
- [EventServiceClient](@ref EventServiceClient-service-account-snippet)
- [JobServiceClient](@ref JobServiceClient-service-account-snippet)
- [TenantServiceClient](@ref TenantServiceClient-service-account-snippet)
+ [talent::CompanyServiceClient](@ref talent::CompanyServiceClient-service-account-snippet)
+ [talent::CompletionClient](@ref talent::CompletionClient-service-account-snippet)
+ [talent::EventServiceClient](@ref talent::EventServiceClient-service-account-snippet)
+ [talent::JobServiceClient](@ref talent::JobServiceClient-service-account-snippet)
+ [talent::TenantServiceClient](@ref talent::TenantServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -168,61 +168,61 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CompanyServiceClient-endpoint-snippet Override CompanyServiceClient Endpoint Configuration
+/*! @page talent::CompanyServiceClient-endpoint-snippet Override talent::CompanyServiceClient Endpoint Configuration
 
 @snippet google/cloud/talent/samples/company_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CompanyServiceClient-service-account-snippet Override CompanyServiceClient Authentication Defaults
+/*! @page talent::CompanyServiceClient-service-account-snippet Override talent::CompanyServiceClient Authentication Defaults
 
 @snippet google/cloud/talent/samples/company_client_samples.cc with-service-account
 
 */
 
-/*! @page CompletionClient-endpoint-snippet Override CompletionClient Endpoint Configuration
+/*! @page talent::CompletionClient-endpoint-snippet Override talent::CompletionClient Endpoint Configuration
 
 @snippet google/cloud/talent/samples/completion_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CompletionClient-service-account-snippet Override CompletionClient Authentication Defaults
+/*! @page talent::CompletionClient-service-account-snippet Override talent::CompletionClient Authentication Defaults
 
 @snippet google/cloud/talent/samples/completion_client_samples.cc with-service-account
 
 */
 
-/*! @page EventServiceClient-endpoint-snippet Override EventServiceClient Endpoint Configuration
+/*! @page talent::EventServiceClient-endpoint-snippet Override talent::EventServiceClient Endpoint Configuration
 
 @snippet google/cloud/talent/samples/event_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page EventServiceClient-service-account-snippet Override EventServiceClient Authentication Defaults
+/*! @page talent::EventServiceClient-service-account-snippet Override talent::EventServiceClient Authentication Defaults
 
 @snippet google/cloud/talent/samples/event_client_samples.cc with-service-account
 
 */
 
-/*! @page JobServiceClient-endpoint-snippet Override JobServiceClient Endpoint Configuration
+/*! @page talent::JobServiceClient-endpoint-snippet Override talent::JobServiceClient Endpoint Configuration
 
 @snippet google/cloud/talent/samples/job_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page JobServiceClient-service-account-snippet Override JobServiceClient Authentication Defaults
+/*! @page talent::JobServiceClient-service-account-snippet Override talent::JobServiceClient Authentication Defaults
 
 @snippet google/cloud/talent/samples/job_client_samples.cc with-service-account
 
 */
 
-/*! @page TenantServiceClient-endpoint-snippet Override TenantServiceClient Endpoint Configuration
+/*! @page talent::TenantServiceClient-endpoint-snippet Override talent::TenantServiceClient Endpoint Configuration
 
 @snippet google/cloud/talent/samples/tenant_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TenantServiceClient-service-account-snippet Override TenantServiceClient Authentication Defaults
+/*! @page talent::TenantServiceClient-service-account-snippet Override talent::TenantServiceClient Authentication Defaults
 
 @snippet google/cloud/talent/samples/tenant_client_samples.cc with-service-account
 

--- a/google/cloud/talent/samples/company_client_samples.cc
+++ b/google/cloud/talent/samples/company_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CompanyServiceClient
+// main-dox-marker: talent::CompanyServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/talent/samples/completion_client_samples.cc
+++ b/google/cloud/talent/samples/completion_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CompletionClient
+// main-dox-marker: talent::CompletionClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/talent/samples/event_client_samples.cc
+++ b/google/cloud/talent/samples/event_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: EventServiceClient
+// main-dox-marker: talent::EventServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/talent/samples/job_client_samples.cc
+++ b/google/cloud/talent/samples/job_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: JobServiceClient
+// main-dox-marker: talent::JobServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/talent/samples/tenant_client_samples.cc
+++ b/google/cloud/talent/samples/tenant_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TenantServiceClient
+// main-dox-marker: talent::TenantServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `CloudTasksClient`:
+For example, this will override the default endpoint for `tasks::CloudTasksClient`:
 
 @snippet cloud_tasks_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page CloudTasksClient-endpoint-snippet Override CloudTasksClient Endpoint Configuration
+/*! @page tasks::CloudTasksClient-endpoint-snippet Override tasks::CloudTasksClient Endpoint Configuration
 
 @snippet google/cloud/tasks/samples/cloud_tasks_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page CloudTasksClient-service-account-snippet Override CloudTasksClient Authentication Defaults
+/*! @page tasks::CloudTasksClient-service-account-snippet Override tasks::CloudTasksClient Authentication Defaults
 
 @snippet google/cloud/tasks/samples/cloud_tasks_client_samples.cc with-service-account
 

--- a/google/cloud/tasks/samples/cloud_tasks_client_samples.cc
+++ b/google/cloud/tasks/samples/cloud_tasks_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: CloudTasksClient
+// main-dox-marker: tasks::CloudTasksClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/texttospeech/doc/main.dox
+++ b/google/cloud/texttospeech/doc/main.dox
@@ -93,7 +93,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `TextToSpeechClient`:
+For example, this will override the default endpoint for `texttospeech::TextToSpeechClient`:
 
 @snippet text_to_speech_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page TextToSpeechClient-endpoint-snippet Override TextToSpeechClient Endpoint Configuration
+/*! @page texttospeech::TextToSpeechClient-endpoint-snippet Override texttospeech::TextToSpeechClient Endpoint Configuration
 
 @snippet google/cloud/texttospeech/samples/text_to_speech_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TextToSpeechClient-service-account-snippet Override TextToSpeechClient Authentication Defaults
+/*! @page texttospeech::TextToSpeechClient-service-account-snippet Override texttospeech::TextToSpeechClient Authentication Defaults
 
 @snippet google/cloud/texttospeech/samples/text_to_speech_client_samples.cc with-service-account
 

--- a/google/cloud/texttospeech/samples/text_to_speech_client_samples.cc
+++ b/google/cloud/texttospeech/samples/text_to_speech_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TextToSpeechClient
+// main-dox-marker: texttospeech::TextToSpeechClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `TpuClient`:
+For example, this will override the default endpoint for `tpu::TpuClient`:
 
 @snippet tpu_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page TpuClient-endpoint-snippet Override TpuClient Endpoint Configuration
+/*! @page tpu::TpuClient-endpoint-snippet Override tpu::TpuClient Endpoint Configuration
 
 @snippet google/cloud/tpu/samples/tpu_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TpuClient-service-account-snippet Override TpuClient Authentication Defaults
+/*! @page tpu::TpuClient-service-account-snippet Override tpu::TpuClient Authentication Defaults
 
 @snippet google/cloud/tpu/samples/tpu_client_samples.cc with-service-account
 

--- a/google/cloud/tpu/samples/tpu_client_samples.cc
+++ b/google/cloud/tpu/samples/tpu_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TpuClient
+// main-dox-marker: tpu::TpuClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/trace/doc/main.dox
+++ b/google/cloud/trace/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `TraceServiceClient`:
+For example, this will override the default endpoint for `trace::TraceServiceClient`:
 
 @snippet trace_client_samples.cc set-client-endpoint
 
@@ -140,13 +140,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page TraceServiceClient-endpoint-snippet Override TraceServiceClient Endpoint Configuration
+/*! @page trace::TraceServiceClient-endpoint-snippet Override trace::TraceServiceClient Endpoint Configuration
 
 @snippet google/cloud/trace/samples/trace_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TraceServiceClient-service-account-snippet Override TraceServiceClient Authentication Defaults
+/*! @page trace::TraceServiceClient-service-account-snippet Override trace::TraceServiceClient Authentication Defaults
 
 @snippet google/cloud/trace/samples/trace_client_samples.cc with-service-account
 

--- a/google/cloud/trace/samples/trace_client_samples.cc
+++ b/google/cloud/trace/samples/trace_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TraceServiceClient
+// main-dox-marker: trace::TraceServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/translate/doc/main.dox
+++ b/google/cloud/translate/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `TranslationServiceClient`:
+For example, this will override the default endpoint for `translate::TranslationServiceClient`:
 
 @snippet translation_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page TranslationServiceClient-endpoint-snippet Override TranslationServiceClient Endpoint Configuration
+/*! @page translate::TranslationServiceClient-endpoint-snippet Override translate::TranslationServiceClient Endpoint Configuration
 
 @snippet google/cloud/translate/samples/translation_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TranslationServiceClient-service-account-snippet Override TranslationServiceClient Authentication Defaults
+/*! @page translate::TranslationServiceClient-service-account-snippet Override translate::TranslationServiceClient Authentication Defaults
 
 @snippet google/cloud/translate/samples/translation_client_samples.cc with-service-account
 

--- a/google/cloud/translate/samples/translation_client_samples.cc
+++ b/google/cloud/translate/samples/translation_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TranslationServiceClient
+// main-dox-marker: translate::TranslationServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/video/doc/main.dox
+++ b/google/cloud/video/doc/main.dox
@@ -107,14 +107,14 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `LivestreamServiceClient`:
+For example, this will override the default endpoint for `video::LivestreamServiceClient`:
 
 @snippet livestream_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [LivestreamServiceClient](@ref LivestreamServiceClient-endpoint-snippet)
- [TranscoderServiceClient](@ref TranscoderServiceClient-endpoint-snippet)
- [VideoStitcherServiceClient](@ref VideoStitcherServiceClient-endpoint-snippet)
+ [video::LivestreamServiceClient](@ref video::LivestreamServiceClient-endpoint-snippet)
+ [video::TranscoderServiceClient](@ref video::TranscoderServiceClient-endpoint-snippet)
+ [video::VideoStitcherServiceClient](@ref video::VideoStitcherServiceClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -129,9 +129,9 @@ to explicitly load a service account key file.
 @snippet livestream_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [LivestreamServiceClient](@ref LivestreamServiceClient-service-account-snippet)
- [TranscoderServiceClient](@ref TranscoderServiceClient-service-account-snippet)
- [VideoStitcherServiceClient](@ref VideoStitcherServiceClient-service-account-snippet)
+ [video::LivestreamServiceClient](@ref video::LivestreamServiceClient-service-account-snippet)
+ [video::TranscoderServiceClient](@ref video::TranscoderServiceClient-service-account-snippet)
+ [video::VideoStitcherServiceClient](@ref video::VideoStitcherServiceClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -164,37 +164,37 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page LivestreamServiceClient-endpoint-snippet Override LivestreamServiceClient Endpoint Configuration
+/*! @page video::LivestreamServiceClient-endpoint-snippet Override video::LivestreamServiceClient Endpoint Configuration
 
 @snippet google/cloud/video/samples/livestream_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page LivestreamServiceClient-service-account-snippet Override LivestreamServiceClient Authentication Defaults
+/*! @page video::LivestreamServiceClient-service-account-snippet Override video::LivestreamServiceClient Authentication Defaults
 
 @snippet google/cloud/video/samples/livestream_client_samples.cc with-service-account
 
 */
 
-/*! @page TranscoderServiceClient-endpoint-snippet Override TranscoderServiceClient Endpoint Configuration
+/*! @page video::TranscoderServiceClient-endpoint-snippet Override video::TranscoderServiceClient Endpoint Configuration
 
 @snippet google/cloud/video/samples/transcoder_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page TranscoderServiceClient-service-account-snippet Override TranscoderServiceClient Authentication Defaults
+/*! @page video::TranscoderServiceClient-service-account-snippet Override video::TranscoderServiceClient Authentication Defaults
 
 @snippet google/cloud/video/samples/transcoder_client_samples.cc with-service-account
 
 */
 
-/*! @page VideoStitcherServiceClient-endpoint-snippet Override VideoStitcherServiceClient Endpoint Configuration
+/*! @page video::VideoStitcherServiceClient-endpoint-snippet Override video::VideoStitcherServiceClient Endpoint Configuration
 
 @snippet google/cloud/video/samples/video_stitcher_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page VideoStitcherServiceClient-service-account-snippet Override VideoStitcherServiceClient Authentication Defaults
+/*! @page video::VideoStitcherServiceClient-service-account-snippet Override video::VideoStitcherServiceClient Authentication Defaults
 
 @snippet google/cloud/video/samples/video_stitcher_client_samples.cc with-service-account
 

--- a/google/cloud/video/samples/livestream_client_samples.cc
+++ b/google/cloud/video/samples/livestream_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: LivestreamServiceClient
+// main-dox-marker: video::LivestreamServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/video/samples/transcoder_client_samples.cc
+++ b/google/cloud/video/samples/transcoder_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: TranscoderServiceClient
+// main-dox-marker: video::TranscoderServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/video/samples/video_stitcher_client_samples.cc
+++ b/google/cloud/video/samples/video_stitcher_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: VideoStitcherServiceClient
+// main-dox-marker: video::VideoStitcherServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/videointelligence/doc/main.dox
+++ b/google/cloud/videointelligence/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `VideoIntelligenceServiceClient`:
+For example, this will override the default endpoint for `videointelligence::VideoIntelligenceServiceClient`:
 
 @snippet video_intelligence_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page VideoIntelligenceServiceClient-endpoint-snippet Override VideoIntelligenceServiceClient Endpoint Configuration
+/*! @page videointelligence::VideoIntelligenceServiceClient-endpoint-snippet Override videointelligence::VideoIntelligenceServiceClient Endpoint Configuration
 
 @snippet google/cloud/videointelligence/samples/video_intelligence_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page VideoIntelligenceServiceClient-service-account-snippet Override VideoIntelligenceServiceClient Authentication Defaults
+/*! @page videointelligence::VideoIntelligenceServiceClient-service-account-snippet Override videointelligence::VideoIntelligenceServiceClient Authentication Defaults
 
 @snippet google/cloud/videointelligence/samples/video_intelligence_client_samples.cc with-service-account
 

--- a/google/cloud/videointelligence/samples/video_intelligence_client_samples.cc
+++ b/google/cloud/videointelligence/samples/video_intelligence_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: VideoIntelligenceServiceClient
+// main-dox-marker: videointelligence::VideoIntelligenceServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -98,13 +98,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ImageAnnotatorClient`:
+For example, this will override the default endpoint for `vision::ImageAnnotatorClient`:
 
 @snippet image_annotator_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [ImageAnnotatorClient](@ref ImageAnnotatorClient-endpoint-snippet)
- [ProductSearchClient](@ref ProductSearchClient-endpoint-snippet)
+ [vision::ImageAnnotatorClient](@ref vision::ImageAnnotatorClient-endpoint-snippet)
+ [vision::ProductSearchClient](@ref vision::ProductSearchClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -119,8 +119,8 @@ to explicitly load a service account key file.
 @snippet image_annotator_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [ImageAnnotatorClient](@ref ImageAnnotatorClient-service-account-snippet)
- [ProductSearchClient](@ref ProductSearchClient-service-account-snippet)
+ [vision::ImageAnnotatorClient](@ref vision::ImageAnnotatorClient-service-account-snippet)
+ [vision::ProductSearchClient](@ref vision::ProductSearchClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -151,25 +151,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ImageAnnotatorClient-endpoint-snippet Override ImageAnnotatorClient Endpoint Configuration
+/*! @page vision::ImageAnnotatorClient-endpoint-snippet Override vision::ImageAnnotatorClient Endpoint Configuration
 
 @snippet google/cloud/vision/samples/image_annotator_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ImageAnnotatorClient-service-account-snippet Override ImageAnnotatorClient Authentication Defaults
+/*! @page vision::ImageAnnotatorClient-service-account-snippet Override vision::ImageAnnotatorClient Authentication Defaults
 
 @snippet google/cloud/vision/samples/image_annotator_client_samples.cc with-service-account
 
 */
 
-/*! @page ProductSearchClient-endpoint-snippet Override ProductSearchClient Endpoint Configuration
+/*! @page vision::ProductSearchClient-endpoint-snippet Override vision::ProductSearchClient Endpoint Configuration
 
 @snippet google/cloud/vision/samples/product_search_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ProductSearchClient-service-account-snippet Override ProductSearchClient Authentication Defaults
+/*! @page vision::ProductSearchClient-service-account-snippet Override vision::ProductSearchClient Authentication Defaults
 
 @snippet google/cloud/vision/samples/product_search_client_samples.cc with-service-account
 

--- a/google/cloud/vision/samples/image_annotator_client_samples.cc
+++ b/google/cloud/vision/samples/image_annotator_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ImageAnnotatorClient
+// main-dox-marker: vision::ImageAnnotatorClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/vision/samples/product_search_client_samples.cc
+++ b/google/cloud/vision/samples/product_search_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ProductSearchClient
+// main-dox-marker: vision::ProductSearchClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/vmmigration/doc/main.dox
+++ b/google/cloud/vmmigration/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `VmMigrationClient`:
+For example, this will override the default endpoint for `vmmigration::VmMigrationClient`:
 
 @snippet vm_migration_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page VmMigrationClient-endpoint-snippet Override VmMigrationClient Endpoint Configuration
+/*! @page vmmigration::VmMigrationClient-endpoint-snippet Override vmmigration::VmMigrationClient Endpoint Configuration
 
 @snippet google/cloud/vmmigration/samples/vm_migration_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page VmMigrationClient-service-account-snippet Override VmMigrationClient Authentication Defaults
+/*! @page vmmigration::VmMigrationClient-service-account-snippet Override vmmigration::VmMigrationClient Authentication Defaults
 
 @snippet google/cloud/vmmigration/samples/vm_migration_client_samples.cc with-service-account
 

--- a/google/cloud/vmmigration/samples/vm_migration_client_samples.cc
+++ b/google/cloud/vmmigration/samples/vm_migration_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: VmMigrationClient
+// main-dox-marker: vmmigration::VmMigrationClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/vpcaccess/doc/main.dox
+++ b/google/cloud/vpcaccess/doc/main.dox
@@ -92,7 +92,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `VpcAccessServiceClient`:
+For example, this will override the default endpoint for `vpcaccess::VpcAccessServiceClient`:
 
 @snippet vpc_access_client_samples.cc set-client-endpoint
 
@@ -137,13 +137,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page VpcAccessServiceClient-endpoint-snippet Override VpcAccessServiceClient Endpoint Configuration
+/*! @page vpcaccess::VpcAccessServiceClient-endpoint-snippet Override vpcaccess::VpcAccessServiceClient Endpoint Configuration
 
 @snippet google/cloud/vpcaccess/samples/vpc_access_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page VpcAccessServiceClient-service-account-snippet Override VpcAccessServiceClient Authentication Defaults
+/*! @page vpcaccess::VpcAccessServiceClient-service-account-snippet Override vpcaccess::VpcAccessServiceClient Authentication Defaults
 
 @snippet google/cloud/vpcaccess/samples/vpc_access_client_samples.cc with-service-account
 

--- a/google/cloud/vpcaccess/samples/vpc_access_client_samples.cc
+++ b/google/cloud/vpcaccess/samples/vpc_access_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: VpcAccessServiceClient
+// main-dox-marker: vpcaccess::VpcAccessServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -94,7 +94,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `WebRiskServiceClient`:
+For example, this will override the default endpoint for `webrisk::WebRiskServiceClient`:
 
 @snippet web_risk_client_samples.cc set-client-endpoint
 
@@ -138,13 +138,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page WebRiskServiceClient-endpoint-snippet Override WebRiskServiceClient Endpoint Configuration
+/*! @page webrisk::WebRiskServiceClient-endpoint-snippet Override webrisk::WebRiskServiceClient Endpoint Configuration
 
 @snippet google/cloud/webrisk/samples/web_risk_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page WebRiskServiceClient-service-account-snippet Override WebRiskServiceClient Authentication Defaults
+/*! @page webrisk::WebRiskServiceClient-service-account-snippet Override webrisk::WebRiskServiceClient Authentication Defaults
 
 @snippet google/cloud/webrisk/samples/web_risk_client_samples.cc with-service-account
 

--- a/google/cloud/webrisk/samples/web_risk_client_samples.cc
+++ b/google/cloud/webrisk/samples/web_risk_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: WebRiskServiceClient
+// main-dox-marker: webrisk::WebRiskServiceClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -95,7 +95,7 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `WebSecurityScannerClient`:
+For example, this will override the default endpoint for `websecurityscanner::WebSecurityScannerClient`:
 
 @snippet web_security_scanner_client_samples.cc set-client-endpoint
 
@@ -139,13 +139,13 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page WebSecurityScannerClient-endpoint-snippet Override WebSecurityScannerClient Endpoint Configuration
+/*! @page websecurityscanner::WebSecurityScannerClient-endpoint-snippet Override websecurityscanner::WebSecurityScannerClient Endpoint Configuration
 
 @snippet google/cloud/websecurityscanner/samples/web_security_scanner_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page WebSecurityScannerClient-service-account-snippet Override WebSecurityScannerClient Authentication Defaults
+/*! @page websecurityscanner::WebSecurityScannerClient-service-account-snippet Override websecurityscanner::WebSecurityScannerClient Authentication Defaults
 
 @snippet google/cloud/websecurityscanner/samples/web_security_scanner_client_samples.cc with-service-account
 

--- a/google/cloud/websecurityscanner/samples/web_security_scanner_client_samples.cc
+++ b/google/cloud/websecurityscanner/samples/web_security_scanner_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: WebSecurityScannerClient
+// main-dox-marker: websecurityscanner::WebSecurityScannerClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -98,13 +98,13 @@ library. Use the `google::cloud::EndpointOption` when initializing the client
 library to change this default.
 
 <!-- inject-endpoint-snippet-start -->
-For example, this will override the default endpoint for `ExecutionsClient`:
+For example, this will override the default endpoint for `workflows::ExecutionsClient`:
 
 @snippet executions_client_samples.cc set-client-endpoint
 
 Follow these links to find examples for other \c *Client classes:
- [ExecutionsClient](@ref ExecutionsClient-endpoint-snippet)
- [WorkflowsClient](@ref WorkflowsClient-endpoint-snippet)
+ [workflows::ExecutionsClient](@ref workflows::ExecutionsClient-endpoint-snippet)
+ [workflows::WorkflowsClient](@ref workflows::WorkflowsClient-endpoint-snippet)
 
 <!-- inject-endpoint-snippet-end -->
 
@@ -119,8 +119,8 @@ to explicitly load a service account key file.
 @snippet executions_client_samples.cc with-service-account
 
 Follow these links to find examples for other \c *Client classes:
- [ExecutionsClient](@ref ExecutionsClient-service-account-snippet)
- [WorkflowsClient](@ref WorkflowsClient-service-account-snippet)
+ [workflows::ExecutionsClient](@ref workflows::ExecutionsClient-service-account-snippet)
+ [workflows::WorkflowsClient](@ref workflows::WorkflowsClient-service-account-snippet)
 
 <!-- inject-service-account-snippet-end -->
 
@@ -150,25 +150,25 @@ can override the default policies.
 
 // <!-- inject-endpoint-pages-start -->
 
-/*! @page ExecutionsClient-endpoint-snippet Override ExecutionsClient Endpoint Configuration
+/*! @page workflows::ExecutionsClient-endpoint-snippet Override workflows::ExecutionsClient Endpoint Configuration
 
 @snippet google/cloud/workflows/samples/executions_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page ExecutionsClient-service-account-snippet Override ExecutionsClient Authentication Defaults
+/*! @page workflows::ExecutionsClient-service-account-snippet Override workflows::ExecutionsClient Authentication Defaults
 
 @snippet google/cloud/workflows/samples/executions_client_samples.cc with-service-account
 
 */
 
-/*! @page WorkflowsClient-endpoint-snippet Override WorkflowsClient Endpoint Configuration
+/*! @page workflows::WorkflowsClient-endpoint-snippet Override workflows::WorkflowsClient Endpoint Configuration
 
 @snippet google/cloud/workflows/samples/workflows_client_samples.cc set-client-endpoint
 
 */
 
-/*! @page WorkflowsClient-service-account-snippet Override WorkflowsClient Authentication Defaults
+/*! @page workflows::WorkflowsClient-service-account-snippet Override workflows::WorkflowsClient Authentication Defaults
 
 @snippet google/cloud/workflows/samples/workflows_client_samples.cc with-service-account
 

--- a/google/cloud/workflows/samples/executions_client_samples.cc
+++ b/google/cloud/workflows/samples/executions_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: ExecutionsClient
+// main-dox-marker: workflows::ExecutionsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {

--- a/google/cloud/workflows/samples/workflows_client_samples.cc
+++ b/google/cloud/workflows/samples/workflows_client_samples.cc
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-// main-dox-marker: WorkflowsClient
+// main-dox-marker: workflows::WorkflowsClient
 namespace {
 
 void SetClientEndpoint(std::vector<std::string> const& argv) {


### PR DESCRIPTION
Part of the work for #10170 

We will need this for speech, which has conflicting client names.

![image](https://user-images.githubusercontent.com/23088558/201734844-bbf77b15-1da4-417d-942a-3478ef5b0694.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10241)
<!-- Reviewable:end -->
