### PR TITLE
impl: simplify `oauth2_internal::ComputeEngineCredentials`

### DIFF
--- a/google/cloud/internal/oauth2_compute_engine_credentials.h
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.h
@@ -139,7 +139,7 @@ class ComputeEngineCredentials : public Credentials {
    * https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances
    * for more details.
    */
-  Status RetrieveServiceAccountInfo() const;
+  void RetrieveServiceAccountInfo() const;
 
   /**
    * Attempts to refresh the credentials.
@@ -150,6 +150,7 @@ class ComputeEngineCredentials : public Credentials {
   CurrentTimeFn current_time_fn_;
   std::unique_ptr<rest_internal::RestClient> rest_client_;
   RefreshingCredentialsWrapper refreshing_creds_;
+  mutable bool metadata_retrieved_ = false;
   mutable std::set<std::string> scopes_;
   mutable std::string service_account_email_;
   Options options_;

--- a/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
@@ -254,7 +254,7 @@ TEST(ComputeEngineCredentialsTest, FailedRetrieveServiceAccountInfo) {
   EXPECT_EQ(actual, alias);
   // Response 2
   actual = credentials.AccountEmail();
-  EXPECT_THAT(actual, alias);
+  EXPECT_EQ(actual, alias);
 }
 
 /// @test Mock a failed refresh response.

--- a/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
@@ -235,7 +235,9 @@ TEST(ComputeEngineCredentialsTest, FailedRetrieveServiceAccountInfo) {
   ::testing::InSequence sequence;
   auto mock_rest_client = absl::make_unique<MockRestClient>();
   EXPECT_CALL(*mock_rest_client, Get(expect_service_config(alias)))
-      .WillOnce(Return(Status{StatusCode::kAborted, "Fake Curl error", {}}));
+      .WillOnce([] {
+        return Status{StatusCode::kAborted, "Fake Curl error"};
+      });
   EXPECT_CALL(*mock_rest_client, Get(expect_service_config(alias)))
       .WillOnce([&] {
         auto response = absl::make_unique<MockRestResponse>();


### PR DESCRIPTION
The implementation of `ComputeEngineCredentials` queries the metadata service to support self-signed URLs in `google/cloud/storage`. This query only needs to be done once, once the data is successfully retrieved it is not going to change as it is immutable in the GCE instance.

It also makes no sense to fail the token creation if the metadata query fails.

Part of the work for #10316

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10356)
<!-- Reviewable:end -->
