### PR TITLE
refactor(common): prefer `internal::AccessToken`

### DIFF
--- a/google/cloud/internal/oauth2_authorized_user_credentials.h
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.h
@@ -46,8 +46,7 @@ StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri = GoogleOAuthRefreshEndpoint());
 
-/// Parses a refresh response JSON string into an authorization header. The
-/// header and the current time (for the expiration) form a TemporaryToken.
+/// Parses a refresh response JSON string into an access token.
 StatusOr<internal::AccessToken> ParseAuthorizedUserRefreshResponse(
     rest_internal::RestResponse& response,
     std::chrono::system_clock::time_point now);

--- a/google/cloud/internal/oauth2_authorized_user_credentials.h
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.h
@@ -48,9 +48,9 @@ StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
 
 /// Parses a refresh response JSON string into an authorization header. The
 /// header and the current time (for the expiration) form a TemporaryToken.
-StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
-ParseAuthorizedUserRefreshResponse(rest_internal::RestResponse& response,
-                                   std::chrono::system_clock::time_point now);
+StatusOr<internal::AccessToken> ParseAuthorizedUserRefreshResponse(
+    rest_internal::RestResponse& response,
+    std::chrono::system_clock::time_point now);
 
 /**
  * Wrapper class for Google OAuth 2.0 user account credentials.
@@ -94,7 +94,7 @@ class AuthorizedUserCredentials : public Credentials {
   StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
 
  private:
-  StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh();
+  StatusOr<internal::AccessToken> Refresh();
 
   AuthorizedUserCredentialsInfo info_;
   Options options_;

--- a/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
@@ -394,7 +394,7 @@ TEST_F(AuthorizedUserCredentialsTest,
                        HasSubstr("Could not find all required fields")));
 }
 
-/// @test Parsing a refresh response yields a TemporaryToken.
+/// @test Parsing a refresh response yields an access token.
 TEST_F(AuthorizedUserCredentialsTest, ParseAuthorizedUserRefreshResponse) {
   std::string r1 = R"""({
     "token_type": "Type",

--- a/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
@@ -424,15 +424,14 @@ TEST_F(AuthorizedUserCredentialsTest, ParseAuthorizedUserRefreshResponse) {
   EXPECT_STATUS_OK(status);
   auto token = *status;
   EXPECT_EQ(
-      std::chrono::time_point_cast<std::chrono::seconds>(token.expiration_time)
+      std::chrono::time_point_cast<std::chrono::seconds>(token.expiration)
           .time_since_epoch()
           .count(),
       std::chrono::time_point_cast<std::chrono::seconds>(
           std::chrono::system_clock::from_time_t(clock_value + expires_in))
           .time_since_epoch()
           .count());
-  EXPECT_EQ(token.token, std::make_pair(std::string{"Authorization"},
-                                        std::string{"Type access-token-r1"}));
+  EXPECT_EQ(token.token, "Type access-token-r1");
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_compute_engine_credentials.h
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.h
@@ -49,8 +49,7 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
  */
 ServiceAccountMetadata ParseMetadataServerResponse(std::string const& payload);
 
-/// Parses a refresh response JSON string into an authorization header. The
-/// header and the current time (for the expiration) form a TemporaryToken.
+/// Parses a refresh response JSON string into an access token.
 StatusOr<internal::AccessToken> ParseComputeEngineRefreshResponse(
     rest_internal::RestResponse& response,
     std::chrono::system_clock::time_point now);

--- a/google/cloud/internal/oauth2_compute_engine_credentials.h
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.h
@@ -51,9 +51,9 @@ ServiceAccountMetadata ParseMetadataServerResponse(std::string const& payload);
 
 /// Parses a refresh response JSON string into an authorization header. The
 /// header and the current time (for the expiration) form a TemporaryToken.
-StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
-ParseComputeEngineRefreshResponse(rest_internal::RestResponse& response,
-                                  std::chrono::system_clock::time_point now);
+StatusOr<internal::AccessToken> ParseComputeEngineRefreshResponse(
+    rest_internal::RestResponse& response,
+    std::chrono::system_clock::time_point now);
 
 /**
  * Wrapper class for Google OAuth 2.0 GCE instance service account credentials.
@@ -145,7 +145,7 @@ class ComputeEngineCredentials : public Credentials {
   /**
    * Attempts to refresh the credentials.
    */
