### PR TITLE
refactor(common): split `internal::AccessToken` struct

### DIFF
--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -28,6 +28,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/absl_str_cat_quiet.h",
     "internal/absl_str_join_quiet.h",
     "internal/absl_str_replace_quiet.h",
+    "internal/access_token.h",
     "internal/algorithm.h",
     "internal/api_client_header.h",
     "internal/attributes.h",
@@ -90,6 +91,7 @@ google_cloud_cpp_common_hdrs = [
 
 google_cloud_cpp_common_srcs = [
     "credentials.cc",
+    "internal/access_token.cc",
     "internal/api_client_header.cc",
     "internal/auth_header_error.cc",
     "internal/backoff_policy.cc",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -41,6 +41,8 @@ add_library(
     internal/absl_str_cat_quiet.h
     internal/absl_str_join_quiet.h
     internal/absl_str_replace_quiet.h
+    internal/access_token.cc
+    internal/access_token.h
     internal/algorithm.h
     internal/api_client_header.cc
     internal/api_client_header.h
@@ -282,6 +284,7 @@ if (BUILD_TESTING)
         future_generic_then_test.cc
         future_void_test.cc
         future_void_then_test.cc
+        internal/access_token_test.cc
         internal/algorithm_test.cc
         internal/api_client_header_test.cc
         internal/backoff_policy_test.cc

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -23,6 +23,7 @@ google_cloud_cpp_common_unit_tests = [
     "future_generic_then_test.cc",
     "future_void_test.cc",
     "future_void_then_test.cc",
+    "internal/access_token_test.cc",
     "internal/algorithm_test.cc",
     "internal/api_client_header_test.cc",
     "internal/backoff_policy_test.cc",

--- a/google/cloud/internal/access_token.cc
+++ b/google/cloud/internal/access_token.cc
@@ -1,0 +1,39 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/access_token.h"
+#include "absl/time/time.h"
+#include <ostream>
+#include <tuple>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+std::ostream& operator<<(std::ostream& os, AccessToken const& rhs) {
+  // Tokens are truncated because they contain security secrets.
+  return os << "token=<" << rhs.token.substr(0, 32) << ">, expiration="
+            << absl::FormatTime(absl::FromChrono(rhs.expiration));
+}
+
+bool operator==(AccessToken const& lhs, AccessToken const& rhs) {
+  return std::tie(lhs.token, lhs.expiration) ==
+         std::tie(rhs.token, rhs.expiration);
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/access_token.h
+++ b/google/cloud/internal/access_token.h
@@ -1,0 +1,47 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ACCESS_TOKEN_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ACCESS_TOKEN_H
+
+#include "google/cloud/version.h"
+#include <chrono>
+#include <iosfwd>
+#include <string>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+/// Represents an access token with a known expiration time.
+struct AccessToken {
+  std::string token;
+  std::chrono::system_clock::time_point expiration;
+};
+
+std::ostream& operator<<(std::ostream& os, AccessToken const& rhs);
+
+bool operator==(AccessToken const& lhs, AccessToken const& rhs);
+
+inline bool operator!=(AccessToken const& lhs, AccessToken const& rhs) {
+  return !(lhs == rhs);
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ACCESS_TOKEN_H

--- a/google/cloud/internal/access_token_test.cc
+++ b/google/cloud/internal/access_token_test.cc
@@ -1,0 +1,62 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/access_token.h"
+#include "absl/time/time.h"
+#include <gmock/gmock.h>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+using ::testing::HasSubstr;
+
+TEST(AccessToken, Compare) {
+  auto now = std::chrono::system_clock::now();
+  auto a = AccessToken{"a", now};
+  auto b = AccessToken{"b", now};
+  auto c = AccessToken{"b", now + std::chrono::seconds(10)};
+  auto d = AccessToken{"b", now + std::chrono::seconds(10)};
+  EXPECT_EQ(a, a);
+  EXPECT_NE(a, b);
+  EXPECT_NE(a, c);
+  EXPECT_EQ(c, d);
+}
+
+TEST(AccessToken, Stream) {
+  auto now = std::chrono::system_clock::now();
+  auto const token = std::string{
+      "123456789a"
+      "123456789b"
+      "123456789c"
+      "123456789d"};
+  auto const input = AccessToken{token, now};
+  std::ostringstream os;
+  os << input;
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr("token=<"
+                                "123456789a"
+                                "123456789b"
+                                "123456789c"
+                                "12>"));
+  auto expiration = absl::FormatTime(absl::FromChrono(now));
+  EXPECT_THAT(actual, HasSubstr("expiration=" + expiration));
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/credentials_impl.h
+++ b/google/cloud/internal/credentials_impl.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CREDENTIALS_IMPL_H
 
 #include "google/cloud/credentials.h"
+#include "google/cloud/internal/access_token.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -30,12 +31,6 @@ namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
-
-/// Represents an access token with a known expiration time.
-struct AccessToken {
-  std::string token;
-  std::chrono::system_clock::time_point expiration;
-};
 
 class InsecureCredentialsConfig;
 class GoogleDefaultCredentialsConfig;


### PR DESCRIPTION
I think this will be handy in the implementation of external account credentials.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10258)
<!-- Reviewable:end -->
