### PR TITLE
refactor(common): use `AuthorizationHeader()` adapter

### DIFF
--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -213,6 +213,7 @@ if (BUILD_TESTING)
         internal/oauth2_authorized_user_credentials_test.cc
         internal/oauth2_cached_credentials_test.cc
         internal/oauth2_compute_engine_credentials_test.cc
+        internal/oauth2_credentials_test.cc
         internal/oauth2_google_application_default_credentials_file_test.cc
         internal/oauth2_google_credentials_test.cc
         internal/oauth2_impersonate_service_account_credentials_test.cc

--- a/google/cloud/google_cloud_cpp_rest_internal_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal_unit_tests.bzl
@@ -39,6 +39,7 @@ google_cloud_cpp_rest_internal_unit_tests = [
     "internal/oauth2_authorized_user_credentials_test.cc",
     "internal/oauth2_cached_credentials_test.cc",
     "internal/oauth2_compute_engine_credentials_test.cc",
+    "internal/oauth2_credentials_test.cc",
     "internal/oauth2_google_application_default_credentials_file_test.cc",
     "internal/oauth2_google_credentials_test.cc",
     "internal/oauth2_impersonate_service_account_credentials_test.cc",

--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -110,7 +110,7 @@ StatusOr<std::unique_ptr<CurlImpl>> CurlRestClient::CreateCurlImpl(
   auto impl =
       absl::make_unique<CurlImpl>(std::move(handle), handle_factory_, options_);
   if (credentials_) {
-    auto auth_header = credentials_->AuthorizationHeader();
+    auto auth_header = oauth2_internal::AuthorizationHeader(*credentials_);
     if (!auth_header.ok()) return std::move(auth_header).status();
     impl->SetHeader(auth_header.value());
   }

--- a/google/cloud/internal/oauth2_credentials.cc
+++ b/google/cloud/internal/oauth2_credentials.cc
@@ -32,6 +32,19 @@ StatusOr<internal::AccessToken> Credentials::GetToken(
       "WIP(#10316) - use decorator for credentials", GCP_ERROR_INFO());
 }
 
+StatusOr<std::pair<std::string, std::string>> AuthorizationHeader(
+    Credentials& credentials, std::chrono::system_clock::time_point /*tp*/) {
+  return credentials.AuthorizationHeader();
+}
+
+StatusOr<std::string> AuthorizationHeaderJoined(
+    Credentials& credentials, std::chrono::system_clock::time_point /*tp*/) {
+  auto header = credentials.AuthorizationHeader();
+  if (!header) return std::move(header).status();
+  if (header->first.empty() || header->second.empty()) return std::string{};
+  return header->first + ": " + header->second;
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal
 }  // namespace cloud

--- a/google/cloud/internal/oauth2_credentials.h
+++ b/google/cloud/internal/oauth2_credentials.h
@@ -19,6 +19,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -86,6 +87,24 @@ class Credentials {
   /// Return the account's key_id associated with these credentials, if any.
   virtual std::string KeyId() const { return std::string{}; }
 };
+
+/**
+ * Attempts to obtain a value for the Authorization HTTP header.
+ *
+ * If unable to obtain a value for the Authorization header, which could
+ * happen for `Credentials` that need to be periodically refreshed, the
+ * underlying `Status` will indicate failure details from the refresh HTTP
+ * request. Otherwise, the returned value will contain the Authorization
+ * header to be used in HTTP requests.
+ */
+StatusOr<std::pair<std::string, std::string>> AuthorizationHeader(
+    Credentials& credentials, std::chrono::system_clock::time_point tp =
+                                  std::chrono::system_clock::now());
+
+/// @copydoc AuthorizationHeader()
+StatusOr<std::string> AuthorizationHeaderJoined(
+    Credentials& credentials, std::chrono::system_clock::time_point tp =
+                                  std::chrono::system_clock::now());
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal

--- a/google/cloud/internal/oauth2_credentials_test.cc
+++ b/google/cloud/internal/oauth2_credentials_test.cc
@@ -24,6 +24,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::internal::UnavailableError;
+using ::testing::IsEmpty;
 using ::testing::Return;
 
 class MockCredentials : public Credentials {
@@ -50,6 +51,16 @@ TEST(Credentials, AuthorizationHeaderJoinedSuccess) {
   auto actual = AuthorizationHeaderJoined(mock);
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(*actual, "Authorization: Bearer test-token");
+}
+
+TEST(Credentials, AuthorizationHeaderJoinedEmpty) {
+  MockCredentials mock;
+  auto const expected =
+      std::make_pair(std::string("Authorization"), std::string{});
+  EXPECT_CALL(mock, AuthorizationHeader).WillOnce(Return(expected));
+  auto actual = AuthorizationHeaderJoined(mock);
+  ASSERT_STATUS_OK(actual);
+  EXPECT_THAT(*actual, IsEmpty());
 }
 
 TEST(Credentials, AuthorizationHeaderError) {

--- a/google/cloud/internal/oauth2_credentials_test.cc
+++ b/google/cloud/internal/oauth2_credentials_test.cc
@@ -1,0 +1,75 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/oauth2_credentials.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace oauth2_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::internal::UnavailableError;
+using ::testing::Return;
+
+class MockCredentials : public Credentials {
+ public:
+  MOCK_METHOD((StatusOr<std::pair<std::string, std::string>>),
+              AuthorizationHeader, (), (override));
+};
+
+TEST(Credentials, AuthorizationHeaderSuccess) {
+  MockCredentials mock;
+  auto const expected = std::make_pair(std::string("Authorization"),
+                                       std::string("Bearer test-token"));
+  EXPECT_CALL(mock, AuthorizationHeader).WillOnce(Return(expected));
+  auto actual = AuthorizationHeader(mock);
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(*actual, expected);
+}
+
+TEST(Credentials, AuthorizationHeaderJoinedSuccess) {
+  MockCredentials mock;
+  auto const expected = std::make_pair(std::string("Authorization"),
+                                       std::string("Bearer test-token"));
+  EXPECT_CALL(mock, AuthorizationHeader).WillOnce(Return(expected));
+  auto actual = AuthorizationHeaderJoined(mock);
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(*actual, "Authorization: Bearer test-token");
+}
+
+TEST(Credentials, AuthorizationHeaderError) {
+  MockCredentials mock;
+  EXPECT_CALL(mock, AuthorizationHeader)
+      .WillOnce(Return(UnavailableError("try-again")));
+  auto actual = AuthorizationHeader(mock);
+  EXPECT_EQ(actual.status(), UnavailableError("try-again"));
+}
+
+TEST(Credentials, AuthorizationHeaderJoinedError) {
+  MockCredentials mock;
+  EXPECT_CALL(mock, AuthorizationHeader)
+      .WillOnce(Return(UnavailableError("try-again")));
+  auto actual = AuthorizationHeaderJoined(mock);
+  EXPECT_EQ(actual.status(), UnavailableError("try-again"));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace oauth2_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/unified_rest_credentials.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials.cc
@@ -44,9 +44,7 @@ class WrapRestCredentials : public oauth2::Credentials {
       : impl_(std::move(impl)) {}
 
   StatusOr<std::string> AuthorizationHeader() override {
-    auto header = impl_->AuthorizationHeader();
-    if (!header) return std::move(header).status();
-    return header->first + ": " + header->second;
+    return oauth2_internal::AuthorizationHeaderJoined(*impl_);
   }
 
   StatusOr<std::vector<std::uint8_t>> SignBlob(

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -106,9 +106,7 @@ class AuthorizedUserCredentials<storage::internal::CurlRequestBuilder,
                                    channel_options.ssl_root_path())) {}
 
   StatusOr<std::string> AuthorizationHeader() override {
-    auto header = impl_.AuthorizationHeader();
-    if (!header.ok()) return header.status();
-    return header->first + ": " + header->second;
+    return oauth2_internal::AuthorizationHeaderJoined(impl_);
   }
 
  private:

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -91,9 +91,7 @@ class ComputeEngineCredentials<storage::internal::CurlRequestBuilder,
       : impl_(std::move(service_account_email)) {}
 
   StatusOr<std::string> AuthorizationHeader() override {
-    auto header = impl_.AuthorizationHeader();
-    if (!header.ok()) return header.status();
-    return header->first + ": " + header->second;
+    return oauth2_internal::AuthorizationHeaderJoined(impl_);
   }
 
   std::string AccountEmail() const override { return impl_.AccountEmail(); }

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -186,9 +186,7 @@ class ServiceAccountCredentials<storage::internal::CurlRequestBuilder,
             Options{}.set<CARootsFilePathOption>(options.ssl_root_path()))) {}
 
   StatusOr<std::string> AuthorizationHeader() override {
-    auto header = impl_->AuthorizationHeader();
-    if (!header.ok()) return header.status();
-    return header->first + ": " + header->second;
+    return oauth2_internal::AuthorizationHeaderJoined(*impl_);
   }
 
   /**


### PR DESCRIPTION
The Storage library has multiple places where we call `oauth2_internal::Credentials::AuthorizationHeader()`.  I am planning to remove this function, but first I am introducing an adapter to change the code in a single place.

Part of the work for #10316

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10332)
<!-- Reviewable:end -->
