### PR TITLE
impl(rest): change ServerTimeout type to match type of literals

### DIFF
--- a/google/cloud/rest_options.h
+++ b/google/cloud/rest_options.h
@@ -60,7 +60,7 @@ struct UserIpOption {
  * @ingroup rest-options
  */
 struct ServerTimeoutOption {
-  using Type = float;
+  using Type = double;
 };
 
 /// The complete list of options accepted by `CurlRestClient`

--- a/google/cloud/rest_options.h
+++ b/google/cloud/rest_options.h
@@ -18,8 +18,6 @@
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include <chrono>
-#include <cstdint>
-#include <memory>
 #include <string>
 
 namespace google {
@@ -54,13 +52,13 @@ struct UserIpOption {
 };
 
 /**
- * Timeout (in seconds) for the server to finish processing the request. This
- * system param only applies to REST APIs for which client-side timeout is not
- * applicable.
+ * Timeout for the server to finish processing the request. This system param
+ * only applies to REST APIs for which client-side timeout is not applicable.
+ *
  * @ingroup rest-options
  */
 struct ServerTimeoutOption {
-  using Type = double;
+  using Type = std::chrono::milliseconds;
 };
 
 /// The complete list of options accepted by `CurlRestClient`


### PR DESCRIPTION
`Options{}.set<ServerTimeoutOption>(3.14)` creates a double not a float, which in turn results in a narrowing conversion warning. Change the option type to double as a quality of life improvement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10253)
<!-- Reviewable:end -->
