### PR TITLE
fix: add missing `<cstdint>` includes

### DIFF
--- a/google/cloud/internal/curl_handle.h
+++ b/google/cloud/internal/curl_handle.h
@@ -20,6 +20,7 @@
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
 #include <curl/curl.h>
+#include <cstdint>
 #include <string>
 #include <type_traits>
 

--- a/google/cloud/internal/oauth2_credentials.h
+++ b/google/cloud/internal/oauth2_credentials.h
@@ -20,6 +20,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <chrono>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/google/cloud/internal/rest_response.h
+++ b/google/cloud/internal/rest_response.h
@@ -19,6 +19,7 @@
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <cstdint>
 #include <map>
 
 namespace google {

--- a/google/cloud/pubsub/ack_handler.h
+++ b/google/cloud/pubsub/ack_handler.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/status.h"
+#include <cstdint>
 #include <memory>
 
 namespace google {

--- a/google/cloud/storage/bucket_cors_entry.h
+++ b/google/cloud/storage/bucket_cors_entry.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/version.h"
 #include "absl/types/optional.h"
+#include <cstdint>
 #include <iosfwd>
 #include <tuple>
 #include <utility>

--- a/google/cloud/storage/iam_policy.h
+++ b/google/cloud/storage/iam_policy.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/google/cloud/storage/internal/hash_function_impl.h
+++ b/google/cloud/storage/internal/hash_function_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/version.h"
 #include <openssl/evp.h>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/google/cloud/storage/internal/object_read_source.h
+++ b/google/cloud/storage/internal/object_read_source.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
+#include <cstdint>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
Without the change build fails on this week's `gcc-13` as:

    In file included from google/cloud/internal/curl_handle.cc:15:
    google/cloud/internal/curl_handle.h:107:8:
      error: 'int32_t' in namespace 'std' does not name a type
      107 |   std::int32_t GetResponseCode();
          |        ^~~~~~~

`gcc-13` cleaned up `<string>` not to include `<cstdint>` for newer c++ standards. Hence the build failures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10421)
<!-- Reviewable:end -->
