### PR TITLE
ci(otel): add bazel build with otel disabled

### DIFF
--- a/ci/cloudbuild/builds/otel-disabled-bazel.sh
+++ b/ci/cloudbuild/builds/otel-disabled-bazel.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+
+export CC=clang
+export CXX=clang++
+
+mapfile -t args < <(bazel::common_args)
+args+=("--//:experimental-open_telemetry=false")
+bazel test "${args[@]}" --test_tag_filters=-integration-test ...

--- a/ci/cloudbuild/triggers/otel-disabled-bazel-ci.yaml
+++ b/ci/cloudbuild/triggers/otel-disabled-bazel-ci.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^main$
+name: otel-disabled-bazel-ci
+substitutions:
+  _BUILD_NAME: otel-disabled-bazel
+  _DISTRO: fedora-36-bazel
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/otel-disabled-bazel-pr.yaml
+++ b/ci/cloudbuild/triggers/otel-disabled-bazel-pr.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^main$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: otel-disabled-bazel-pr
+substitutions:
+  _BUILD_NAME: otel-disabled-bazel
+  _DISTRO: fedora-36-bazel
+  _TRIGGER_TYPE: pr
+tags:
+- pr


### PR DESCRIPTION
Part of the work for #10283 

I will add the trigger on Cloud Build after this PR goes through.

I decided not to run the integration tests, in this build. I think the unit tests will be sufficient.

Note that `//:experimental-open_telemetry` is set to false by default in all of our bazel builds. The plan of record is to change that, but in a separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10313)
<!-- Reviewable:end -->
