### PR TITLE
impl(oauth2): building blocks for AWS external accounts

### DIFF
--- a/google/cloud/internal/external_account_token_source_aws.cc
+++ b/google/cloud/internal/external_account_token_source_aws.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/external_account_token_source_aws.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/external_account_source_format.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/json_parsing.h"
 #include "google/cloud/internal/make_status.h"
 #include "absl/strings/match.h"
@@ -42,7 +43,26 @@ namespace {
 auto constexpr kDefaultUrl =
     "http://169.254.169.254/latest/meta-data/iam/security-credentials";
 
+auto constexpr kMetadataTokenTtlHeader = "X-aws-ec2-metadata-token-ttl-seconds";
+auto constexpr kDefaultMetadataTokenTtl = std::chrono::seconds(900);
+auto constexpr kMetadataTokenHeader = "X-aws-ec2-metadata-token";
+
 using ::google::cloud::internal::InvalidArgumentError;
+
+StatusOr<std::string> GetMetadata(std::string path,
+                                  std::string const& session_token,
+                                  HttpClientFactory const& client_factory,
+                                  Options const& opts) {
+  auto client = client_factory(opts);
+  auto request = rest_internal::RestRequest().SetPath(std::move(path));
+  if (!session_token.empty()) {
+    request.AddHeader(kMetadataTokenHeader, session_token);
+  }
+  auto response = client->Get(request);
+  if (!response) return std::move(response).status();
+  if (IsHttpError(**response)) return AsStatus(std::move(**response));
+  return rest_internal::ReadAll(std::move(**response).ExtractPayload());
+}
 
 }  // namespace
 
@@ -93,6 +113,94 @@ StatusOr<ExternalAccountTokenSourceAwsInfo> ParseExternalAccountTokenSourceAws(
       /*url=*/*std::move(url),
       /*regional_cred_verification_url=*/*std::move(regional_url),
       /*imdsv2_session_token_url=*/*std::move(imdsv2)};
