### PR TITLE
ci: run installed GCS+gRPC quickstart

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -164,8 +164,9 @@ env -C "${out_dir}" ctest "${ctest_args[@]}"
 
 # Tests the installed artifacts by building and running the quickstarts.
 # shellcheck disable=SC2046
-libraries="$(printf ";%s" $(features::list_full | grep -v grafeas))"
-libraries="${libraries:1}"
+libraries="$(printf "%s;" $(features::libraries))"
+# GCS+gRPC is not a library, but it has a quickstart.
+libraries="${libraries}experimental-storage-grpc"
 cmake -G Ninja \
   -S "${PROJECT_ROOT}/ci/verify_quickstart" \
   -B "${PROJECT_ROOT}/cmake-out/quickstart" \
@@ -178,6 +179,7 @@ cmake --build "${PROJECT_ROOT}/cmake-out/quickstart"
 rm -rf "${INSTALL_PREFIX:?}"/{include,lib64}
 cmake --install cmake-out --component google_cloud_cpp_runtime
 quickstart::run_cmake_and_make "${INSTALL_PREFIX}"
+quickstart::run_gcs_grpc_quickstart "${INSTALL_PREFIX}"
 
 # Be a little more explicit because we often run this manually
 io::log_h1 "SUCCESS"

--- a/ci/cloudbuild/builds/lib/quickstart.sh
+++ b/ci/cloudbuild/builds/lib/quickstart.sh
@@ -48,23 +48,6 @@ function quickstart::build_cmake_and_make() {
   done
 }
 
-function quickstart::build_gcs_grpc_quickstart() {
-  local prefix="$1"
-  local src_dir="${PROJECT_ROOT}/google/cloud/storage/quickstart"
-
-  io::log "[ CMake ]"
-  local cmake_bin_dir="${PROJECT_ROOT}/cmake-out/quickstart/cmake-storage"
-  cmake -H"${src_dir}" -B"${cmake_bin_dir}" "-DCMAKE_PREFIX_PATH=${prefix}"
-  cmake --build "${cmake_bin_dir}" --target quickstart_grpc
-
-  echo
-  io::log "[ Make ]"
-  local makefile_bin_dir="${PROJECT_ROOT}/cmake-out/quickstart/makefile-storage"
-  mkdir -p "${makefile_bin_dir}"
-  PKG_CONFIG_PATH="${prefix}/lib64/pkgconfig:${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
-    make -C "${src_dir}" BIN="${makefile_bin_dir}" "${makefile_bin_dir}/quickstart_grpc"
-}
-
 function quickstart::build_one_quickstart() {
   local prefix="$1"
   local src_dir="$2"

--- a/ci/verify_quickstart/CMakeLists.txt
+++ b/ci/verify_quickstart/CMakeLists.txt
@@ -42,10 +42,10 @@ function (add_cmake_quickstart_target feature library target)
     externalproject_add(
         verify-quickstart-cmake-${feature}
         EXCLUDE_FROM_ALL ON
-        PREFIX "${PROJECT_BINARY_DIR}/cmake-${feature}-prefix"
+        PREFIX "${PROJECT_BINARY_DIR}/cmake-${library}-prefix"
         SOURCE_DIR
             "${PROJECT_SOURCE_DIR}/../../google/cloud/${library}/quickstart"
-        BINARY_DIR "${PROJECT_BINARY_DIR}/cmake-${feature}"
+        BINARY_DIR "${PROJECT_BINARY_DIR}/cmake-${library}"
         CMAKE_ARGS ${COMMON_CMAKE_ARGS}
         BUILD_COMMAND "${CMAKE_COMMAND}" "--build" "<BINARY_DIR>" "--target"
                       "${target}"
@@ -62,10 +62,10 @@ function (add_make_quickstart_target feature library target)
     externalproject_add(
         verify-quickstart-makefile-${feature}
         EXCLUDE_FROM_ALL ON
-        PREFIX "${PROJECT_BINARY_DIR}/makefile-${feature}-prefix"
+        PREFIX "${PROJECT_BINARY_DIR}/makefile-${library}-prefix"
         SOURCE_DIR
             "${PROJECT_SOURCE_DIR}/../../google/cloud/${library}/quickstart"
-        BINARY_DIR "${PROJECT_BINARY_DIR}/makefile-${feature}"
+        BINARY_DIR "${PROJECT_BINARY_DIR}/makefile-${library}"
         CONFIGURE_COMMAND ""
         BUILD_COMMAND
             "env"


### PR DESCRIPTION
I think we stopped running the installed GCS+gRPC quickstart in #9329. Now we should see output like the following in `cmake-install`:

```
---------------------------------------
|   Running quickstart for GCS+gRPC   |
---------------------------------------
2022-12-05T21:48:37Z (+204s): [ CMake ]
etc....
```

call `run_gcs_grpc_quickstart()` and make sure the target is where we expect it (in `quickstart/cmake-storage`; not `quickstart/cmake-experimental-storage-grpc`).

`build_gcs_grpc_quickstart()` was uncalled, so remove it.