### PR TITLE
refactor(common): decorators for credential caching

### DIFF
--- a/google/cloud/internal/oauth2_access_token_credentials.cc
+++ b/google/cloud/internal/oauth2_access_token_credentials.cc
@@ -20,13 +20,12 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AccessTokenCredentials::AccessTokenCredentials(
-    google::cloud::internal::AccessToken const& access_token)
-    : header_(std::make_pair("Authorization", "Bearer " + access_token.token)) {
-}
+    google::cloud::internal::AccessToken access_token)
+    : access_token_(std::move(access_token)) {}
 
-StatusOr<std::pair<std::string, std::string>>
-AccessTokenCredentials::AuthorizationHeader() {
-  return header_;
+StatusOr<internal::AccessToken> AccessTokenCredentials::GetToken(
+    std::chrono::system_clock::time_point /*tp*/) {
+  return access_token_;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_access_token_credentials.h
+++ b/google/cloud/internal/oauth2_access_token_credentials.h
@@ -33,12 +33,13 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AccessTokenCredentials : public oauth2_internal::Credentials {
  public:
   explicit AccessTokenCredentials(
-      google::cloud::internal::AccessToken const& access_token);
+      google::cloud::internal::AccessToken access_token);
 
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
  private:
-  std::pair<std::string, std::string> header_;
+  internal::AccessToken access_token_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_access_token_credentials_test.cc
+++ b/google/cloud/internal/oauth2_access_token_credentials_test.cc
@@ -25,16 +25,12 @@ namespace {
 using ::google::cloud::internal::AccessToken;
 
 TEST(AccessTokenCredentials, Simple) {
-  auto const expiration =
-      std::chrono::system_clock::now() - std::chrono::minutes(10);
-
-  AccessTokenCredentials tested(AccessToken{"token1", expiration});
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Bearer token1"}),
-            tested.AuthorizationHeader().value());
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Bearer token1"}),
-            tested.AuthorizationHeader().value());
+  auto const now = std::chrono::system_clock::now();
+  auto const expiration = now - std::chrono::minutes(10);
+  auto const expected = AccessToken{"token1", expiration};
+  AccessTokenCredentials tested(expected);
+  EXPECT_EQ(expected, tested.GetToken(now).value());
+  EXPECT_EQ(expected, tested.GetToken(now).value());
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_anonymous_credentials.cc
+++ b/google/cloud/internal/oauth2_anonymous_credentials.cc
@@ -19,9 +19,9 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<std::pair<std::string, std::string>>
-AnonymousCredentials::AuthorizationHeader() {
-  return std::make_pair(std::string{}, std::string{});
+StatusOr<internal::AccessToken> AnonymousCredentials::GetToken(
+    std::chrono::system_clock::time_point tp) {
+  return internal::AccessToken{std::string{}, tp};
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_anonymous_credentials.h
+++ b/google/cloud/internal/oauth2_anonymous_credentials.h
@@ -44,7 +44,8 @@ class AnonymousCredentials : public oauth2_internal::Credentials {
    * Authorization HTTP header from this method, this class always returns an
    * empty string as its value.
    */
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_anonymous_credentials_test.cc
+++ b/google/cloud/internal/oauth2_anonymous_credentials_test.cc
@@ -22,12 +22,15 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::testing::IsEmpty;
+
 /// @test Verify `AnonymousCredentials` works as expected.
-TEST(AnonymousCredentialsTest, AuthorizationHeaderReturnsEmptyString) {
+TEST(AnonymousCredentialsTest, ReturnsEmptyString) {
   AnonymousCredentials credentials;
-  auto header = credentials.AuthorizationHeader();
-  ASSERT_STATUS_OK(header);
-  EXPECT_EQ(std::make_pair(std::string{}, std::string{}), header.value());
+  auto const now = std::chrono::system_clock::now();
+  auto const actual = credentials.GetToken(now);
+  ASSERT_STATUS_OK(actual);
+  EXPECT_THAT(actual->token, IsEmpty());
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_authorized_user_credentials.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.cc
@@ -77,21 +77,16 @@ StatusOr<internal::AccessToken> ParseAuthorizedUserRefreshResponse(
         " token for service account credentials.";
     return AsStatus(status_code, error_payload);
   }
-  std::string header_value = access_token.value("token_type", "");
-  header_value += ' ';
-  header_value += access_token.value("access_token", "");
   auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
-  auto new_expiration = now + expires_in;
-  return internal::AccessToken{std::move(header_value), new_expiration};
+  return internal::AccessToken{access_token.value("access_token", ""),
+                               now + expires_in};
 }
 
 AuthorizedUserCredentials::AuthorizedUserCredentials(
     AuthorizedUserCredentialsInfo info, Options options,
-    std::unique_ptr<rest_internal::RestClient> rest_client,
-    CurrentTimeFn current_time_fn)
+    std::unique_ptr<rest_internal::RestClient> rest_client)
     : info_(std::move(info)),
       options_(std::move(options)),
-      current_time_fn_(std::move(current_time_fn)),
       rest_client_(std::move(rest_client)) {
   if (!rest_client_) {
     rest_client_ =
@@ -99,13 +94,8 @@ AuthorizedUserCredentials::AuthorizedUserCredentials(
   }
 }
 
-StatusOr<std::pair<std::string, std::string>>
-AuthorizedUserCredentials::AuthorizationHeader() {
-  std::unique_lock<std::mutex> lock(mu_);
-  return refreshing_creds_.AuthorizationHeader([this] { return Refresh(); });
-}
-
-StatusOr<internal::AccessToken> AuthorizedUserCredentials::Refresh() {
+StatusOr<internal::AccessToken> AuthorizedUserCredentials::GetToken(
+    std::chrono::system_clock::time_point tp) {
   rest_internal::RestRequest request;
   request.AddHeader("content-type", "application/x-www-form-urlencoded");
   std::vector<std::pair<std::string, std::string>> form_data;
@@ -118,9 +108,10 @@ StatusOr<internal::AccessToken> AuthorizedUserCredentials::Refresh() {
   if (!response.ok()) return std::move(response).status();
   std::unique_ptr<rest_internal::RestResponse> real_response =
       std::move(response.value());
-  if (real_response->StatusCode() >= 300)
+  if (real_response->StatusCode() >= 300) {
     return AsStatus(std::move(*real_response));
-  return ParseAuthorizedUserRefreshResponse(*real_response, current_time_fn_());
+  }
+  return ParseAuthorizedUserRefreshResponse(*real_response, tp);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_authorized_user_credentials.h
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.h
@@ -18,14 +18,11 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/oauth2_credential_constants.h"
 #include "google/cloud/internal/oauth2_credentials.h"
-#include "google/cloud/internal/oauth2_refreshing_credentials_wrapper.h"
 #include "google/cloud/internal/rest_client.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include <chrono>
-#include <iostream>
-#include <mutex>
 #include <string>
 
 namespace google {
@@ -70,37 +67,27 @@ StatusOr<internal::AccessToken> ParseAuthorizedUserRefreshResponse(
  */
 class AuthorizedUserCredentials : public Credentials {
  public:
-  using CurrentTimeFn =
-      std::function<std::chrono::time_point<std::chrono::system_clock>()>;
-
   /**
    * Creates an instance of AuthorizedUserCredentials.
    *
    * @param rest_client a dependency injection point. It makes it possible to
    *     mock internal REST types. This should generally not be overridden
    *     except for testing.
-   * @param current_time_fn a dependency injection point to fetch the current
-   *     time. This should generally not be overridden except for testing.
    */
   explicit AuthorizedUserCredentials(
       AuthorizedUserCredentialsInfo info, Options options = {},
-      std::unique_ptr<rest_internal::RestClient> rest_client = nullptr,
-      CurrentTimeFn current_time_fn = std::chrono::system_clock::now);
+      std::unique_ptr<rest_internal::RestClient> rest_client = nullptr);
 
   /**
    * Returns a key value pair for an "Authorization" header.
    */
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
  private:
-  StatusOr<internal::AccessToken> Refresh();
-
   AuthorizedUserCredentialsInfo info_;
   Options options_;
-  CurrentTimeFn current_time_fn_;
   std::unique_ptr<rest_internal::RestClient> rest_client_;
-  mutable std::mutex mu_;
-  RefreshingCredentialsWrapper refreshing_creds_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_cached_credentials.cc
+++ b/google/cloud/internal/oauth2_cached_credentials.cc
@@ -53,11 +53,6 @@ StatusOr<internal::AccessToken> CachedCredentials::GetToken(
   return token_;
 }
 
-StatusOr<std::pair<std::string, std::string>>
-CachedCredentials::AuthorizationHeader() {
-  return impl_->AuthorizationHeader();
-}
-
 StatusOr<std::vector<std::uint8_t>> CachedCredentials::SignBlob(
     absl::optional<std::string> const& signing_service_account,
     std::string const& string_to_sign) const {

--- a/google/cloud/internal/oauth2_cached_credentials.h
+++ b/google/cloud/internal/oauth2_cached_credentials.h
@@ -45,7 +45,6 @@ class CachedCredentials : public Credentials {
 
   StatusOr<internal::AccessToken> GetToken(
       std::chrono::system_clock::time_point now) override;
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
   StatusOr<std::vector<std::uint8_t>> SignBlob(
       absl::optional<std::string> const& signing_service_account,
       std::string const& string_to_sign) const override;

--- a/google/cloud/internal/oauth2_cached_credentials_test.cc
+++ b/google/cloud/internal/oauth2_cached_credentials_test.cc
@@ -35,8 +35,6 @@ class MockCredentials : public Credentials {
  public:
   MOCK_METHOD(StatusOr<internal::AccessToken>, GetToken,
               (std::chrono::system_clock::time_point), (override));
-  MOCK_METHOD((StatusOr<std::pair<std::string, std::string>>),
-              AuthorizationHeader, (), (override));
   MOCK_METHOD(StatusOr<std::vector<std::uint8_t>>, SignBlob,
               (absl::optional<std::string> const&, std::string const&),
               (const, override));
@@ -134,17 +132,6 @@ TEST(CachedCredentials, GetTokenExpiredWithError) {
 
   auto a2 = tested.GetToken(tp2);
   EXPECT_THAT(a2, StatusIs(StatusCode::kUnavailable));
-}
-
-TEST(CachedCredentials, AuthorizationHeader) {
-  auto mock = std::make_shared<MockCredentials>();
-  auto const expected = std::make_pair(std::string{"Authorization"},
-                                       std::string{"Bearer test-token"});
-  EXPECT_CALL(*mock, AuthorizationHeader()).WillOnce(Return(expected));
-  CachedCredentials tested(mock);
-  auto actual = tested.AuthorizationHeader();
-  ASSERT_STATUS_OK(actual);
-  EXPECT_EQ(*actual, expected);
 }
 
 TEST(CachedCredentials, SignBlob) {

--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -103,7 +103,7 @@ ComputeEngineCredentials::ComputeEngineCredentials(
 
 StatusOr<internal::AccessToken> ComputeEngineCredentials::GetToken(
     std::chrono::system_clock::time_point tp) {
-  // Ignore failures fetching the account metadata, we can still get a token
+  // Ignore failures fetching the account metadata. We can still get a token
   // using the initial `service_account_email_` value.
   auto email = RetrieveServiceAccountInfo();
   auto response = DoMetadataServerGetRequest(

--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -78,13 +78,11 @@ StatusOr<internal::AccessToken> ParseComputeEngineRefreshResponse(
         " compute engine credentials.";
     return Status{StatusCode::kInvalidArgument, error_payload, {}};
   }
-  std::string header_value = access_token.value("token_type", "");
-  header_value += ' ';
-  header_value += access_token.value("access_token", "");
   auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
   auto new_expiration = now + expires_in;
 
-  return internal::AccessToken{std::move(header_value), new_expiration};
+  return internal::AccessToken{access_token.value("access_token", ""),
+                               new_expiration};
 }
 
 ComputeEngineCredentials::ComputeEngineCredentials()
@@ -92,10 +90,8 @@ ComputeEngineCredentials::ComputeEngineCredentials()
 
 ComputeEngineCredentials::ComputeEngineCredentials(
     std::string service_account_email, Options options,
-    std::unique_ptr<rest_internal::RestClient> rest_client,
-    CurrentTimeFn current_time_fn)
-    : current_time_fn_(std::move(current_time_fn)),
-      rest_client_(std::move(rest_client)),
+    std::unique_ptr<rest_internal::RestClient> rest_client)
+    : rest_client_(std::move(rest_client)),
       service_account_email_(std::move(service_account_email)),
       options_(std::move(options)) {
   if (!rest_client_) {
@@ -105,16 +101,26 @@ ComputeEngineCredentials::ComputeEngineCredentials(
   }
 }
 
-StatusOr<std::pair<std::string, std::string>>
-ComputeEngineCredentials::AuthorizationHeader() {
-  std::unique_lock<std::mutex> lock(mu_);
-  return refreshing_creds_.AuthorizationHeader([this] { return Refresh(); });
+StatusOr<internal::AccessToken> ComputeEngineCredentials::GetToken(
+    std::chrono::system_clock::time_point tp) {
+  // Ignore failures fetching the account metadata, we can still get a token
+  // using the initial `service_account_email_` value.
+  auto email = RetrieveServiceAccountInfo();
+  auto response = DoMetadataServerGetRequest(
+      "computeMetadata/v1/instance/service-accounts/" + email + "/token",
+      false);
+  if (!response) return std::move(response).status();
+  if ((*response)->StatusCode() >= 300) {
+    return AsStatus(std::move(**response));
+  }
+
+  return ParseComputeEngineRefreshResponse(**response, tp);
 }
 
 std::string ComputeEngineCredentials::AccountEmail() const {
-  std::unique_lock<std::mutex> lock(mu_);
+  std::lock_guard<std::mutex> lock(mu_);
   // Force a refresh on the account info.
-  RetrieveServiceAccountInfo();
+  RetrieveServiceAccountInfo(lock);
   return service_account_email_;
 }
 
@@ -138,38 +144,28 @@ ComputeEngineCredentials::DoMetadataServerGetRequest(std::string const& path,
   return rest_client_->Get(request);
 }
 
-void ComputeEngineCredentials::RetrieveServiceAccountInfo() const {
+std::string ComputeEngineCredentials::RetrieveServiceAccountInfo() const {
+  return RetrieveServiceAccountInfo(std::lock_guard<std::mutex>{mu_});
+}
+
+std::string ComputeEngineCredentials::RetrieveServiceAccountInfo(
+    std::lock_guard<std::mutex> const&) const {
   // Fetch the metadata only once.
-  if (metadata_retrieved_) return;
+  if (metadata_retrieved_) return service_account_email_;
 
   auto response = DoMetadataServerGetRequest(
       "computeMetadata/v1/instance/service-accounts/" + service_account_email_ +
           "/",
       true);
-  if (!response || (*response)->StatusCode() >= 300) return;
-
+  if (!response || (*response)->StatusCode() >= 300) {
+    return service_account_email_;
+  }
   auto metadata = ParseMetadataServerResponse(**response);
-  if (!metadata) return;
+  if (!metadata) return service_account_email_;
   service_account_email_ = std::move(metadata->email);
   scopes_ = std::move(metadata->scopes);
   metadata_retrieved_ = true;
-}
-
-StatusOr<internal::AccessToken> ComputeEngineCredentials::Refresh() const {
-  // Ignore failures fetching the account metadata, we can still get a token
-  // using the initial `service_account_email_` value.
-  RetrieveServiceAccountInfo();
-
-  auto response = DoMetadataServerGetRequest(
-      "computeMetadata/v1/instance/service-accounts/" + service_account_email_ +
-          "/token",
-      false);
-  if (!response) return std::move(response).status();
-  if ((*response)->StatusCode() >= 300) {
-    return AsStatus(std::move(**response));
-  }
-
-  return ParseComputeEngineRefreshResponse(**response, current_time_fn_());
+  return service_account_email_;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
@@ -169,17 +169,13 @@ TEST(ComputeEngineCredentialsTest, ParseComputeEngineRefreshResponse) {
   EXPECT_CALL(std::move(*mock_response), ExtractPayload)
       .WillOnce(Return(ByMove(std::move(mock_http_payload))));
 
-  auto expires_in = 3600;
-  auto clock_value = 2000;
+  auto const now = std::chrono::system_clock::now();
+  auto const expires_in = std::chrono::seconds(3600);
 
-  auto status = ParseComputeEngineRefreshResponse(
-      *mock_response, std::chrono::system_clock::from_time_t(clock_value));
+  auto status = ParseComputeEngineRefreshResponse(*mock_response, now);
   EXPECT_STATUS_OK(status);
   auto token = *status;
-  EXPECT_EQ(std::chrono::time_point_cast<std::chrono::seconds>(token.expiration)
-                .time_since_epoch()
-                .count(),
-            clock_value + expires_in);
+  EXPECT_EQ(token.expiration, now + expires_in);
   EXPECT_EQ(token.token, "mysupersecrettoken");
 }
 

--- a/google/cloud/internal/oauth2_credentials.h
+++ b/google/cloud/internal/oauth2_credentials.h
@@ -55,19 +55,7 @@ class Credentials {
    *     considered.
    */
   virtual StatusOr<internal::AccessToken> GetToken(
-      std::chrono::system_clock::time_point tp);
-
-  /**
-   * Attempts to obtain a value for the Authorization HTTP header.
-   *
-   * If unable to obtain a value for the Authorization header, which could
-   * happen for `Credentials` that need to be periodically refreshed, the
-   * underlying `Status` will indicate failure details from the refresh HTTP
-   * request. Otherwise, the returned value will contain the Authorization
-   * header to be used in HTTP requests.
-   */
-  virtual StatusOr<std::pair<std::string, std::string>>
-  AuthorizationHeader() = 0;
+      std::chrono::system_clock::time_point tp) = 0;
 
   /**
    * Try to sign @p string_to_sign using @p service_account.

--- a/google/cloud/internal/oauth2_error_credentials.cc
+++ b/google/cloud/internal/oauth2_error_credentials.cc
@@ -19,8 +19,8 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<std::pair<std::string, std::string>>
-ErrorCredentials::AuthorizationHeader() {
+StatusOr<internal::AccessToken> ErrorCredentials::GetToken(
+    std::chrono::system_clock::time_point /*tp*/) {
   return status_;
 }
 

--- a/google/cloud/internal/oauth2_error_credentials.h
+++ b/google/cloud/internal/oauth2_error_credentials.h
@@ -48,7 +48,8 @@ class ErrorCredentials : public oauth2_internal::Credentials {
  public:
   explicit ErrorCredentials(Status status) : status_(std::move(status)) {}
 
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
  private:
   Status status_;

--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -157,12 +157,6 @@ StatusOr<internal::AccessToken> ExternalAccountCredentials::GetToken(
   return internal::AccessToken{*token, tp + std::chrono::seconds(*expires_in)};
 }
 
-StatusOr<std::pair<std::string, std::string>>
-ExternalAccountCredentials::AuthorizationHeader() {
-  return internal::UnimplementedError(
-      "WIP(#10316) - use decorator for credentials", GCP_ERROR_INFO());
-}
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal
 }  // namespace cloud

--- a/google/cloud/internal/oauth2_external_account_credentials.h
+++ b/google/cloud/internal/oauth2_external_account_credentials.h
@@ -49,7 +49,6 @@ class ExternalAccountCredentials : public oauth2_internal::Credentials {
 
   StatusOr<internal::AccessToken> GetToken(
       std::chrono::system_clock::time_point tp) override;
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
 
  private:
   ExternalAccountInfo info_;

--- a/google/cloud/internal/oauth2_google_credentials_test.cc
+++ b/google/cloud/internal/oauth2_google_credentials_test.cc
@@ -260,8 +260,8 @@ TEST_F(GoogleCredentialsTest, MissingCredentialsViaGcloudFilePath) {
   auto creds = GoogleDefaultCredentials();
   ASSERT_STATUS_OK(creds);
   ASSERT_THAT(*creds, NotNull());
-  auto header = (*creds)->AuthorizationHeader();
-  EXPECT_THAT(header, StatusIs(Not(StatusCode::kOk)));
+  auto token = (*creds)->GetToken(std::chrono::system_clock::now());
+  EXPECT_THAT(token, StatusIs(Not(StatusCode::kOk)));
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_impersonate_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_impersonate_service_account_credentials.h
@@ -18,7 +18,7 @@
 #include "google/cloud/internal/oauth2_credentials.h"
 #include "google/cloud/internal/oauth2_minimal_iam_credentials_rest.h"
 #include "google/cloud/version.h"
-#include <mutex>
+#include <memory>
 #include <string>
 
 namespace google {
@@ -32,9 +32,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ImpersonateServiceAccountCredentials
     : public oauth2_internal::Credentials {
  public:
-  using CurrentTimeFn =
-      std::function<std::chrono::time_point<std::chrono::system_clock>()>;
-
   /**
    * Creates an instance of ImpersonateServiceAccountCredentials.
    *
@@ -42,24 +39,17 @@ class ImpersonateServiceAccountCredentials
    *     time. This should generally not be overridden except for testing.
    */
   explicit ImpersonateServiceAccountCredentials(
-      google::cloud::internal::ImpersonateServiceAccountConfig const& config,
-      CurrentTimeFn current_time_fn = std::chrono::system_clock::now);
+      google::cloud::internal::ImpersonateServiceAccountConfig const& config);
   ImpersonateServiceAccountCredentials(
       google::cloud::internal::ImpersonateServiceAccountConfig const& config,
-      std::shared_ptr<MinimalIamCredentialsRest> stub,
-      CurrentTimeFn current_time_fn = std::chrono::system_clock::now);
+      std::shared_ptr<MinimalIamCredentialsRest> stub);
 
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader(
-      std::chrono::system_clock::time_point now);
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
  private:
   std::shared_ptr<MinimalIamCredentialsRest> stub_;
   GenerateAccessTokenRequest request_;
-  CurrentTimeFn current_time_fn_;
-  std::mutex mu_;
-  std::pair<std::string, std::string> header_;
-  std::chrono::system_clock::time_point expiration_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -50,7 +50,7 @@ MinimalIamCredentialsRestStub::MinimalIamCredentialsRestStub(
 StatusOr<google::cloud::internal::AccessToken>
 MinimalIamCredentialsRestStub::GenerateAccessToken(
     GenerateAccessTokenRequest const& request) {
-  auto auth_header = credentials_->AuthorizationHeader();
+  auto auth_header = AuthorizationHeader(*credentials_);
   if (!auth_header) return std::move(auth_header).status();
 
   rest_internal::RestRequest rest_request;

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
@@ -44,8 +44,8 @@ using ::testing::Return;
 
 class MockCredentials : public google::cloud::oauth2_internal::Credentials {
  public:
-  MOCK_METHOD((StatusOr<std::pair<std::string, std::string>>),
-              AuthorizationHeader, (), (override));
+  MOCK_METHOD(StatusOr<internal::AccessToken>, GetToken,
+              (std::chrono::system_clock::time_point), (override));
 };
 
 class MinimalIamCredentialsRestTest : public ::testing::Test {
@@ -65,8 +65,8 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenSuccess) {
   std::string scope = "my_scope";
   std::string delegate = "my_delegate";
 
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
-    return std::make_pair(std::string("Authorization"), std::string("Foo"));
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
+    return internal::AccessToken{"test-token", tp + lifetime};
   });
 
   std::string response = R"""({
@@ -116,8 +116,8 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenNonRfc3339Time) {
   std::string scope = "my_scope";
   std::string delegate = "my_delegate";
 
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
-    return std::make_pair(std::string("Authorization"), std::string("Foo"));
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
+    return internal::AccessToken{"test-token", tp + lifetime};
   });
 
   std::string response = R"""({
@@ -166,8 +166,8 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenInvalidResponse) {
   std::string scope = "my_scope";
   std::string delegate = "my_delegate";
 
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
-    return std::make_pair(std::string("Authorization"), std::string("Foo"));
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
+    return internal::AccessToken{"test-token", tp + lifetime};
   });
 
   std::string response = R"""({
@@ -215,8 +215,8 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenPostFailure) {
   std::string scope = "my_scope";
   std::string delegate = "my_delegate";
 
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
-    return std::make_pair(std::string("Authorization"), std::string("Foo"));
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
+    return internal::AccessToken{"test-token", tp + lifetime};
   });
 
   auto* mock_response = new MockRestResponse();
@@ -255,7 +255,7 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenPostFailure) {
 }
 
 TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenCredentialFailure) {
-  EXPECT_CALL(*mock_credentials_, AuthorizationHeader).WillOnce([] {
+  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([] {
     return Status(StatusCode::kPermissionDenied, "Permission Denied");
   });
   auto stub = MinimalIamCredentialsRestStub(std::move(mock_credentials_), {},

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -17,14 +17,12 @@
 
 #include "google/cloud/internal/oauth2_credential_constants.h"
 #include "google/cloud/internal/oauth2_credentials.h"
-#include "google/cloud/internal/oauth2_refreshing_credentials_wrapper.h"
 #include "google/cloud/internal/rest_client.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
 #include <chrono>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -193,9 +191,6 @@ StatusOr<std::string> MakeSelfSignedJWT(
  */
 class ServiceAccountCredentials : public oauth2_internal::Credentials {
  public:
-  using CurrentTimeFn =
-      std::function<std::chrono::time_point<std::chrono::system_clock>()>;
-
   /**
    * Creates an instance of ServiceAccountCredentials.
    *
@@ -207,13 +202,13 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
    */
   explicit ServiceAccountCredentials(
       ServiceAccountCredentialsInfo info, Options options = {},
-      std::unique_ptr<rest_internal::RestClient> rest_client = nullptr,
-      CurrentTimeFn current_time_fn = std::chrono::system_clock::now);
+      std::unique_ptr<rest_internal::RestClient> rest_client = nullptr);
 
   /**
    * Returns a key value pair for an "Authorization" header.
    */
-  StatusOr<std::pair<std::string, std::string>> AuthorizationHeader() override;
+  StatusOr<internal::AccessToken> GetToken(
+      std::chrono::system_clock::time_point tp) override;
 
   /**
    * Create a RSA SHA256 signature of the blob using the Credential object.
@@ -236,16 +231,14 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
 
  private:
   bool UseOAuth();
-  StatusOr<internal::AccessToken> Refresh();
-  StatusOr<internal::AccessToken> RefreshOAuth() const;
-  StatusOr<internal::AccessToken> RefreshSelfSigned() const;
+  StatusOr<internal::AccessToken> GetTokenOAuth(
+      std::chrono::system_clock::time_point tp) const;
+  StatusOr<internal::AccessToken> GetTokenSelfSigned(
+      std::chrono::system_clock::time_point tp) const;
 
   ServiceAccountCredentialsInfo info_;
-  CurrentTimeFn current_time_fn_;
   std::unique_ptr<rest_internal::RestClient> rest_client_;
   Options options_;
-  mutable std::mutex mu_;
-  RefreshingCredentialsWrapper refreshing_creds_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/internal/oauth2_credential_constants.h"
 #include "google/cloud/internal/openssl_util.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/testing_util/mock_fake_clock.h"
+#include "google/cloud/testing_util/chrono_output.h"
 #include "google/cloud/testing_util/mock_http_payload.h"
 #include "google/cloud/testing_util/mock_rest_client.h"
 #include "google/cloud/testing_util/mock_rest_response.h"
@@ -36,7 +36,6 @@ namespace {
 
 using ::google::cloud::internal::SignUsingSha256;
 using ::google::cloud::internal::UrlsafeBase64Decode;
-using ::google::cloud::testing_util::FakeClock;
 using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
 using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
@@ -49,9 +48,7 @@ using ::testing::Contains;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
 using ::testing::Not;
-using ::testing::Pair;
 using ::testing::Return;
-using ::testing::StartsWith;
 
 constexpr char kScopeForTest0[] =
     "https://www.googleapis.com/auth/devstorage.full_control";
@@ -124,7 +121,8 @@ std::string MakeTestContents() {
 
 void CheckInfoYieldsExpectedAssertion(std::unique_ptr<MockRestClient> mock,
                                       ServiceAccountCredentialsInfo const& info,
-                                      std::string const& assertion) {
+                                      std::string const& assertion,
+                                      std::time_t assertion_time) {
   std::string response = R"""({
       "token_type": "Type",
       "access_token": "access-token-value",
@@ -151,12 +149,13 @@ void CheckInfoYieldsExpectedAssertion(std::unique_ptr<MockRestClient> mock,
             return std::unique_ptr<rest_internal::RestResponse>(mock_response1);
           });
 
-  ServiceAccountCredentials credentials(info, Options{}, std::move(mock),
-                                        FakeClock::now);
+  auto const tp = std::chrono::system_clock::from_time_t(assertion_time);
+  ServiceAccountCredentials credentials(info, Options{}, std::move(mock));
   // Calls Refresh to obtain the access token for our authorization header.
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Type access-token-value"}),
-            credentials.AuthorizationHeader().value());
+  auto token = credentials.GetToken(tp);
+  ASSERT_STATUS_OK(token);
+  EXPECT_EQ(token->token, "access-token-value");
+  EXPECT_EQ(token->expiration, tp + std::chrono::seconds(1234));
 }
 
 TEST(ServiceAccountCredentialsTest, MakeSelfSignedJWT) {
@@ -265,7 +264,6 @@ TEST(ServiceAccountCredentialsTest,
   auto const expected_header =
       nlohmann::json{{"alg", "RS256"}, {"typ", "JWT"}, {"kid", kPrivateKeyId}};
 
-  FakeClock::reset_clock(kFixedJwtTimestamp);
   auto const iat = static_cast<std::intmax_t>(kFixedJwtTimestamp);
   auto const exp = iat + 3600;
   auto const expected_payload = nlohmann::json{
@@ -279,7 +277,7 @@ TEST(ServiceAccountCredentialsTest,
   auto const assertion = MakeJWTAssertion(expected_header.dump(),
                                           expected_payload.dump(), kPrivateKey);
   CheckInfoYieldsExpectedAssertion(absl::make_unique<MockRestClient>(), *info,
-                                   assertion);
+                                   assertion, kFixedJwtTimestamp);
 }
 
 /// @test Verify that ServiceAccountCredentials defaults to self-signed JWTs.
@@ -306,16 +304,15 @@ TEST(ServiceAccountCredentialsTest, RefreshWithSelfSignedJWT) {
       Post(_, A<std::vector<std::pair<std::string, std::string>> const&>()))
       .Times(0);
 
-  ServiceAccountCredentials credentials(*info, Options{}, std::move(mock),
-                                        FakeClock::now);
-  auto header = credentials.AuthorizationHeader();
-  ASSERT_STATUS_OK(header);
-  ASSERT_THAT(*header, Pair("Authorization", StartsWith("Bearer ")));
+  ServiceAccountCredentials credentials(*info, Options{}, std::move(mock));
+  auto const now = std::chrono::system_clock::now();
+  auto access_token = credentials.GetToken(now);
+  ASSERT_STATUS_OK(access_token);
 
-  auto token = MakeSelfSignedJWT(*info, FakeClock::now());
+  auto token = MakeSelfSignedJWT(*info, now);
   ASSERT_STATUS_OK(token);
 
-  EXPECT_EQ(header->second, "Bearer " + *token);
+  EXPECT_EQ(access_token->token, *token);
 }
 
 /// @test Verify that we can create service account credentials from a keyfile.
@@ -332,7 +329,6 @@ TEST(ServiceAccountCredentialsTest,
   auto const expected_header =
       nlohmann::json{{"alg", "RS256"}, {"typ", "JWT"}, {"kid", kPrivateKeyId}};
 
-  FakeClock::reset_clock(kFixedJwtTimestamp);
   auto const iat = static_cast<std::intmax_t>(kFixedJwtTimestamp);
   auto const exp = iat + 3600;
   auto const expected_payload = nlohmann::json{
@@ -344,7 +340,7 @@ TEST(ServiceAccountCredentialsTest,
   auto const assertion = MakeJWTAssertion(expected_header.dump(),
                                           expected_payload.dump(), kPrivateKey);
   CheckInfoYieldsExpectedAssertion(absl::make_unique<MockRestClient>(), *info,
-                                   assertion);
+                                   assertion, kFixedJwtTimestamp);
 }
 
 TEST(ServiceAccountCredentialsTest, MultipleScopes) {
@@ -367,76 +363,6 @@ TEST(ServiceAccountCredentialsTest, MultipleScopes) {
   actual_info.subject = std::string(kSubjectForGrant);
   auto const actual_components = AssertionComponentsFromInfo(actual_info, now);
   EXPECT_EQ(actual_components, expected_components);
-}
-
-/// @test Verify that we refresh service account credentials appropriately.
-TEST(ServiceAccountCredentialsTest,
-     RefreshCalledOnlyWhenAccessTokenIsMissingOrInvalid) {
-  ScopedEnvironment disable_self_signed_jwt(
-      "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT", "1");
-
-  // Prepare two responses, the first one is used but becomes immediately
-  // expired, resulting in another refresh next time the caller tries to get
-  // an authorization header.
-  std::string r1 = R"""({
-    "token_type": "Type",
-    "access_token": "access-token-r1",
-    "expires_in": 0
-})""";
-  std::string r2 = R"""({
-    "token_type": "Type",
-    "access_token": "access-token-r2",
-    "expires_in": 1000
-})""";
-
-  auto* mock_response1 = new MockRestResponse();
-  EXPECT_CALL(*mock_response1, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
-  EXPECT_CALL(std::move(*mock_response1), ExtractPayload).WillOnce([&] {
-    return MakeMockHttpPayloadSuccess(r1);
-  });
-
-  auto* mock_response2 = new MockRestResponse();
-  EXPECT_CALL(*mock_response2, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
-  EXPECT_CALL(std::move(*mock_response2), ExtractPayload).WillOnce([&] {
-    return MakeMockHttpPayloadSuccess(r2);
-  });
-
-  auto mock = absl::make_unique<MockRestClient>();
-  EXPECT_CALL(
-      *mock,
-      Post(_, A<std::vector<std::pair<std::string, std::string>> const&>()))
-      .WillOnce(
-          [&](rest_internal::RestRequest const&,
-              std::vector<std::pair<std::string, std::string>> const& payload) {
-            EXPECT_THAT(payload, Contains(std::pair<std::string, std::string>(
-                                     "grant_type", kGrantParamUnescaped)));
-            return std::unique_ptr<rest_internal::RestResponse>(mock_response1);
-          })
-      .WillOnce(
-          [&](rest_internal::RestRequest const&,
-              std::vector<std::pair<std::string, std::string>> const& payload) {
-            EXPECT_THAT(payload, Contains(std::pair<std::string, std::string>(
-                                     "grant_type", kGrantParamUnescaped)));
-            return std::unique_ptr<rest_internal::RestResponse>(mock_response2);
-          });
-
-  auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
-  ASSERT_STATUS_OK(info);
-  ServiceAccountCredentials credentials(*info, {}, std::move(mock));
-  // Calls Refresh to obtain the access token for our authorization header.
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Type access-token-r1"}),
-            credentials.AuthorizationHeader().value());
-  // Token is expired, resulting in another call to Refresh.
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Type access-token-r2"}),
-            credentials.AuthorizationHeader().value());
-  // Token still valid; should return cached token instead of calling Refresh.
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Type access-token-r2"}),
-            credentials.AuthorizationHeader().value());
 }
 
 /// @test Verify that `nlohmann::json::parse()` failures are reported as
@@ -573,116 +499,6 @@ TEST(ServiceAccountCredentialsTest, ParseOptionalField) {
   ASSERT_STATUS_OK(actual.status());
 }
 
-/// @test Verify that refreshing a credential updates the timestamps.
-TEST(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
-  ScopedEnvironment disable_self_signed_jwt(
-      "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT", "1");
-
-  auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
-  ASSERT_STATUS_OK(info);
-
-  // NOLINTNEXTLINE(google-runtime-int)
-  auto request_assertion =
-      [&info](int timestamp,
-              std::vector<std::pair<std::string, std::string>> const& p) {
-        EXPECT_THAT(p, Contains(std::pair<std::string, std::string>(
-                           "grant_type", kGrantParamUnescaped)));
-
-        auto assertion =
-            std::find_if(p.begin(), p.end(),
-                         [](std::pair<std::string, std::string> const& e) {
-                           return e.first == "assertion";
-                         });
-        ASSERT_NE(assertion, p.end());
-
-        std::vector<std::string> const tokens =
-            absl::StrSplit(assertion->second, '.');
-        std::string const& encoded_header = tokens[0];
-        std::string const& encoded_payload = tokens[1];
-
-        auto header_bytes =
-            internal::UrlsafeBase64Decode(encoded_header).value();
-        std::string header_str{header_bytes.begin(), header_bytes.end()};
-        auto payload_bytes =
-            internal::UrlsafeBase64Decode(encoded_payload).value();
-        std::string payload_str{payload_bytes.begin(), payload_bytes.end()};
-
-        auto header = nlohmann::json::parse(header_str);
-        EXPECT_EQ("RS256", header.value("alg", ""));
-        EXPECT_EQ("JWT", header.value("typ", ""));
-        EXPECT_EQ(info->private_key_id, header.value("kid", ""));
-
-        auto payload = nlohmann::json::parse(payload_str);
-        EXPECT_EQ(timestamp, payload.value("iat", 0));
-        EXPECT_EQ(timestamp + 3600, payload.value("exp", 0));
-        EXPECT_EQ(info->client_email, payload.value("iss", ""));
-        EXPECT_EQ(info->token_uri, payload.value("aud", ""));
-      };
-
-  // Set up the mock request / response for the first Refresh().
-  auto const clock_value_1 = 10000;
-  auto const clock_value_2 = 20000;
-
-  auto response = [&](int timestamp) {
-    std::string token = "mock-token-value-" + std::to_string(timestamp);
-    nlohmann::json response{{"token_type", "Mock-Type"},
-                            {"access_token", token},
-                            {"expires_in", 3600}};
-    return response.dump();
-  };
-
-  auto* mock_response1 = new MockRestResponse();
-  EXPECT_CALL(*mock_response1, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
-  EXPECT_CALL(std::move(*mock_response1), ExtractPayload).WillOnce([&] {
-    return MakeMockHttpPayloadSuccess(response(clock_value_1));
-  });
-
-  auto* mock_response2 = new MockRestResponse();
-  EXPECT_CALL(*mock_response2, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
-  EXPECT_CALL(std::move(*mock_response2), ExtractPayload).WillOnce([&] {
-    return MakeMockHttpPayloadSuccess(response(clock_value_2));
-  });
-
-  auto mock = absl::make_unique<MockRestClient>();
-  EXPECT_CALL(
-      *mock,
-      Post(_, A<std::vector<std::pair<std::string, std::string>> const&>()))
-      .WillOnce(
-          [&](rest_internal::RestRequest const&,
-              std::vector<std::pair<std::string, std::string>> const& payload) {
-            request_assertion(clock_value_1, payload);
-            return std::unique_ptr<rest_internal::RestResponse>(mock_response1);
-          })
-      .WillOnce(
-          [&](rest_internal::RestRequest const&,
-              std::vector<std::pair<std::string, std::string>> const& payload) {
-            request_assertion(clock_value_2, payload);
-            return std::unique_ptr<rest_internal::RestResponse>(mock_response2);
-          });
-
-  FakeClock::now_value_ = clock_value_1;
-  ServiceAccountCredentials credentials(*info, {}, std::move(mock),
-                                        FakeClock::now);
-  // Call Refresh to obtain the access token for our authorization header.
-  auto authorization_header = credentials.AuthorizationHeader();
-  ASSERT_STATUS_OK(authorization_header);
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Mock-Type mock-token-value-10000"}),
-            authorization_header.value());
-
-  // Advance the clock past the expiration time of the token and then get a
-  // new header.
-  FakeClock::now_value_ = clock_value_2;
-  EXPECT_GT(clock_value_2 - clock_value_1, 2 * 3600);
-  authorization_header = credentials.AuthorizationHeader();
-  ASSERT_STATUS_OK(authorization_header);
-  EXPECT_EQ(std::make_pair(std::string{"Authorization"},
-                           std::string{"Mock-Type mock-token-value-20000"}),
-            authorization_header.value());
-}
-
 /// @test Verify that we can create sign blobs using a service account.
 TEST(ServiceAccountCredentialsTest, SignBlob) {
   auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
@@ -748,9 +564,8 @@ TEST(ServiceAccountCredentialsTest, ClientId) {
 TEST(ServiceAccountCredentialsTest, AssertionComponentsFromInfo) {
   auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
   ASSERT_STATUS_OK(info);
-  auto const clock_value_1 = 10000;
-  FakeClock::reset_clock(clock_value_1);
-  auto components = AssertionComponentsFromInfo(*info, FakeClock::now());
+  auto const now = std::chrono::system_clock::now();
+  auto components = AssertionComponentsFromInfo(*info, now);
 
   auto header = nlohmann::json::parse(components.first);
   EXPECT_EQ("RS256", header.value("alg", ""));
@@ -758,8 +573,10 @@ TEST(ServiceAccountCredentialsTest, AssertionComponentsFromInfo) {
   EXPECT_EQ(info->private_key_id, header.value("kid", ""));
 
   auto payload = nlohmann::json::parse(components.second);
-  EXPECT_EQ(clock_value_1, payload.value("iat", 0));
-  EXPECT_EQ(clock_value_1 + 3600, payload.value("exp", 0));
+  EXPECT_EQ(std::chrono::system_clock::to_time_t(now), payload.value("iat", 0));
+  EXPECT_EQ(
+      std::chrono::system_clock::to_time_t(now + std::chrono::seconds(3600)),
+      payload.value("exp", 0));
   EXPECT_EQ(info->client_email, payload.value("iss", ""));
   EXPECT_EQ(info->token_uri, payload.value("aud", ""));
 }
@@ -769,9 +586,8 @@ TEST(ServiceAccountCredentialsTest, AssertionComponentsFromInfo) {
 TEST(ServiceAccountCredentialsTest, MakeJWTAssertion) {
   auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
   ASSERT_STATUS_OK(info);
-  FakeClock::reset_clock(kFixedJwtTimestamp);
-  auto const tp = FakeClock::now();
 
+  auto const tp = std::chrono::system_clock::from_time_t(kFixedJwtTimestamp);
   auto components = AssertionComponentsFromInfo(*info, tp);
   auto assertion =
       MakeJWTAssertion(components.first, components.second, info->private_key);
@@ -815,12 +631,11 @@ TEST(ServiceAccountCredentialsTest, MakeJWTAssertion) {
 TEST(ServiceAccountCredentialsTest, CreateServiceAccountRefreshPayload) {
   auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
   ASSERT_STATUS_OK(info);
-  FakeClock::reset_clock(kFixedJwtTimestamp);
-  auto components = AssertionComponentsFromInfo(*info, FakeClock::now());
+  auto const now = std::chrono::system_clock::now();
+  auto components = AssertionComponentsFromInfo(*info, now);
   auto assertion =
       MakeJWTAssertion(components.first, components.second, info->private_key);
-  auto actual_payload =
-      CreateServiceAccountRefreshPayload(*info, FakeClock::now());
+  auto actual_payload = CreateServiceAccountRefreshPayload(*info, now);
 
   EXPECT_THAT(actual_payload, Contains(std::pair<std::string, std::string>(
                                   "assertion", assertion)));
@@ -854,15 +669,13 @@ TEST(ServiceAccountCredentialsTest,
   EXPECT_CALL(std::move(*mock_response2), ExtractPayload)
       .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(r2))));
 
-  FakeClock::reset_clock(1000);
-  auto status =
-      ParseServiceAccountRefreshResponse(*mock_response1, FakeClock::now());
+  auto const now = std::chrono::system_clock::now();
+  auto status = ParseServiceAccountRefreshResponse(*mock_response1, now);
   EXPECT_THAT(status,
               StatusIs(StatusCode::kInvalidArgument,
                        HasSubstr("Could not find all required fields")));
 
-  status =
-      ParseServiceAccountRefreshResponse(*mock_response2, FakeClock::now());
+  status = ParseServiceAccountRefreshResponse(*mock_response2, now);
   EXPECT_THAT(status,
               StatusIs(StatusCode::kInvalidArgument,
                        HasSubstr("Could not find all required fields")));
@@ -873,6 +686,7 @@ TEST(ServiceAccountCredentialsTest, ParseServiceAccountRefreshResponse) {
   ScopedEnvironment disable_self_signed_jwt(
       "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT", "1");
 
+  auto const expires_in = 1000;
   std::string r1 = R"""({
     "token_type": "Type",
     "access_token": "access-token-r1",
@@ -885,17 +699,12 @@ TEST(ServiceAccountCredentialsTest, ParseServiceAccountRefreshResponse) {
   EXPECT_CALL(std::move(*mock_response1), ExtractPayload)
       .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(r1))));
 
-  auto expires_in = 1000;
-  FakeClock::reset_clock(2000);
-  auto status =
-      ParseServiceAccountRefreshResponse(*mock_response1, FakeClock::now());
+  auto const now = std::chrono::system_clock::now();
+  auto status = ParseServiceAccountRefreshResponse(*mock_response1, now);
   EXPECT_STATUS_OK(status);
   auto token = *status;
-  EXPECT_EQ(std::chrono::time_point_cast<std::chrono::seconds>(token.expiration)
-                .time_since_epoch()
-                .count(),
-            FakeClock::now_value_ + expires_in);
-  EXPECT_EQ(token.token, "Type access-token-r1");
+  EXPECT_EQ(token.expiration, now + std::chrono::seconds(expires_in));
+  EXPECT_EQ(token.token, "access-token-r1");
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -686,7 +686,7 @@ TEST(ServiceAccountCredentialsTest, ParseServiceAccountRefreshResponse) {
   ScopedEnvironment disable_self_signed_jwt(
       "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT", "1");
 
-  auto const expires_in = 1000;
+  auto const expires_in = std::chrono::seconds(1000);
   std::string r1 = R"""({
     "token_type": "Type",
     "access_token": "access-token-r1",
@@ -703,7 +703,7 @@ TEST(ServiceAccountCredentialsTest, ParseServiceAccountRefreshResponse) {
   auto status = ParseServiceAccountRefreshResponse(*mock_response1, now);
   EXPECT_STATUS_OK(status);
   auto token = *status;
-  EXPECT_EQ(token.expiration, now + std::chrono::seconds(expires_in));
+  EXPECT_EQ(token.expiration, now + expires_in);
   EXPECT_EQ(token.token, "access-token-r1");
 }
 


### PR DESCRIPTION
Remove the `AuthorizationHeader()` function from all the `oauth2_internal::*Credential` classes. The new function can be used with a decorator to implement caching in a single place. The new implementations are much simpler, and the tests can be simplified too.

Part of the work for #10316

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10362)
<!-- Reviewable:end -->
