### PR TITLE
impl(otel): handle cmake build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ function (google_cloud_cpp_enable_features)
             if (NOT ("storage" IN_LIST GOOGLE_CLOUD_CPP_ENABLE))
                 add_subdirectory(google/cloud/storage)
             endif ()
+        elseif ("${feature}" STREQUAL "experimental-opentelemetry")
         else ()
             if (NOT IS_DIRECTORY
                 "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}"

--- a/ci/cloudbuild/builds/lib/features.sh
+++ b/ci/cloudbuild/builds/lib/features.sh
@@ -36,6 +36,8 @@ function features::always_build() {
     bigquery
     iam
     logging
+    # By default, build the library with OpenTelemetry in our CI.
+    experimental-opentelemetry
   )
   printf "%s\n" "${list[@]}" | sort -u
 }
@@ -56,7 +58,8 @@ function features::libraries() {
 function features::list_full() {
   local feature_list
   mapfile -t feature_list < <(features::libraries)
-  printf "%s\n" "${feature_list[@]}" experimental-storage-grpc grafeas | sort -u
+  feature_list+=(experimental-opentelemetry experimental-storage-grpc grafeas)
+  printf "%s\n" "${feature_list[@]}" | sort -u
 }
 
 function features::list_full_cmake() {

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -147,6 +147,12 @@ target_link_libraries(
            absl::variant
            Threads::Threads
            OpenSSL::Crypto)
+if (GOOGLE_CLOUD_CPP_ENABLE_EXPERIMENTAL_OPENTELEMETRY)
+    # TODO(#10283): find_package(opentelemetry-cpp CONFIG QUIET)
+    message(
+        WARNING
+            "OpenTelemetry requested, but the feature is not yet implemented.")
+endif ()
 google_cloud_cpp_add_common_options(google_cloud_cpp_common)
 target_include_directories(
     google_cloud_cpp_common PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>


### PR DESCRIPTION
Part of the work for #10283 

Third time's the charm...

Process `-DGOOGLE_CLOUD_CPP_ENABLE=experimental-opentelemetry`. Default some of our cmake builds (e.g. `clang-tidy`, `cmake-install`) to supply this option. The demo builds, for example, do not supply the option.

Note that we are not taking a dependency on `opentelemetry-cpp` in this PR. Nor are we advertising the feature yet.

Leave a placeholder for where the work will pick up. The builds will emit a little warning, but it's temporary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10381)
<!-- Reviewable:end -->
