### PR TITLE
fix(pubsublite): update retryable error codes for Admin and TopicStats clients

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -1145,7 +1145,7 @@ service {
   product_path: "google/cloud/pubsublite"
   initial_copyright_year: "2021"
   gen_async_rpcs: ["GetTopicPartitions"]
-  retryable_status_codes: ["kInternal", "kUnavailable"]
+  retryable_status_codes: ["kAborted", "kInternal", "kUnavailable", "kUnknown"]
 }
 
 service {
@@ -1176,7 +1176,7 @@ service {
   service_proto_path: "google/cloud/pubsublite/v1/topic_stats.proto"
   product_path: "google/cloud/pubsublite"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kInternal", "kUnavailable"]
+  retryable_status_codes: ["kAborted", "kInternal", "kUnavailable", "kUnknown"]
 }
 
 # Recommender


### PR DESCRIPTION
For consistency with Pub/Sub Lite clients in other languages. For example, Java:
https://github.com/googleapis/java-pubsublite/blob/c4a9ff8e42f188e648d1bbf39333cd41615b1fa1/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/v1/stub/AdminServiceStubSettings.java#L745

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10389)
<!-- Reviewable:end -->
