### PR TITLE
impl: support impersonation for external accounts

### DIFF
--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/oauth2_external_account_credentials.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/external_account_token_source_file.h"
 #include "google/cloud/internal/external_account_token_source_url.h"
 #include "google/cloud/internal/json_parsing.h"
@@ -195,7 +196,7 @@ StatusOr<internal::AccessToken>
 ExternalAccountCredentials::GetTokenImpersonation(
     std::string const& access_token, internal::ErrorContext const& ec) {
   auto request = rest_internal::RestRequest(info_.impersonation_config->url);
-  request.AddHeader("Authorization", "Bearer " + access_token);
+  request.AddHeader("Authorization", absl::StrCat("Bearer ", access_token));
   request.AddHeader("Content-Type", "application/json");
   auto const lifetime = info_.impersonation_config->token_lifetime;
   auto request_payload = nlohmann::json{

--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -17,6 +17,9 @@
 #include "google/cloud/internal/external_account_token_source_url.h"
 #include "google/cloud/internal/json_parsing.h"
 #include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/oauth2_credential_constants.h"
+#include "google/cloud/internal/oauth2_minimal_iam_credentials_rest.h"
+#include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/internal/rest_client.h"
 #include <nlohmann/json.hpp>
 
@@ -84,9 +87,38 @@ StatusOr<ExternalAccountInfo> ParseExternalAccountConfiguration(
   auto source = MakeExternalAccountTokenSource(*credential_source, ec);
   if (!source) return std::move(source).status();
 
-  return ExternalAccountInfo{*std::move(audience),
-                             *std::move(subject_token_type),
-                             *std::move(token_url), *std::move(source)};
+  auto info = ExternalAccountInfo{
+      *std::move(audience),  *std::move(subject_token_type),
+      *std::move(token_url), *std::move(source),
+      absl::nullopt,
+  };
+
+  auto it = json.find("service_account_impersonation_url");
+  if (it == json.end()) return info;
+
+  auto constexpr kDefaultImpersonationTokenLifetime =
+      std::chrono::seconds(3600);
+  if (!it->is_string()) {
+    return InvalidTypeError("service_account_impersonation_url",
+                            "credentials-file", ec);
+  }
+  info.impersonation_config = ExternalAccountImpersonationConfig{
+      it->get<std::string>(), kDefaultImpersonationTokenLifetime};
+  it = json.find("service_account_impersonation");
+  if (it == json.end()) return info;
+  if (!it->is_object()) {
+    return InvalidTypeError("service_account_impersonation", "credentials-file",
+                            ec);
+  }
+  auto lifetime = ValidateIntField(
+      it.value(), "token_lifetime_seconds",
+      "credentials-file.service_account_impersonation",
+      static_cast<std::int32_t>(kDefaultImpersonationTokenLifetime.count()),
+      ec);
+  if (!lifetime) return std::move(lifetime).status();
+  info.impersonation_config->token_lifetime = std::chrono::seconds(*lifetime);
+
+  return info;
 }
 
 ExternalAccountCredentials::ExternalAccountCredentials(
@@ -149,10 +181,32 @@ StatusOr<internal::AccessToken> ExternalAccountCredentials::GetToken(
             .WithMetadata("token_type", *token_type)
             .WithMetadata("issued_token_type", *issued_token_type));
   }
+  if (info_.impersonation_config.has_value()) {
+    return GetTokenImpersonation(*token, ec);
+  }
+
   auto expires_in =
       ValidateIntField(access, "expires_in", "token-exchange-response", ec);
   if (!expires_in) return std::move(expires_in).status();
   return internal::AccessToken{*token, tp + std::chrono::seconds(*expires_in)};
+}
+
+StatusOr<internal::AccessToken>
+ExternalAccountCredentials::GetTokenImpersonation(
+    std::string const& access_token, internal::ErrorContext const& ec) {
+  auto request = rest_internal::RestRequest(info_.impersonation_config->url);
+  request.AddHeader("Authorization", "Bearer " + access_token);
+  request.AddHeader("Content-Type", "application/json");
+  auto const lifetime = info_.impersonation_config->token_lifetime;
+  auto request_payload = nlohmann::json{
+      {"delegates", nlohmann::json::array()},
+      {"scope", nlohmann::json::array({GoogleOAuthScopeCloudPlatform()})},
+      {"lifetime", std::to_string(lifetime.count()) + "s"}};
+
+  auto client = client_factory_(options_);
+  auto response = client->Post(request, {request_payload.dump()});
+  if (!response) return std::move(response).status();
+  return ParseGenerateAccessTokenResponse(**response, ec);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_external_account_credentials.h
+++ b/google/cloud/internal/oauth2_external_account_credentials.h
@@ -32,12 +32,12 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * The (optional) configuration for service account impersonation.
  *
- * External accounts may require a call tt ohe IAM credentials service to
+ * External accounts may require a call to the IAM Credentials service to
  * convert the initial access token to a specific service account access token.
  * Yes, this means up to 3 tokens may be involved:
- * - First the subject token obtained from a file, URL or external program.
+ * - First the subject token obtained from a file, URL, or external program.
  * - Then the access token exchanged from the subject token via Google's
- *   Secure Token Service (STS)
+ *   Secure Token Service (STS).
  * - And then the access token exchanged from the initial access token to a
  *   different service account via IAM credentials.
  *

--- a/google/cloud/internal/oauth2_external_account_credentials.h
+++ b/google/cloud/internal/oauth2_external_account_credentials.h
@@ -29,11 +29,44 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/**
+ * The (optional) configuration for service account impersonation.
+ *
+ * External accounts may require a call tt ohe IAM credentials service to
+ * convert the initial access token to a specific service account access token.
+ * Yes, this means up to 3 tokens may be involved:
+ * - First the subject token obtained from a file, URL or external program.
+ * - Then the access token exchanged from the subject token via Google's
+ *   Secure Token Service (STS)
+ * - And then the access token exchanged from the initial access token to a
+ *   different service account via IAM credentials.
+ *
+ * The JSON representation of this configuration has the (optional)
+ * `service_account_impersonation_url` field separate from the
+ * `service_account_impersonation` field. The latter is also optional, and only
+ * has an effect if `service_account_impersonation_url` is set. Furthermore,
+ * `service_account_impersonation` is a JSON object with a single (optional)
+ * `token_lifetime` field.  The `token_lifetime` field has a default value of
+ * `3600` seconds.  All these levels of "optional" can be represented in C++,
+ * but it is easier to just have a single struct wrapped in an optional.
+ */
+struct ExternalAccountImpersonationConfig {
+  std::string url;
+  std::chrono::seconds token_lifetime;
+};
+
+/**
+ * An external account configuration.
+ *
+ * This structure represents the result of parsing an external account JSON
+ * object configuration.
+ */
 struct ExternalAccountInfo {
   std::string audience;
   std::string subject_token_type;
   std::string token_url;
   ExternalAccountTokenSource token_source;
+  absl::optional<ExternalAccountImpersonationConfig> impersonation_config;
 };
 
 /// Parse a JSON string with an external account configuration.
@@ -51,6 +84,9 @@ class ExternalAccountCredentials : public oauth2_internal::Credentials {
       std::chrono::system_clock::time_point tp) override;
 
  private:
+  StatusOr<internal::AccessToken> GetTokenImpersonation(
+      std::string const& access_token, internal::ErrorContext const& ec);
+
   ExternalAccountInfo info_;
   HttpClientFactory client_factory_;
   Options options_;


### PR DESCRIPTION
External accounts may require the service account impersonation flow to convert access tokens to access tokens associated with an specific service account.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10383)
<!-- Reviewable:end -->
