### PR TITLE
fix(common): create default gRPC credentials only if needed

### DIFF
--- a/google/cloud/internal/populate_grpc_options.cc
+++ b/google/cloud/internal/populate_grpc_options.cc
@@ -29,7 +29,8 @@ Options PopulateGrpcOptions(Options opts, std::string const& emulator_env_var) {
       opts.set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
     }
   }
-  if (!opts.has<GrpcCredentialOption>()) {
+  if (!opts.has<GrpcCredentialOption>() &&
+      !opts.has<UnifiedCredentialsOption>()) {
     opts.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }
   if (!opts.has<GrpcTracingOptionsOption>()) {


### PR DESCRIPTION
For backwards compatibility with the pre-Unified Credentials world we were calling `grpc::GoogleDefaultCredentials()` if `g::c::GrpcCredentialsOption` was not set. In many cases the option is not set, but `g::c::UnifiedCredentialsOption` is. If that is the case, the unified options are preferred. Calling
`grpc::GoogleDefaultCredentials()` produces spurious errors, and these credentials won't be used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10280)
<!-- Reviewable:end -->
