### PR TITLE
impl(otel): define GOOGLE_CLOUD_CPP_HAVE_OPEN_TELEMETRY

### DIFF
--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -46,6 +46,13 @@ cc_library(
     name = "google_cloud_cpp_common_private",
     srcs = google_cloud_cpp_common_srcs + ["internal/build_info.cc"],
     hdrs = google_cloud_cpp_common_hdrs,
+    defines = select({
+        ":enable_open_telemetry_valid": [
+            # Enable OpenTelemetry features in google-cloud-cpp
+            "GOOGLE_CLOUD_CPP_HAVE_OPEN_TELEMETRY",
+        ],
+        "//conditions:default": [],
+    }),
     target_compatible_with = select(
         {
             ":enable_open_telemetry_valid": [],
@@ -344,3 +351,19 @@ load(":google_cloud_cpp_rest_protobuf_internal_unit_tests.bzl", "google_cloud_cp
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in google_cloud_cpp_rest_protobuf_internal_unit_tests]
+
+cc_test(
+    name = "internal_open_telemetry_defines_test",
+    srcs = select({
+        ":enable_open_telemetry_valid": [
+            "internal/open_telemetry_enabled_test.cc",
+        ],
+        "//conditions:default": [
+            "internal/open_telemetry_disabled_test.cc",
+        ],
+    }),
+    deps = [
+        "//:common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -150,7 +150,6 @@ target_link_libraries(
 # Take a dependency on the OpenTelemetry API, if it is available.
 find_package(opentelemetry-cpp CONFIG)
 if (opentelemetry-cpp_FOUND)
-    target_link_libraries(google_cloud_cpp_common PUBLIC opentelemetry-cpp::api)
     target_compile_definitions(
         google_cloud_cpp_common
         PUBLIC # Enable OpenTelemetry features in google-cloud-cpp

--- a/google/cloud/internal/open_telemetry_disabled_test.cc
+++ b/google/cloud/internal/open_telemetry_disabled_test.cc
@@ -1,0 +1,23 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+TEST(OpenTelemetry, VerifyDisabled) {
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPEN_TELEMETRY
+  GTEST_FAIL();
+#else
+  GTEST_SUCCEED();
+#endif
+}

--- a/google/cloud/internal/open_telemetry_enabled_test.cc
+++ b/google/cloud/internal/open_telemetry_enabled_test.cc
@@ -1,0 +1,23 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+TEST(OpenTelemetry, VerifyEnabled) {
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPEN_TELEMETRY
+  GTEST_SUCCEED();
+#else
+  GTEST_FAIL();
+#endif
+}


### PR DESCRIPTION
Part of the work for #10283 

define `GOOGLE_CLOUD_CPP_HAVE_OPEN_TELEMETRY` if OpenTelemetry is present in cmake, or requested in bazel. Verify that the defines switch works correctly with a test.

(Aside: will my `otel-disabled-bazel` build run on presubmit??)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10322)
<!-- Reviewable:end -->