-  StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh() const;
+  StatusOr<internal::AccessToken> Refresh() const;
 
   mutable std::mutex mu_;
   CurrentTimeFn current_time_fn_;

--- a/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
@@ -185,7 +185,7 @@ TEST_F(ComputeEngineCredentialsTest,
                        HasSubstr("Could not find all required fields")));
 }
 
-/// @test Parsing a refresh response yields a TemporaryToken.
+/// @test Parsing a refresh response yields an access token.
 TEST_F(ComputeEngineCredentialsTest, ParseComputeEngineRefreshResponse) {
   std::string token_info_resp = R"""({
       "access_token": "mysupersecrettoken",

--- a/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
@@ -215,14 +215,11 @@ TEST_F(ComputeEngineCredentialsTest, ParseComputeEngineRefreshResponse) {
       *mock_response, std::chrono::system_clock::from_time_t(clock_value));
   EXPECT_STATUS_OK(status);
   auto token = *status;
-  EXPECT_EQ(
-      std::chrono::time_point_cast<std::chrono::seconds>(token.expiration_time)
-          .time_since_epoch()
-          .count(),
-      clock_value + expires_in);
-  EXPECT_EQ(token.token,
-            std::make_pair(std::string{"Authorization"},
-                           std::string{"tokentype mysupersecrettoken"}));
+  EXPECT_EQ(std::chrono::time_point_cast<std::chrono::seconds>(token.expiration)
+                .time_since_epoch()
+                .count(),
+            clock_value + expires_in);
+  EXPECT_EQ(token.token, "tokentype mysupersecrettoken");
 }
 
 /// @test Parsing a metadata server response yields a ServiceAccountMetadata.

--- a/google/cloud/internal/oauth2_refreshing_credentials_wrapper.h
+++ b/google/cloud/internal/oauth2_refreshing_credentials_wrapper.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OAUTH2_REFRESHING_CREDENTIALS_WRAPPER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OAUTH2_REFRESHING_CREDENTIALS_WRAPPER_H
 
+#include "google/cloud/internal/access_token.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -40,13 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class RefreshingCredentialsWrapper {
  public:
-  struct TemporaryToken {
-    std::pair<std::string, std::string> token;
-    std::chrono::system_clock::time_point expiration_time;
-  };
-
-  using RefreshFunctor = absl::FunctionRef<
-      StatusOr<RefreshingCredentialsWrapper::TemporaryToken>()>;
+  using RefreshFunctor = absl::FunctionRef<StatusOr<internal::AccessToken>()>;
   using CurrentTimeFn =
       std::function<std::chrono::time_point<std::chrono::system_clock>()>;
 
@@ -89,7 +84,7 @@ class RefreshingCredentialsWrapper {
   bool IsExpired() const;
   bool NeedsRefresh() const;
 
-  mutable TemporaryToken temporary_token_;
+  mutable internal::AccessToken token_;
   CurrentTimeFn current_time_fn_;
 };
 

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -68,9 +68,9 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
 
 /// Parses a refresh response JSON string and uses the current time to create a
 /// TemporaryToken.
-StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
-ParseServiceAccountRefreshResponse(rest_internal::RestResponse& response,
-                                   std::chrono::system_clock::time_point now);
+StatusOr<internal::AccessToken> ParseServiceAccountRefreshResponse(
+    rest_internal::RestResponse& response,
+    std::chrono::system_clock::time_point now);
 
 /**
  * Splits a ServiceAccountCredentialsInfo into header and payload components
@@ -237,10 +237,9 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
 
  private:
   bool UseOAuth();
-  StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh();
-  StatusOr<RefreshingCredentialsWrapper::TemporaryToken> RefreshOAuth() const;
-  StatusOr<RefreshingCredentialsWrapper::TemporaryToken> RefreshSelfSigned()
-      const;
+  StatusOr<internal::AccessToken> Refresh();
+  StatusOr<internal::AccessToken> RefreshOAuth() const;
+  StatusOr<internal::AccessToken> RefreshSelfSigned() const;
 
   ServiceAccountCredentialsInfo info_;
   CurrentTimeFn current_time_fn_;

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -66,8 +66,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri = GoogleOAuthRefreshEndpoint());
 
-/// Parses a refresh response JSON string and uses the current time to create a
-/// TemporaryToken.
+/// Parses a refresh response JSON string to create an access token.
 StatusOr<internal::AccessToken> ParseServiceAccountRefreshResponse(
     rest_internal::RestResponse& response,
     std::chrono::system_clock::time_point now);

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -951,13 +951,11 @@ TEST(ServiceAccountCredentialsTest, ParseServiceAccountRefreshResponse) {
       ParseServiceAccountRefreshResponse(*mock_response1, FakeClock::now());
   EXPECT_STATUS_OK(status);
   auto token = *status;
-  EXPECT_EQ(
-      std::chrono::time_point_cast<std::chrono::seconds>(token.expiration_time)
-          .time_since_epoch()
-          .count(),
-      FakeClock::now_value_ + expires_in);
-  EXPECT_EQ(token.token, std::make_pair(std::string{"Authorization"},
-                                        std::string{"Type access-token-r1"}));
+  EXPECT_EQ(std::chrono::time_point_cast<std::chrono::seconds>(token.expiration)
+                .time_since_epoch()
+                .count(),
+            FakeClock::now_value_ + expires_in);
+  EXPECT_EQ(token.token, "Type access-token-r1");
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -920,7 +920,7 @@ TEST(ServiceAccountCredentialsTest,
                        HasSubstr("Could not find all required fields")));
 }
 
-/// @test Parsing a refresh response yields a TemporaryToken.
+/// @test Parsing a refresh response yields an access token.
 TEST(ServiceAccountCredentialsTest, ParseServiceAccountRefreshResponse) {
   ScopedEnvironment disable_self_signed_jwt(
       "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT", "1");

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
@@ -36,15 +36,13 @@ std::pair<std::string, std::string> RefreshingCredentialsWrapper::SplitToken(
 
 bool RefreshingCredentialsWrapper::IsExpired(
     std::chrono::system_clock::time_point now) const {
-  return now > (impl_->temporary_token_.expiration_time -
-                GoogleOAuthAccessTokenExpirationSlack());
+  return now >
+         (impl_->token_.expiration - GoogleOAuthAccessTokenExpirationSlack());
 }
 
 bool RefreshingCredentialsWrapper::IsValid(
     std::chrono::system_clock::time_point now) const {
-  return (!impl_->temporary_token_.token.first.empty() ||
-          !impl_->temporary_token_.token.second.empty()) &&
-         !IsExpired(now);
+  return !impl_->token_.token.empty() && !IsExpired(now);
 }
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
@@ -44,17 +44,16 @@ class RefreshingCredentialsWrapper {
   template <typename RefreshFunctor>
   StatusOr<std::string> AuthorizationHeader(
       std::chrono::system_clock::time_point, RefreshFunctor refresh_fn) const {
-    auto refresh_fn_wrapper = [refresh_fn]()
-        -> StatusOr<
-            oauth2_internal::RefreshingCredentialsWrapper::TemporaryToken> {
+    auto refresh_fn_wrapper =
+        [refresh_fn]() -> StatusOr<google::cloud::internal::AccessToken> {
       auto temp_token = refresh_fn();
       if (!temp_token.ok()) return temp_token.status();
       auto token = SplitToken(temp_token->token);
-      return oauth2_internal::RefreshingCredentialsWrapper::TemporaryToken{
-          std::move(token), temp_token->expiration_time};
+      return google::cloud::internal::AccessToken{std::move(token.second),
+                                                  temp_token->expiration_time};
     };
     auto header = impl_->AuthorizationHeader(refresh_fn_wrapper);
-    if (!header.ok()) return header.status();
+    if (!header.ok()) return std::move(header).status();
     return header->first + ": " + header->second;
   }
 


### PR DESCRIPTION
Prefer `internal::AccessToken` over the (now removed) `RefreshingCredentialsWrapper::TemporaryToken`. This will make it easier to replace `AuthorizationHeader()` with `GetToken()` in the `oauth2_internal::*Credentials` classes.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10326)
<!-- Reviewable:end -->
