### PR TITLE
cleanup(pubsub): simplify emulator workarounds

### DIFF
--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -148,8 +148,6 @@ TEST_F(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
 
   // To create snapshots we need at least one subscription, so we test those
   // here too.
-  // TODO(#4792) - cannot test server-side assigned names, the emulator lacks
-  //    support for them.
   Snapshot snapshot(project_id, pubsub_testing::RandomSnapshotId(generator));
   auto create_snapshot_response =
       subscription_admin.CreateSnapshot(subscription, snapshot);
@@ -170,7 +168,7 @@ TEST_F(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   ASSERT_STATUS_OK(get_snapshot_response);
   EXPECT_THAT(*get_snapshot_response, IsProtoEqual(*create_snapshot_response));
 
-  // TODO(#4792) - the emulator does not support UpdateSnapshot()
+  // Skip, as this is not supported by the emulator.
   if (!UsingEmulator()) {
     auto update_snapshot_response = subscription_admin.UpdateSnapshot(
         snapshot, SnapshotBuilder{}.add_label("test-label", "test-value"));
@@ -188,7 +186,7 @@ TEST_F(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   EXPECT_THAT(snapshot_names(subscription_admin, project_id),
               Not(Contains(snapshot.FullName())));
 
-  // TODO(#4792) - the emulator does not support DetachSubscription()
+  // Skip, as this is not supported by the emulator.
   if (!UsingEmulator()) {
     auto detach_response = topic_admin.DetachSubscription(subscription);
     ASSERT_STATUS_OK(detach_response);

--- a/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
@@ -87,10 +87,10 @@ TEST_F(TopicAdminIntegrationTest, TopicCRUD) {
   ASSERT_STATUS_OK(get_response);
   EXPECT_THAT(*create_response, IsProtoEqual(*get_response));
 
-  auto update_response = publisher.UpdateTopic(
-      TopicBuilder(topic).add_label("test-key", "test-value"));
-  // TODO(#4792) - cleanup this workaround whenever the emulator is fixed
+  // Skip, as this is not supported by the emulator.
   if (!UsingEmulator()) {
+    auto update_response = publisher.UpdateTopic(
+        TopicBuilder(topic).add_label("test-key", "test-value"));
     ASSERT_STATUS_OK(update_response);
   }
 

--- a/google/cloud/pubsub/subscription_admin_client.h
+++ b/google/cloud/pubsub/subscription_admin_client.h
@@ -221,7 +221,6 @@ class SubscriptionAdminClient {
    * @param opts Override the class-level options, such as retry and backoff
    *     policies.
    */
-  // TODO(#4792) - add missing example once it is testable
   StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
       Subscription const& subscription, SnapshotBuilder builder = {},
       Options opts = {}) {


### PR DESCRIPTION
Just throw from the samples and have a little wrapper capture and ignore the right exceptions when running with the emulator.

Fixes #4792 - or at least we will not be worrying about unimplemented features in the emulator after this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10441)
<!-- Reviewable:end -->
