### PR TITLE
ci(otel): enable otel by default in our project

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,10 @@ build --experimental_convenience_symlinks=ignore
 # in a random order to help expose undesirable interdependencies.
 test --test_env=GTEST_SHUFFLE --test_env=GTEST_RANDOM_SEED
 
+# By default, build the library with OpenTelemetry
+build --@io_opentelemetry_cpp//api:with_abseil
+build --//:experimental-open_telemetry
+
 # Clang Sanitizers, use with (for example):
 #
 # --client_env=CXX=clang++ --client_env=CC=clang --config asan


### PR DESCRIPTION
Part of the work for #10283

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10314)
<!-- Reviewable:end -->
