### PR TITLE
doc: update howto generate library guide

### DIFF
--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -86,9 +86,9 @@ index ab033dde9..3753287d8 100644
 +# Secret Manager
 +service {
 +  service_proto_path: "google/cloud/secretmanager/v1/service.proto"
-+  product_path: "google/cloud/secretmanager"
++  product_path: "google/cloud/secretmanager/v1"
 +  initial_copyright_year: "2021"
-+  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
++  retryable_status_codes: ["kUnavailable"]
 +}
 +
 ```
@@ -122,7 +122,7 @@ bazel run \
   --googleapis_proto_path="${bazel_output_base}"/external/com_google_googleapis \
   --output_path="${PWD}" \
   --config_file="${PWD}/generator/generator_config.textproto" \
-  --scaffold="google/cloud/${library}"
+  --scaffold="google/cloud/${library}/"
 ```
 
 To generate a library that is initially experimental, add an
@@ -158,6 +158,17 @@ The generated `BUILD.bazel` file may require manual editing. The scaffold will
 add one dependency from `@com_github_googleapis//${subdir}`, which might not be
 correct. You may need to modify that dependency and/or add additional
 dependencies for more complex libraries.
+
+## Potentially update the service directories
+
+A library may contain services in several subdirectories. The scaffold only
+knows about one such subdirectory. You may need to manually update the
+`service_dirs` lists to include all subdirectories in the following files:
+
+- `google/cloud/${library}/BUILD.bazel`
+- `google/cloud/${library}/CMakeLists.txt`
+
+[#10237] offers one way to automate this step.
 
 ## Update the root files
 
@@ -290,4 +301,5 @@ git commit -m"Manually update READMEs, quickstart, and top-level stuff" \
    "google/cloud/${library}" BUILD.bazel CHANGELOG.md ci README.md
 ```
 
+[#10237]: https://github.com/googleapis/google-cloud-cpp/issues/10237
 [retryable-status-codes]: https://github.com/googleapis/googleapis/blob/0fea253787a4f2769b97b0ed3a8f5b28ef17ffa7/google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json#L77-L80

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -46,6 +46,10 @@ ABSL_FLAG(bool, update_ci, true, "Update the CI support files.");
 
 namespace {
 
+using google::cloud::generator_internal::GenerateScaffold;
+using google::cloud::generator_internal::LibraryName;
+using google::cloud::generator_internal::LibraryPath;
+
 google::cloud::StatusOr<google::cloud::cpp::generator::GeneratorConfiguration>
 GetConfig(std::string const& filepath) {
   std::ifstream input(filepath);
@@ -112,8 +116,7 @@ int WriteInstallDirectories(
     if (!service.omit_connection()) {
       install_directories.push_back("./include/" + product_path + "/mocks");
     }
-    auto const lib =
-        google::cloud::generator_internal::LibraryName(product_path);
+    auto const lib = LibraryName(product_path);
     install_directories.push_back("./lib64/cmake/google_cloud_cpp_" + lib);
   }
   std::sort(install_directories.begin(), install_directories.end());
@@ -135,8 +138,7 @@ int WriteFeatureList(
                      << service.DebugString() << "\n";
       return 1;
     }
-    features.push_back(
-        google::cloud::generator_internal::LibraryName(service.product_path()));
+    features.push_back(LibraryName(service.product_path()));
   }
   std::sort(features.begin(), features.end());
   auto const end = std::unique(features.begin(), features.end());
@@ -192,9 +194,9 @@ int main(int argc, char** argv) {
 
   std::vector<std::future<google::cloud::Status>> tasks;
   for (auto const& service : config->service()) {
-    if (service.product_path() == scaffold) {
-      google::cloud::generator_internal::GenerateScaffold(
-          googleapis_path, output_path, service, experimental_scaffold);
+    if (LibraryPath(service.product_path()) == scaffold) {
+      GenerateScaffold(googleapis_path, output_path, service,
+                       experimental_scaffold);
     }
     std::vector<std::string> args;
     // empty arg prevents first real arg from being ignored.


### PR DESCRIPTION
Part of the work for #10170 

A pass on the howto add a new library docs, in light of https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2022-11-11-multiple-versions-of-GCP-service-in-one-library.md

The main change in the code is to compare `LibraryPath(product_path)` instead of the `product_path` directly. `LibraryPath()` has a trailinng `/`, so update the howto guide to match the expectation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10342)
<!-- Reviewable:end -->
