### PR TITLE
refactor: split IAMCredentials `GenerateAccessToken()`

### DIFF
--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/internal/json_parsing.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/oauth2_credentials.h"
 #include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/internal/rest_client.h"
@@ -31,9 +33,12 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
+
+using ::google::cloud::internal::InvalidArgumentError;
+
 auto constexpr kIamCredentialsEndpoint =
     "https://iamcredentials.googleapis.com/v1/";
-}
+}  // namespace
 
 MinimalIamCredentialsRestStub::MinimalIamCredentialsRestStub(
     std::shared_ptr<oauth2_internal::Credentials> credentials, Options options,
@@ -65,21 +70,12 @@ MinimalIamCredentialsRestStub::GenerateAccessToken(
 
   auto response = rest_client_->Post(rest_request, {payload.dump()});
   if (!response) return std::move(response).status();
-  if (IsHttpError(**response)) return AsStatus(std::move(**response));
-  auto response_payload =
-      rest_internal::ReadAll(std::move(**response).ExtractPayload());
-  if (!response_payload.ok()) return response_payload.status();
-  auto parsed = nlohmann::json::parse(*response_payload, nullptr);
-  if (parsed.is_null() || parsed.count("accessToken") == 0 ||
-      parsed.count("expireTime") == 0) {
-    return Status(StatusCode::kUnknown,
-                  "invalid response from service <" + parsed.dump() + ">");
-  }
-  auto expire_time = google::cloud::internal::ParseRfc3339(
-      parsed["expireTime"].get<std::string>());
-  if (!expire_time) return std::move(expire_time).status();
-  return google::cloud::internal::AccessToken{
-      parsed["accessToken"].get<std::string>(), *expire_time};
+  return ParseGenerateAccessTokenResponse(
+      **response,
+      internal::ErrorContext(
+          {{"gcloud-cpp.root.class", "MinimalIamCredentialsRestStub"},
+           {"gcloud-cpp.root.function", __func__},
+           {"serviceAccount", request.service_account}}));
 }
 
 std::string MinimalIamCredentialsRestStub::MakeRequestPath(
@@ -111,6 +107,34 @@ MinimalIamCredentialsRestLogging::GenerateAccessToken(
                 << google::cloud::internal::FormatRfc3339(response->expiration)
                 << "}";
   return response;
+}
+
+StatusOr<internal::AccessToken> ParseGenerateAccessTokenResponse(
+    rest_internal::RestResponse& response,
+    google::cloud::internal::ErrorContext const& ec) {
+  if (IsHttpError(response)) return AsStatus(std::move(response));
+  auto response_payload =
+      rest_internal::ReadAll(std::move(response).ExtractPayload());
+  if (!response_payload.ok()) return response_payload.status();
+  auto parsed = nlohmann::json::parse(*response_payload, nullptr, false);
+  if (!parsed.is_object()) {
+    return InvalidArgumentError("cannot parse response as a JSON object",
+                                GCP_ERROR_INFO().WithContext(ec));
+  }
+  auto token = ValidateStringField(parsed, "accessToken",
+                                   "GenerateAccessToken() response", ec);
+  if (!token) return std::move(token).status();
+  auto expire_time_field = ValidateStringField(
+      parsed, "expireTime", "GenerateAccessToken() response", ec);
+  if (!expire_time_field) return std::move(expire_time_field).status();
+  auto expire_time = google::cloud::internal::ParseRfc3339(*expire_time_field);
+  if (!expire_time) {
+    return InvalidArgumentError(
+        "invalid format for `expireTime` field in `GenerateAccessToken() "
+        "response`",
+        GCP_ERROR_INFO().WithContext(ec));
+  }
+  return google::cloud::internal::AccessToken{*std::move(token), *expire_time};
 }
 
 std::shared_ptr<MinimalIamCredentialsRest> MakeMinimalIamCredentialsRestStub(

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -115,7 +115,7 @@ StatusOr<internal::AccessToken> ParseGenerateAccessTokenResponse(
   if (IsHttpError(response)) return AsStatus(std::move(response));
   auto response_payload =
       rest_internal::ReadAll(std::move(response).ExtractPayload());
-  if (!response_payload.ok()) return response_payload.status();
+  if (!response_payload.ok()) return std::move(response_payload).status();
   auto parsed = nlohmann::json::parse(*response_payload, nullptr, false);
   if (!parsed.is_object()) {
     return InvalidArgumentError("cannot parse response as a JSON object",

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -115,7 +115,7 @@ StatusOr<internal::AccessToken> ParseGenerateAccessTokenResponse(
   if (IsHttpError(response)) return AsStatus(std::move(response));
   auto response_payload =
       rest_internal::ReadAll(std::move(response).ExtractPayload());
-  if (!response_payload.ok()) return std::move(response_payload).status();
+  if (!response_payload) return std::move(response_payload).status();
   auto parsed = nlohmann::json::parse(*response_payload, nullptr, false);
   if (!parsed.is_object()) {
     return InvalidArgumentError("cannot parse response as a JSON object",

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.h
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud//version.h"
 #include "google/cloud/internal/credentials_impl.h"
+#include "google/cloud/internal/error_context.h"
 #include "google/cloud/internal/oauth2_credentials.h"
 #include "google/cloud/internal/rest_client.h"
 #include "google/cloud/options.h"
@@ -36,6 +37,11 @@ struct GenerateAccessTokenRequest {
   std::vector<std::string> scopes;
   std::vector<std::string> delegates;
 };
+
+/// Parse the HTTP response from a `GenerateAccessToken()` call.
+StatusOr<google::cloud::internal::AccessToken> ParseGenerateAccessTokenResponse(
+    rest_internal::RestResponse& response,
+    google::cloud::internal::ErrorContext const& ec);
 
 /**
  * Wrapper for IAM Credentials intended for use with

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
@@ -40,6 +40,7 @@ using ::google::cloud::testing_util::MockRestResponse;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::A;
+using ::testing::ByMove;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -72,7 +73,7 @@ TEST(ParseGenerateAccessTokenResponse, Success) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);
@@ -89,7 +90,7 @@ TEST(ParseGenerateAccessTokenResponse, HttpError) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kNotFound));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);
@@ -102,7 +103,7 @@ TEST(ParseGenerateAccessTokenResponse, NotJson) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);
@@ -117,7 +118,7 @@ TEST(ParseGenerateAccessTokenResponse, NotJsonObject) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);
@@ -134,7 +135,7 @@ TEST(ParseGenerateAccessTokenResponse, MissingAccessToken) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);
@@ -150,7 +151,7 @@ TEST(ParseGenerateAccessTokenResponse, InvalidAccessToken) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);
@@ -167,7 +168,7 @@ TEST(ParseGenerateAccessTokenResponse, MissingExpireTime) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);
@@ -183,7 +184,7 @@ TEST(ParseGenerateAccessTokenResponse, InvalidExpireTime) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);
@@ -200,7 +201,7 @@ TEST(ParseGenerateAccessTokenResponse, InvalidExpireTimeFormat) {
   EXPECT_CALL(mock, StatusCode)
       .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
   EXPECT_CALL(std::move(mock), ExtractPayload)
-      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+      .WillOnce(Return(ByMove(MakeMockHttpPayloadSuccess(response))));
 
   auto ec = internal::ErrorContext();
   auto token = ParseGenerateAccessTokenResponse(mock, ec);

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/http_payload.h"
 #include "google/cloud/internal/rest_request.h"
 #include "google/cloud/internal/rest_response.h"
+#include "google/cloud/testing_util/chrono_output.h"
 #include "google/cloud/testing_util/mock_http_payload.h"
 #include "google/cloud/testing_util/mock_rest_client.h"
 #include "google/cloud/testing_util/mock_rest_response.h"
@@ -40,6 +41,7 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::A;
 using ::testing::Eq;
+using ::testing::HasSubstr;
 using ::testing::Return;
 
 class MockCredentials : public google::cloud::oauth2_internal::Credentials {
@@ -58,6 +60,154 @@ class MinimalIamCredentialsRestTest : public ::testing::Test {
   std::shared_ptr<MockRestClient> mock_rest_client_;
   std::shared_ptr<MockCredentials> mock_credentials_;
 };
+
+TEST(ParseGenerateAccessTokenResponse, Success) {
+  auto const response = std::string{R"""({
+    "accessToken": "test-access-token",
+    "expireTime": "2022-10-12T07:20:50.520Z"})"""};
+  //  date --date=2022-10-12T07:20:50.52Z +%s
+  auto const expiration = std::chrono::system_clock::from_time_t(1665559250) +
+                          std::chrono::milliseconds(520);
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  ASSERT_STATUS_OK(token);
+  EXPECT_EQ(token->token, "test-access-token");
+  EXPECT_EQ(token->expiration, expiration);
+}
+
+TEST(ParseGenerateAccessTokenResponse, HttpError) {
+  auto const response = std::string{R"""({
+    "accessToken": "test-access-token",
+    "expireTime": "2022-10-12T07:20:50.520Z"})"""};
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kNotFound));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  EXPECT_THAT(token, StatusIs(StatusCode::kNotFound));
+}
+
+TEST(ParseGenerateAccessTokenResponse, NotJson) {
+  auto const response = std::string{R"""(not-json)"""};
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  EXPECT_THAT(token,
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("cannot parse response as a JSON object")));
+}
+
+TEST(ParseGenerateAccessTokenResponse, NotJsonObject) {
+  auto const response = std::string{R"""("JSON-but-not-object")"""};
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  EXPECT_THAT(token,
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("cannot parse response as a JSON object")));
+}
+
+TEST(ParseGenerateAccessTokenResponse, MissingAccessToken) {
+  auto const response = std::string{R"""({
+    "missing-accessToken": "test-access-token",
+    "expireTime": "2022-10-12T07:20:50.520Z"})"""};
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  EXPECT_THAT(token, StatusIs(StatusCode::kInvalidArgument,
+                              HasSubstr("cannot find `accessToken` field")));
+}
+
+TEST(ParseGenerateAccessTokenResponse, InvalidAccessToken) {
+  auto const response = std::string{R"""({
+    "accessToken": true,
+    "expireTime": "2022-10-12T07:20:50.520Z"})"""};
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  EXPECT_THAT(token,
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("invalid type for `accessToken` field")));
+}
+
+TEST(ParseGenerateAccessTokenResponse, MissingExpireTime) {
+  auto const response = std::string{R"""({
+    "accessToken": "unused",
+    "missing-expireTime": "2022-10-12T07:20:50.520Z"})"""};
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  EXPECT_THAT(token, StatusIs(StatusCode::kInvalidArgument,
+                              HasSubstr("cannot find `expireTime` field")));
+}
+
+TEST(ParseGenerateAccessTokenResponse, InvalidExpireTime) {
+  auto const response = std::string{R"""({
+    "accessToken": "unused",
+    "expireTime": true})"""};
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  EXPECT_THAT(token,
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("invalid type for `expireTime` field")));
+}
+
+TEST(ParseGenerateAccessTokenResponse, InvalidExpireTimeFormat) {
+  auto const response = std::string{R"""({
+    "accessToken": "unused",
+    "expireTime": "not-a-RFC-3339-date"})"""};
+  MockRestResponse mock;
+  EXPECT_CALL(mock, StatusCode)
+      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(mock), ExtractPayload)
+      .WillOnce(Return(MakeMockHttpPayloadSuccess(response)));
+
+  auto ec = internal::ErrorContext();
+  auto token = ParseGenerateAccessTokenResponse(mock, ec);
+  EXPECT_THAT(token,
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("invalid format for `expireTime` field")));
+}
 
 TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenSuccess) {
   std::string service_account = "foo@somewhere.com";
@@ -108,150 +258,6 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenSuccess) {
   auto access_token = stub.GenerateAccessToken(request);
   EXPECT_THAT(access_token, IsOk());
   EXPECT_THAT(access_token->token, Eq("my_access_token"));
-}
-
-TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenNonRfc3339Time) {
-  std::string service_account = "foo@somewhere.com";
-  std::chrono::seconds lifetime(3600);
-  std::string scope = "my_scope";
-  std::string delegate = "my_delegate";
-
-  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
-    return internal::AccessToken{"test-token", tp + lifetime};
-  });
-
-  std::string response = R"""({
-  "accessToken": "my_access_token",
-  "expireTime": "Tomorrow"
-})""";
-
-  auto* mock_response = new MockRestResponse();
-  EXPECT_CALL(*mock_response, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
-  EXPECT_CALL(std::move(*mock_response), ExtractPayload).WillOnce([&] {
-    return MakeMockHttpPayloadSuccess(response);
-  });
-
-  EXPECT_CALL(*mock_rest_client_,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
-                    std::vector<absl::Span<char const>> const& payload) {
-        EXPECT_THAT(request.path(),
-                    Eq(absl::StrCat("projects/-/serviceAccounts/",
-                                    service_account, ":generateAccessToken")));
-        std::string str_payload(payload[0].begin(), payload[0].end());
-        EXPECT_THAT(str_payload, testing::HasSubstr("\"lifetime\":\"3600s\""));
-        EXPECT_THAT(str_payload,
-                    testing::HasSubstr("\"scope\":[\"my_scope\"]"));
-        EXPECT_THAT(str_payload,
-                    testing::HasSubstr("\"delegates\":[\"my_delegate\"]"));
-        return std::unique_ptr<RestResponse>(std::move(mock_response));
-      });
-
-  auto stub = MinimalIamCredentialsRestStub(std::move(mock_credentials_), {},
-                                            std::move(mock_rest_client_));
-  GenerateAccessTokenRequest request;
-  request.service_account = service_account;
-  request.lifetime = lifetime;
-  request.scopes.push_back(scope);
-  request.delegates.push_back(delegate);
-
-  auto access_token = stub.GenerateAccessToken(request);
-  EXPECT_THAT(access_token, StatusIs(StatusCode::kInvalidArgument));
-}
-
-TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenInvalidResponse) {
-  std::string service_account = "foo@somewhere.com";
-  std::chrono::seconds lifetime(3600);
-  std::string scope = "my_scope";
-  std::string delegate = "my_delegate";
-
-  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
-    return internal::AccessToken{"test-token", tp + lifetime};
-  });
-
-  std::string response = R"""({
-  "accessToken": "my_access_token"
-})""";
-
-  auto* mock_response = new MockRestResponse();
-  EXPECT_CALL(*mock_response, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kOk));
-  EXPECT_CALL(std::move(*mock_response), ExtractPayload).WillOnce([&] {
-    return MakeMockHttpPayloadSuccess(response);
-  });
-
-  EXPECT_CALL(*mock_rest_client_,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
-                    std::vector<absl::Span<char const>> const& payload) {
-        EXPECT_THAT(request.path(),
-                    Eq(absl::StrCat("projects/-/serviceAccounts/",
-                                    service_account, ":generateAccessToken")));
-        std::string str_payload(payload[0].begin(), payload[0].end());
-        EXPECT_THAT(str_payload, testing::HasSubstr("\"lifetime\":\"3600s\""));
-        EXPECT_THAT(str_payload,
-                    testing::HasSubstr("\"scope\":[\"my_scope\"]"));
-        EXPECT_THAT(str_payload,
-                    testing::HasSubstr("\"delegates\":[\"my_delegate\"]"));
-        return std::unique_ptr<RestResponse>(std::move(mock_response));
-      });
-
-  auto stub = MinimalIamCredentialsRestStub(std::move(mock_credentials_), {},
-                                            std::move(mock_rest_client_));
-  GenerateAccessTokenRequest request;
-  request.service_account = service_account;
-  request.lifetime = lifetime;
-  request.scopes.push_back(scope);
-  request.delegates.push_back(delegate);
-
-  auto access_token = stub.GenerateAccessToken(request);
-  EXPECT_THAT(access_token, StatusIs(StatusCode::kUnknown));
-}
-
-TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenPostFailure) {
-  std::string service_account = "foo@somewhere.com";
-  std::chrono::seconds lifetime(3600);
-  std::string scope = "my_scope";
-  std::string delegate = "my_delegate";
-
-  EXPECT_CALL(*mock_credentials_, GetToken).WillOnce([lifetime](auto tp) {
-    return internal::AccessToken{"test-token", tp + lifetime};
-  });
-
-  auto* mock_response = new MockRestResponse();
-  EXPECT_CALL(*mock_response, StatusCode)
-      .WillRepeatedly(Return(rest_internal::HttpStatusCode::kNotFound));
-  EXPECT_CALL(std::move(*mock_response), ExtractPayload).WillOnce([&] {
-    return MakeMockHttpPayloadSuccess(std::string{});
-  });
-
-  EXPECT_CALL(*mock_rest_client_,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
-                    std::vector<absl::Span<char const>> const& payload) {
-        EXPECT_THAT(request.path(),
-                    Eq(absl::StrCat("projects/-/serviceAccounts/",
-                                    service_account, ":generateAccessToken")));
-        std::string str_payload(payload[0].begin(), payload[0].end());
-        EXPECT_THAT(str_payload, testing::HasSubstr("\"lifetime\":\"3600s\""));
-        EXPECT_THAT(str_payload,
-                    testing::HasSubstr("\"scope\":[\"my_scope\"]"));
-        EXPECT_THAT(str_payload,
-                    testing::HasSubstr("\"delegates\":[\"my_delegate\"]"));
-        return std::unique_ptr<RestResponse>(std::move(mock_response));
-      });
-
-  auto stub = MinimalIamCredentialsRestStub(std::move(mock_credentials_), {},
-                                            std::move(mock_rest_client_));
-  GenerateAccessTokenRequest request;
-  request.service_account = service_account;
-  request.lifetime = lifetime;
-  request.scopes.push_back(scope);
-  request.delegates.push_back(delegate);
-
-  auto access_token = stub.GenerateAccessToken(request);
-  EXPECT_THAT(access_token, StatusIs(StatusCode::kNotFound));
 }
 
 TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenCredentialFailure) {


### PR DESCRIPTION
We will need to parse the `GenerateAccessToken()` response in the external account implementation. This splits the parsing to a standalone function.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10378)
<!-- Reviewable:end -->
