### PR TITLE
impl(otel): take dependency on library

### DIFF
--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -46,6 +46,13 @@ cc_library(
     name = "google_cloud_cpp_common_private",
     srcs = google_cloud_cpp_common_srcs + ["internal/build_info.cc"],
     hdrs = google_cloud_cpp_common_hdrs,
+    defines = select({
+        ":enable_open_telemetry_valid": [
+            # Enable OpenTelemetry features in google-cloud-cpp
+            "GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY",
+        ],
+        "//conditions:default": [],
+    }),
     target_compatible_with = select(
         {
             ":enable_open_telemetry_valid": [],
@@ -76,7 +83,12 @@ to your build command, or set this value in your `.bazelrc` file(s).
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/types:variant",
-    ],
+    ] + select({
+        ":enable_open_telemetry_valid": [
+            "@io_opentelemetry_cpp//api",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(

--- a/google/cloud/config.cmake.in
+++ b/google/cloud/config.cmake.in
@@ -15,5 +15,6 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 find_dependency(absl)
+@GOOGLE_CLOUD_CPP_FIND_OPTIONAL_DEPENDENCIES@
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_common-targets.cmake")

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -147,11 +147,19 @@ target_link_libraries(
            absl::variant
            Threads::Threads
            OpenSSL::Crypto)
-if (GOOGLE_CLOUD_CPP_ENABLE_EXPERIMENTAL_OPENTELEMETRY)
-    # TODO(#10283): find_package(opentelemetry-cpp CONFIG QUIET)
-    message(
-        WARNING
-            "OpenTelemetry requested, but the feature is not yet implemented.")
+
+if (experimental-opentelemetry IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+    find_package(opentelemetry-cpp CONFIG)
+    if (opentelemetry-cpp_FOUND)
+        target_link_libraries(google_cloud_cpp_common
+                              PUBLIC opentelemetry-cpp::api)
+        target_compile_definitions(
+            google_cloud_cpp_common
+            PUBLIC # Enable OpenTelemetry features in google-cloud-cpp
+                   GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY)
+        set(GOOGLE_CLOUD_CPP_FIND_OPTIONAL_DEPENDENCIES
+            "find_dependency(opentelemetry-cpp)")
+    endif ()
 endif ()
 google_cloud_cpp_add_common_options(google_cloud_cpp_common)
 target_include_directories(
@@ -313,6 +321,7 @@ if (BUILD_TESTING)
         internal/invoke_result_test.cc
         internal/log_impl_test.cc
         internal/make_status_test.cc
+        internal/opentelemetry_test.cc
         internal/pagination_range_test.cc
         internal/parse_rfc3339_test.cc
         internal/populate_common_options_test.cc

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -40,6 +40,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/invoke_result_test.cc",
     "internal/log_impl_test.cc",
     "internal/make_status_test.cc",
+    "internal/opentelemetry_test.cc",
     "internal/pagination_range_test.cc",
     "internal/parse_rfc3339_test.cc",
     "internal/populate_common_options_test.cc",

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -14,8 +14,8 @@
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include <gmock/gmock.h>
-#include <opentelemetry/version.h>
 #include <opentelemetry/trace/default_span.h>
+#include <opentelemetry/version.h>
 
 namespace {
 

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include <gmock/gmock.h>
+#include <opentelemetry/version.h>
+#include <opentelemetry/trace/default_span.h>
+
+namespace {
+
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+TEST(OpenTelemetry, IsUsable) {
+  auto version = std::string{OPENTELEMETRY_VERSION};
+  EXPECT_THAT(version, Not(IsEmpty()));
+  auto span = opentelemetry::trace::DefaultSpan::GetInvalid();
+  EXPECT_EQ(span.ToString(), "DefaultSpan");
+}
+
+}  // namespace
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY


### PR DESCRIPTION
Part of the work for #10283 

Take a dependency on `opentelemetry-cpp`, if requested, and the library is present. Maybe the build should just fail if OpenTelemetry is requested, but not found... cmake will warn.

Add a way to optionally `find_dependency` for `cmake --install` build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10387)
<!-- Reviewable:end -->
