### PR TITLE
ci: restore `rest` integration tests

### DIFF
--- a/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
@@ -36,7 +36,7 @@ ctest_args=("$@")
 cd "${BINARY_DIR}"
 start_emulator
 
-ctest -R "^rest_" "${ctest_args[@]}"
+ctest -R "^common_" "${ctest_args[@]}"
 exit_status=$?
 
 kill_emulator


### PR DESCRIPTION
I neglected to update the driver script while renaming the test targets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10443)
<!-- Reviewable:end -->
