### PR TITLE
refactor(common): use decorators for credential caching

### DIFF
--- a/google/cloud/internal/oauth2_access_token_credentials.cc
+++ b/google/cloud/internal/oauth2_access_token_credentials.cc
@@ -20,13 +20,12 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AccessTokenCredentials::AccessTokenCredentials(
-    google::cloud::internal::AccessToken const& access_token)
-    : header_(std::make_pair("Authorization", "Bearer " + access_token.token)) {
-}
+    google::cloud::internal::AccessToken access_token)
+    : access_token_(std::move(access_token)) {}
 
-StatusOr<std::pair<std::string, std::string>>
-AccessTokenCredentials::AuthorizationHeader() {
-  return header_;
+StatusOr<internal::AccessToken> AccessTokenCredentials::GetToken(
+    std::chrono::system_clock::time_point /*tp*/) {
+  return access_token_;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_access_token_credentials.h
+++ b/google/cloud/internal/oauth2_access_token_credentials.h
@@ -33,12 +33,13 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AccessTokenCredentials : public oauth2_internal::Credentials {
  public:
   explicit AccessTokenCredentials(
-      google::cloud::internal::AccessToken const& access_token);
+      google::cloud::internal::AccessToken access_token);
 
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
  private:
-  std::pair<std::string, std::string> header_;
+  internal::AccessToken access_token_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_access_token_credentials_test.cc
+++ b/google/cloud/internal/oauth2_access_token_credentials_test.cc
@@ -25,16 +25,12 @@ namespace {
 using ::google::cloud::internal::AccessToken;
 
 TEST(AccessTokenCredentials, Simple) {
-  auto const expiration =
-      std::chrono::system_clock::now() - std::chrono::minutes(10);
-
-  AccessTokenCredentials tested(AccessToken{"token1", expiration});
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Bearer token1"}),
-            tested.AuthorizationHeader().value());
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Bearer token1"}),
-            tested.AuthorizationHeader().value());
+  auto const now = std::chrono::system_clock::now();
+  auto const expiration = now - std::chrono::minutes(10);
+  auto const expected = AccessToken{"token1", expiration};
+  AccessTokenCredentials tested(expected);
+  EXPECT_EQ(expected, tested.GetToken(now).value());
+  EXPECT_EQ(expected, tested.GetToken(now).value());
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_anonymous_credentials.cc
+++ b/google/cloud/internal/oauth2_anonymous_credentials.cc
@@ -19,9 +19,9 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<std::pair<std::string, std::string>>
-AnonymousCredentials::AuthorizationHeader() {
-  return std::make_pair(std::string{}, std::string{});
+StatusOr<internal::AccessToken> AnonymousCredentials::GetToken(
+    std::chrono::system_clock::time_point tp) {
+  return internal::AccessToken{std::string{}, tp};
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_anonymous_credentials.h
+++ b/google/cloud/internal/oauth2_anonymous_credentials.h
@@ -44,7 +44,8 @@ class AnonymousCredentials : public oauth2_internal::Credentials {
    * Authorization HTTP header from this method, this class always returns an
    * empty string as its value.
    */
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_anonymous_credentials_test.cc
+++ b/google/cloud/internal/oauth2_anonymous_credentials_test.cc
@@ -22,12 +22,15 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::testing::IsEmpty;
+
 /// @test Verify `AnonymousCredentials` works as expected.
-TEST(AnonymousCredentialsTest, AuthorizationHeaderReturnsEmptyString) {
+TEST(AnonymousCredentialsTest, ReturnsEmptyString) {
   AnonymousCredentials credentials;
-  auto header = credentials.AuthorizationHeader();
-  ASSERT_STATUS_OK(header);
-  EXPECT_EQ(std::make_pair(std::string{}, std::string{}), header.value());
+  auto const now = std::chrono::system_clock::now();
+  auto const actual = credentials.GetToken(now);
+  ASSERT_STATUS_OK(actual);
+  EXPECT_THAT(actual->token, IsEmpty());
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_authorized_user_credentials.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.cc
@@ -77,21 +77,16 @@ StatusOr<internal::AccessToken> ParseAuthorizedUserRefreshResponse(
         " token for service account credentials.";
     return AsStatus(status_code, error_payload);
   }
-  std::string header_value = access_token.value("token_type", "");
-  header_value += ' ';
-  header_value += access_token.value("access_token", "");
   auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
-  auto new_expiration = now + expires_in;
-  return internal::AccessToken{std::move(header_value), new_expiration};
+  return internal::AccessToken{access_token.value("access_token", ""),
+                               now + expires_in};
 }
 
 AuthorizedUserCredentials::AuthorizedUserCredentials(
     AuthorizedUserCredentialsInfo info, Options options,
-    std::unique_ptr<rest_internal::RestClient> rest_client,
-    CurrentTimeFn current_time_fn)
+    std::unique_ptr<rest_internal::RestClient> rest_client)
     : info_(std::move(info)),
       options_(std::move(options)),
-      current_time_fn_(std::move(current_time_fn)),
       rest_client_(std::move(rest_client)) {
   if (!rest_client_) {
     rest_client_ =
@@ -99,13 +94,26 @@ AuthorizedUserCredentials::AuthorizedUserCredentials(
   }
 }
 
-StatusOr<std::pair<std::string, std::string>>
-AuthorizedUserCredentials::AuthorizationHeader() {
+StatusOr<internal::AccessToken> AuthorizedUserCredentials::GetToken(
+    std::chrono::system_clock::time_point tp) {
   std::unique_lock<std::mutex> lock(mu_);
-  return refreshing_creds_.AuthorizationHeader([this] { return Refresh(); });
+  if (tp + GoogleOAuthAccessTokenExpirationSlack() <=
+      access_token_.expiration) {
+    return access_token_;
+  }
+  // If the token is "about" to expire, try to get a new one.
+  auto response = Refresh(tp);
+  if (!response) {
+    // If the refresh failed, but the token is still valid, continue to use it.
+    if (tp < access_token_.expiration) return access_token_;
+    return std::move(response).status();
+  }
+  access_token_ = *std::move(response);
+  return access_token_;
 }
 
-StatusOr<internal::AccessToken> AuthorizedUserCredentials::Refresh() {
+StatusOr<internal::AccessToken> AuthorizedUserCredentials::Refresh(
+    std::chrono::system_clock::time_point tp) {
   rest_internal::RestRequest request;
   request.AddHeader("content-type", "application/x-www-form-urlencoded");
   std::vector<std::pair<std::string, std::string>> form_data;
@@ -120,7 +128,7 @@ StatusOr<internal::AccessToken> AuthorizedUserCredentials::Refresh() {
       std::move(response.value());
   if (real_response->StatusCode() >= 300)
     return AsStatus(std::move(*real_response));
-  return ParseAuthorizedUserRefreshResponse(*real_response, current_time_fn_());
+  return ParseAuthorizedUserRefreshResponse(*real_response, tp);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_authorized_user_credentials.h
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.h
@@ -70,37 +70,32 @@ StatusOr<internal::AccessToken> ParseAuthorizedUserRefreshResponse(
  */
 class AuthorizedUserCredentials : public Credentials {
  public:
-  using CurrentTimeFn =
-      std::function<std::chrono::time_point<std::chrono::system_clock>()>;
-
   /**
    * Creates an instance of AuthorizedUserCredentials.
    *
    * @param rest_client a dependency injection point. It makes it possible to
    *     mock internal REST types. This should generally not be overridden
    *     except for testing.
-   * @param current_time_fn a dependency injection point to fetch the current
-   *     time. This should generally not be overridden except for testing.
    */
   explicit AuthorizedUserCredentials(
       AuthorizedUserCredentialsInfo info, Options options = {},
-      std::unique_ptr<rest_internal::RestClient> rest_client = nullptr,
-      CurrentTimeFn current_time_fn = std::chrono::system_clock::now);
+      std::unique_ptr<rest_internal::RestClient> rest_client = nullptr);
 
   /**
    * Returns a key value pair for an "Authorization" header.
    */
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
  private:
-  StatusOr<internal::AccessToken> Refresh();
+  StatusOr<internal::AccessToken> Refresh(
+      std::chrono::system_clock::time_point tp);
 
   AuthorizedUserCredentialsInfo info_;
   Options options_;
-  CurrentTimeFn current_time_fn_;
   std::unique_ptr<rest_internal::RestClient> rest_client_;
   mutable std::mutex mu_;
-  RefreshingCredentialsWrapper refreshing_creds_;
+  internal::AccessToken access_token_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
@@ -31,7 +31,6 @@ namespace {
 using ::google::cloud::rest_internal::HttpPayload;
 using ::google::cloud::rest_internal::RestRequest;
 using ::google::cloud::rest_internal::RestResponse;
-using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockHttpPayload;
 using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
@@ -104,133 +103,9 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
 
   AuthorizedUserCredentials credentials(*info, {},
                                         std::move(mock_rest_client_));
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Type access-token-value"}),
-            credentials.AuthorizationHeader().value());
-}
-
-/// @test Verify that we can refresh service account credentials.
-TEST_F(AuthorizedUserCredentialsTest, Refresh) {
-  // Prepare two responses, the first one is used but becomes immediately
-  // expired, resulting in another refresh next time the caller tries to get
-  // an authorization header.
-  std::string r1 = R"""({
-    "token_type": "Type",
-    "access_token": "access-token-r1",
-    "id_token": "id-token-value",
-    "expires_in": 0
-})""";
-  std::string r2 = R"""({
-    "token_type": "Type",
-    "access_token": "access-token-r2",
-    "id_token": "id-token-value",
-    "expires_in": 1000
-})""";
-
-  auto mock_response1 = absl::make_unique<MockRestResponse>();
-  EXPECT_CALL(*mock_response1, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
-  EXPECT_CALL(std::move(*mock_response1), ExtractPayload).WillOnce([&] {
-    auto mock_http_payload = absl::make_unique<MockHttpPayload>();
-    EXPECT_CALL(*mock_http_payload, Read)
-        .WillOnce([r1](absl::Span<char> buffer) {
-          std::copy(r1.begin(), r1.end(), buffer.begin());
-          return r1.size();
-        })
-        .WillOnce([](absl::Span<char>) { return 0; });
-    return std::unique_ptr<HttpPayload>(std::move(mock_http_payload));
-  });
-
-  auto mock_response2 = absl::make_unique<MockRestResponse>();
-  EXPECT_CALL(*mock_response2, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
-  EXPECT_CALL(std::move(*mock_response2), ExtractPayload).WillOnce([&] {
-    auto mock_http_payload = absl::make_unique<MockHttpPayload>();
-    EXPECT_CALL(*mock_http_payload, Read)
-        .WillOnce([r2](absl::Span<char> buffer) {
-          std::copy(r2.begin(), r2.end(), buffer.begin());
-          return r2.size();
-        })
-        .WillOnce([](absl::Span<char>) { return 0; });
-    return std::unique_ptr<HttpPayload>(std::move(mock_http_payload));
-  });
-
-  EXPECT_CALL(
-      *mock_rest_client_,
-      Post(_, A<std::vector<std::pair<std::string, std::string>> const&>()))
-      .WillOnce([&](RestRequest const&,
-                    std::vector<std::pair<std::string, std::string>> const&) {
-        return std::unique_ptr<RestResponse>(std::move(mock_response1));
-      })
-      .WillOnce([&](RestRequest const&,
-                    std::vector<std::pair<std::string, std::string>> const&) {
-        return std::unique_ptr<RestResponse>(std::move(mock_response2));
-      });
-
-  std::string config = R"""({
-      "client_id": "a-client-id.example.com",
-      "client_secret": "a-123456ABCDEF",
-      "refresh_token": "1/THETOKEN",
-      "type": "magic_type"
-})""";
-  auto info = ParseAuthorizedUserCredentials(config, "test");
-  ASSERT_STATUS_OK(info);
-  AuthorizedUserCredentials credentials(*info, {},
-                                        std::move(mock_rest_client_));
-
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Type access-token-r1"}),
-            credentials.AuthorizationHeader().value());
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Type access-token-r2"}),
-            credentials.AuthorizationHeader().value());
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Type access-token-r2"}),
-            credentials.AuthorizationHeader().value());
-}
-
-/// @test Mock a failed refresh response.
-TEST_F(AuthorizedUserCredentialsTest, FailedRefresh) {
-  auto mock_response = absl::make_unique<MockRestResponse>();
-  EXPECT_CALL(*mock_response, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kBadRequest));
-  EXPECT_CALL(std::move(*mock_response), ExtractPayload).WillOnce([&] {
-    auto mock_http_payload = absl::make_unique<MockHttpPayload>();
-    EXPECT_CALL(*mock_http_payload, Read).WillOnce([](absl::Span<char>) {
-      return 0;
-    });
-    return std::unique_ptr<HttpPayload>(std::move(mock_http_payload));
-  });
-
-  EXPECT_CALL(
-      *mock_rest_client_,
-      Post(_, A<std::vector<std::pair<std::string, std::string>> const&>()))
-      .WillOnce([](RestRequest const&,
-                   std::vector<std::pair<std::string, std::string>> const&)
-                    -> StatusOr<std::unique_ptr<RestResponse>> {
-        return {Status(StatusCode::kAborted, "Fake Curl error", {})};
-      })
-      .WillOnce([&](RestRequest const&,
-                    std::vector<std::pair<std::string, std::string>> const&) {
-        return std::unique_ptr<RestResponse>(std::move(mock_response));
-      });
-
-  std::string config = R"""({
-      "client_id": "a-client-id.example.com",
-      "client_secret": "a-123456ABCDEF",
-      "refresh_token": "1/THETOKEN",
-      "type": "magic_type"
-})""";
-  auto info = ParseAuthorizedUserCredentials(config, "test");
-  ASSERT_STATUS_OK(info);
-  AuthorizedUserCredentials credentials(*info, {},
-                                        std::move(mock_rest_client_));
-  // Response 1
-  auto status = credentials.AuthorizationHeader();
-  EXPECT_THAT(status, StatusIs(StatusCode::kAborted));
-  // Response 2
-  status = credentials.AuthorizationHeader();
-  EXPECT_THAT(status, Not(IsOk()));
+  auto token = credentials.GetToken(std::chrono::system_clock::now());
+  ASSERT_STATUS_OK(token);
+  EXPECT_EQ(token->token, "access-token-value");
 }
 
 /// @test Verify that parsing an authorized user account JSON string works.
@@ -431,7 +306,7 @@ TEST_F(AuthorizedUserCredentialsTest, ParseAuthorizedUserRefreshResponse) {
           std::chrono::system_clock::from_time_t(clock_value + expires_in))
           .time_since_epoch()
           .count());
-  EXPECT_EQ(token.token, "Type access-token-r1");
+  EXPECT_EQ(token.token, "access-token-r1");
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_cached_credentials.cc
+++ b/google/cloud/internal/oauth2_cached_credentials.cc
@@ -53,11 +53,6 @@ StatusOr<internal::AccessToken> CachedCredentials::GetToken(
   return token_;
 }
 
-StatusOr<std::pair<std::string, std::string>>
-CachedCredentials::AuthorizationHeader() {
-  return impl_->AuthorizationHeader();
-}
-
 StatusOr<std::vector<std::uint8_t>> CachedCredentials::SignBlob(
     absl::optional<std::string> const& signing_service_account,
     std::string const& string_to_sign) const {

--- a/google/cloud/internal/oauth2_cached_credentials.h
+++ b/google/cloud/internal/oauth2_cached_credentials.h
@@ -45,7 +45,6 @@ class CachedCredentials : public Credentials {
 
   StatusOr<internal::AccessToken> GetToken(
       std::chrono::system_clock::time_point now) override;
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
   StatusOr<std::vector<std::uint8_t>> SignBlob(
       absl::optional<std::string> const& signing_service_account,
       std::string const& string_to_sign) const override;

--- a/google/cloud/internal/oauth2_cached_credentials_test.cc
+++ b/google/cloud/internal/oauth2_cached_credentials_test.cc
@@ -35,8 +35,6 @@ class MockCredentials : public Credentials {
  public:
   MOCK_METHOD(StatusOr<internal::AccessToken>, GetToken,
               (std::chrono::system_clock::time_point), (override));
-  MOCK_METHOD((StatusOr<std::pair<std::string, std::string>>),
-              AuthorizationHeader, (), (override));
   MOCK_METHOD(StatusOr<std::vector<std::uint8_t>>, SignBlob,
               (absl::optional<std::string> const&, std::string const&),
               (const, override));
@@ -134,17 +132,6 @@ TEST(CachedCredentials, GetTokenExpiredWithError) {
 
   auto a2 = tested.GetToken(tp2);
   EXPECT_THAT(a2, StatusIs(StatusCode::kUnavailable));
-}
-
-TEST(CachedCredentials, AuthorizationHeader) {
-  auto mock = std::make_shared<MockCredentials>();
-  auto const expected = std::make_pair(std::string{"Authorization"},
-                                       std::string{"Bearer test-token"});
-  EXPECT_CALL(*mock, AuthorizationHeader()).WillOnce(Return(expected));
-  CachedCredentials tested(mock);
-  auto actual = tested.AuthorizationHeader();
-  ASSERT_STATUS_OK(actual);
-  EXPECT_EQ(*actual, expected);
 }
 
 TEST(CachedCredentials, SignBlob) {

--- a/google/cloud/internal/oauth2_credentials.h
+++ b/google/cloud/internal/oauth2_credentials.h
@@ -58,18 +58,6 @@ class Credentials {
       std::chrono::system_clock::time_point tp);
 
   /**
-   * Attempts to obtain a value for the Authorization HTTP header.
-   *
-   * If unable to obtain a value for the Authorization header, which could
-   * happen for `Credentials` that need to be periodically refreshed, the
-   * underlying `Status` will indicate failure details from the refresh HTTP
-   * request. Otherwise, the returned value will contain the Authorization
-   * header to be used in HTTP requests.
-   */
-  virtual StatusOr<std::pair<std::string, std::string>>
-  AuthorizationHeader() = 0;
-
-  /**
    * Try to sign @p string_to_sign using @p service_account.
    *
    * Some %Credentials types can locally sign a blob, most often just on behalf

--- a/google/cloud/internal/oauth2_error_credentials.cc
+++ b/google/cloud/internal/oauth2_error_credentials.cc
@@ -19,8 +19,8 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<std::pair<std::string, std::string>>
-ErrorCredentials::AuthorizationHeader() {
+StatusOr<internal::AccessToken> ErrorCredentials::GetToken(
+    std::chrono::system_clock::time_point /*tp*/) {
   return status_;
 }
 

--- a/google/cloud/internal/oauth2_error_credentials.h
+++ b/google/cloud/internal/oauth2_error_credentials.h
@@ -48,7 +48,8 @@ class ErrorCredentials : public oauth2_internal::Credentials {
  public:
   explicit ErrorCredentials(Status status) : status_(std::move(status)) {}
 
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
  private:
   Status status_;

--- a/google/cloud/internal/oauth2_google_credentials_test.cc
+++ b/google/cloud/internal/oauth2_google_credentials_test.cc
@@ -260,7 +260,7 @@ TEST_F(GoogleCredentialsTest, MissingCredentialsViaGcloudFilePath) {
   auto creds = GoogleDefaultCredentials();
   ASSERT_STATUS_OK(creds);
   ASSERT_THAT(*creds, NotNull());
-  auto header = (*creds)->AuthorizationHeader();
+  auto header = (*creds)->GetToken(std::chrono::system_clock::now());
   EXPECT_THAT(header, StatusIs(Not(StatusCode::kOk)));
 }
 

--- a/google/cloud/internal/oauth2_impersonate_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_impersonate_service_account_credentials.h
@@ -32,9 +32,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ImpersonateServiceAccountCredentials
     : public oauth2_internal::Credentials {
  public:
-  using CurrentTimeFn =
-      std::function<std::chrono::time_point<std::chrono::system_clock>()>;
-
   /**
    * Creates an instance of ImpersonateServiceAccountCredentials.
    *
@@ -42,24 +39,17 @@ class ImpersonateServiceAccountCredentials
    *     time. This should generally not be overridden except for testing.
    */
   explicit ImpersonateServiceAccountCredentials(
-      google::cloud::internal::ImpersonateServiceAccountConfig const& config,
-      CurrentTimeFn current_time_fn = std::chrono::system_clock::now);
+      google::cloud::internal::ImpersonateServiceAccountConfig const& config);
   ImpersonateServiceAccountCredentials(
       google::cloud::internal::ImpersonateServiceAccountConfig const& config,
-      std::shared_ptr<MinimalIamCredentialsRest> stub,
-      CurrentTimeFn current_time_fn = std::chrono::system_clock::now);
+      std::shared_ptr<MinimalIamCredentialsRest> stub);
 
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader(
-      std::chrono::system_clock::time_point now);
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
  private:
   std::shared_ptr<MinimalIamCredentialsRest> stub_;
   GenerateAccessTokenRequest request_;
-  CurrentTimeFn current_time_fn_;
-  std::mutex mu_;
-  std::pair<std::string, std::string> header_;
-  std::chrono::system_clock::time_point expiration_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -50,7 +50,8 @@ MinimalIamCredentialsRestStub::MinimalIamCredentialsRestStub(
 StatusOr<google::cloud::internal::AccessToken>
 MinimalIamCredentialsRestStub::GenerateAccessToken(
     GenerateAccessTokenRequest const& request) {
-  auto auth_header = credentials_->AuthorizationHeader();
+  auto auth_header =
+      AuthorizationHeader(*credentials_, std::chrono::system_clock::now());
   if (!auth_header) return std::move(auth_header).status();
 
   rest_internal::RestRequest rest_request;

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
@@ -45,8 +45,8 @@ using ::testing::Return;
 
 class MockCredentials : public google::cloud::oauth2_internal::Credentials {
  public:
-  MOCK_METHOD((StatusOr<std::pair<std::string, std::string>>),
-              AuthorizationHeader, (), (override));
+  MOCK_METHOD(StatusOr<internal::AccessToken>, GetToken,
+              (std::chrono::system_clock::time_point), (override));
 };
 
 class MinimalIamCredentialsRestTest : public ::testing::Test {
@@ -66,8 +66,8 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenSuccess) {
   std::string scope = "my_scope";
   std::string delegate = "my_delegate";
 
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
-    return std::make_pair(std::string("Authorization"), std::string("Foo"));
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
+    return internal::AccessToken{"test-token", tp + lifetime};
   });
 
   std::string response = R"""({
@@ -124,8 +124,8 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenNonRfc3339Time) {
   std::string scope = "my_scope";
   std::string delegate = "my_delegate";
 
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
-    return std::make_pair(std::string("Authorization"), std::string("Foo"));
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
+    return internal::AccessToken{"test-token", tp + lifetime};
   });
 
   std::string response = R"""({
@@ -181,8 +181,8 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenInvalidResponse) {
   std::string scope = "my_scope";
   std::string delegate = "my_delegate";
 
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
-    return std::make_pair(std::string("Authorization"), std::string("Foo"));
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
+    return internal::AccessToken{"test-token", tp + lifetime};
   });
 
   std::string response = R"""({
@@ -237,8 +237,8 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenPostFailure) {
   std::string scope = "my_scope";
   std::string delegate = "my_delegate";
 
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
-    return std::make_pair(std::string("Authorization"), std::string("Foo"));
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
+    return internal::AccessToken{"test-token", tp + lifetime};
   });
 
   auto* mock_response = new MockRestResponse();
@@ -281,7 +281,7 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenPostFailure) {
 }
 
 TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenCredentialFailure) {
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([] {
     return Status(StatusCode::kPermissionDenied, "Permission Denied");
   });
   auto stub = MinimalIamCredentialsRestStub(std::move(mock_credentials_), {},

--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -158,14 +158,9 @@ StatusOr<internal::AccessToken> ParseServiceAccountRefreshResponse(
     return AsStatus(status_code, error_payload);
   }
 
-  // Response should have the attributes "access_token", "expires_in", and
-  // "token_type".
-  std::string header_value = access_token.value("token_type", "");
-  header_value += ' ';
-  header_value += access_token.value("access_token", "");
   auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
-  auto new_expiration = now + expires_in;
-  return internal::AccessToken{std::move(header_value), new_expiration};
+  return internal::AccessToken{access_token.value("access_token", ""),
+                               now + expires_in};
 }
 
 StatusOr<std::string> MakeSelfSignedJWT(
@@ -202,10 +197,8 @@ StatusOr<std::string> MakeSelfSignedJWT(
 
 ServiceAccountCredentials::ServiceAccountCredentials(
     ServiceAccountCredentialsInfo info, Options options,
-    std::unique_ptr<rest_internal::RestClient> rest_client,
-    CurrentTimeFn current_time_fn)
+    std::unique_ptr<rest_internal::RestClient> rest_client)
     : info_(std::move(info)),
-      current_time_fn_(std::move(current_time_fn)),
       rest_client_(std::move(rest_client)),
       options_(internal::MergeOptions(
           std::move(options),
@@ -217,10 +210,21 @@ ServiceAccountCredentials::ServiceAccountCredentials(
   }
 }
 
-StatusOr<std::pair<std::string, std::string>>
-ServiceAccountCredentials::AuthorizationHeader() {
+StatusOr<internal::AccessToken> ServiceAccountCredentials::GetToken(
+    std::chrono::system_clock::time_point tp) {
   std::unique_lock<std::mutex> lock(mu_);
-  return refreshing_creds_.AuthorizationHeader([this] { return Refresh(); });
+  if (tp + GoogleOAuthAccessTokenExpirationSlack() < access_token_.expiration) {
+    return access_token_;
+  }
+  // If the token is "about" to expire, try to get a new one.
+  auto response = Refresh(tp);
+  if (!response) {
+    // If the refresh failed, but the token is still valid, continue to use it.
+    if (tp < access_token_.expiration) return access_token_;
+    return std::move(response).status();
+  }
+  access_token_ = *std::move(response);
+  return access_token_;
 }
 
 StatusOr<std::vector<std::uint8_t>> ServiceAccountCredentials::SignBlob(
@@ -355,15 +359,16 @@ bool ServiceAccountCredentials::UseOAuth() {
   return ServiceAccountUseOAuth(info_);
 }
 
-StatusOr<internal::AccessToken> ServiceAccountCredentials::Refresh() {
-  if (UseOAuth()) return RefreshOAuth();
-  return RefreshSelfSigned();
+StatusOr<internal::AccessToken> ServiceAccountCredentials::Refresh(
+    std::chrono::system_clock::time_point tp) {
+  if (UseOAuth()) return RefreshOAuth(tp);
+  return RefreshSelfSigned(tp);
 }
 
-StatusOr<internal::AccessToken> ServiceAccountCredentials::RefreshOAuth()
-    const {
+StatusOr<internal::AccessToken> ServiceAccountCredentials::RefreshOAuth(
+    std::chrono::system_clock::time_point tp) const {
   rest_internal::RestRequest request;
-  auto payload = CreateServiceAccountRefreshPayload(info_, current_time_fn_());
+  auto payload = CreateServiceAccountRefreshPayload(info_, tp);
   StatusOr<std::unique_ptr<rest_internal::RestResponse>> response =
       rest_client_->Post(request, payload);
   if (!response.ok()) return std::move(response).status();
@@ -371,16 +376,14 @@ StatusOr<internal::AccessToken> ServiceAccountCredentials::RefreshOAuth()
       std::move(response.value());
   if (real_response->StatusCode() >= 300)
     return AsStatus(std::move(*real_response));
-  return ParseServiceAccountRefreshResponse(*real_response, current_time_fn_());
+  return ParseServiceAccountRefreshResponse(*real_response, tp);
 }
 
-StatusOr<internal::AccessToken> ServiceAccountCredentials::RefreshSelfSigned()
-    const {
-  auto const tp = current_time_fn_();
+StatusOr<internal::AccessToken> ServiceAccountCredentials::RefreshSelfSigned(
+    std::chrono::system_clock::time_point tp) const {
   auto token = MakeSelfSignedJWT(info_, tp);
   if (!token) return std::move(token).status();
-  return internal::AccessToken{"Bearer " + *token,
-                               tp + GoogleOAuthAccessTokenLifetime()};
+  return internal::AccessToken{*token, tp + GoogleOAuthAccessTokenLifetime()};
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -207,13 +207,13 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
    */
   explicit ServiceAccountCredentials(
       ServiceAccountCredentialsInfo info, Options options = {},
-      std::unique_ptr<rest_internal::RestClient> rest_client = nullptr,
-      CurrentTimeFn current_time_fn = std::chrono::system_clock::now);
+      std::unique_ptr<rest_internal::RestClient> rest_client = nullptr);
 
   /**
    * Returns a key value pair for an "Authorization" header.
    */
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
   /**
    * Create a RSA SHA256 signature of the blob using the Credential object.
@@ -236,16 +236,18 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
 
  private:
   bool UseOAuth();
-  StatusOr<internal::AccessToken> Refresh();
-  StatusOr<internal::AccessToken> RefreshOAuth() const;
-  StatusOr<internal::AccessToken> RefreshSelfSigned() const;
+  StatusOr<internal::AccessToken> Refresh(
+      std::chrono::system_clock::time_point tp);
+  StatusOr<internal::AccessToken> RefreshOAuth(
+      std::chrono::system_clock::time_point tp) const;
+  StatusOr<internal::AccessToken> RefreshSelfSigned(
+      std::chrono::system_clock::time_point tp) const;
 
   ServiceAccountCredentialsInfo info_;
-  CurrentTimeFn current_time_fn_;
   std::unique_ptr<rest_internal::RestClient> rest_client_;
   Options options_;
   mutable std::mutex mu_;
-  RefreshingCredentialsWrapper refreshing_creds_;
+  internal::AccessToken access_token_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Remove the `AuthorizationHeader()` function from all the `oauth2_internal::*Credential` classes. The new function can be used with a decorator to implement caching in a single place. The new implementations are much simpler, and the tests can be simplified too.

Part of the work for #10316

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10337)
<!-- Reviewable:end -->
