### PR TITLE
ci(otel): enable for minimum gcc, clang builds

### DIFF
--- a/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
@@ -164,4 +164,18 @@ RUN curl -sSL https://github.com/google/benchmark/archive/v1.7.0.tar.gz | \
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 
+WORKDIR /var/tmp/build/
+RUN curl -sSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_EXAMPLES=OFF \
+        -DWITH_ABSEIL=ON \
+        -DBUILD_TESTING=OFF \
+        -H. -Bcmake-out -GNinja && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
 RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
@@ -174,6 +174,20 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.51.1.tar.gz | \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
+WORKDIR /var/tmp/build/
+RUN curl -sSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_EXAMPLES=OFF \
+        -DWITH_ABSEIL=ON \
+        -DBUILD_TESTING=OFF \
+        -H. -Bcmake-out -GNinja && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
 # Install Python packages used in the integration tests.
 RUN update-alternatives --install /usr/bin/python python $(which python3) 10
 RUN pip3 install setuptools wheel


### PR DESCRIPTION
Fixes #10283 