+}
+
+StatusOr<std::string> FetchMetadataToken(
+    ExternalAccountTokenSourceAwsInfo const& info,
+    HttpClientFactory const& client_factory, Options const& opts,
+    internal::ErrorContext const& /*ec*/) {
+  if (info.imdsv2_session_token_url.empty()) return std::string{};
+  auto client = client_factory(opts);
+  auto request =
+      rest_internal::RestRequest()
+          .SetPath(std::move(info.imdsv2_session_token_url))
+          .AddHeader(kMetadataTokenTtlHeader,
+                     std::to_string(kDefaultMetadataTokenTtl.count()));
+  auto response = client->Put(request, {});
+  if (!response) return std::move(response).status();
+  if (IsHttpError(**response)) return AsStatus(std::move(**response));
+  return rest_internal::ReadAll(std::move(**response).ExtractPayload());
+}
+
+StatusOr<std::string> FetchRegion(ExternalAccountTokenSourceAwsInfo const& info,
+                                  std::string const& metadata_token,
+                                  HttpClientFactory const& cf,
+                                  Options const& opts,
+                                  internal::ErrorContext const& ec) {
+  for (auto const* name : {"AWS_REGION", "AWS_DEFAULT_REGION"}) {
+    auto env = internal::GetEnv(name);
+    if (env.has_value()) return std::move(*env);
+  }
+
+  auto payload = GetMetadata(info.region_url, metadata_token, cf, opts);
+  if (!payload) return std::move(payload).status();
+  if (payload->empty()) {
+    return InvalidArgumentError(
+        absl::StrCat("invalid (empty) region returned from ", info.region_url),
+        GCP_ERROR_INFO().WithContext(ec));
+  }
+  // The metadata service returns an availability zone, we must remove the last
+  // character to return the region.
+  payload->pop_back();
+  return *std::move(payload);
+}
+
+StatusOr<ExternalAccountTokenSourceAwsSecrets> FetchSecrets(
+    ExternalAccountTokenSourceAwsInfo const& info,
+    std::string const& metadata_token, HttpClientFactory const& cf,
+    Options const& opts, internal::ErrorContext const& ec) {
+  auto access_key_id_env = internal::GetEnv("AWS_ACCESS_KEY_ID");
+  auto secret_access_key_env = internal::GetEnv("AWS_SECRET_ACCESS_KEY");
+  auto session_token_env = internal::GetEnv("AWS_SESSION_TOKEN");
+  if (access_key_id_env.has_value() && secret_access_key_env.has_value()) {
+    return ExternalAccountTokenSourceAwsSecrets{
+        /*access_key_id=*/std::move(*access_key_id_env),
+        /*secret_access_key=*/std::move(*secret_access_key_env),
+        /*session_token=*/session_token_env.value_or("")};
+  }
+
+  // This code fetches the security credentials from the metadata services in an
+  // AWS EC2 instance, i.e., a VM. The requests and responses are documented in:
+  //  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
+  auto role = GetMetadata(info.url, metadata_token, cf, opts);
+  if (!role) return std::move(role).status();
+  auto path = info.url;
+  if (path.back() != '/') path.push_back('/');
+  path.append(*role);
+  auto secrets = GetMetadata(path, metadata_token, cf, opts);
+  if (!secrets) return std::move(secrets).status();
+  auto json = nlohmann::json::parse(*secrets, nullptr, false);
+  if (!json.is_object()) {
+    return InvalidArgumentError(
+        absl::StrCat("cannot parse AWS security-credentials metadata as JSON"),
+        GCP_ERROR_INFO()
+            .WithContext(ec)
+            .WithMetadata("aws.role", *role)
+            .WithMetadata("aws.metadata.path", path));
+  }
+  auto name = absl::string_view{"aws-security-credentials-response"};
+  auto access_key_id = ValidateStringField(json, "AccessKeyId", name, ec);
+  if (!access_key_id) return std::move(access_key_id).status();
+  auto secret_access_key =
+      ValidateStringField(json, "SecretAccessKey", name, ec);
+  if (!secret_access_key) return std::move(secret_access_key).status();
+  auto session_token = ValidateStringField(json, "Token", name, ec);
+  if (!session_token) return std::move(session_token).status();
+
+  return ExternalAccountTokenSourceAwsSecrets{
+      /*access_key_id=*/*std::move(access_key_id),
+      /*secret_access_key=*/*std::move(secret_access_key),
+      /*session_token=*/*std::move(session_token)};
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/external_account_token_source_aws.h
+++ b/google/cloud/internal/external_account_token_source_aws.h
@@ -65,8 +65,38 @@ struct ExternalAccountTokenSourceAwsInfo {
   std::string imdsv2_session_token_url;
 };
 
+struct ExternalAccountTokenSourceAwsSecrets {
+  std::string access_key_id;
+  std::string secret_access_key;
+  std::string session_token;
+};
+
 StatusOr<ExternalAccountTokenSourceAwsInfo> ParseExternalAccountTokenSourceAws(
     nlohmann::json const& credentials_source, internal::ErrorContext const& ec);
+
+/**
+ * If needed, gets the IMDSv2 metadata session token from the AWS EC2 metadata
+ * server.
+ *
+ * If the configuration does not require IMDSv2 tokens, returns an empty string.
+ */
+StatusOr<std::string> FetchMetadataToken(
+    ExternalAccountTokenSourceAwsInfo const& info,
+    HttpClientFactory const& client_factory, Options const& opts,
+    internal::ErrorContext const& ec);
+
+/// Obtains the AWS region for IMDSv1 configurations.
+StatusOr<std::string> FetchRegion(ExternalAccountTokenSourceAwsInfo const& info,
+                                  std::string const& metadata_token,
+                                  HttpClientFactory const& cf,
+                                  Options const& opts,
+                                  internal::ErrorContext const& ec);
+
+/// Obtains the AWS secrets for the default role.
+StatusOr<ExternalAccountTokenSourceAwsSecrets> FetchSecrets(
+    ExternalAccountTokenSourceAwsInfo const& info,
+    std::string const& metadata_token, HttpClientFactory const& cf,
+    Options const& opts, internal::ErrorContext const& ec);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal

--- a/google/cloud/internal/external_account_token_source_aws_test.cc
+++ b/google/cloud/internal/external_account_token_source_aws_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/testing_util/mock_http_payload.h"
 #include "google/cloud/testing_util/mock_rest_client.h"
 #include "google/cloud/testing_util/mock_rest_response.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <algorithm>
@@ -26,11 +27,24 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::rest_internal::HttpStatusCode;
+using ::google::cloud::rest_internal::RestClient;
+using ::google::cloud::rest_internal::RestRequest;
+using ::google::cloud::rest_internal::RestResponse;
+using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
+using ::google::cloud::testing_util::MockRestClient;
+using ::google::cloud::testing_util::MockRestResponse;
+using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::ByMove;
+using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::IsSupersetOf;
 using ::testing::Pair;
+using ::testing::Property;
+using ::testing::ResultOf;
+using ::testing::Return;
 
 using MockClientFactory =
     ::testing::MockFunction<std::unique_ptr<rest_internal::RestClient>(
@@ -39,6 +53,51 @@ using MockClientFactory =
 internal::ErrorContext MakeTestErrorContext() {
   return internal::ErrorContext{
       {{"filename", "my-credentials.json"}, {"key", "value"}}};
+}
+
+std::unique_ptr<RestResponse> MakeMockResponseSuccess(std::string contents) {
+  auto response = absl::make_unique<MockRestResponse>();
+  EXPECT_CALL(*response, StatusCode)
+      .WillRepeatedly(Return(HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(*response), ExtractPayload)
+      .WillOnce(
+          Return(ByMove(MakeMockHttpPayloadSuccess(std::move(contents)))));
+  return response;
+}
+
+Options MakeTestOptions() {
+  return Options{}.set<QuotaUserOption>("test-quota-user");
+}
+
+auto make_expected_options = [] {
+  return ResultOf([](Options const& o) { return o.get<QuotaUserOption>(); },
+                  "test-quota-user");
+};
+
+auto constexpr kTestRegionUrl = "http://169.254.169.254/region";
+auto constexpr kTestMetadataUrl = "http://169.254.169.254/metadata";
+auto constexpr kTestVerificationUrl =
+    "https://sts.{region}.aws.example.com"
+    "?Action=GetCallerIdentity&Version=2011-06-15";
+auto constexpr kTestImdsv2Url = "http://169.254.169.254/imdsv2";
+auto constexpr kTestImdsv2SessionToken = "test-imdsv2-token";
+
+auto constexpr kMetadataTokenTtlHeader = "x-aws-ec2-metadata-token-ttl-seconds";
+auto constexpr kMetadataTokenHeader = "x-aws-ec2-metadata-token";
+
+ExternalAccountTokenSourceAwsInfo MakeTestInfoImdsV1() {
+  return ExternalAccountTokenSourceAwsInfo{
+      /*environment_id=*/"aws1",
+      /*region_url=*/kTestRegionUrl,
+      /*url=*/kTestMetadataUrl,
+      /*regional_cred_verification_url=*/kTestVerificationUrl,
+      /*imdsv2_session_token_url=*/std::string{}};
+}
+
+ExternalAccountTokenSourceAwsInfo MakeTestInfoImdsV2() {
+  auto info = MakeTestInfoImdsV1();
+  info.imdsv2_session_token_url = kTestImdsv2Url;
+  return info;
 }
 
 TEST(ExternalAccountTokenSource, ParseSuccess) {
@@ -256,6 +315,274 @@ TEST(ExternalAccountTokenSource, InvalidImdsv2SessionTokenUrl) {
   EXPECT_THAT(info.status().error_info().metadata(),
               IsSupersetOf({Pair("filename", "my-credentials.json"),
                             Pair("key", "value")}));
+}
+
+TEST(ExternalAccountTokenSource, FetchMetadataTokenV1) {
+  auto const info = MakeTestInfoImdsV1();
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).Times(0);
+
+  auto const actual = FetchMetadataToken(info, client_factory.AsStdFunction(),
+                                         Options{}, MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_THAT(*actual, IsEmpty());
+}
+
+TEST(ExternalAccountTokenSource, FetchMetadataTokenV2) {
+  auto const info = MakeTestInfoImdsV2();
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call(make_expected_options())).WillOnce([] {
+    using ::testing::_;
+    auto mock = absl::make_unique<MockRestClient>();
+    auto expected_request = AllOf(
+        Property(&RestRequest::path, kTestImdsv2Url),
+        Property(&RestRequest::headers,
+                 Contains(Pair(kMetadataTokenTtlHeader, Not(IsEmpty())))));
+    EXPECT_CALL(*mock, Put(expected_request, _))
+        .WillOnce(
+            Return(ByMove(MakeMockResponseSuccess(kTestImdsv2SessionToken))));
+    return mock;
+  });
+
+  auto const actual =
+      FetchMetadataToken(info, client_factory.AsStdFunction(),
+                         MakeTestOptions(), MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(*actual, kTestImdsv2SessionToken);
+}
+
+TEST(ExternalAccountTokenSource, FetchRegionFromEnvRegion) {
+  auto const info = MakeTestInfoImdsV1();
+  auto const region = ScopedEnvironment("AWS_REGION", "expected-region");
+  auto const default_region =
+      ScopedEnvironment("AWS_DEFAULT_REGION", "default-region-unused");
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).Times(0);
+
+  auto const actual =
+      FetchRegion(info, std::string{}, client_factory.AsStdFunction(),
+                  Options{}, MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(*actual, "expected-region");
+}
+
+TEST(ExternalAccountTokenSource, FetchRegionFromEnvDefaultRegion) {
+  auto const info = MakeTestInfoImdsV1();
+  auto const region = ScopedEnvironment("AWS_REGION", absl::nullopt);
+  auto const default_region =
+      ScopedEnvironment("AWS_DEFAULT_REGION", "default-region");
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).Times(0);
+
+  auto const actual =
+      FetchRegion(info, std::string{}, client_factory.AsStdFunction(),
+                  Options{}, MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(*actual, "default-region");
+}
+
+TEST(ExternalAccountTokenSource, FetchRegionFromUrlV1) {
+  auto const info = MakeTestInfoImdsV1();
+  auto const region = ScopedEnvironment("AWS_REGION", absl::nullopt);
+  auto const default_region =
+      ScopedEnvironment("AWS_DEFAULT_REGION", absl::nullopt);
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call(make_expected_options()))
+      .WillOnce([url = info.region_url]() {
+        auto mock = absl::make_unique<MockRestClient>();
+        auto expected_request = Property(&RestRequest::path, url);
+        EXPECT_CALL(*mock, Get(expected_request))
+            .WillOnce(Return(ByMove(MakeMockResponseSuccess("test-only-1d"))));
+        return mock;
+      });
+
+  auto const actual =
+      FetchRegion(info, std::string{}, client_factory.AsStdFunction(),
+                  MakeTestOptions(), MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(*actual, "test-only-1");
+}
+
+TEST(ExternalAccountTokenSource, FetchRegionFromUrlV2) {
+  auto const info = MakeTestInfoImdsV2();
+  auto const region = ScopedEnvironment("AWS_REGION", absl::nullopt);
+  auto const default_region =
+      ScopedEnvironment("AWS_DEFAULT_REGION", absl::nullopt);
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call(make_expected_options()))
+      .WillOnce([url = info.region_url]() {
+        auto mock = absl::make_unique<MockRestClient>();
+        auto expected_request =
+            AllOf(Property(&RestRequest::path, url),
+                  // We expect the token returned by MakeImdsV2Client()
+                  Property(&RestRequest::headers,
+                           Contains(Pair(kMetadataTokenHeader,
+                                         Contains(kTestImdsv2SessionToken)))));
+        EXPECT_CALL(*mock, Get(expected_request))
+            .WillOnce(Return(ByMove(MakeMockResponseSuccess("test-only-1d"))));
+        return mock;
+      });
+
+  auto const actual =
+      FetchRegion(info, kTestImdsv2SessionToken, client_factory.AsStdFunction(),
+                  MakeTestOptions(), MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(*actual, "test-only-1");
+}
+
+TEST(ExternalAccountTokenSource, FetchRegionFromUrlEmpty) {
+  auto const info = MakeTestInfoImdsV1();
+  auto const region = ScopedEnvironment("AWS_REGION", absl::nullopt);
+  auto const default_region =
+      ScopedEnvironment("AWS_DEFAULT_REGION", absl::nullopt);
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call(make_expected_options()))
+      .WillOnce([url = info.region_url]() {
+        auto mock = absl::make_unique<MockRestClient>();
+        auto expected_request = Property(&RestRequest::path, url);
+        EXPECT_CALL(*mock, Get(expected_request))
+            .WillOnce(Return(ByMove(MakeMockResponseSuccess(""))));
+        return mock;
+      });
+
+  auto const actual =
+      FetchRegion(info, kTestImdsv2SessionToken, client_factory.AsStdFunction(),
+                  MakeTestOptions(), MakeTestErrorContext());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kInvalidArgument,
+                               HasSubstr("invalid (empty) region")));
+  EXPECT_THAT(actual.status().error_info().metadata(),
+              IsSupersetOf({Pair("filename", "my-credentials.json"),
+                            Pair("key", "value")}));
+}
+
+TEST(ExternalAccountTokenSource, FetchSecretsFromEnv) {
+  auto const info = MakeTestInfoImdsV1();
+  auto const access_key_id =
+      ScopedEnvironment("AWS_ACCESS_KEY_ID", "test-access-key-id");
+  auto const secret_access_key =
+      ScopedEnvironment("AWS_SECRET_ACCESS_KEY", "test-secret-access-key");
+  auto const token =
+      ScopedEnvironment("AWS_SESSION_TOKEN", "test-session-token");
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).Times(0);
+
+  auto const actual =
+      FetchSecrets(info, std::string{}, client_factory.AsStdFunction(),
+                   MakeTestOptions(), MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(actual->access_key_id, "test-access-key-id");
+  EXPECT_EQ(actual->secret_access_key, "test-secret-access-key");
+  EXPECT_EQ(actual->session_token, "test-session-token");
+}
+
+TEST(ExternalAccountTokenSource, FetchSecretsFromEnvNoSessionToken) {
+  auto const info = MakeTestInfoImdsV1();
+  auto const access_key_id =
+      ScopedEnvironment("AWS_ACCESS_KEY_ID", "test-access-key-id");
+  auto const secret_access_key =
+      ScopedEnvironment("AWS_SECRET_ACCESS_KEY", "test-secret-access-key");
+  auto const token = ScopedEnvironment("AWS_SESSION_TOKEN", absl::nullopt);
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).Times(0);
+
+  auto const actual =
+      FetchSecrets(info, std::string{}, client_factory.AsStdFunction(),
+                   MakeTestOptions(), MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(actual->access_key_id, "test-access-key-id");
+  EXPECT_EQ(actual->secret_access_key, "test-secret-access-key");
+  EXPECT_EQ(actual->session_token, "");
+}
+
+TEST(ExternalAccountTokenSource, FetchSecretsFromUrlV1) {
+  auto const info = MakeTestInfoImdsV1();
+  auto const access_key_id =
+      ScopedEnvironment("AWS_ACCESS_KEY_ID", absl::nullopt);
+  auto const secret_access_key =
+      ScopedEnvironment("AWS_SECRET_ACCESS_KEY", absl::nullopt);
+  auto const token = ScopedEnvironment("AWS_SESSION_TOKEN", absl::nullopt);
+
+  auto make_client = [](std::string const& url, std::string const& contents) {
+    auto mock = absl::make_unique<MockRestClient>();
+    auto expected_request = Property(&RestRequest::path, url);
+    EXPECT_CALL(*mock, Get(expected_request))
+        .WillOnce(Return(ByMove(MakeMockResponseSuccess(contents))));
+    return mock;
+  };
+
+  auto const response = nlohmann::json{
+      {"Code", "Success"},
+      {"Type", "AWS-HMAC"},
+      {"AccessKeyId", "test-access-key-id"},
+      {"SecretAccessKey", "test-secret-access-key"},
+      {"Token", "test-token"},
+  };
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call(make_expected_options()))
+      .WillOnce(Return(ByMove(make_client(info.url, "test-role"))))
+      .WillOnce(Return(
+          ByMove(make_client(info.url + "/test-role", response.dump()))));
+
+  auto const actual =
+      FetchSecrets(info, std::string{}, client_factory.AsStdFunction(),
+                   MakeTestOptions(), MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(actual->access_key_id, "test-access-key-id");
+  EXPECT_EQ(actual->secret_access_key, "test-secret-access-key");
+  EXPECT_EQ(actual->session_token, "test-token");
+}
+
+TEST(ExternalAccountTokenSource, FetchSecretsFromUrlV2) {
+  auto const info = MakeTestInfoImdsV2();
+  auto const access_key_id =
+      ScopedEnvironment("AWS_ACCESS_KEY_ID", absl::nullopt);
+  auto const secret_access_key =
+      ScopedEnvironment("AWS_SECRET_ACCESS_KEY", absl::nullopt);
+  auto const token = ScopedEnvironment("AWS_SESSION_TOKEN", absl::nullopt);
+
+  auto make_client = [](std::string const& url, std::string const& contents) {
+    auto mock = absl::make_unique<MockRestClient>();
+    auto expected_request =
+        AllOf(Property(&RestRequest::path, url),
+              Property(&RestRequest::headers,
+                       Contains(Pair(kMetadataTokenHeader,
+                                     Contains(kTestImdsv2SessionToken)))));
+    EXPECT_CALL(*mock, Get(expected_request))
+        .WillOnce(Return(ByMove(MakeMockResponseSuccess(contents))));
+    return mock;
+  };
+
+  auto const response = nlohmann::json{
+      {"Code", "Success"},
+      {"Type", "AWS-HMAC"},
+      {"AccessKeyId", "test-access-key-id"},
+      {"SecretAccessKey", "test-secret-access-key"},
+      {"Token", "test-token"},
+  };
+
+  MockClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call(make_expected_options()))
+      .WillOnce(Return(ByMove(make_client(info.url, "test-role"))))
+      .WillOnce(Return(
+          ByMove(make_client(info.url + "/test-role", response.dump()))));
+
+  auto const actual = FetchSecrets(info, kTestImdsv2SessionToken,
+                                   client_factory.AsStdFunction(),
+                                   MakeTestOptions(), MakeTestErrorContext());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(actual->access_key_id, "test-access-key-id");
+  EXPECT_EQ(actual->secret_access_key, "test-secret-access-key");
+  EXPECT_EQ(actual->session_token, "test-token");
 }
 
 }  // namespace


### PR DESCRIPTION
As with the other external accounts, we need to build a subject token for AWS external accounts. Building this subject token requires obtaining a number of pieces of information. These can be found on environment variables or via the VM's metadata service. The functions to get them are complex enough that they deserve their own tests.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10439)
<!-- Reviewable:end -->
