### PR TITLE
cleanup(generator): product options group from LibraryPath

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_options.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_options.h
@@ -34,7 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Use with `google::cloud::Options` to configure the retry policy.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 struct GoldenKitchenSinkRetryPolicyOption {
   using Type = std::shared_ptr<GoldenKitchenSinkRetryPolicy>;
@@ -43,7 +43,7 @@ struct GoldenKitchenSinkRetryPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure the backoff policy.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 struct GoldenKitchenSinkBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
@@ -52,7 +52,7 @@ struct GoldenKitchenSinkBackoffPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure which operations are retried.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 struct GoldenKitchenSinkConnectionIdempotencyPolicyOption {
   using Type = std::shared_ptr<GoldenKitchenSinkConnectionIdempotencyPolicy>;
@@ -61,7 +61,7 @@ struct GoldenKitchenSinkConnectionIdempotencyPolicyOption {
 /**
  * The options applicable to GoldenKitchenSink.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 using GoldenKitchenSinkPolicyOptionList =
     OptionList<GoldenKitchenSinkRetryPolicyOption,

--- a/generator/integration_tests/golden/golden_thing_admin_options.h
+++ b/generator/integration_tests/golden/golden_thing_admin_options.h
@@ -34,7 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Use with `google::cloud::Options` to configure the retry policy.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 struct GoldenThingAdminRetryPolicyOption {
   using Type = std::shared_ptr<GoldenThingAdminRetryPolicy>;
@@ -43,7 +43,7 @@ struct GoldenThingAdminRetryPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure the backoff policy.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 struct GoldenThingAdminBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
@@ -52,7 +52,7 @@ struct GoldenThingAdminBackoffPolicyOption {
 /**
  * Use with `google::cloud::Options` to configure which operations are retried.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 struct GoldenThingAdminConnectionIdempotencyPolicyOption {
   using Type = std::shared_ptr<GoldenThingAdminConnectionIdempotencyPolicy>;
@@ -62,7 +62,7 @@ struct GoldenThingAdminConnectionIdempotencyPolicyOption {
  * Use with `google::cloud::Options` to configure the long-running operations
  * polling policy.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 struct GoldenThingAdminPollingPolicyOption {
   using Type = std::shared_ptr<PollingPolicy>;
@@ -71,7 +71,7 @@ struct GoldenThingAdminPollingPolicyOption {
 /**
  * The options applicable to GoldenThingAdmin.
  *
- * @ingroup google-cloud-golden-options
+ * @ingroup generator-integration_tests-golden-options
  */
 using GoldenThingAdminPolicyOptionList =
     OptionList<GoldenThingAdminRetryPolicyOption,

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -851,8 +851,7 @@ VarsDictionary CreateServiceVars(
     google::protobuf::ServiceDescriptor const& descriptor,
     std::vector<std::pair<std::string, std::string>> const& initial_values) {
   VarsDictionary vars(initial_values.begin(), initial_values.end());
-  vars["product_options_page"] = absl::StrCat(
-      "google-cloud-", LibraryName(vars["product_path"]), "-options");
+  vars["product_options_page"] = OptionsGroup(vars["product_path"]);
   vars["additional_pb_header_paths"] = FormatAdditionalPbHeaderPaths(vars);
   vars["class_comment_block"] =
       FormatClassCommentsFromServiceComments(descriptor);

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -81,6 +81,11 @@ std::string ServiceSubdirectory(std::string const& product_path) {
   return absl::StrCat(parsed.service_subdirectory, "/");
 }
 
+std::string OptionsGroup(std::string const& product_path) {
+  return absl::StrCat(
+      absl::StrReplaceAll(LibraryPath(product_path), {{"/", "-"}}), "options");
+}
+
 std::string SiteRoot(
     google::cloud::cpp::generator::ServiceConfiguration const& service) {
   // TODO(#7605) - get a configurable source for this
@@ -121,8 +126,7 @@ std::map<std::string, std::string> ScaffoldVars(
   auto const library = LibraryName(service.product_path());
   vars["copyright_year"] = service.initial_copyright_year();
   vars["library"] = library;
-  vars["product_options_page"] =
-      absl::StrCat("google-cloud-", library, "-options");
+  vars["product_options_page"] = OptionsGroup(service.product_path());
   vars["site_root"] = SiteRoot(service);
   vars["library_prefix"] = experimental ? "experimental-" : "";
   vars["doxygen_version_suffix"] = experimental ? " (Experimental)" : "";

--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -51,6 +51,15 @@ std::string LibraryPath(std::string const& product_path);
  */
 std::string ServiceSubdirectory(std::string const& product_path);
 
+/**
+ * Returns the name of the doxygen refgroup for options in a given product path.
+ *
+ * There is a single refgroup for all options in a library. For example, the
+ * options in `google/cloud/foo/v1/` and `google/cloud/foo/bar/v1` will both map
+ * to the group: `google-cloud-foo-options`.
+ */
+std::string OptionsGroup(std::string const& product_path);
+
 std::map<std::string, std::string> ScaffoldVars(
     std::string const& googleapis_path,
     google::cloud::cpp::generator::ServiceConfiguration const& service,

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -79,6 +79,14 @@ TEST(ScaffoldGeneratorTest, ServiceSubdirectory) {
   EXPECT_EQ("", ServiceSubdirectory("foo/bar/service"));
 }
 
+TEST(ScaffoldGeneratorTest, OptionsGroup) {
+  EXPECT_EQ("google-cloud-test-options", LibraryPath("google/cloud/test"));
+  EXPECT_EQ("google-cloud-test-options", LibraryPath("google/cloud/test/v1"));
+  EXPECT_EQ("blah-golden-options", LibraryPath("blah/golden"));
+  EXPECT_EQ("blah-golden-options", LibraryPath("blah/golden/v1"));
+  EXPECT_EQ("foo-bar-service-options", LibraryPath("foo/bar/service"));
+}
+
 class ScaffoldGenerator : public ::testing::Test {
  protected:
   ~ScaffoldGenerator() override {


### PR DESCRIPTION
This is a totally unnecessary change, but it is slightly cleaner to use `LibraryPath()` than to assume `google/cloud/foo/...`. :shrug: