### PR TITLE
cleanup(storage): remove Bazel workspace name workaround

### DIFF
--- a/google/cloud/storage/quickstart/WORKSPACE.bazel
+++ b/google/cloud/storage/quickstart/WORKSPACE.bazel
@@ -19,21 +19,6 @@ workspace(name = "qs")
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# TODO(#10208) - cleanup after the v2.5.0 release
-#  This is a temporary workaround.  google-cloud-cpp <= 2.4.0 requires
-#  downstream projects to load it as `google_cloud_cpp`.
-#  Starting with google-cloud-cpp==2.5.0 downstreams project can use any name
-#  they want (as we do here).
-#  Apparently (see https://github.com/bazelbuild/bazel/issues/3219) there are no
-#  mechanisms in Bazel to smooth this transition other than duplicating the
-#  project name.
-http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
-    sha256 = "245e198e29c4ec19734cc99ef631daaefbdb874307fc3743e22514ee8bcb36c4",
-    strip_prefix = "google-cloud-cpp-2.4.0",
-    url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.4.0.tar.gz",
-)
-
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(


### PR DESCRIPTION
Part of the work for #10208

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10350)
<!-- Reviewable:end -->
