### PR TITLE
impl(pubsub): add `SubscriberConnectionImpl::Pull()`

### DIFF
--- a/google/cloud/pubsub/internal/subscriber_connection_impl.h
+++ b/google/cloud/pubsub/internal/subscriber_connection_impl.h
@@ -15,7 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_SUBSCRIBER_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_SUBSCRIBER_CONNECTION_IMPL_H
 
+#include "google/cloud/pubsub/ack_handler.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/pull_ack_handler.h"
 #include "google/cloud/pubsub/subscriber_connection.h"
+#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 
 namespace google {
@@ -34,6 +38,14 @@ class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
   future<Status> Subscribe(SubscribeParams p) override;
 
   future<Status> ExactlyOnceSubscribe(ExactlyOnceSubscribeParams p) override;
+
+  // TODO(#7187) - move to pubsub::SubscriberConnection
+  struct PullResponse {
+    pubsub::PullAckHandler handler;
+    pubsub::Message message;
+  };
+
+  StatusOr<PullResponse> Pull();
 
   Options options() override;
 


### PR DESCRIPTION
Note that this function is not yet in the base class. We can implement it and write a unit test first, keeping future PRs smaller.

Part of the work for #7187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10315)
<!-- Reviewable:end -->
