### PR TITLE
samples(bigtable): build admin samples with cmake

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -432,6 +432,7 @@ endif ()
 # Only compile integration tests and benchmarks if testing is enabled.
 if (BUILD_TESTING)
     add_subdirectory(admin/integration_tests)
+    add_subdirectory(admin/samples)
     add_subdirectory(benchmarks)
     add_subdirectory(tests)
 endif ()

--- a/google/cloud/bigtable/admin/samples/CMakeLists.txt
+++ b/google/cloud/bigtable/admin/samples/CMakeLists.txt
@@ -16,4 +16,4 @@ if ((NOT BUILD_TESTING) OR (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS))
     return()
 endif ()
 
-google_cloud_cpp_add_samples(admin)
+google_cloud_cpp_add_samples(bigtable)


### PR DESCRIPTION
These samples were never built with cmake. We run them with bazel in the `integration-production` build.

We still do not run them, but at least they are built in `clang-tidy`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10246)
<!-- Reviewable:end -->
