### PR TITLE
impl(scaffold): support new directory structure

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -308,16 +308,9 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-service_dirs = [
-    "$service_subdirectory$",
-]
+service_dirs = ["$service_subdirectory$"]
 
-internal_dirs = [
-    "",
-    "internal/",
-]
-
-src_dirs = [s + i for s in service_dirs for i in internal_dirs]
+src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
 
 filegroup(
     name = "srcs",
@@ -331,7 +324,7 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([s + "mocks/*.h" for s in service_dirs]),
+    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
 )
 
 cc_library(
@@ -364,7 +357,7 @@ cc_library(
         "//:$library$",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
-) for sample in glob([s + "samples/*.cc" for s in service_dirs])]
+) for sample in glob([d + "samples/*.cc" for d in service_dirs])]
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -140,7 +140,7 @@ class ScaffoldGenerator : public ::testing::Test {
 )""";
 
     google::cloud::cpp::generator::ServiceConfiguration service;
-    service.set_product_path("google/cloud/test/");
+    service.set_product_path("google/cloud/test/v1");
     service.set_service_proto_path("google/cloud/test/v1/service.proto");
     service.set_initial_copyright_year("2034");
     service_ = std::move(service);
@@ -164,6 +164,7 @@ TEST_F(ScaffoldGenerator, Vars) {
             Contains(Pair("description",
                           "Provides a placeholder to write this test.")),
             Contains(Pair("library", "test")),
+            Contains(Pair("service_subdirectory", "v1/")),
             Contains(Pair("product_options_page", "google-cloud-test-options")),
             Contains(Pair("copyright_year", "2034")),
             Contains(Pair("library_prefix", "")),
@@ -178,6 +179,7 @@ TEST_F(ScaffoldGenerator, Vars) {
             Contains(Pair("description",
                           "Provides a placeholder to write this test.")),
             Contains(Pair("library", "test")),
+            Contains(Pair("service_subdirectory", "v1/")),
             Contains(Pair("product_options_page", "google-cloud-test-options")),
             Contains(Pair("copyright_year", "2034")),
             Contains(Pair("library_prefix", "experimental-")),
@@ -349,27 +351,6 @@ TEST_F(ScaffoldGenerator, QuickstartBazelrc) {
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
-}
-
-TEST_F(ScaffoldGenerator, SamplesBuild) {
-  auto const vars = ScaffoldVars(path(), service(), false);
-  std::ostringstream os;
-  GenerateSamplesBuild(os, vars);
-  auto const actual = std::move(os).str();
-  EXPECT_THAT(actual, HasSubstr("2034"));
-  EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
-  EXPECT_THAT(actual, Not(HasSubstr("$library_prefix$")));
-}
-
-TEST_F(ScaffoldGenerator, SamplesCMake) {
-  auto const vars = ScaffoldVars(path(), service(), false);
-  std::ostringstream os;
-  GenerateSamplesCMake(os, vars);
-  auto const actual = std::move(os).str();
-  EXPECT_THAT(actual, HasSubstr("2034"));
-  EXPECT_THAT(actual, HasSubstr("google_cloud_cpp_add_samples(test)"));
-  EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
-  EXPECT_THAT(actual, Not(HasSubstr("$library_prefix$")));
 }
 
 }  // namespace

--- a/google/cloud/vmwareengine/BUILD.bazel
+++ b/google/cloud/vmwareengine/BUILD.bazel
@@ -16,16 +16,9 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-service_dirs = [
-    "v1/",
-]
+service_dirs = ["v1/"]
 
-internal_dirs = [
-    "",
-    "internal/",
-]
-
-src_dirs = [s + i for s in service_dirs for i in internal_dirs]
+src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
 
 filegroup(
     name = "srcs",
@@ -39,7 +32,7 @@ filegroup(
 
 filegroup(
     name = "mocks",
-    srcs = glob([s + "mocks/*.h" for s in service_dirs]),
+    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
 )
 
 cc_library(
@@ -72,4 +65,4 @@ cc_library(
         "//:vmwareengine",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
-) for sample in glob([s + "samples/*.cc" for s in service_dirs])]
+) for sample in glob([d + "samples/*.cc" for d in service_dirs])]


### PR DESCRIPTION
Part of the work for #10170 

Drop the `samples/{BUILD.bazel,CMakeLists.txt}`. Instead build the samples from the library's top level build files.

Support a `service.product_path()` like `google/cloud/foo/bar/baz/quux/v1alpha7` by using `LibraryPath(...)` to strip it to `google/cloud/foo/`.

The changes were based off of @devbww's #10278. These scaffolding changes were used to generate: https://github.com/dbolduc/google-cloud-cpp/tree/feat-paymentgateway-generate-library

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10338)
<!-- Reviewable:end -->
