### PR TITLE
impl(generator): support experimental clients

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -100,6 +100,13 @@ message ServiceConfiguration {
   // most gRPC services can also support REST via gRPC/HTTP transcoding
   // https://cloud.google.com/endpoints/docs/grpc/transcoding.
   bool generate_rest_transport = 17;
+
+  // Sometimes we want to add a non-GA client to an already-GA library, (e.g. if
+  // the service itself is in Private Preview).
+  //
+  // If set, this flag will add an `ExperimentalTag` parameter to the client
+  // constructor and the connection factory function.
+  bool experimental = 18;
 }
 
 message GeneratorConfiguration {

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -1397,6 +1397,8 @@ service {
   product_path: "google/cloud/speech/v2"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  #TODO(#10264): Remove experimental when service goes GA.
+  experimental: true
 }
 
 # Storage

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -71,12 +71,13 @@ Status ClientGenerator::GenerateHeader() {
 
   // includes
   HeaderPrint("\n");
-  HeaderLocalIncludes(
-      {vars("connection_header_path"),
-       HasBidirStreamingMethod() ? "google/cloud/experimental_tag.h" : "",
-       "google/cloud/future.h", "google/cloud/options.h",
-       "google/cloud/polling_policy.h", "google/cloud/status_or.h",
-       "google/cloud/version.h"});
+  HeaderLocalIncludes({vars("connection_header_path"),
+                       HasBidirStreamingMethod() || IsExperimental()
+                           ? "google/cloud/experimental_tag.h"
+                           : "",
+                       "google/cloud/future.h", "google/cloud/options.h",
+                       "google/cloud/polling_policy.h",
+                       "google/cloud/status_or.h", "google/cloud/version.h"});
   if (get_iam_policy_extension_ && set_iam_policy_extension_) {
     HeaderLocalIncludes({"google/cloud/iam_updater.h"});
   }
@@ -89,32 +90,35 @@ Status ClientGenerator::GenerateHeader() {
   if (!result.ok()) return result;
 
   // Client Class
-  HeaderPrint(  // clang-format off
-    "\n"
-    "$class_comment_block$\n"
-    "class $client_class_name$ {\n"
-    " public:\n"
-    "  explicit $client_class_name$(std::shared_ptr<$connection_class_name$> connection, Options opts = {});\n"
-    "  ~$client_class_name$();\n"
-    "\n"
-    "  //@{\n"
-    "  // @name Copy and move support\n"
-    "  $client_class_name$($client_class_name$ const&) = default;\n"
-    "  $client_class_name$& operator=($client_class_name$ const&) = default;\n"
-    "  $client_class_name$($client_class_name$&&) = default;\n"
-    "  $client_class_name$& operator=($client_class_name$&&) = default;\n"
-    "  //@}\n"
-    "\n"
-    "  //@{\n"
-    "  // @name Equality\n"
-    "  friend bool operator==($client_class_name$ const& a, $client_class_name$ const& b) {\n"
-    "    return a.connection_ == b.connection_;\n"
-    "  }\n"
-    "  friend bool operator!=($client_class_name$ const& a, $client_class_name$ const& b) {\n"
-    "    return !(a == b);\n"
-    "  }\n"
-    "  //@}\n");
-  // clang-format on
+  HeaderPrint(
+      R"""(
+$class_comment_block$
+class $client_class_name$ {
+ public:
+  explicit $client_class_name$()""");
+  if (IsExperimental()) HeaderPrint("ExperimentalTag, ");
+  HeaderPrint(
+      R"""(std::shared_ptr<$connection_class_name$> connection, Options opts = {});
+  ~$client_class_name$();
+
+  //@{
+  // @name Copy and move support
+  $client_class_name$($client_class_name$ const&) = default;
+  $client_class_name$& operator=($client_class_name$ const&) = default;
+  $client_class_name$($client_class_name$&&) = default;
+  $client_class_name$& operator=($client_class_name$&&) = default;
+  //@}
+
+  //@{
+  // @name Equality
+  friend bool operator==($client_class_name$ const& a, $client_class_name$ const& b) {
+    return a.connection_ == b.connection_;
+  }
+  friend bool operator!=($client_class_name$ const& a, $client_class_name$ const& b) {
+    return !(a == b);
+  }
+  //@}
+)""");
 
   for (google::protobuf::MethodDescriptor const& method : methods()) {
     if (IsBidirStreaming(method)) {
@@ -354,7 +358,11 @@ Status ClientGenerator::GenerateCc() {
 
   CcPrint(  // clang-format off
     "\n"
-    "$client_class_name$::$client_class_name$(std::shared_ptr<$connection_class_name$> connection, Options opts)"
+    "$client_class_name$::$client_class_name$("
+    );
+  if (IsExperimental()) CcPrint("ExperimentalTag, ");
+  CcPrint(
+    "std::shared_ptr<$connection_class_name$> connection, Options opts)"
     " : connection_(std::move(connection)),"
     " options_(internal::MergeOptions(std::move(opts),"
     " connection_->options())) {}\n");

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -330,6 +330,14 @@ TEST(ProcessCommandLineArgs, ProcessEndpointLocationStyle) {
                                      "LOCATION_DEPENDENT_COMPAT")));
 }
 
+TEST(ProcessCommandLineArgs, ProcessExperimental) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/"
+      ",experimental=true");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("experimental", "true")));
+}
+
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -62,7 +62,9 @@ Status ConnectionGenerator::GenerateHeader() {
        HasBidirStreamingMethod()
            ? "google/cloud/internal/async_read_write_stream_impl.h"
            : "",
-       HasBidirStreamingMethod() ? "google/cloud/experimental_tag.h" : "",
+       HasBidirStreamingMethod() || IsExperimental()
+           ? "google/cloud/experimental_tag.h"
+           : "",
        "google/cloud/version.h"});
   HeaderSystemIncludes(
       {HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
@@ -247,6 +249,7 @@ class $connection_class_name$ {
 std::shared_ptr<$connection_class_name$> Make$connection_class_name$(
 )""");
   HeaderPrint("    ");
+  if (IsExperimental()) HeaderPrint("ExperimentalTag, ");
   switch (endpoint_location_style) {
     case ServiceConfiguration::LOCATION_DEPENDENT:
     case ServiceConfiguration::LOCATION_DEPENDENT_COMPAT:
@@ -434,6 +437,7 @@ $connection_class_name$::Async$method_name$(
 std::shared_ptr<$connection_class_name$> Make$connection_class_name$(
 )""");
   CcPrint("    ");
+  if (IsExperimental()) CcPrint("ExperimentalTag, ");
   switch (endpoint_location_style) {
     case ServiceConfiguration::LOCATION_DEPENDENT:
     case ServiceConfiguration::LOCATION_DEPENDENT_COMPAT:

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -95,6 +95,11 @@ ServiceCodeGenerator::EndpointLocationStyle() const {
   return endpoint_location_style;
 }
 
+bool ServiceCodeGenerator::IsExperimental() const {
+  auto iter = vars().find("experimental");
+  return iter != vars().end() && iter->second == "true";
+}
+
 bool ServiceCodeGenerator::HasLongrunningMethod() const {
   return std::any_of(methods_.begin(), methods_.end(),
                      [](google::protobuf::MethodDescriptor const& m) {

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -101,6 +101,12 @@ class ServiceCodeGenerator : public GeneratorInterface {
   ServiceConfiguration::EndpointLocationStyle EndpointLocationStyle() const;
 
   /**
+   * Whether a service is experimental. If true, we add the `ExperimentalTag` to
+   * certain APIs.
+   */
+  bool IsExperimental() const;
+
+  /**
    * Determines if the service contains at least one method that returns a
    * google::longrunning::Operation.
    */

--- a/generator/internal/service_code_generator_test.cc
+++ b/generator/internal/service_code_generator_test.cc
@@ -71,10 +71,11 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
 class TestGenerator : public ServiceCodeGenerator {
  public:
   TestGenerator(google::protobuf::ServiceDescriptor const* service_descriptor,
-                google::protobuf::compiler::GeneratorContext* context)
+                google::protobuf::compiler::GeneratorContext* context,
+                VarsDictionary service_vars = {{"header_path_key",
+                                                "header_path"}})
       : ServiceCodeGenerator("header_path_key", service_descriptor,
-                             {{"header_path_key", "header_path"}}, {},
-                             context) {}
+                             std::move(service_vars), {}, context) {}
 
   using ServiceCodeGenerator::HasBidirStreamingMethod;
   using ServiceCodeGenerator::HasExplicitRoutingMethod;
@@ -83,11 +84,43 @@ class TestGenerator : public ServiceCodeGenerator {
   using ServiceCodeGenerator::HasPaginatedMethod;
   using ServiceCodeGenerator::HasStreamingReadMethod;
   using ServiceCodeGenerator::HasStreamingWriteMethod;
+  using ServiceCodeGenerator::IsExperimental;
   using ServiceCodeGenerator::MethodSignatureWellKnownProtobufTypeIncludes;
 
   Status GenerateHeader() override { return {}; }
   Status GenerateCc() override { return {}; }
 };
+
+TEST(PredicateUtilsTest, IsExperimental) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.foo.v1"
+    service { name: "Service" }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  auto generator_context = absl::make_unique<MockGeneratorContext>();
+  EXPECT_CALL(*generator_context, Open("header_path"))
+      .WillRepeatedly(Return(nullptr));
+
+  TestGenerator g1(service_file_descriptor->service(0),
+                   generator_context.get());
+  EXPECT_FALSE(g1.IsExperimental());
+
+  TestGenerator g2(
+      service_file_descriptor->service(0), generator_context.get(),
+      {{"header_path_key", "header_path"}, {"experimental", "true"}});
+
+  TestGenerator g3(
+      service_file_descriptor->service(0), generator_context.get(),
+      {{"header_path_key", "header_path"}, {"experimental", "false"}});
+  EXPECT_FALSE(g3.IsExperimental());
+}
 
 TEST(PredicateUtilsTest, HasLongRunningMethodNone) {
   FileDescriptorProto longrunning_file;

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -257,6 +257,9 @@ int main(int argc, char** argv) {
     for (auto const& additional_proto_file : service.additional_proto_files()) {
       args.emplace_back(additional_proto_file);
     }
+    if (service.experimental()) {
+      args.emplace_back("--cpp_codegen_opt=experimental=true");
+    }
 
     GCP_LOG(INFO) << "Generating service code using: "
                   << absl::StrJoin(args, ";") << "\n";

--- a/google/cloud/speech/v2/speech_client.cc
+++ b/google/cloud/speech/v2/speech_client.cc
@@ -24,7 +24,8 @@ namespace cloud {
 namespace speech_v2 {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-SpeechClient::SpeechClient(std::shared_ptr<SpeechConnection> connection,
+SpeechClient::SpeechClient(ExperimentalTag,
+                           std::shared_ptr<SpeechConnection> connection,
                            Options opts)
     : connection_(std::move(connection)),
       options_(

--- a/google/cloud/speech/v2/speech_client.h
+++ b/google/cloud/speech/v2/speech_client.h
@@ -63,7 +63,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ///
 class SpeechClient {
  public:
-  explicit SpeechClient(std::shared_ptr<SpeechConnection> connection,
+  explicit SpeechClient(ExperimentalTag,
+                        std::shared_ptr<SpeechConnection> connection,
                         Options opts = {});
   ~SpeechClient();
 

--- a/google/cloud/speech/v2/speech_connection.cc
+++ b/google/cloud/speech/v2/speech_connection.cc
@@ -206,7 +206,8 @@ SpeechConnection::UndeletePhraseSet(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-std::shared_ptr<SpeechConnection> MakeSpeechConnection(Options options) {
+std::shared_ptr<SpeechConnection> MakeSpeechConnection(ExperimentalTag,
+                                                       Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  SpeechPolicyOptionList>(options, __func__);

--- a/google/cloud/speech/v2/speech_connection.h
+++ b/google/cloud/speech/v2/speech_connection.h
@@ -174,7 +174,8 @@ class SpeechConnection {
  * @param options (optional) Configure the `SpeechConnection` created by
  * this function.
  */
-std::shared_ptr<SpeechConnection> MakeSpeechConnection(Options options = {});
+std::shared_ptr<SpeechConnection> MakeSpeechConnection(ExperimentalTag,
+                                                       Options options = {});
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace speech_v2


### PR DESCRIPTION
Fixes #10263 

I originally used an `$experimental_tag$`, but decided the generator code was not as easy to read.

I am compromising and not adding a new golden service in the generator, just to verify that these two `ExperimentalTag`s show up. Instead, I decided to just turn it on for speech v2. :shrug: 

If someone twists my arm hard enough, I will add a new golden service for testing.