### PR TITLE
impl(otel): add experimental cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,10 @@ option(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC
        "${GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC_DEFAULT}")
 mark_as_advanced(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
 
+option(GOOGLE_CLOUD_CPP_ENABLE_EXPERIMENTAL_OPENTELEMETRY
+       "Compile google-cloud-cpp with OpenTelemetry (EXPERIMENTAL)")
+mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_EXPERIMENTAL_OPENTELEMETRY)
+
 # We no longer build the generator by default, but if it was explicitly
 # requested, we add it to the list of enabled libraries.
 if (GOOGLE_CLOUD_CPP_ENABLE_GENERATOR)
@@ -341,6 +345,7 @@ function (google_cloud_cpp_enable_features)
             if (NOT ("storage" IN_LIST GOOGLE_CLOUD_CPP_ENABLE))
                 add_subdirectory(google/cloud/storage)
             endif ()
+        elseif ("${feature}" STREQUAL "experimental-opentelemetry")
         else ()
             if (NOT IS_DIRECTORY
                 "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}"

--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -31,7 +31,7 @@ mapfile -t cmake_args < <(cmake::common_args)
 cmake "${cmake_args[@]}" \
   -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
   -DCMAKE_CXX_STANDARD=14 \
-  -DGOOGLE_CLOUD_CPP_ENABLE="bigtable;bigquery;generator;iam;logging;pubsub;pubsublite;spanner;storage" \
+  -DGOOGLE_CLOUD_CPP_ENABLE="bigtable;bigquery;experimental-opentelemetry;generator;iam;logging;pubsub;pubsublite;spanner;storage" \
   -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON
 cmake --build cmake-out
 

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -147,6 +147,12 @@ target_link_libraries(
            absl::variant
            Threads::Threads
            OpenSSL::Crypto)
+if (GOOGLE_CLOUD_CPP_ENABLE_EXPERIMENTAL_OPENTELEMETRY)
+    # TODO(#10283): find_package(opentelemetry-cpp CONFIG QUIET)
+    message(
+        WARNING
+            "OpenTelemetry requested, but the feature is not yet implemented.")
+endif ()
 google_cloud_cpp_add_common_options(google_cloud_cpp_common)
 target_include_directories(
     google_cloud_cpp_common PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>


### PR DESCRIPTION
Part of the work for #10283 

Add a top level cmake option to enable open telemetry as an experimental feature. Use it in the `clang-tidy` build. Leave a `TODO` / `message()` placeholder to speak to the intended use of the feature.

Arguably the option is unnecessary. We could just use `-DGOOGLE_CLOUD_CPP_ENABLE`.... but I think being able to append a `-DGOOGLE_CLOUD_CPP_EXPERIMENTAL_OPENTELEMETRY` adds some amount of convenience to the customers.

Aside: I decided I no longer want to break up `opentelemetry` into two words in our code. I will update the existing uses (e.g. `//:experimetnal-open_telemetry` -> `//:experimental-opentelemetry).
