### PR TITLE
chore: teach renovate how to parse googletest version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -69,7 +69,7 @@
     {
       "matchPackageNames": ["com_google_googletest", "google/googletest"],
       "groupName": "GoogleTest",
-      "versioning": "loose"
+      "versioning": "regex:^release-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$"
     },
     {
       "matchManagers": ["pip_requirements"],


### PR DESCRIPTION
Manually parse the version for `googletest`. [Previous runs](https://app.renovatebot.com/dashboard#github/googleapis/google-cloud-cpp/908580241) would fail with:
> DEBUG: Dependency google/googletest has unsupported value release-1.12.1

I used the same `renovate.json` in my test repo and the bots sent me this: https://github.com/dbolduc/test-renovate/pull/13