### PR TITLE
ci: use gRPC 1.36.4 in `oldest-deps` build

### DIFF
--- a/ci/etc/oldest-deps/vcpkg.json
+++ b/ci/etc/oldest-deps/vcpkg.json
@@ -34,6 +34,8 @@
     ],
     "overrides": [
       { "name": "protobuf", "version": "3.15.8" },
+      { "name": "grpc", "version": "1.36.4" },
+      { "name": "upb", "version": "2020-12-19" },
       { "name": "gtest", "version": "1.11.0" }
     ]
 }


### PR DESCRIPTION
Testing with gRPC==1.33 is untenable, as we need features only available in gRPC==1.35. Unfortunately `vcpkg` skipped gRPC 1.34 and gRPC 1.35, so we need to skip forward. That opens a gap in our test coverage, but that is better than getting stuck without any ability to make progress.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10394)
<!-- Reviewable:end -->
