### PR TITLE
feat(pubsub): add option to override subscription

### DIFF
--- a/google/cloud/pubsub/internal/subscriber_connection_impl.h
+++ b/google/cloud/pubsub/internal/subscriber_connection_impl.h
@@ -29,8 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
  public:
   explicit SubscriberConnectionImpl(
-      pubsub::Subscription subscription, Options opts,
-      std::shared_ptr<pubsub_internal::SubscriberStub> stub);
+      Options opts, std::shared_ptr<pubsub_internal::SubscriberStub> stub);
 
   ~SubscriberConnectionImpl() override;
 
@@ -45,7 +44,6 @@ class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
  private:
   std::string MakeClientId();
 
-  pubsub::Subscription const subscription_;
   Options const opts_;
   std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
   std::shared_ptr<BackgroundThreads> background_;

--- a/google/cloud/pubsub/internal/subscriber_connection_impl_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_connection_impl_test.cc
@@ -40,12 +40,14 @@ using ::google::pubsub::v1::PullRequest;
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::AtLeast;
+using ::testing::AtMost;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Property;
 using ::testing::StartsWith;
 
-Options MakeTestOptions(Options opts = {}) {
+Options MakeTestOptions(Subscription subscription, Options opts = {}) {
+  opts.set<pubsub::SubscriptionOption>(std::move(subscription));
   opts.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
   opts = pubsub_internal::DefaultSubscriberOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
@@ -55,11 +57,92 @@ Options MakeTestOptions(Options opts = {}) {
   return opts;
 }
 
-Options MakeTestOptions(CompletionQueue const& cq) {
-  return MakeTestOptions(Options{}.set<GrpcCompletionQueueOption>(cq));
+Options MakeTestOptions(Subscription subscription, CompletionQueue const& cq) {
+  return MakeTestOptions(std::move(subscription),
+                         Options{}.set<GrpcCompletionQueueOption>(cq));
 }
 
-TEST(SubscriberConnectionTest, Basic) {
+using StreamingPullMock =
+    std::function<std::unique_ptr<pubsub_testing::MockAsyncPullStream>(
+        google::cloud::CompletionQueue const&,
+        std::unique_ptr<grpc::ClientContext>)>;
+
+StreamingPullMock MakeAsyncStreamingPullMock(
+    std::string const& expected_subscription_name) {
+  return [expected_subscription_name](
+             google::cloud::CompletionQueue const& completion_queue,
+             std::unique_ptr<grpc::ClientContext>) {
+    using us = std::chrono::microseconds;
+
+    auto cq = completion_queue;
+    auto start_response = [cq]() mutable {
+      return cq.MakeRelativeTimer(us(10)).then([](auto) { return true; });
+    };
+    auto write_response = [cq](google::pubsub::v1::StreamingPullRequest const&,
+                               grpc::WriteOptions const&) mutable {
+      return cq.MakeRelativeTimer(us(10)).then([](auto) { return true; });
+    };
+
+    using Response = ::google::pubsub::v1::StreamingPullResponse;
+    using Request = ::google::pubsub::v1::StreamingPullRequest;
+    class MessageGenerator {
+     public:
+      MessageGenerator() = default;
+
+      Response Generate(int n) {
+        Response response;
+        std::unique_lock<std::mutex> lk(mu_);
+        for (int i = 0; i != n; ++i) {
+          auto& m = *response.add_received_messages();
+          m.set_ack_id("test-ack-id-" + std::to_string(count_));
+          m.mutable_message()->set_message_id("test-message-id-" +
+                                              std::to_string(count_));
+          ++count_;
+        }
+        return response;
+      }
+
+     private:
+      std::mutex mu_;
+      int count_ = 0;
+    };
+
+    auto generator = std::make_shared<MessageGenerator>();
+    auto read_response = [cq, generator]() mutable {
+      return cq.MakeRelativeTimer(us(10)).then([generator](auto) {
+        return absl::make_optional(generator->Generate(10));
+      });
+    };
+    auto canceled_response = [cq]() mutable {
+      return cq.MakeRelativeTimer(us(10)).then(
+          [](auto) { return absl::optional<Response>{}; });
+    };
+    auto finish_response = [cq]() mutable {
+      return cq.MakeRelativeTimer(us(10)).then([](auto) { return Status{}; });
+    };
+
+    auto stream = absl::make_unique<pubsub_testing::MockAsyncPullStream>();
+    EXPECT_CALL(*stream, Start).WillOnce(start_response);
+    EXPECT_CALL(
+        *stream,
+        Write(Property(&Request::subscription, expected_subscription_name), _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(write_response);
+    EXPECT_CALL(*stream, Read).Times(AtLeast(1)).WillRepeatedly(read_response);
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*stream, Cancel).Times(1);
+    EXPECT_CALL(*stream, Read)
+        .Times(AtMost(1))
+        .WillRepeatedly(canceled_response);
+    EXPECT_CALL(*stream, Finish)
+        .Times(AtMost(1))
+        .WillRepeatedly(finish_response);
+
+    return stream;
+  };
+}
+
+TEST(SubscriberConnectionTest, Subscribe) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
@@ -81,7 +164,7 @@ TEST(SubscriberConnectionTest, Basic) {
 
   CompletionQueue cq;
   auto subscriber = std::make_shared<SubscriberConnectionImpl>(
-      subscription, MakeTestOptions(cq), mock);
+      MakeTestOptions(subscription, cq), mock);
   std::atomic_flag received_one{false};
   promise<void> waiter;
   auto handler = [&](Message const& m, AckHandler h) {
@@ -92,6 +175,52 @@ TEST(SubscriberConnectionTest, Basic) {
   };
   std::thread t([&cq] { cq.Run(); });
   google::cloud::internal::OptionsSpan span(subscriber->options());
+  auto response = subscriber->Subscribe({handler});
+  waiter.get_future().wait();
+  response.cancel();
+  ASSERT_STATUS_OK(response.get());
+  // We need to explicitly cancel any pending timers (some of which may be quite
+  // long) left by the subscription.
+  cq.CancelAll();
+  cq.Shutdown();
+  t.join();
+}
+
+TEST(SubscriberConnectionTest, SubscribeOverrideSubscription) {
+  auto const s1 = Subscription("test-project", "test-subscription");
+  auto const s2 = Subscription("test-project", "test-override-subscription");
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline)
+      .WillRepeatedly([](google::cloud::CompletionQueue&,
+                         std::unique_ptr<grpc::ClientContext>,
+                         google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+        return make_ready_future(Status{});
+      });
+  EXPECT_CALL(*mock, AsyncAcknowledge)
+      .WillOnce([](google::cloud::CompletionQueue&,
+                   std::unique_ptr<grpc::ClientContext>,
+                   google::pubsub::v1::AcknowledgeRequest const& request) {
+        EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
+        return make_ready_future(Status{});
+      });
+  EXPECT_CALL(*mock, AsyncStreamingPull)
+      .Times(AtLeast(1))
+      .WillRepeatedly(MakeAsyncStreamingPullMock(s2.FullName()));
+
+  CompletionQueue cq;
+  auto subscriber =
+      std::make_shared<SubscriberConnectionImpl>(MakeTestOptions(s1, cq), mock);
+  std::atomic_flag received_one{false};
+  promise<void> waiter;
+  auto handler = [&](Message const& m, AckHandler h) {
+    if (received_one.test_and_set()) return;
+    EXPECT_THAT(m.message_id(), StartsWith("test-message-id-"));
+    ASSERT_NO_FATAL_FAILURE(std::move(h).ack());
+    waiter.set_value();
+  };
+  std::thread t([&cq] { cq.Run(); });
+  google::cloud::internal::OptionsSpan span(
+      subscriber->options().set<pubsub::SubscriptionOption>(s2));
   auto response = subscriber->Subscribe({handler});
   waiter.get_future().wait();
   response.cancel();
@@ -126,7 +255,7 @@ TEST(SubscriberConnectionTest, ExactlyOnce) {
 
   CompletionQueue cq;
   auto subscriber = std::make_shared<SubscriberConnectionImpl>(
-      subscription, MakeTestOptions(cq), mock);
+      MakeTestOptions(subscription, cq), mock);
   std::atomic_flag received_one{false};
   promise<void> waiter;
   auto callback = [&](Message const& m, ExactlyOnceAckHandler h) {
@@ -139,6 +268,52 @@ TEST(SubscriberConnectionTest, ExactlyOnce) {
   std::thread t([&cq] { cq.Run(); });
   google::cloud::internal::OptionsSpan span(subscriber->options());
   auto response = subscriber->ExactlyOnceSubscribe({callback});
+  waiter.get_future().wait();
+  response.cancel();
+  ASSERT_STATUS_OK(response.get());
+  // We need to explicitly cancel any pending timers (some of which may be quite
+  // long) left by the subscription.
+  cq.CancelAll();
+  cq.Shutdown();
+  t.join();
+}
+
+TEST(SubscriberConnectionTest, ExactlyOnceOverrideSubscription) {
+  auto const s1 = Subscription("test-project", "test-subscription");
+  auto const s2 = Subscription("test-project", "test-override-subscription");
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline)
+      .WillRepeatedly([](google::cloud::CompletionQueue&,
+                         std::unique_ptr<grpc::ClientContext>,
+                         google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+        return make_ready_future(Status{});
+      });
+  EXPECT_CALL(*mock, AsyncAcknowledge)
+      .WillOnce([](google::cloud::CompletionQueue&,
+                   std::unique_ptr<grpc::ClientContext>,
+                   google::pubsub::v1::AcknowledgeRequest const& request) {
+        EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
+        return make_ready_future(Status{});
+      });
+  EXPECT_CALL(*mock, AsyncStreamingPull)
+      .Times(AtLeast(1))
+      .WillRepeatedly(MakeAsyncStreamingPullMock(s2.FullName()));
+
+  CompletionQueue cq;
+  auto subscriber =
+      std::make_shared<SubscriberConnectionImpl>(MakeTestOptions(s1, cq), mock);
+  std::atomic_flag received_one{false};
+  promise<void> waiter;
+  auto handler = [&](Message const& m, AckHandler h) {
+    if (received_one.test_and_set()) return;
+    EXPECT_THAT(m.message_id(), StartsWith("test-message-id-"));
+    ASSERT_NO_FATAL_FAILURE(std::move(h).ack());
+    waiter.set_value();
+  };
+  std::thread t([&cq] { cq.Run(); });
+  google::cloud::internal::OptionsSpan span(
+      subscriber->options().set<pubsub::SubscriptionOption>(s2));
+  auto response = subscriber->Subscribe({handler});
   waiter.get_future().wait();
   response.cancel();
   ASSERT_STATUS_OK(response.get());
@@ -191,7 +366,9 @@ TEST(SubscriberConnectionTest, StreamingPullFailure) {
       });
 
   auto subscriber = std::make_shared<SubscriberConnectionImpl>(
-      subscription, pubsub_testing::MakeTestOptions(), mock);
+      pubsub_testing::MakeTestOptions(
+          Options{}.set<pubsub::SubscriptionOption>(subscription)),
+      mock);
   auto handler = [&](Message const&, AckHandler const&) {};
   google::cloud::internal::OptionsSpan span(subscriber->options());
   auto response = subscriber->Subscribe({handler});
@@ -235,8 +412,58 @@ TEST(SubscriberConnectionTest, Pull) {
   std::thread t([&cq] { cq.Run(); });
 
   auto subscriber = std::make_shared<SubscriberConnectionImpl>(
-      subscription, MakeTestOptions(cq), mock);
+      MakeTestOptions(subscription, cq), mock);
   google::cloud::internal::OptionsSpan span(subscriber->options());
+  auto response = subscriber->Pull();
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(response->message.data(), "test-data-0");
+  std::move(response->handler).ack();
+
+  cq.Shutdown();
+  t.join();
+}
+
+TEST(SubscriberConnectionTest, PullOverrideSubscription) {
+  auto const s1 = Subscription("test-project", "test-subscription");
+  auto const s2 = Subscription("test-project", "test-override-subscription");
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline)
+      .WillRepeatedly([](google::cloud::CompletionQueue&,
+                         std::unique_ptr<grpc::ClientContext>,
+                         google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+        return make_ready_future(Status{});
+      });
+  EXPECT_CALL(*mock, AsyncAcknowledge)
+      .WillOnce([](google::cloud::CompletionQueue&,
+                   std::unique_ptr<grpc::ClientContext>,
+                   google::pubsub::v1::AcknowledgeRequest const& request) {
+        EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
+        return make_ready_future(
+            Status{StatusCode::kUnknown, "test-only-unknown"});
+      });
+  EXPECT_CALL(
+      *mock,
+      Pull(_, AllOf(Property(&PullRequest::max_messages, 1),
+                    Property(&PullRequest::subscription, s2.FullName()))))
+      .WillOnce([](auto&, google::pubsub::v1::PullRequest const&) {
+        return Status(StatusCode::kUnavailable, "try-again");
+      })
+      .WillOnce([](auto&, google::pubsub::v1::PullRequest const&) {
+        google::pubsub::v1::PullResponse response;
+        auto& message = *response.add_received_messages();
+        message.set_delivery_attempt(42);
+        message.set_ack_id("test-ack-id-0");
+        message.mutable_message()->set_data("test-data-0");
+        return response;
+      });
+
+  CompletionQueue cq;
+  std::thread t([&cq] { cq.Run(); });
+
+  auto subscriber =
+      std::make_shared<SubscriberConnectionImpl>(MakeTestOptions(s1, cq), mock);
+  google::cloud::internal::OptionsSpan span(
+      subscriber->options().set<pubsub::SubscriptionOption>(s2));
   auto response = subscriber->Pull();
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->message.data(), "test-data-0");
@@ -260,7 +487,7 @@ TEST(SubscriberConnectionTest, PullPermanentFailure) {
   std::thread t([&cq] { cq.Run(); });
 
   auto subscriber = std::make_shared<SubscriberConnectionImpl>(
-      subscription, MakeTestOptions(cq), mock);
+      MakeTestOptions(subscription, cq), mock);
   google::cloud::internal::OptionsSpan span(subscriber->options());
   auto response = subscriber->Pull();
   EXPECT_THAT(response,
@@ -285,7 +512,7 @@ TEST(SubscriberConnectionTest, PullTooManyTransientFailures) {
   std::thread t([&cq] { cq.Run(); });
 
   auto subscriber = std::make_shared<SubscriberConnectionImpl>(
-      subscription, MakeTestOptions(cq), mock);
+      MakeTestOptions(subscription, cq), mock);
   google::cloud::internal::OptionsSpan span(subscriber->options());
   auto response = subscriber->Pull();
   EXPECT_THAT(response,

--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -192,12 +192,13 @@ class SubscriptionSessionImpl
 }  // namespace
 
 future<Status> CreateSubscriptionSession(
-    pubsub::Subscription const& subscription, Options const& opts,
-    std::shared_ptr<SubscriberStub> const& stub, CompletionQueue const& cq,
-    std::string client_id, pubsub::ApplicationCallback application_callback) {
+    Options const& opts, std::shared_ptr<SubscriberStub> const& stub,
+    CompletionQueue const& cq, std::string client_id,
+    pubsub::ApplicationCallback application_callback) {
   auto shutdown_manager = std::make_shared<SessionShutdownManager>();
   auto batch = std::make_shared<StreamingSubscriptionBatchSource>(
-      cq, shutdown_manager, stub, subscription.FullName(), std::move(client_id),
+      cq, shutdown_manager, stub,
+      opts.get<pubsub::SubscriptionOption>().FullName(), std::move(client_id),
       opts);
   auto lease_management = SubscriptionLeaseManagement::Create(
       cq, shutdown_manager, std::move(batch),
@@ -210,13 +211,13 @@ future<Status> CreateSubscriptionSession(
 }
 
 future<Status> CreateSubscriptionSession(
-    pubsub::Subscription const& subscription, Options const& opts,
-    std::shared_ptr<SubscriberStub> const& stub, CompletionQueue const& cq,
-    std::string client_id,
+    Options const& opts, std::shared_ptr<SubscriberStub> const& stub,
+    CompletionQueue const& cq, std::string client_id,
     pubsub::ExactlyOnceApplicationCallback application_callback) {
   auto shutdown_manager = std::make_shared<SessionShutdownManager>();
   auto batch = std::make_shared<StreamingSubscriptionBatchSource>(
-      cq, shutdown_manager, stub, subscription.FullName(), std::move(client_id),
+      cq, shutdown_manager, stub,
+      opts.get<pubsub::SubscriptionOption>().FullName(), std::move(client_id),
       opts);
   auto lease_management = SubscriptionLeaseManagement::Create(
       cq, shutdown_manager, std::move(batch),

--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -36,14 +36,13 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 future<Status> CreateSubscriptionSession(
-    pubsub::Subscription const& subscription, Options const& opts,
-    std::shared_ptr<SubscriberStub> const& stub, CompletionQueue const& cq,
-    std::string client_id, pubsub::ApplicationCallback application_callback);
+    Options const& opts, std::shared_ptr<SubscriberStub> const& stub,
+    CompletionQueue const& cq, std::string client_id,
+    pubsub::ApplicationCallback application_callback);
 
 future<Status> CreateSubscriptionSession(
-    pubsub::Subscription const& subscription, Options const& opts,
-    std::shared_ptr<SubscriberStub> const& stub, CompletionQueue const& cq,
-    std::string client_id,
+    Options const& opts, std::shared_ptr<SubscriberStub> const& stub,
+    CompletionQueue const& cq, std::string client_id,
     pubsub::ExactlyOnceApplicationCallback application_callback);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -50,20 +50,22 @@ future<Status> CreateTestSubscriptionSession(
     pubsub::Subscription const& subscription, Options opts,
     std::shared_ptr<SubscriberStub> const& mock, CompletionQueue const& cq,
     pubsub::SubscriberConnection::SubscribeParams p) {
+  opts.set<pubsub::SubscriptionOption>(subscription);
   opts = DefaultSubscriberOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return CreateSubscriptionSession(subscription, std::move(opts), mock, cq,
-                                   "test-client-id", std::move(p.callback));
+  return CreateSubscriptionSession(std::move(opts), mock, cq, "test-client-id",
+                                   std::move(p.callback));
 }
 
 future<Status> CreateTestSubscriptionSession(
     pubsub::Subscription const& subscription, Options opts,
     std::shared_ptr<SubscriberStub> const& mock, CompletionQueue const& cq,
     pubsub::ExactlyOnceApplicationCallback callback) {
+  opts.set<pubsub::SubscriptionOption>(subscription);
   opts = DefaultSubscriberOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return CreateSubscriptionSession(subscription, std::move(opts), mock, cq,
-                                   "test-client-id", std::move(callback));
+  return CreateSubscriptionSession(std::move(opts), mock, cq, "test-client-id",
+                                   std::move(callback));
 }
 
 /// @test Verify callbacks are scheduled in the background threads.

--- a/google/cloud/pubsub/options.h
+++ b/google/cloud/pubsub/options.h
@@ -369,7 +369,8 @@ struct ShutdownPollingPeriodOption {
  * Override the default subscription for a request.
  *
  * Some applications need to receive messages from multiple subscriptions. In
- * these case they can use this option to override the default
+ * this case they can use this option to override the default subscription
+ * in a `Subscriber::Pull()` or `Subscriber::Subscribe()` call.
  *
  * @ingroup pubsub-options
  */

--- a/google/cloud/pubsub/options.h
+++ b/google/cloud/pubsub/options.h
@@ -40,6 +40,7 @@
 
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/retry_policy.h"
+#include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/options.h"
 #include <chrono>
@@ -364,12 +365,25 @@ struct ShutdownPollingPeriodOption {
   using Type = std::chrono::milliseconds;
 };
 
+/**
+ * Override the default subscription for a request.
+ *
+ * Some applications need to receive messages from multiple subscriptions. In
+ * these case they can use this option to override the default
+ *
+ * @ingroup pubsub-options
+ */
+struct SubscriptionOption {
+  using Type = Subscription;
+};
+
 /// The list of options specific to subscribers.
+/// @ingroup pubsub-options
 using SubscriberOptionList =
     OptionList<MaxDeadlineTimeOption, MaxDeadlineExtensionOption,
                MinDeadlineExtensionOption, MaxOutstandingMessagesOption,
                MaxOutstandingBytesOption, MaxConcurrencyOption,
-               ShutdownPollingPeriodOption>;
+               ShutdownPollingPeriodOption, SubscriptionOption>;
 
 /**
  * Convenience function to initialize a

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -89,6 +89,9 @@ std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList, PolicyOptionList,
                                  SubscriberOptionList>(opts, __func__);
+  opts = internal::MergeOptions(
+      std::move(opts),
+      Options{}.set<SubscriptionOption>(std::move(subscription)));
   opts = pubsub_internal::DefaultSubscriberOptions(std::move(opts));
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto auth = google::cloud::internal::CreateAuthenticationStrategy(
@@ -104,7 +107,7 @@ std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
   auto stub =
       DecorateSubscriberStub(opts, std::move(auth), std::move(children));
   return std::make_shared<pubsub_internal::SubscriberConnectionImpl>(
-      std::move(subscription), std::move(opts), std::move(stub));
+      std::move(opts), std::move(stub));
 }
 
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
@@ -134,8 +137,9 @@ std::shared_ptr<pubsub::SubscriberConnection> MakeTestSubscriberConnection(
       background->cq(), opts);
   auto stub =
       pubsub::DecorateSubscriberStub(opts, std::move(auth), std::move(stubs));
-  return std::make_shared<SubscriberConnectionImpl>(
-      std::move(subscription), std::move(opts), std::move(stub));
+  opts.set<pubsub::SubscriptionOption>(std::move(subscription));
+  return std::make_shared<SubscriberConnectionImpl>(std::move(opts),
+                                                    std::move(stub));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/subscription.cc
+++ b/google/cloud/pubsub/subscription.cc
@@ -19,6 +19,8 @@ namespace cloud {
 namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+Subscription::Subscription() : Subscription("--invalid--", "--invalid--") {}
+
 std::string Subscription::FullName() const {
   return "projects/" + project_id() + "/subscriptions/" + subscription_id();
 }

--- a/google/cloud/pubsub/subscription.h
+++ b/google/cloud/pubsub/subscription.h
@@ -36,6 +36,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class Subscription {
  public:
+  /// The default constructor creates an invalid subscription.
+  Subscription();
   Subscription(std::string project_id, std::string subscription_id)
       : project_id_(std::move(project_id)),
         subscription_id_(std::move(subscription_id)) {}


### PR DESCRIPTION
For historical reasons, a `pubsub::SubscriberConnection` has a subscription assigned to it.  With this change that subscription becomes the default, and one can provide an override via the `Options` argument.

Motivated by #10320 and #9171

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10327)
<!-- Reviewable:end -->
