### PR TITLE
impl(otel): add experimental flag

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -295,3 +295,11 @@ cc_library(
         "//google/cloud:google_cloud_cpp_mocks",
     ],
 )
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+bool_flag(
+    name = "experimental-open_telemetry",
+    build_setting_default = False,
+    visibility = ["//:__subpackages__"],
+)

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -28,7 +28,7 @@ capture_build_info(
 )
 
 config_setting(
-    name = "have_open_telemetry",
+    name = "enable_open_telemetry_valid",
     flag_values = {
         "//:experimental-open_telemetry": "true",
         "@io_opentelemetry_cpp//api:with_abseil": "true",
@@ -36,7 +36,7 @@ config_setting(
 )
 
 config_setting(
-    name = "not_have_open_telemetry",
+    name = "disable_open_telemetry",
     flag_values = {"//:experimental-open_telemetry": "false"},
 )
 
@@ -48,10 +48,21 @@ cc_library(
     hdrs = google_cloud_cpp_common_hdrs,
     target_compatible_with = select(
         {
-            ":have_open_telemetry": [],
-            ":not_have_open_telemetry": [],
+            ":enable_open_telemetry_valid": [],
+            ":disable_open_telemetry": [],
         },
-        no_match_error = "OpenTelemetry must be built with Abseil. To fix this error, supply the `--@io_opentelemetry_cpp//api:with_abseil` flag to your build command.",
+        # else, OpenTelemetry is enabled, but with an invalid configuration.
+        no_match_error = """
+
+
+You requested OpenTelemetry support for `google-cloud-cpp`, but OpenTelemetry is
+configured without Abseil support. This configuration will result in ODR
+violations, and possibly build-time errors, as OpenTelemetry redefines Abseil
+symbols in this case, and `google-cloud-cpp` uses Abseil directly too.
+
+To fix this problem, supply the `--@io_opentelemetry_cpp//api:with_abseil` flag
+to your build command, or set this value in your `.bazelrc` file(s).
+""",
     ),
     visibility = [
         ":__subpackages__",

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -27,12 +27,32 @@ capture_build_info(
     ],
 )
 
+config_setting(
+    name = "have_open_telemetry",
+    flag_values = {
+        "//:experimental-open_telemetry": "true",
+        "@io_opentelemetry_cpp//api:with_abseil": "true",
+    },
+)
+
+config_setting(
+    name = "not_have_open_telemetry",
+    flag_values = {"//:experimental-open_telemetry": "false"},
+)
+
 load(":google_cloud_cpp_common.bzl", "google_cloud_cpp_common_hdrs", "google_cloud_cpp_common_srcs")
 
 cc_library(
     name = "google_cloud_cpp_common_private",
     srcs = google_cloud_cpp_common_srcs + ["internal/build_info.cc"],
     hdrs = google_cloud_cpp_common_hdrs,
+    target_compatible_with = select(
+        {
+            ":have_open_telemetry": [],
+            ":not_have_open_telemetry": [],
+        },
+        no_match_error = "OpenTelemetry must be built with Abseil. To fix this error, supply the `--@io_opentelemetry_cpp//api:with_abseil` flag to your build command.",
+    ),
     visibility = [
         ":__subpackages__",
         "//:__pkg__",


### PR DESCRIPTION
Part of the work for #10283 

We will keep the flag internal until it does anything.

We verify the configuration, by breaking the build in the [Analysis Phase](https://bazel.build/run/build#analysis) if OpenTelemetry is not built with Abseil.

Now is the time to bikeshed the error message, and the target the error is attached to. (We could pick `//:common` instead.). Here is what an error looks like:

```
$ bazel build --//:experimental-open_telemetry //:common

ERROR: google-cloud-cpp/google/cloud/BUILD.bazel:45:11: configurable attribute "target_compatible_with" in //google/cloud:google_cloud_cpp_common_private doesn't match this configuration: OpenTelemetry must be built with Abseil. To fix this error, supply the `--@io_opentelemetry_cpp//api:with_abseil` flag to your build command.

This instance of //google/cloud:google_cloud_cpp_common_private has configuration identifier ab52c64. To inspect its configuration, run: bazel config ab52c64.

For more help, see https://docs.bazel.build/configurable-attributes.html#why-doesnt-my-select-choose-what-i-expect.

ERROR: Analysis of target '//:common' failed; build aborted: 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10295)
<!-- Reviewable:end -->
