### PR TITLE
fix(common): correctly parse external account configuration

### DIFF
--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -32,9 +32,9 @@ StatusOr<ExternalAccountTokenSource> MakeExternalAccountTokenSource(
     nlohmann::json const& credentials_source,
     internal::ErrorContext const& ec) {
   auto source = MakeExternalAccountTokenSourceUrl(credentials_source, ec);
-  if (!source) return source;
+  if (source) return source;
   source = MakeExternalAccountTokenSourceFile(credentials_source, ec);
-  if (!source) return source;
+  if (source) return source;
   return InvalidArgumentError(
       "unknown subject token source for external account",
       GCP_ERROR_INFO().WithContext(ec));
@@ -66,7 +66,7 @@ StatusOr<ExternalAccountInfo> ParseExternalAccountConfiguration(
   if (!subject_token_type) return std::move(subject_token_type).status();
   auto token_url =
       ValidateStringField(json, "token_url", "credentials-file", ec);
-  if (!token_url) return std::move(subject_token_type).status();
+  if (!token_url) return std::move(token_url).status();
 
   auto credential_source = json.find("credential_source");
   if (credential_source == json.end()) {


### PR DESCRIPTION
Also add a bunch of missing tests.

Tested in https://github.com/coryan/google-cloud-cpp/actions/runs/3605392288

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10357)
<!-- Reviewable:end -->
