### PR TITLE
impl(common): make `ErrorContext` a collection

### DIFF
--- a/google/cloud/internal/error_metadata.h
+++ b/google/cloud/internal/error_metadata.h
@@ -74,6 +74,12 @@ namespace internal {
 class ErrorContext {
  public:
   using Container = std::vector<std::pair<std::string, std::string>>;
+  using value_type = Container::value_type;
+  using reference = Container::reference;
+  using const_reference = Container::const_reference;
+  using difference_type = Container::difference_type;
+  using size_type = Container::size_type;
+  using const_iterator = Container::const_iterator;
 
   ErrorContext() = default;
   explicit ErrorContext(Container m) : metadata_(std::move(m)) {}
@@ -83,20 +89,32 @@ class ErrorContext {
   ErrorContext(ErrorContext&&) = default;
   ErrorContext& operator=(ErrorContext&&) = default;
 
-  template <typename... A>
-  Container::reference emplace_back(A&&... a) {
-    return metadata_.emplace_back(std::forward<A>(a)...);
+  friend bool operator==(ErrorContext const& lhs, ErrorContext const& rhs) {
+    return lhs.metadata_ == rhs.metadata_;
   }
 
-  void push_back(Container::value_type p) {
-    return metadata_.push_back(std::move(p));
+  friend bool operator!=(ErrorContext const& lhs, ErrorContext const& rhs) {
+    return !(lhs == rhs);
   }
+
+  void swap(ErrorContext& rhs) { metadata_.swap(rhs.metadata_); }
+
+  template <typename... A>
+  void emplace_back(A&&... a) {
+    metadata_.emplace_back(std::forward<A>(a)...);
+  }
+
+  void push_back(Container::value_type p) { metadata_.push_back(std::move(p)); }
+
+  size_type size() const { return metadata_.size(); }
+
+  size_type max_size() const { return metadata_.max_size(); }
 
   bool empty() const { return metadata_.empty(); }
 
-  Container::const_iterator begin() const { return metadata_.begin(); }
+  const_iterator begin() const { return metadata_.begin(); }
 
-  Container::const_iterator end() const { return metadata_.end(); }
+  const_iterator end() const { return metadata_.end(); }
 
  private:
   Container metadata_;

--- a/google/cloud/internal/error_metadata_test.cc
+++ b/google/cloud/internal/error_metadata_test.cc
@@ -22,7 +22,22 @@ namespace internal {
 namespace {
 
 using ::testing::HasSubstr;
+using ::testing::Pair;
 using ::testing::StartsWith;
+using ::testing::UnorderedElementsAre;
+
+TEST(ErrorContext, Basic) {
+  auto const other =
+      ErrorContext{{{"key", "value"}, {"filename", "the-filename"}}};
+  auto actual = ErrorContext{other};
+  EXPECT_EQ(other, actual);
+  actual.push_back(std::make_pair("k0", "v0"));
+  actual.emplace_back("k1", "v1");
+  EXPECT_NE(other, actual);
+  EXPECT_THAT(actual, UnorderedElementsAre(Pair("key", "value"),
+                                           Pair("filename", "the-filename"),
+                                           Pair("k0", "v0"), Pair("k1", "v1")));
+}
 
 TEST(ErrorContext, FormatEmpty) {
   EXPECT_EQ("error message", Format("error message", ErrorContext{}));


### PR DESCRIPTION
TIL: the return type for `push_back()` changed between C++14 and C++17, I had to fix that, then add some tests, then I noticed the thing was not easy to test because it did not behave like a C++ collection, so I fixed that too.

Motivated by #5915 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10275)
<!-- Reviewable:end -->
