### PR TITLE
impl(scaffold): more intense parsing of product path

### DIFF
--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -35,6 +35,22 @@ namespace generator_internal {
  */
 std::string LibraryName(std::string const& product_path);
 
+/**
+ * Returns the path to the library directory.
+ *
+ * Extract the library path (e.g. `google/cloud/foo/`) from a product path (e.g.
+ * `google/cloud/foo/bar/v1`).
+ */
+std::string LibraryPath(std::string const& product_path);
+
+/**
+ * Returns the relative path to the service from its library path.
+ *
+ * Extract the relative path (e.g. `bar/v1/`) from a product path (e.g.
+ * `google/cloud/foo/bar/v1`).
+ */
+std::string ServiceSubdirectory(std::string const& product_path);
+
 std::map<std::string, std::string> ScaffoldVars(
     std::string const& googleapis_path,
     google::cloud::cpp::generator::ServiceConfiguration const& service,

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -49,7 +49,34 @@ TEST(ScaffoldGeneratorTest, LibraryName) {
   EXPECT_EQ("test", LibraryName("google/cloud/test"));
   EXPECT_EQ("test", LibraryName("google/cloud/test/"));
   EXPECT_EQ("test", LibraryName("google/cloud/test/v1"));
+  EXPECT_EQ("test", LibraryName("google/cloud/test/v1/"));
+  EXPECT_EQ("test", LibraryName("google/cloud/test/foo/v1"));
   EXPECT_EQ("golden", LibraryName("blah/golden"));
+  EXPECT_EQ("golden", LibraryName("blah/golden/v1"));
+  EXPECT_EQ("service", LibraryName("foo/bar/service"));
+}
+
+TEST(ScaffoldGeneratorTest, LibraryPath) {
+  EXPECT_EQ("google/cloud/test/", LibraryPath("google/cloud/test"));
+  EXPECT_EQ("google/cloud/test/", LibraryPath("google/cloud/test/"));
+  EXPECT_EQ("google/cloud/test/", LibraryPath("google/cloud/test/v1"));
+  EXPECT_EQ("google/cloud/test/", LibraryPath("google/cloud/test/v1/"));
+  EXPECT_EQ("google/cloud/test/", LibraryPath("google/cloud/test/foo/v1"));
+  EXPECT_EQ("blah/golden/", LibraryPath("blah/golden"));
+  EXPECT_EQ("blah/golden/", LibraryPath("blah/golden/v1"));
+  EXPECT_EQ("foo/bar/service/", LibraryPath("foo/bar/service"));
+}
+
+TEST(ScaffoldGeneratorTest, ServiceSubdirectory) {
+  EXPECT_EQ("", ServiceSubdirectory("google/cloud/test"));
+  EXPECT_EQ("", ServiceSubdirectory("google/cloud/test/"));
+  EXPECT_EQ("v1/", ServiceSubdirectory("google/cloud/test/v1"));
+  EXPECT_EQ("v1/", ServiceSubdirectory("google/cloud/test/v1/"));
+  EXPECT_EQ("foo/v1/", ServiceSubdirectory("google/cloud/test/foo/v1"));
+  EXPECT_EQ("", ServiceSubdirectory("blah/golden"));
+  EXPECT_EQ("v1/", ServiceSubdirectory("blah/golden/v1"));
+  EXPECT_EQ("v1/", ServiceSubdirectory("blah/golden/v1"));
+  EXPECT_EQ("", ServiceSubdirectory("foo/bar/service"));
 }
 
 class ScaffoldGenerator : public ::testing::Test {


### PR DESCRIPTION
Part of the work for #10170 

These will help us generate scaffolding in the form we want. For context, the full change is [here](https://github.com/googleapis/google-cloud-cpp/compare/main...dbolduc:scaffold-update?expand=1), but I thought there was value in breaking down the changes a bit.

Hopefully I will never touch these helpers again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10336)
<!-- Reviewable:end -->
