### PR TITLE
impl: support external accounts mapping

### DIFF
--- a/google/cloud/internal/credentials_impl.cc
+++ b/google/cloud/internal/credentials_impl.cc
@@ -84,6 +84,9 @@ ServiceAccountConfig::ServiceAccountConfig(std::string json_object,
     : json_object_(std::move(json_object)),
       options_(PopulateAuthOptions(std::move(opts))) {}
 
+ExternalAccountConfig::ExternalAccountConfig(std::string j, Options o)
+    : json_object_(std::move(j)), options_(PopulateAuthOptions(std::move(o))) {}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/credentials_impl.cc
+++ b/google/cloud/internal/credentials_impl.cc
@@ -84,8 +84,10 @@ ServiceAccountConfig::ServiceAccountConfig(std::string json_object,
     : json_object_(std::move(json_object)),
       options_(PopulateAuthOptions(std::move(opts))) {}
 
-ExternalAccountConfig::ExternalAccountConfig(std::string j, Options o)
-    : json_object_(std::move(j)), options_(PopulateAuthOptions(std::move(o))) {}
+ExternalAccountConfig::ExternalAccountConfig(std::string json_object,
+                                             Options options)
+    : json_object_(std::move(json_object)),
+      options_(PopulateAuthOptions(std::move(options))) {}
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/credentials_impl.h
+++ b/google/cloud/internal/credentials_impl.h
@@ -135,7 +135,7 @@ class ServiceAccountConfig : public Credentials {
 
 class ExternalAccountConfig : public Credentials {
  public:
-  ExternalAccountConfig(std::string j, Options o);
+  ExternalAccountConfig(std::string json_object, Options options);
 
   std::string const& json_object() const { return json_object_; }
   Options const& options() const { return options_; }

--- a/google/cloud/internal/credentials_impl.h
+++ b/google/cloud/internal/credentials_impl.h
@@ -37,6 +37,7 @@ class GoogleDefaultCredentialsConfig;
 class AccessTokenConfig;
 class ImpersonateServiceAccountConfig;
 class ServiceAccountConfig;
+class ExternalAccountConfig;
 
 class CredentialsVisitor {
  public:
@@ -46,6 +47,7 @@ class CredentialsVisitor {
   virtual void visit(AccessTokenConfig&) = 0;
   virtual void visit(ImpersonateServiceAccountConfig&) = 0;
   virtual void visit(ServiceAccountConfig&) = 0;
+  virtual void visit(ExternalAccountConfig&) = 0;
 
   static void dispatch(Credentials& credentials, CredentialsVisitor& visitor);
 };
@@ -120,6 +122,20 @@ class ImpersonateServiceAccountConfig : public Credentials {
 class ServiceAccountConfig : public Credentials {
  public:
   ServiceAccountConfig(std::string json_object, Options opts);
+
+  std::string const& json_object() const { return json_object_; }
+  Options const& options() const { return options_; }
+
+ private:
+  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+
+  std::string json_object_;
+  Options options_;
+};
+
+class ExternalAccountConfig : public Credentials {
+ public:
+  ExternalAccountConfig(std::string j, Options o);
 
   std::string const& json_object() const { return json_object_; }
   Options const& options() const { return options_; }


### PR DESCRIPTION
Create the class derived from `google::cloud::Credentials` that will represent external accounts. These classes are mapped to the implementation using `google::cloud::internal::CredentialsVisitor`, which now supports external accounts. I change the integration test for external accounts to use the credentials to make a GCS request.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10391)
<!-- Reviewable:end -->
