### PR TITLE
fix(storage): scopes should disable self-signed JWTs

### DIFF
--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -49,6 +49,7 @@ struct ServiceAccountCredentialsInfo {
   absl::optional<std::set<std::string>> scopes;
   // See https://developers.google.com/identity/protocols/OAuth2ServiceAccount.
   absl::optional<std::string> subject;
+  bool enable_self_signed_jwt;
 };
 
 /// Indicates whether or not to use a self-signed JWT or issue a request to

--- a/google/cloud/storage/internal/unified_rest_credentials.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials.cc
@@ -61,18 +61,6 @@ class WrapRestCredentials : public oauth2::Credentials {
   std::shared_ptr<oauth2_internal::Credentials> impl_;
 };
 
-oauth2_internal::ServiceAccountCredentialsInfo MapInfo(
-    oauth2::ServiceAccountCredentialsInfo info) {
-  oauth2_internal::ServiceAccountCredentialsInfo result;
-  result.client_email = std::move(info.client_email);
-  result.private_key_id = std::move(info.private_key_id);
-  result.private_key = std::move(info.private_key);
-  result.token_uri = std::move(info.token_uri);
-  result.scopes = std::move(info.scopes);
-  result.subject = std::move(info.subject);
-  return result;
-}
-
 struct RestVisitor : public CredentialsVisitor {
   std::shared_ptr<oauth2::Credentials> result;
 
@@ -102,7 +90,7 @@ struct RestVisitor : public CredentialsVisitor {
     }
     result = std::make_shared<WrapRestCredentials>(
         std::make_shared<oauth2_internal::ServiceAccountCredentials>(
-            MapInfo(*std::move(info))));
+            internal::MapServiceAccountCredentialsInfo(*std::move(info))));
   }
 };
 

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -133,8 +133,10 @@ namespace internal {
 oauth2_internal::ServiceAccountCredentialsInfo MapServiceAccountCredentialsInfo(
     oauth2::ServiceAccountCredentialsInfo info) {
   // Storage has more stringent requirements w.r.t. self-signed JWTs
-  // than most services (which the base class
-  // Disable them in the implementation class
+  // than most services. Any scope makes the self-signed JWTs unusable with
+  // storage, but they remain usable with other services. We need to disable
+  // self-signed JWTs in the implementation class as it is unaware of the
+  // storage service limitations.
   auto enable_self_signed_jwt = !ServiceAccountUseOAuth(info);
   return {std::move(info.client_email), std::move(info.private_key_id),
           std::move(info.private_key),  std::move(info.token_uri),

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -56,10 +56,7 @@ std::pair<std::string, std::string> AssertionComponentsFromInfo(
     ServiceAccountCredentialsInfo const& info,
     std::chrono::system_clock::time_point now) {
   return oauth2_internal::AssertionComponentsFromInfo(
-      oauth2_internal::ServiceAccountCredentialsInfo{
-          info.client_email, info.private_key_id, info.private_key,
-          info.token_uri, info.scopes, info.subject},
-      now);
+      internal::MapServiceAccountCredentialsInfo(info), now);
 }
 
 std::string MakeJWTAssertion(std::string const& header,
@@ -73,10 +70,7 @@ std::string CreateServiceAccountRefreshPayload(
     ServiceAccountCredentialsInfo const& info, std::string const&,
     std::chrono::system_clock::time_point now) {
   auto params = oauth2_internal::CreateServiceAccountRefreshPayload(
-      oauth2_internal::ServiceAccountCredentialsInfo{
-          info.client_email, info.private_key_id, info.private_key,
-          info.token_uri, info.scopes, info.subject},
-      now);
+      internal::MapServiceAccountCredentialsInfo(info), now);
   return absl::StrJoin(params, "&", absl::PairFormatter("="));
 }
 
@@ -111,26 +105,44 @@ ParseServiceAccountRefreshResponse(
 StatusOr<std::string> MakeSelfSignedJWT(
     ServiceAccountCredentialsInfo const& info,
     std::chrono::system_clock::time_point tp) {
-  // This only runs about once an hour, the copies are ugly, but should be
-  // harmless.
-  oauth2_internal::ServiceAccountCredentialsInfo mapped;
-  mapped.client_email = info.client_email;
-  mapped.private_key_id = info.private_key_id;
-  mapped.private_key = info.private_key;
-  mapped.token_uri = info.token_uri;
-  mapped.scopes = info.scopes;
-  mapped.subject = info.subject;
+  auto mapped = internal::MapServiceAccountCredentialsInfo(info);
   return ::google::cloud::oauth2_internal::MakeSelfSignedJWT(mapped, tp);
 }
 
 bool ServiceAccountUseOAuth(ServiceAccountCredentialsInfo const& info) {
   if (info.private_key_id == kP12PrivateKeyIdMarker) return true;
+  // Self-signed JWTs do not work in GCS if they have scopes.
+  if (info.scopes.has_value()) return true;
   auto disable_jwt = google::cloud::internal::GetEnv(
       "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT");
   return disable_jwt.has_value();
 }
 
+ServiceAccountCredentials<storage::internal::CurlRequestBuilder,
+                          std::chrono::system_clock>::
+    ServiceAccountCredentials(ServiceAccountCredentialsInfo info,
+                              ChannelOptions const& options)
+    : impl_(absl::make_unique<oauth2_internal::ServiceAccountCredentials>(
+          internal::MapServiceAccountCredentialsInfo(std::move(info)),
+          Options{}.set<CARootsFilePathOption>(options.ssl_root_path()))) {}
+
 }  // namespace oauth2
+
+namespace internal {
+
+oauth2_internal::ServiceAccountCredentialsInfo MapServiceAccountCredentialsInfo(
+    oauth2::ServiceAccountCredentialsInfo info) {
+  // Storage has more stringent requirements w.r.t. self-signed JWTs
+  // than most services (which the base class
+  // Disable them in the implementation class
+  auto enable_self_signed_jwt = !ServiceAccountUseOAuth(info);
+  return {std::move(info.client_email), std::move(info.private_key_id),
+          std::move(info.private_key),  std::move(info.token_uri),
+          std::move(info.scopes),       std::move(info.subject),
+          enable_self_signed_jwt};
+}
+
+}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -208,15 +208,10 @@ class ServiceAccountCredentials<storage::internal::CurlRequestBuilder,
                                 std::chrono::system_clock>
     : public Credentials {
  public:
-  explicit ServiceAccountCredentials(ServiceAccountCredentialsInfo const& info)
+  explicit ServiceAccountCredentials(ServiceAccountCredentialsInfo info)
       : ServiceAccountCredentials(std::move(info), {}) {}
-  ServiceAccountCredentials(ServiceAccountCredentialsInfo const& info,
-                            ChannelOptions const& options)
-      : impl_(absl::make_unique<oauth2_internal::ServiceAccountCredentials>(
-            oauth2_internal::ServiceAccountCredentialsInfo{
-                info.client_email, info.private_key_id, info.private_key,
-                info.token_uri, info.scopes, info.subject},
-            Options{}.set<CARootsFilePathOption>(options.ssl_root_path()))) {}
+  ServiceAccountCredentials(ServiceAccountCredentialsInfo info,
+                            ChannelOptions const& options);
 
   StatusOr<std::string> AuthorizationHeader() override {
     return oauth2_internal::AuthorizationHeaderJoined(*impl_);
@@ -344,6 +339,13 @@ class ServiceAccountCredentials : public Credentials {
 };
 
 }  // namespace oauth2
+
+namespace internal {
+
+oauth2_internal::ServiceAccountCredentialsInfo MapServiceAccountCredentialsInfo(
+    oauth2::ServiceAccountCredentialsInfo info);
+
+}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
The storage service does not support self-signed JWTs with scopes. With this change, self-signed JWTs will be automatically disabled when using the legacy `storage::oauth2::Credentials`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10369)
<!-- Reviewable:end -->
