### PR TITLE
test(oauth2): simplify and restore WIF integration test

### DIFF
--- a/.github/workflows/external-account-integration.yml
+++ b/.github/workflows/external-account-integration.yml
@@ -72,8 +72,10 @@ jobs:
           service_account: 'github-actions@cloud-cpp-identity-federation.iam.gserviceaccount.com'
       - id: 'test'
         if: '!github.event.pull_request.head.repo.fork'
-        name: 'test'
+        name: 'Run Integration Test'
         env:
-          GOOGLE_CLOUD_CPP_EXTERNAL_ACCOUNT_FILE: "${{ steps.auth.outputs.credentials_file_path }}"
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+          GOOGLE_CLOUD_CPP_TEST_WIF_BUCKET: "cloud-cpp-wif-test-bucket"
+          GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG: "lastN,1024,WARNING"
         run: |
-          ctest --test-dir "${{runner.temp}}/build" --output-on-failure -R rest_internal_internal_external_account_integration_test
+          ctest --test-dir "${{runner.temp}}/build" --output-on-failure -R common_internal_external_account_integration_test


### PR DESCRIPTION
Another test that I renamed and neglected to run with the new name. It needed fixing in any case, as it can now use normal credential initialization.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10447)
<!-- Reviewable:end -->
