### PR TITLE
cleanup: shorter names for CMake targets

### DIFF
--- a/.github/workflows/external-account-integration.yml
+++ b/.github/workflows/external-account-integration.yml
@@ -59,7 +59,7 @@ jobs:
       - name: build
         run: |
           cmake --build "${{runner.temp}}/build" -j 2 \
-            --target rest_internal_internal_external_account_integration_test
+            --target common_internal_external_account_integration_test
 
       # Configure Workload Identity Federation and generate an access token.
       - id: 'auth'

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -162,8 +162,7 @@ function (google_cloud_cpp_generator_define_tests)
 
     # Generate a target for each unit test.
     foreach (fname ${google_cloud_cpp_generator_unit_tests})
-        google_cloud_cpp_add_executable(target "google_cloud_cpp_generator"
-                                        "${fname}")
+        google_cloud_cpp_add_executable(target "generator" "${fname}")
         target_link_libraries(
             ${target}
             PRIVATE google_cloud_cpp_generator

--- a/generator/integration_tests/CMakeLists.txt
+++ b/generator/integration_tests/CMakeLists.txt
@@ -136,8 +136,7 @@ export_list_to_bazel("google_cloud_cpp_generator_golden_tests.bzl"
                      "google_cloud_cpp_generator_golden_tests" YEAR "2020")
 
 foreach (fname ${google_cloud_cpp_generator_golden_tests})
-    google_cloud_cpp_add_executable(target "google_cloud_cpp_generator_golden"
-                                    "${fname}")
+    google_cloud_cpp_add_executable(target "generator_golden" "${fname}")
     target_link_libraries(
         ${target}
         PRIVATE google_cloud_cpp_generator_golden_testing

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -57,7 +57,7 @@ if (BUILD_TESTING)
                          "bigtable_benchmarks_unit_tests" YEAR "2020")
 
     foreach (fname ${bigtable_benchmarks_unit_tests})
-        google_cloud_cpp_add_executable(target "bigtable_benchmarks" "${fname}")
+        google_cloud_cpp_add_executable(target "bigtable" "${fname}")
         target_link_libraries(
             ${target}
             PRIVATE bigtable_benchmark_common

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -189,7 +189,7 @@ install(
     COMPONENT google_cloud_cpp_development)
 
 function (google_cloud_cpp_grpc_utils_add_test fname labels)
-    google_cloud_cpp_add_executable(target "common_grpc_utils" "${fname}")
+    google_cloud_cpp_add_executable(target "common" "${fname}")
     target_link_libraries(
         ${target}
         PRIVATE google-cloud-cpp::grpc_utils

--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -174,7 +174,7 @@ create_bazel_config(google_cloud_cpp_rest_internal YEAR 2021)
 
 # Define the unit tests in a function so we have a new scope for variable names.
 function (google_cloud_cpp_rest_internal_add_test fname labels)
-    google_cloud_cpp_add_executable(target "rest_internal" "${fname}")
+    google_cloud_cpp_add_executable(target "common" "${fname}")
     target_link_libraries(
         ${target}
         PRIVATE google-cloud-cpp::rest_internal

--- a/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
@@ -101,7 +101,7 @@ install(
     COMPONENT google_cloud_cpp_development)
 
 function (google_cloud_cpp_rest_protobuf_internal_add_test fname labels)
-    google_cloud_cpp_add_executable(target "common_rest_protobuf" "${fname}")
+    google_cloud_cpp_add_executable(target "common" "${fname}")
     target_link_libraries(
         ${target}
         PRIVATE google-cloud-cpp::rest_protobuf_internal

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -87,7 +87,7 @@ export_list_to_bazel("google_cloud_cpp_testing_unit_tests.bzl"
                      "google_cloud_cpp_testing_unit_tests" YEAR "2018")
 
 foreach (fname ${google_cloud_cpp_testing_unit_tests})
-    google_cloud_cpp_add_executable(target "common_testing" "${fname}")
+    google_cloud_cpp_add_executable(target "testing_util" "${fname}")
     target_link_libraries(
         ${target} PRIVATE google_cloud_cpp_testing google-cloud-cpp::common
                           GTest::gmock_main GTest::gmock GTest::gtest)

--- a/google/cloud/testing_util/google_cloud_cpp_testing_grpc.cmake
+++ b/google/cloud/testing_util/google_cloud_cpp_testing_grpc.cmake
@@ -46,7 +46,7 @@ export_list_to_bazel("google_cloud_cpp_testing_grpc_unit_tests.bzl"
                      "google_cloud_cpp_testing_grpc_unit_tests" YEAR "2020")
 
 foreach (fname ${google_cloud_cpp_testing_grpc_unit_tests})
-    google_cloud_cpp_add_executable(target "common_testing_grpc" "${fname}")
+    google_cloud_cpp_add_executable(target "testing_util" "${fname}")
     target_link_libraries(
         ${target}
         PRIVATE google_cloud_cpp_testing_grpc


### PR DESCRIPTION
The CMake targets need to be unique across the whole project. That is trivial for libraries, but tests often have conflicting names. A `foo_test.cc` will typically result in a target name of `foo` regardless of what directory it is in. Note that only the target name needs to be globally unique, the output file (`foo_test`) is already in the same directory as `foo_test.cc` and not likely to conflict.

In some places we used something inspired by the path (relative to the project root or to `google/cloud`) to prefix the target name. In other places we used something inspired by the associated library. I think it is simpler to always use the path. And it also yields shorter target.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10431)
<!-- Reviewable:end -->
