### PR TITLE
cleanup(otel): rename bazel flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,7 +40,7 @@ test --test_env=GTEST_SHUFFLE --test_env=GTEST_RANDOM_SEED
 
 # By default, build the library with OpenTelemetry
 build --@io_opentelemetry_cpp//api:with_abseil
-build --//:experimental-open_telemetry
+build --//:experimental-opentelemetry
 
 # Clang Sanitizers, use with (for example):
 #

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -299,7 +299,7 @@ cc_library(
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 bool_flag(
-    name = "experimental-open_telemetry",
+    name = "experimental-opentelemetry",
     build_setting_default = False,
     visibility = ["//:__subpackages__"],
 )

--- a/ci/cloudbuild/builds/otel-disabled-bazel.sh
+++ b/ci/cloudbuild/builds/otel-disabled-bazel.sh
@@ -23,5 +23,5 @@ export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
-args+=("--//:experimental-open_telemetry=false")
+args+=("--//:experimental-opentelemetry=false")
 bazel test "${args[@]}" --test_tag_filters=-integration-test ...

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -28,16 +28,16 @@ capture_build_info(
 )
 
 config_setting(
-    name = "enable_open_telemetry_valid",
+    name = "enable_opentelemetry_valid",
     flag_values = {
-        "//:experimental-open_telemetry": "true",
+        "//:experimental-opentelemetry": "true",
         "@io_opentelemetry_cpp//api:with_abseil": "true",
     },
 )
 
 config_setting(
-    name = "disable_open_telemetry",
-    flag_values = {"//:experimental-open_telemetry": "false"},
+    name = "disable_opentelemetry",
+    flag_values = {"//:experimental-opentelemetry": "false"},
 )
 
 load(":google_cloud_cpp_common.bzl", "google_cloud_cpp_common_hdrs", "google_cloud_cpp_common_srcs")
@@ -47,7 +47,7 @@ cc_library(
     srcs = google_cloud_cpp_common_srcs + ["internal/build_info.cc"],
     hdrs = google_cloud_cpp_common_hdrs,
     defines = select({
-        ":enable_open_telemetry_valid": [
+        ":enable_opentelemetry_valid": [
             # Enable OpenTelemetry features in google-cloud-cpp
             "GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY",
         ],
@@ -55,8 +55,8 @@ cc_library(
     }),
     target_compatible_with = select(
         {
-            ":enable_open_telemetry_valid": [],
-            ":disable_open_telemetry": [],
+            ":enable_opentelemetry_valid": [],
+            ":disable_opentelemetry": [],
         },
         # else, OpenTelemetry is enabled, but with an invalid configuration.
         no_match_error = """
@@ -84,7 +84,7 @@ to your build command, or set this value in your `.bazelrc` file(s).
         "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/types:variant",
     ] + select({
-        ":enable_open_telemetry_valid": [
+        ":enable_opentelemetry_valid": [
             "@io_opentelemetry_cpp//api",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
I have settled on the convention that `opentelemetry` should be stylized as one word. (The OT repo does us no favors. It is `open-telemetry/opentelemetry-cpp`).

yes, the `bool_flag` is public, but it is experimental, and it doesn't do anything yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10396)
<!-- Reviewable:end -->
