### PR TITLE
doc: clean up some howto-doc opening paragraphs

### DIFF
--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -1,12 +1,11 @@
 # How-to Guide: Adding generated libraries
 
 This document describes the steps required to add a new library to
-`google-cloud-cpp`. The document is intended for contributors to the
-`google-cloud-cpp` libraries, it assumes you are familiar with the build systems
-used in these libraries, that you are familiar with existing libraries, and with
-which libraries are based on gRPC.
+`google-cloud-cpp`. It is intended for contributors, and assumes you are
+familiar with the existing libraries, the build systems used in those
+libraries, and which libraries are based on gRPC.
 
-> :warning: for libraries that include multiple services, the scaffold README
+> :warning: For libraries that include multiple services, the scaffold README
 > files (and any other documentation) will use the **last** service description
 > as the description of the library. Adjust the ordering and/or fix the
 > documentation after the fact.

--- a/doc/contributor/howto-guide-declare-a-library-ga.md
+++ b/doc/contributor/howto-guide-declare-a-library-ga.md
@@ -1,9 +1,8 @@
 # How-to Guide: Declare a library as GA
 
 This document describes the steps required to promote a `google-cloud-cpp`
-library to GA. The document is intended for contributors to the
-`google-cloud-cpp` libraries. It assumes you are familiar with the build systems
-used in these libraries, and that you are familiar with existing libraries.
+library to GA (General Availability). It is intended for contributors,
+and assumes you are familiar with the build system used in the library.
 
 This document applies to both hand-crafted and generated libraries, but mostly
 it will be using generated libraries as examples.

--- a/doc/contributor/howto-guide-running-ci-builds-locally.md
+++ b/doc/contributor/howto-guide-running-ci-builds-locally.md
@@ -1,8 +1,8 @@
 # How-to Guide: Running CI builds locally
 
 The `google-cloud-cpp` libraries need to be tested with different compilers,
-different build tools, as shared libraries, as static libraries, and we need to
-verify our instructions to install the libraries are up to date. This is in
+different build tools, as shared libraries, and as static libraries, and we need to
+verify that our instructions to install the libraries are up to date. This is in
 addition to following best practices for C++, such as running the code with
 dynamic analysis tools (e.g. AddressSanitizer), and enforcing style guidelines
 with `clang-tidy`.
@@ -11,8 +11,8 @@ Each one of these builds may require different compilers, different system
 libraries, or may require different ways to compile the dependencies.
 Fortunately, one can use containers to create isolated environments to run
 each one of these builds, and these containers can be created as-needed in both
-the CI systems and the developer workstation. Well, at least as long as the
-base platform supports containers.
+the CI systems and the developer workstation (assuming the base platform
+supports containers).
 
 ## Running the CI build
 


### PR DESCRIPTION
While taking notes about the changes for generating libraries with version subdirectories (eventually handled in #10342), I made some other small cleanups to the opening paragraph, and those cascaded over into a couple of other guides.  We might as well preserve them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10445)
<!-- Reviewable:end -->
