### PR TITLE
doc(storage): document all `oauth2` names as deprecated

### DIFF
--- a/google/cloud/storage/oauth2/anonymous_credentials.h
+++ b/google/cloud/storage/oauth2/anonymous_credentials.h
@@ -33,6 +33,8 @@ namespace oauth2 {
  * (b) when accessing publicly readable resources (e.g. a Google Cloud Storage
  * object that is readable by the "allUsers" entity), which requires no
  * authentication or authorization.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 class AnonymousCredentials : public Credentials {
  public:

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -36,7 +36,11 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace oauth2 {
 
-/// Object to hold information used to instantiate an AuthorizedUserCredentials.
+/**
+ * Object to hold information used to instantiate an AuthorizedUserCredentials.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 struct AuthorizedUserCredentialsInfo {
   std::string client_id;
   std::string client_secret;
@@ -44,14 +48,23 @@ struct AuthorizedUserCredentialsInfo {
   std::string token_uri;
 };
 
-/// Parses a refresh response JSON string into an authorization header. The
-/// header and the current time (for the expiration) form a TemporaryToken.
+/**
+ * Parses a refresh response JSON string into an authorization header.
+ *
+ * The header and the current time (for the expiration) form a TemporaryToken.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
 ParseAuthorizedUserRefreshResponse(
     storage::internal::HttpResponse const& response,
     std::chrono::system_clock::time_point now);
 
-/// Parses a user credentials JSON string into an AuthorizedUserCredentialsInfo.
+/**
+ * Parses a user credentials JSON string into an AuthorizedUserCredentialsInfo.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri =
@@ -78,6 +91,8 @@ StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
  *     overridden except for testing.
  * @tparam ClockType a dependency injection point to fetch the current time.
  *     This should generally not be overridden except for testing.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 template <typename HttpRequestBuilderType =
               storage::internal::CurlRequestBuilder,

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -36,18 +36,32 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace oauth2 {
-/// A helper struct that contains service account metadata.
+
+/**
+ * A helper struct that contains service account metadata.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 struct ServiceAccountMetadata {
   std::set<std::string> scopes;
   std::string email;
 };
 
-/// Parses a metadata server response JSON string into a ServiceAccountMetadata.
+/**
+ * Parses a metadata server response JSON string into a ServiceAccountMetadata.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
     storage::internal::HttpResponse const& response);
 
-/// Parses a refresh response JSON string into an authorization header. The
-/// header and the current time (for the expiration) form a TemporaryToken.
+/**
+ * Parses a refresh response JSON string into an authorization header.
+ *
+ * The header and the current time (for the expiration) form a TemporaryToken.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
 ParseComputeEngineRefreshResponse(
     storage::internal::HttpResponse const& response,
@@ -75,6 +89,8 @@ ParseComputeEngineRefreshResponse(
  *     be overridden except for testing.
  * @tparam ClockType a dependency injection point to fetch the current time.
  *     This should generally not be overridden except for testing.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 template <typename HttpRequestBuilderType =
               storage::internal::CurlRequestBuilder,

--- a/google/cloud/storage/oauth2/credential_constants.h
+++ b/google/cloud/storage/oauth2/credential_constants.h
@@ -29,11 +29,17 @@ namespace oauth2 {
  *
  * We currently only support RSA with SHA-256, but use this enum for
  * readability and easy addition of support for other algorithms.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 // NOLINTNEXTLINE(readability-identifier-naming)
 enum class JwtSigningAlgorithms { RS256 };
 
-/// The max lifetime in seconds of an access token.
+/**
+ * The max lifetime in seconds of an access token.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 constexpr std::chrono::seconds GoogleOAuthAccessTokenLifetime() {
   return std::chrono::seconds(3600);
 }
@@ -46,23 +52,34 @@ constexpr std::chrono::seconds GoogleOAuthAccessTokenLifetime() {
  * check expiration time one second before the expiration, see that the token is
  * still valid, then attempt to use it two seconds later and receive an
  * error.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 constexpr std::chrono::seconds GoogleOAuthAccessTokenExpirationSlack() {
   return std::chrono::seconds(300);
 }
 
-/// The endpoint to fetch an OAuth 2.0 access token from.
+/**
+ * The endpoint to fetch an OAuth 2.0 access token from.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 inline char const* GoogleOAuthRefreshEndpoint() {
   static constexpr char kEndpoint[] = "https://oauth2.googleapis.com/token";
   return kEndpoint;
 }
 
-/// String representing the "cloud-platform" OAuth 2.0 scope.
+/**
+ * String representing the "cloud-platform" OAuth 2.0 scope.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 inline char const* GoogleOAuthScopeCloudPlatform() {
   static constexpr char kScope[] =
       "https://www.googleapis.com/auth/cloud-platform";
   return kScope;
 }
+
 }  // namespace oauth2
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -26,7 +26,13 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+/**
+ * Authentication components for Google Cloud Storage.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 namespace oauth2 {
+
 /**
  * Interface for OAuth 2.0 credentials used to access Google Cloud services.
  *
@@ -35,6 +41,8 @@ namespace oauth2 {
  *
  * @see https://cloud.google.com/docs/authentication/ for an overview of
  * authenticating to Google Cloud Platform APIs.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 class Credentials {
  public:
@@ -48,6 +56,8 @@ class Credentials {
    * underlying `Status` will indicate failure details from the refresh HTTP
    * request. Otherwise, the returned value will contain the Authorization
    * header to be used in HTTP requests.
+   *
+   * @deprecated Prefer using the unified credentials documented in @ref guac
    */
   virtual StatusOr<std::string> AuthorizationHeader() = 0;
 
@@ -58,15 +68,25 @@ class Credentials {
    * of an specific service account. This function returns an error if the
    * credentials cannot sign the blob at all, or if the service account is a
    * mismatch.
+   *
+   * @deprecated Prefer using the unified credentials documented in @ref guac
    */
   virtual StatusOr<std::vector<std::uint8_t>> SignBlob(
       SigningAccount const& service_account,
       std::string const& string_to_sign) const;
 
-  /// Return the account's email associated with these credentials, if any.
+  /**
+   * Return the account's email associated with these credentials, if any.
+   *
+   * @deprecated Prefer using the unified credentials documented in @ref guac
+   */
   virtual std::string AccountEmail() const { return std::string{}; }
 
-  /// Return the account's key_id associated with these credentials, if any.
+  /**
+   * Return the account's key_id associated with these credentials, if any.
+   *
+   * @deprecated Prefer using the unified credentials documented in @ref guac
+   */
   virtual std::string KeyId() const { return std::string{}; }
 };
 

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file.h
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file.h
@@ -29,6 +29,8 @@ namespace oauth2 {
  *
  * This environment variable should be checked for a valid file path when
  * attempting to load Google Application Default %Credentials.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 char const* GoogleAdcEnvVar();
 
@@ -38,6 +40,8 @@ char const* GoogleAdcEnvVar();
  * If the Application Default %Credentials environment variable is set, we check
  * the path specified by its value for a file containing ADCs. Returns an
  * empty string if no such path exists or the environment variable is not set.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 std::string GoogleAdcFilePathFromEnvVarOrEmpty();
 
@@ -47,6 +51,8 @@ std::string GoogleAdcFilePathFromEnvVarOrEmpty();
  * If the gcloud utility has configured an Application Default %Credentials
  * file, the path to that file is returned. Returns an empty string if no such
  * file exists at the well known path.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 std::string GoogleAdcFilePathFromWellKnownPathOrEmpty();
 
@@ -55,6 +61,8 @@ std::string GoogleAdcFilePathFromWellKnownPathOrEmpty();
  *
  * This environment variable is used for testing to override the path that
  * should be searched for the gcloud Application Default %Credentials file.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 char const* GoogleGcloudAdcFileEnvVar();
 
@@ -65,6 +73,8 @@ char const* GoogleGcloudAdcFileEnvVar();
  * by this environment variable, varies across environments. That directory is
  * used when constructing the well known path of the Application Default
  * Credentials file.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 char const* GoogleAdcHomeEnvVar();
 

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -41,16 +41,24 @@ namespace oauth2 {
  *
  * @see https://cloud.google.com/docs/authentication/production for details
  * about Application Default %Credentials.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials(
     ChannelOptions const& options = {});
 
-//@{
+///@{
 /**
  * @name Functions to manually create specific credential types.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 
-/// Creates an AnonymousCredentials.
+/**
+ * Creates an AnonymousCredentials.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 std::shared_ptr<Credentials> CreateAnonymousCredentials();
 
 /**
@@ -58,6 +66,8 @@ std::shared_ptr<Credentials> CreateAnonymousCredentials();
  *
  * @note It is strongly preferred to instead use service account credentials
  * with Cloud Storage client libraries.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const& path);
@@ -67,13 +77,19 @@ CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const& path);
  *
  * @note It is strongly preferred to instead use service account credentials
  * with Cloud Storage client libraries.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateAuthorizedUserCredentialsFromJsonContents(
     std::string const& contents, ChannelOptions const& options = {});
 
-//@{
-/// @name Load service account key files.
+///@{
+/**
+ *  @name Load service account key files.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 
 /**
  * Creates a ServiceAccountCredentials from a file at the specified path.
@@ -86,6 +102,8 @@ CreateAuthorizedUserCredentialsFromJsonContents(
  * These credentials use the cloud-platform OAuth 2.0 scope, defined by
  * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes, use the
  * overloaded version of this function.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromFilePath(std::string const& path);
@@ -111,6 +129,8 @@ CreateServiceAccountCredentialsFromFilePath(std::string const& path);
  *
  * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
  *     for more information about domain-wide delegation.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromFilePath(
@@ -123,6 +143,8 @@ CreateServiceAccountCredentialsFromFilePath(
  * These credentials use the cloud-platform OAuth 2.0 scope, defined by
  * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes, use the
  * overloaded version of this function.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path);
@@ -145,6 +167,8 @@ CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path);
  *
  * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
  *     for more information about domain-wide delegation.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(
@@ -157,6 +181,8 @@ CreateServiceAccountCredentialsFromJsonFilePath(
  * These credentials use the cloud-platform OAuth 2.0 scope, defined by
  * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes, use the
  * overloaded version of this function.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromP12FilePath(std::string const& path);
@@ -179,12 +205,14 @@ CreateServiceAccountCredentialsFromP12FilePath(std::string const& path);
  *
  * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
  *     for more information about domain-wide delegation.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromP12FilePath(
     std::string const& path, absl::optional<std::set<std::string>> scopes,
     absl::optional<std::string> subject, ChannelOptions const& options = {});
-//@}
+///@}
 
 /**
  * Produces a ServiceAccountCredentials type by trying to load the standard
@@ -200,6 +228,8 @@ CreateServiceAccountCredentialsFromP12FilePath(
  *
  * @see https://cloud.google.com/docs/authentication/production for details
  *     about Application Default %Credentials.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromDefaultPaths(
@@ -228,6 +258,8 @@ CreateServiceAccountCredentialsFromDefaultPaths(
  *
  * @see https://cloud.google.com/docs/authentication/production for details
  *     about Application Default %Credentials.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromDefaultPaths(
@@ -240,6 +272,8 @@ CreateServiceAccountCredentialsFromDefaultPaths(
  * These credentials use the cloud-platform OAuth 2.0 scope, defined by
  * `GoogleOAuthScopeCloudPlatform()`. To specify an alternate set of scopes, use
  * the overloaded version of this function.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(
@@ -264,20 +298,30 @@ CreateServiceAccountCredentialsFromJsonContents(
  *
  * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
  *     for more information about domain-wide delegation.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(
     std::string const& contents, absl::optional<std::set<std::string>> scopes,
     absl::optional<std::string> subject, ChannelOptions const& options = {});
 
-/// Creates a ComputeEngineCredentials for the VM's default service account.
+/**
+ * Creates a ComputeEngineCredentials for the VM's default service account.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 std::shared_ptr<Credentials> CreateComputeEngineCredentials();
 
-/// Creates a ComputeEngineCredentials for the VM's specified service account.
+/**
+ * Creates a ComputeEngineCredentials for the VM's specified service account.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 std::shared_ptr<Credentials> CreateComputeEngineCredentials(
     std::string const& service_account_email);
 
-//@}
+///@}
 
 }  // namespace oauth2
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
@@ -31,6 +31,8 @@ namespace oauth2 {
 
 /**
  * Wrapper for refreshable parts of a Credentials object.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 class RefreshingCredentialsWrapper {
  public:
@@ -67,6 +69,8 @@ class RefreshingCredentialsWrapper {
    * If a Credentials is close to expiration but not quite expired, this method
    * may still return false. This helps prevent the case where an access token
    * expires between when it is obtained and when it is used.
+   *
+   * @deprecated Prefer using the unified credentials documented in @ref guac
    */
   bool IsExpired(std::chrono::system_clock::time_point now) const;
 
@@ -75,6 +79,8 @@ class RefreshingCredentialsWrapper {
    *
    * This method should be used to determine whether a Credentials object needs
    * to be refreshed.
+   *
+   * @deprecated Prefer using the unified credentials documented in @ref guac
    */
   bool IsValid(std::chrono::system_clock::time_point now) const;
 

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -40,9 +40,13 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
 namespace oauth2 {
-/// Object to hold information used to instantiate an ServiceAccountCredentials.
+
+/**
+ * Object to hold information used to instantiate an ServiceAccountCredentials.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 struct ServiceAccountCredentialsInfo {
   std::string client_email;
   std::string private_key_id;
@@ -54,7 +58,12 @@ struct ServiceAccountCredentialsInfo {
   absl::optional<std::string> subject;
 };
 
-/// Parses the contents of a JSON keyfile into a ServiceAccountCredentialsInfo.
+/**
+ * Parses the contents of a JSON keyfile into a ServiceAccountCredentialsInfo.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
+
 StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri = GoogleOAuthRefreshEndpoint());
@@ -67,13 +76,19 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
  * @note Note that P12 keyfiles do not contain the `client_email` for the
  * service account, the application must obtain this through some other means
  * and provide them to the function.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
     std::string const& source,
     std::string const& default_token_uri = GoogleOAuthRefreshEndpoint());
 
-/// Parses a refresh response JSON string and uses the current time to create a
-/// TemporaryToken.
+/**
+ * Parses a refresh response JSON string and uses the current time to create a
+ * TemporaryToken.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
 ParseServiceAccountRefreshResponse(
     storage::internal::HttpResponse const& response,
@@ -87,6 +102,8 @@ ParseServiceAccountRefreshResponse(
  * https://cloud.google.com/endpoints/docs/frameworks/java/troubleshoot-jwt
  *
  * @see https://tools.ietf.org/html/rfc7523
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 std::pair<std::string, std::string> AssertionComponentsFromInfo(
     ServiceAccountCredentialsInfo const& info,
@@ -96,14 +113,22 @@ std::pair<std::string, std::string> AssertionComponentsFromInfo(
  * Given a key and a JSON header and payload, creates a JWT assertion string.
  *
  * @see https://tools.ietf.org/html/rfc7519
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 std::string MakeJWTAssertion(std::string const& header,
                              std::string const& payload,
                              std::string const& pem_contents);
 
-/// Uses a ServiceAccountCredentialsInfo and the current time to construct a
-/// JWT assertion. The assertion combined with the grant type is used to create
-/// the refresh payload.
+/**
+ * Uses a ServiceAccountCredentialsInfo and the current time to construct a JWT
+ * assertion.
+ *
+ * The assertion combined with the grant type is used to create the refresh
+ * payload.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 std::string CreateServiceAccountRefreshPayload(
     ServiceAccountCredentialsInfo const& info, std::string const& grant_type,
     std::chrono::system_clock::time_point now);
@@ -131,12 +156,18 @@ std::string CreateServiceAccountRefreshPayload(
  * @param tp the current time
  * @return a bearer token for authentication.  Include this value in the
  *   `Authorization` header with the "Bearer" type.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 StatusOr<std::string> MakeSelfSignedJWT(
     ServiceAccountCredentialsInfo const& info,
     std::chrono::system_clock::time_point tp);
 
-/// Return true if we need to use the OAuth path to create tokens
+/**
+ * Return true if we need to use the OAuth path to create tokens
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
+ */
 bool ServiceAccountUseOAuth(ServiceAccountCredentialsInfo const& info);
 
 /**
@@ -163,6 +194,8 @@ bool ServiceAccountUseOAuth(ServiceAccountCredentialsInfo const& info);
  *     overridden except for testing.
  * @tparam ClockType a dependency injection point to fetch the current time.
  *     This should generally not be overridden except for testing.
+ *
+ * @deprecated Prefer using the unified credentials documented in @ref guac
  */
 template <typename HttpRequestBuilderType =
               storage::internal::CurlRequestBuilder,
@@ -199,6 +232,8 @@ class ServiceAccountCredentials<storage::internal::CurlRequestBuilder,
    *   Base64-encode the data before signing.
    * @return the signed blob as raw bytes. An error if the @p signing_account
    *     does not match the email for the credential's account.
+   *
+   * @deprecated Prefer using the unified credentials documented in @ref guac
    */
   StatusOr<std::vector<std::uint8_t>> SignBlob(
       SigningAccount const& signing_account,
@@ -244,6 +279,8 @@ class ServiceAccountCredentials : public Credentials {
    *   Base64-encode the data before signing.
    * @return the signed blob as raw bytes. An error if the @p signing_account
    *     does not match the email for the credential's account.
+   *
+   * @deprecated Prefer using the unified credentials documented in @ref guac
    */
   StatusOr<std::vector<std::uint8_t>> SignBlob(
       SigningAccount const& signing_account,

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -98,6 +98,9 @@ struct IamEndpointOption {
  * Configure oauth2::Credentials for the GCS client library.
  *
  * @ingroup storage-options
+ *
+ * @deprecated prefer using `google::cloud::UnifiedCredentialsOption` and the
+ *     unified credentials documented in @ref guac
  */
 struct Oauth2CredentialsOption {
   using Type = std::shared_ptr<oauth2::Credentials>;


### PR DESCRIPTION
Update the Doxygen comments to mark every type, function, and even the complete namespace as deprecated.  In the next major release we will actually add the `[[deprecated]]` attribute, and (maybe) remove them in the major release following it.

Motivated by #10353 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10352)
<!-- Reviewable:end -->
