### PR TITLE
samples(spanner): build admin samples with cmake

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -440,6 +440,7 @@ if (BUILD_TESTING)
     spanner_client_define_benchmarks()
     add_subdirectory(integration_tests)
     add_subdirectory(admin/integration_tests)
+    add_subdirectory(admin/samples)
     add_subdirectory(benchmarks) # macro benchmarks
 endif (BUILD_TESTING)
 

--- a/google/cloud/spanner/admin/samples/CMakeLists.txt
+++ b/google/cloud/spanner/admin/samples/CMakeLists.txt
@@ -16,4 +16,4 @@ if ((NOT BUILD_TESTING) OR (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS))
     return()
 endif ()
 
-google_cloud_cpp_add_samples(admin)
+google_cloud_cpp_add_samples(spanner)


### PR DESCRIPTION
These samples were never built with cmake. We run them with bazel in the `integration-production` build.

We still do not run them, but at least they are built in `clang-tidy`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10247)
<!-- Reviewable:end -->
