### PR TITLE
impl(common): more consistent HTTP clients

### DIFF
--- a/google/cloud/internal/external_account_integration_test.cc
+++ b/google/cloud/internal/external_account_integration_test.cc
@@ -67,8 +67,7 @@ TEST(ExternalAccountIntegrationTest, UrlSourced) {
   auto make_client = [](Options opts = {}) {
     return rest_internal::MakeDefaultRestClient("", std::move(opts));
   };
-  auto source =
-      MakeExternalAccountTokenSourceUrl(credential_source, make_client, ec);
+  auto source = MakeExternalAccountTokenSourceUrl(credential_source, ec);
   ASSERT_STATUS_OK(source);
 
   auto info =

--- a/google/cloud/internal/external_account_token_source_file.cc
+++ b/google/cloud/internal/external_account_token_source_file.cc
@@ -83,18 +83,19 @@ StatusOr<ExternalAccountTokenSource> MakeExternalAccountTokenSourceFile(
   if (format->type == "text") {
     context.emplace_back("credentials_source.file.type", "text");
     return ExternalAccountTokenSource{
-        [f = *std::move(file), ec = std::move(context)](Options const&) {
+        [f = *std::move(file), ec = std::move(context)](
+            HttpClientFactory const&, Options const&) {
           return TextFileReader(f, ec);
         }};
   }
   context.emplace_back("credentials_source.file.type", "json");
   context.emplace_back("credentials_source.file.source_token_field_name",
                        format->subject_token_field_name);
-  return ExternalAccountTokenSource{[f = *std::move(file),
-                                     field = format->subject_token_field_name,
-                                     ec = std::move(context)](Options const&) {
-    return JsonFileReader(f, field, ec);
-  }};
+  return ExternalAccountTokenSource{
+      [f = *std::move(file), field = format->subject_token_field_name,
+       ec = std::move(context)](HttpClientFactory const&, Options const&) {
+        return JsonFileReader(f, field, ec);
+      }};
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/external_account_token_source_file_test.cc
+++ b/google/cloud/internal/external_account_token_source_file_test.cc
@@ -31,6 +31,10 @@ using ::testing::HasSubstr;
 using ::testing::IsSupersetOf;
 using ::testing::Pair;
 
+using MockClientFactory =
+    ::testing::MockFunction<std::unique_ptr<rest_internal::RestClient>(
+        Options const&)>;
+
 internal::ErrorContext MakeTestErrorContext() {
   return internal::ErrorContext{
       {{"filename", "my-credentials.json"}, {"key", "value"}}};
@@ -51,7 +55,9 @@ TEST(ExternalAccountTokenSource, WorkingTextFile) {
   auto const source =
       MakeExternalAccountTokenSourceFile(creds, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
-  auto const actual = (*source)(Options{});
+  MockClientFactory cf;
+  EXPECT_CALL(cf, Call).Times(0);
+  auto const actual = (*source)(cf.AsStdFunction(), Options{});
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(*actual, internal::SubjectToken{token});
   EXPECT_EQ(std::remove(token_filename.c_str()), 0);
@@ -69,7 +75,9 @@ TEST(ExternalAccountTokenSource, WorkingJsonFile) {
   auto const source =
       MakeExternalAccountTokenSourceFile(creds, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
-  auto const actual = (*source)(Options{});
+  MockClientFactory cf;
+  EXPECT_CALL(cf, Call).Times(0);
+  auto const actual = (*source)(cf.AsStdFunction(), Options{});
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(*actual, internal::SubjectToken{token});
   EXPECT_EQ(std::remove(token_filename.c_str()), 0);
@@ -127,7 +135,9 @@ TEST(ExternalAccountTokenSource, MissingTextFile) {
   auto const source =
       MakeExternalAccountTokenSourceFile(creds, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
-  auto const actual = (*source)(Options{});
+  MockClientFactory cf;
+  EXPECT_CALL(cf, Call).Times(0);
+  auto const actual = (*source)(cf.AsStdFunction(), Options{});
   EXPECT_THAT(actual, StatusIs(StatusCode::kInvalidArgument,
                                HasSubstr("error reading subject token file")));
   EXPECT_THAT(
@@ -149,7 +159,9 @@ TEST(ExternalAccountTokenSource, MissingJsonFile) {
   auto const source =
       MakeExternalAccountTokenSourceFile(creds, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
-  auto const actual = (*source)(Options{});
+  MockClientFactory cf;
+  EXPECT_CALL(cf, Call).Times(0);
+  auto const actual = (*source)(cf.AsStdFunction(), Options{});
   EXPECT_THAT(actual, StatusIs(StatusCode::kInvalidArgument,
                                HasSubstr("error reading subject token file")));
   EXPECT_THAT(
@@ -174,7 +186,9 @@ TEST(ExternalAccountTokenSource, JsonFileIsNotJson) {
   auto const source =
       MakeExternalAccountTokenSourceFile(creds, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
-  auto const actual = (*source)(Options{});
+  MockClientFactory cf;
+  EXPECT_CALL(cf, Call).Times(0);
+  auto const actual = (*source)(cf.AsStdFunction(), Options{});
   EXPECT_THAT(actual, StatusIs(StatusCode::kInvalidArgument,
                                AllOf(HasSubstr("parse error in JSON object"),
                                      HasSubstr(token_filename))));
@@ -201,7 +215,9 @@ TEST(ExternalAccountTokenSource, JsonFileIsNotJsonObject) {
   auto const source =
       MakeExternalAccountTokenSourceFile(creds, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
-  auto const actual = (*source)(Options{});
+  MockClientFactory cf;
+  EXPECT_CALL(cf, Call).Times(0);
+  auto const actual = (*source)(cf.AsStdFunction(), Options{});
   EXPECT_THAT(actual, StatusIs(StatusCode::kInvalidArgument,
                                AllOf(HasSubstr("parse error in JSON object"),
                                      HasSubstr(token_filename))));
@@ -228,7 +244,9 @@ TEST(ExternalAccountTokenSource, JsonFileMissingField) {
   auto const source =
       MakeExternalAccountTokenSourceFile(creds, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
-  auto const actual = (*source)(Options{});
+  MockClientFactory cf;
+  EXPECT_CALL(cf, Call).Times(0);
+  auto const actual = (*source)(cf.AsStdFunction(), Options{});
   EXPECT_THAT(
       actual,
       StatusIs(StatusCode::kInvalidArgument,
@@ -257,7 +275,9 @@ TEST(ExternalAccountTokenSource, JsonFileInvalidField) {
   auto const source =
       MakeExternalAccountTokenSourceFile(creds, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
-  auto const actual = (*source)(Options{});
+  MockClientFactory cf;
+  EXPECT_CALL(cf, Call).Times(0);
+  auto const actual = (*source)(cf.AsStdFunction(), Options{});
   EXPECT_THAT(
       actual,
       StatusIs(StatusCode::kInvalidArgument,

--- a/google/cloud/internal/external_account_token_source_url.h
+++ b/google/cloud/internal/external_account_token_source_url.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/internal/error_metadata.h"
 #include "google/cloud/internal/oauth2_external_account_token_source.h"
-#include "google/cloud/internal/rest_client.h"
 #include "google/cloud/version.h"
 #include <nlohmann/json.hpp>
 #include <functional>
@@ -26,9 +25,6 @@ namespace google {
 namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-using HttpClientFactory =
-    std::function<std::unique_ptr<rest_internal::RestClient>()>;
 
 /**
  * Creates an `ExternalAccountTokenSource` for URL-based credential sources.
@@ -52,8 +48,7 @@ using HttpClientFactory =
  * https://google.aip.dev/auth/4117#determining-the-subject-token-in-microsoft-azure-and-url-sourced-credentials
  */
 StatusOr<ExternalAccountTokenSource> MakeExternalAccountTokenSourceUrl(
-    nlohmann::json const& credentials_source, HttpClientFactory client_factory,
-    internal::ErrorContext const& ec);
+    nlohmann::json const& credentials_source, internal::ErrorContext const& ec);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal

--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -31,7 +31,7 @@ ExternalAccountCredentials::ExternalAccountCredentials(
 
 StatusOr<internal::AccessToken> ExternalAccountCredentials::GetToken(
     std::chrono::system_clock::time_point tp) {
-  auto subject_token = (info_.token_source)(Options{});
+  auto subject_token = (info_.token_source)(client_factory_, Options{});
   if (!subject_token) return std::move(subject_token).status();
 
   auto form_data = std::vector<std::pair<std::string, std::string>>{

--- a/google/cloud/internal/oauth2_external_account_credentials.h
+++ b/google/cloud/internal/oauth2_external_account_credentials.h
@@ -37,9 +37,6 @@ struct ExternalAccountInfo {
 
 class ExternalAccountCredentials : public oauth2_internal::Credentials {
  public:
-  using HttpClientFactory =
-      std::function<std::unique_ptr<rest_internal::RestClient>(Options const&)>;
-
   ExternalAccountCredentials(ExternalAccountInfo info,
                              HttpClientFactory client_factory,
                              Options options = {});

--- a/google/cloud/internal/oauth2_external_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials_test.cc
@@ -239,7 +239,7 @@ TEST(ExternalAccount, HandleHttpPartialError) {
   auto const test_url = std::string{"https://sts.example.com/"};
   auto const expected_access_token = std::string{"test-access-token"};
   auto const response = std::string{R"""({"access_token": "1234--uh-oh)"""};
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -284,7 +284,7 @@ TEST(ExternalAccount, HandleNotJson) {
   auto const test_url = std::string{"https://sts.example.com/"};
   auto const expected_access_token = std::string{"test-access-token"};
   auto const payload = std::string{R"""("abc--unterminated)"""};
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -330,7 +330,7 @@ TEST(ExternalAccount, HandleNotJsonObject) {
   auto const test_url = std::string{"https://sts.example.com/"};
   auto const expected_access_token = std::string{"test-access-token"};
   auto const payload = std::string{R"""("json-string-is-not-object")"""};
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{

--- a/google/cloud/internal/oauth2_external_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials_test.cc
@@ -142,7 +142,7 @@ TEST(ExternalAccount, Working) {
       {"issued_token_type", "urn:ietf:params:oauth:token-type:access_token"},
       {"token_type", "Bearer"},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -195,7 +195,7 @@ TEST(ExternalAccount, HandleHttpError) {
       {"issued_token_type", "urn:ietf:params:oauth:token-type:access_token"},
       {"token_type", "Bearer"},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -382,7 +382,7 @@ TEST(ExternalAccount, MissingToken) {
       {"issued_token_type", "urn:ietf:params:oauth:token-type:access_token"},
       {"token_type", "Bearer"},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -420,7 +420,7 @@ TEST(ExternalAccount, MissingIssuedTokenType) {
       // {"issued_token_type", "urn:ietf:params:oauth:token-type:access_token"},
       {"token_type", "Bearer"},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -458,7 +458,7 @@ TEST(ExternalAccount, MissingTokenType) {
       {"issued_token_type", "urn:ietf:params:oauth:token-type:access_token"},
       // {"token_type", "Bearer"},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -496,7 +496,7 @@ TEST(ExternalAccount, InvalidIssuedTokenType) {
       {"issued_token_type", "--invalid--"},
       {"token_type", "Bearer"},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -536,7 +536,7 @@ TEST(ExternalAccount, InvalidTokenType) {
       {"issued_token_type", "urn:ietf:params:oauth:token-type:access_token"},
       {"token_type", "--invalid--"},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -577,7 +577,7 @@ TEST(ExternalAccount, MissingExpiresIn) {
       {"token_type", "Bearer"},
       // {"expires_in", 3500},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{
@@ -616,7 +616,7 @@ TEST(ExternalAccount, InvalidExpiresIn) {
       {"issued_token_type", "urn:ietf:params:oauth:token-type:access_token"},
       {"token_type", "Bearer"},
   };
-  auto mock_source = [](Options const&) {
+  auto mock_source = [](HttpClientFactory const&, Options const&) {
     return make_status_or(internal::SubjectToken{"test-subject-token"});
   };
   auto const info = ExternalAccountInfo{

--- a/google/cloud/internal/oauth2_external_account_token_source.h
+++ b/google/cloud/internal/oauth2_external_account_token_source.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OAUTH2_EXTERNAL_ACCOUNT_TOKEN_SOURCE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OAUTH2_EXTERNAL_ACCOUNT_TOKEN_SOURCE_H
 
+#include "google/cloud/internal/rest_client.h"
 #include "google/cloud/internal/subject_token.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
@@ -25,6 +26,9 @@ namespace google {
 namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+using HttpClientFactory =
+    std::function<std::unique_ptr<rest_internal::RestClient>(Options const&)>;
 
 /**
  * Return subject tokens for external account credentials.
@@ -52,7 +56,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * [RFC 8663]: https://www.rfc-editor.org/rfc/rfc8693.html
  */
 using ExternalAccountTokenSource =
-    std::function<StatusOr<internal::SubjectToken>(Options)>;
+    std::function<StatusOr<internal::SubjectToken>(HttpClientFactory const&,
+                                                   Options)>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal


### PR DESCRIPTION
For external accounts we will need HTTP clients to exchange subject tokens into access tokens.  Some (most?) subject token sources also need HTTP clients. I think it will be simpler if the subject token sources receive a `RestClient` factory when asked to fetch a subject token, as opposed to binding a factory to the time when the source is created.

The downside is an extra (unused) parameter in the subject token sources that do not use HTTP.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10349)
<!-- Reviewable:end -->
