### PR TITLE
ci: inject nested samples, endpoints

### DIFF
--- a/ci/generate-markdown/update-library-landing-dox.sh
+++ b/ci/generate-markdown/update-library-landing-dox.sh
@@ -38,7 +38,8 @@ inject_end="<!-- inject-endpoint-env-vars-end -->"
 env_vars=("")
 while IFS= read -r -d $'\0' option_defaults_cc; do
   service="$(basename "${option_defaults_cc}" _option_defaults.cc)"
-  connection_h="${LIB}/${service}_connection.h"
+  service_dir="$(dirname "$(dirname "${option_defaults_cc}")")"
+  connection_h="${service_dir}/${service}_connection.h"
   # Should we generate documentation for GOOGLE_CLOUD_CPP_.*_AUTHORITY too?
   variable_re='GOOGLE_CLOUD_CPP_.*_ENDPOINT'
   variable=$(grep -om1 "${variable_re}" "${option_defaults_cc}")
@@ -53,7 +54,7 @@ while IFS= read -r -d $'\0' option_defaults_cc; do
   env_vars+=("  \`EndpointOption\` (which defaults to ${endpoint})")
   env_vars+=("  used by \`${make_connection}()\`.")
   env_vars+=("")
-done < <(git ls-files -z -- "${LIB}/internal/*_option_defaults.cc")
+done < <(git ls-files -z -- "${LIB}/*_option_defaults.cc")
 
 sed -i -f - "${MAIN_DOX}" <<EOT
 /${inject_start}/,/${inject_end}/c \\
@@ -62,7 +63,7 @@ $(printf '%s\\\n' "${env_vars[@]}")
 ${inject_end}
 EOT
 
-IFS= mapfile -d $'\0' -t samples_cc < <(git ls-files -z -- "${LIB}/samples/*_client_samples.cc")
+IFS= mapfile -d $'\0' -t samples_cc < <(git ls-files -z -- "${LIB}/*samples/*_client_samples.cc")
 
 (
   sed '/<!-- inject-endpoint-snippet-start -->/q' "${MAIN_DOX}"


### PR DESCRIPTION
Part of the work for #10170 

Note that no documentation changes. That is because the only services that would be affected are Bigtable and Spanner Admin. The dox for those libraries are handwritten; not maintained by `checkers`.

Applied to `speech`, we see the endpoints (which, admittedly, look pretty dumb)
![image](https://user-images.githubusercontent.com/23088558/201748846-f853a9c4-f670-4449-bb88-e9e6b8e156d3.png)

And the samples:
![image](https://user-images.githubusercontent.com/23088558/201748926-40e21e43-cebe-4277-9123-cf1d707170ca.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10242)
<!-- Reviewable:end -->
