### PR TITLE
cleanup(spanner): do not provide stub functions for unused RPCs

### DIFF
--- a/google/cloud/spanner/internal/logging_spanner_stub.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub.cc
@@ -60,29 +60,6 @@ LoggingSpannerStub::AsyncBatchCreateSessions(
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
-StatusOr<google::spanner::v1::Session> LoggingSpannerStub::GetSession(
-    grpc::ClientContext& client_context,
-    google::spanner::v1::GetSessionRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::spanner::v1::GetSessionRequest const& request) {
-        return child_->GetSession(context, request);
-      },
-      client_context, request, __func__, tracing_options_);
-}
-
-StatusOr<google::spanner::v1::ListSessionsResponse>
-LoggingSpannerStub::ListSessions(
-    grpc::ClientContext& client_context,
-    google::spanner::v1::ListSessionsRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::spanner::v1::ListSessionsRequest const& request) {
-        return child_->ListSessions(context, request);
-      },
-      client_context, request, __func__, tracing_options_);
-}
-
 Status LoggingSpannerStub::DeleteSession(
     grpc::ClientContext& client_context,
     google::spanner::v1::DeleteSessionRequest const& request) {

--- a/google/cloud/spanner/internal/logging_spanner_stub.h
+++ b/google/cloud/spanner/internal/logging_spanner_stub.h
@@ -49,12 +49,6 @@ class LoggingSpannerStub : public SpannerStub {
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
-  StatusOr<google::spanner::v1::Session> GetSession(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::GetSessionRequest const& request) override;
-  StatusOr<google::spanner::v1::ListSessionsResponse> ListSessions(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::ListSessionsRequest const& request) override;
   Status DeleteSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::DeleteSessionRequest const& request) override;

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -96,34 +96,6 @@ TEST_F(LoggingSpannerStubTest, BatchCreateSessions) {
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
-TEST_F(LoggingSpannerStubTest, GetSession) {
-  EXPECT_CALL(*mock_, GetSession).WillOnce(Return(TransientError()));
-
-  LoggingSpannerStub stub(mock_, TracingOptions{});
-  grpc::ClientContext context;
-  auto status =
-      stub.GetSession(context, google::spanner::v1::GetSessionRequest());
-  EXPECT_EQ(TransientError(), status.status());
-
-  auto const log_lines = log_.ExtractLines();
-  EXPECT_THAT(log_lines, Contains(HasSubstr("GetSession")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
-}
-
-TEST_F(LoggingSpannerStubTest, ListSessions) {
-  EXPECT_CALL(*mock_, ListSessions).WillOnce(Return(TransientError()));
-
-  LoggingSpannerStub stub(mock_, TracingOptions{});
-  grpc::ClientContext context;
-  auto status =
-      stub.ListSessions(context, google::spanner::v1::ListSessionsRequest());
-  EXPECT_EQ(TransientError(), status.status());
-
-  auto const log_lines = log_.ExtractLines();
-  EXPECT_THAT(log_lines, Contains(HasSubstr("ListSessions")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
-}
-
 TEST_F(LoggingSpannerStubTest, DeleteSession) {
   EXPECT_CALL(*mock_, DeleteSession).WillOnce(Return(TransientError()));
 

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -54,21 +54,6 @@ MetadataSpannerStub::AsyncBatchCreateSessions(
   return child_->AsyncBatchCreateSessions(cq, std::move(context), request);
 }
 
-StatusOr<google::spanner::v1::Session> MetadataSpannerStub::GetSession(
-    grpc::ClientContext& client_context,
-    google::spanner::v1::GetSessionRequest const& request) {
-  SetMetadata(client_context, "name=" + request.name());
-  return child_->GetSession(client_context, request);
-}
-
-StatusOr<google::spanner::v1::ListSessionsResponse>
-MetadataSpannerStub::ListSessions(
-    grpc::ClientContext& client_context,
-    google::spanner::v1::ListSessionsRequest const& request) {
-  SetMetadata(client_context, "database=" + request.database());
-  return child_->ListSessions(client_context, request);
-}
-
 Status MetadataSpannerStub::DeleteSession(
     grpc::ClientContext& client_context,
     google::spanner::v1::DeleteSessionRequest const& request) {

--- a/google/cloud/spanner/internal/metadata_spanner_stub.h
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.h
@@ -46,12 +46,6 @@ class MetadataSpannerStub : public SpannerStub {
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
-  StatusOr<google::spanner::v1::Session> GetSession(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::GetSessionRequest const& request) override;
-  StatusOr<google::spanner::v1::ListSessionsResponse> ListSessions(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::ListSessionsRequest const& request) override;
   Status DeleteSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::DeleteSessionRequest const& request) override;

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -178,47 +178,6 @@ TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
   EXPECT_EQ(TransientError(), status.status());
 }
 
-TEST_F(MetadataSpannerStubTest, GetSession) {
-  EXPECT_CALL(*mock_, GetSession)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::spanner::v1::GetSessionRequest const& request) {
-        IsContextMDValid(context, "google.spanner.v1.Spanner.GetSession",
-                         request);
-        return TransientError();
-      });
-
-  MetadataSpannerStub stub(mock_, db_.FullName());
-  grpc::ClientContext context;
-  google::spanner::v1::GetSessionRequest request;
-  request.set_name(
-      google::cloud::spanner::Database(
-          google::cloud::spanner::Instance(
-              google::cloud::Project("test-project-id"), "test-instance-id"),
-          "test-database-id")
-          .FullName() +
-      "/sessions/test-session-id");
-  auto status = stub.GetSession(context, request);
-  EXPECT_EQ(TransientError(), status.status());
-}
-
-TEST_F(MetadataSpannerStubTest, ListSessions) {
-  EXPECT_CALL(*mock_, ListSessions)
-      .WillOnce(
-          [this](grpc::ClientContext& context,
-                 google::spanner::v1::ListSessionsRequest const& request) {
-            IsContextMDValid(context, "google.spanner.v1.Spanner.ListSessions",
-                             request);
-            return TransientError();
-          });
-
-  MetadataSpannerStub stub(mock_, db_.FullName());
-  grpc::ClientContext context;
-  google::spanner::v1::ListSessionsRequest request;
-  request.set_database(db_.FullName());
-  auto status = stub.ListSessions(context, request);
-  EXPECT_EQ(TransientError(), status.status());
-}
-
 TEST_F(MetadataSpannerStubTest, DeleteSession) {
   EXPECT_CALL(*mock_, DeleteSession)
       .WillOnce(

--- a/google/cloud/spanner/internal/spanner_auth.cc
+++ b/google/cloud/spanner/internal/spanner_auth.cc
@@ -41,22 +41,6 @@ SpannerAuth::BatchCreateSessions(
   return child_->BatchCreateSessions(context, request);
 }
 
-StatusOr<google::spanner::v1::Session> SpannerAuth::GetSession(
-    grpc::ClientContext& context,
-    google::spanner::v1::GetSessionRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->GetSession(context, request);
-}
-
-StatusOr<google::spanner::v1::ListSessionsResponse> SpannerAuth::ListSessions(
-    grpc::ClientContext& context,
-    google::spanner::v1::ListSessionsRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->ListSessions(context, request);
-}
-
 Status SpannerAuth::DeleteSession(
     grpc::ClientContext& context,
     google::spanner::v1::DeleteSessionRequest const& request) {

--- a/google/cloud/spanner/internal/spanner_auth.h
+++ b/google/cloud/spanner/internal/spanner_auth.h
@@ -40,14 +40,6 @@ class SpannerAuth : public SpannerStub {
       grpc::ClientContext& context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
 
-  StatusOr<google::spanner::v1::Session> GetSession(
-      grpc::ClientContext& context,
-      google::spanner::v1::GetSessionRequest const& request) override;
-
-  StatusOr<google::spanner::v1::ListSessionsResponse> ListSessions(
-      grpc::ClientContext& context,
-      google::spanner::v1::ListSessionsRequest const& request) override;
-
   Status DeleteSession(
       grpc::ClientContext& context,
       google::spanner::v1::DeleteSessionRequest const& request) override;

--- a/google/cloud/spanner/internal/spanner_auth_test.cc
+++ b/google/cloud/spanner/internal/spanner_auth_test.cc
@@ -72,40 +72,6 @@ TEST(SpannerAuthTest, BatchCreateSessions) {
   EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
 }
 
-TEST(SpannerAuthTest, GetSession) {
-  auto mock = std::make_shared<MockSpannerStub>();
-  EXPECT_CALL(*mock, GetSession)
-      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-
-  SpannerAuth under_test(MakeTypicalMockAuth(), mock);
-  google::spanner::v1::GetSessionRequest request;
-  grpc::ClientContext ctx;
-  auto auth_failure = under_test.GetSession(ctx, request);
-  EXPECT_THAT(ctx.credentials(), IsNull());
-  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
-
-  auto auth_success = under_test.GetSession(ctx, request);
-  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
-  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
-}
-
-TEST(SpannerAuthTest, ListSessions) {
-  auto mock = std::make_shared<MockSpannerStub>();
-  EXPECT_CALL(*mock, ListSessions)
-      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-
-  SpannerAuth under_test(MakeTypicalMockAuth(), mock);
-  google::spanner::v1::ListSessionsRequest request;
-  grpc::ClientContext ctx;
-  auto auth_failure = under_test.ListSessions(ctx, request);
-  EXPECT_THAT(ctx.credentials(), IsNull());
-  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
-
-  auto auth_success = under_test.ListSessions(ctx, request);
-  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
-  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
-}
-
 TEST(SpannerAuthTest, DeleteSession) {
   auto mock = std::make_shared<MockSpannerStub>();
   EXPECT_CALL(*mock, DeleteSession)

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -54,12 +54,6 @@ class DefaultSpannerStub : public SpannerStub {
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
-  StatusOr<google::spanner::v1::Session> GetSession(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::GetSessionRequest const& request) override;
-  StatusOr<google::spanner::v1::ListSessionsResponse> ListSessions(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::ListSessionsRequest const& request) override;
   Status DeleteSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::DeleteSessionRequest const& request) override;
@@ -142,31 +136,6 @@ DefaultSpannerStub::AsyncBatchCreateSessions(
         return grpc_stub_->AsyncBatchCreateSessions(context, request, cq);
       },
       request, std::move(context));
-}
-
-StatusOr<google::spanner::v1::Session> DefaultSpannerStub::GetSession(
-    grpc::ClientContext& client_context,
-    google::spanner::v1::GetSessionRequest const& request) {
-  google::spanner::v1::Session response;
-  grpc::Status grpc_status =
-      grpc_stub_->GetSession(&client_context, request, &response);
-  if (!grpc_status.ok()) {
-    return google::cloud::MakeStatusFromRpcError(grpc_status);
-  }
-  return response;
-}
-
-StatusOr<google::spanner::v1::ListSessionsResponse>
-DefaultSpannerStub::ListSessions(
-    grpc::ClientContext& client_context,
-    google::spanner::v1::ListSessionsRequest const& request) {
-  google::spanner::v1::ListSessionsResponse response;
-  grpc::Status grpc_status =
-      grpc_stub_->ListSessions(&client_context, request, &response);
-  if (!grpc_status.ok()) {
-    return google::cloud::MakeStatusFromRpcError(grpc_status);
-  }
-  return response;
 }
 
 Status DefaultSpannerStub::DeleteSession(

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -37,6 +37,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *
  * The API is defined in:
  * https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/spanner.proto
+ *
+ * @note We don't use the GetSession(), ListSessions(), or Read() RPCs.
  */
 class SpannerStub {
  public:
@@ -55,18 +57,11 @@ class SpannerStub {
   BatchCreateSessions(
       grpc::ClientContext& client_context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) = 0;
-
   virtual future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) = 0;
-  virtual StatusOr<google::spanner::v1::Session> GetSession(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::GetSessionRequest const& request) = 0;
-  virtual StatusOr<google::spanner::v1::ListSessionsResponse> ListSessions(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::ListSessionsRequest const& request) = 0;
   virtual Status DeleteSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::DeleteSessionRequest const& request) = 0;

--- a/google/cloud/spanner/testing/mock_spanner_stub.h
+++ b/google/cloud/spanner/testing/mock_spanner_stub.h
@@ -45,16 +45,6 @@ class MockSpannerStub : public google::cloud::spanner_internal::SpannerStub {
        google::spanner::v1::BatchCreateSessionsRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::spanner::v1::Session>, GetSession,
-              (grpc::ClientContext&,
-               google::spanner::v1::GetSessionRequest const&),
-              (override));
-
-  MOCK_METHOD(StatusOr<google::spanner::v1::ListSessionsResponse>, ListSessions,
-              (grpc::ClientContext&,
-               google::spanner::v1::ListSessionsRequest const&),
-              (override));
-
   MOCK_METHOD(Status, DeleteSession,
               (grpc::ClientContext&,
                google::spanner::v1::DeleteSessionRequest const&),


### PR DESCRIPTION
We do not provide a stub function for `Spanner.Read` because the client implementation doesn't use it.  So, do the same for `Spanner.GetSession` and `Spanner.ListSessions`, which are similarly unused.

This will make it clearer that `GetSession` (like `Read`) does not need to be considered when adding routing-header support in the future.