### PR TITLE
refactor: change CompletionQueueImpl::cq return type

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -476,8 +476,7 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWriteRead) {
       });
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
-  grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(nullptr));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok) {
@@ -548,8 +547,7 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingRead) {
       });
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
-  grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(nullptr));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok) {
@@ -620,8 +618,7 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWrite) {
           });
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
-  grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(nullptr));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok) {

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -35,7 +35,6 @@ using ::google::test::admin::database::v1::Request;
 using ::google::test::admin::database::v1::Response;
 using ::testing::_;
 using ::testing::Return;
-using ::testing::ReturnRef;
 
 class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
                                           v1::GoldenKitchenSink::StubInterface {
@@ -478,7 +477,7 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWriteRead) {
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok) {
@@ -550,7 +549,7 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingRead) {
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok) {
@@ -622,7 +621,7 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWrite) {
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok) {

--- a/generator/integration_tests/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_stub_test.cc
@@ -32,7 +32,6 @@ using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::Return;
-using ::testing::ReturnRef;
 
 class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
                                          v1::GoldenThingAdmin::StubInterface {
@@ -601,7 +600,7 @@ TEST_F(GoldenStubTest, AsyncCreateDatabase) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(ReturnRef(grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(Return(&grpc_cq_));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -638,7 +637,7 @@ TEST_F(GoldenStubTest, AsyncUpdateDatabaseDdl) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::ReturnRef(grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -734,7 +733,7 @@ TEST_F(GoldenStubTest, AsyncCreateBackup) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::ReturnRef(grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -816,7 +815,7 @@ TEST_F(GoldenStubTest, AsyncRestoreDatabase) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::ReturnRef(grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -868,7 +867,7 @@ TEST_F(GoldenStubTest, AsyncGetDatabase) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::ReturnRef(grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -889,7 +888,7 @@ TEST_F(GoldenStubTest, AsyncDropDatabase) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::ReturnRef(grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -911,7 +910,7 @@ TEST_F(GoldenStubTest, AsyncGetOperation) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::ReturnRef(grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -933,7 +932,7 @@ TEST_F(GoldenStubTest, AsyncCancelOperation) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::ReturnRef(grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),

--- a/generator/integration_tests/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_stub_test.cc
@@ -570,7 +570,6 @@ class GoldenStubTest : public ::testing::Test {
 
   std::unique_ptr<MockGrpcGoldenThingAdminStub> grpc_stub_;
   std::unique_ptr<MockLongrunningOperationsStub> longrunning_stub_;
-  grpc::CompletionQueue grpc_cq_;
 };
 
 TEST_F(GoldenStubTest, ListDatabases) {
@@ -600,7 +599,7 @@ TEST_F(GoldenStubTest, AsyncCreateDatabase) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(Return(&grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(Return(nullptr));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -637,7 +636,7 @@ TEST_F(GoldenStubTest, AsyncUpdateDatabaseDdl) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(nullptr));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -733,7 +732,7 @@ TEST_F(GoldenStubTest, AsyncCreateBackup) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(nullptr));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -815,7 +814,7 @@ TEST_F(GoldenStubTest, AsyncRestoreDatabase) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(nullptr));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -867,7 +866,7 @@ TEST_F(GoldenStubTest, AsyncGetDatabase) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(nullptr));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -888,7 +887,7 @@ TEST_F(GoldenStubTest, AsyncDropDatabase) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(nullptr));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -910,7 +909,7 @@ TEST_F(GoldenStubTest, AsyncGetOperation) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(nullptr));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),
@@ -932,7 +931,7 @@ TEST_F(GoldenStubTest, AsyncCancelOperation) {
         f(op.get());
         op->Notify(false);
       });
-  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(&grpc_cq_));
+  EXPECT_CALL(*mock, cq).WillOnce(::testing::Return(nullptr));
   CompletionQueue cq(mock);
 
   DefaultGoldenThingAdminStub stub(std::move(grpc_stub_),

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh_test.cc
@@ -75,13 +75,13 @@ TEST(BigtableChannelRefresh, Disabled) {
 TEST(BigtableChannelRefresh, Continuations) {
   using ms = std::chrono::milliseconds;
   using ns = std::chrono::nanoseconds;
-  using ::testing::ReturnRef;
+  using ::testing::Return;
 
   promise<StatusOr<std::chrono::system_clock::time_point>> p;
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
 
   ::testing::InSequence s;
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -129,7 +129,7 @@ class CompletionQueue {
     auto op =
         std::make_shared<internal::AsyncUnaryRpcFuture<Request, Response>>();
     impl_->StartOperation(op, [&](void* tag) {
-      op->Start(async_call, std::move(context), request, &impl_->cq(), tag);
+      op->Start(async_call, std::move(context), request, impl_->cq(), tag);
     });
     return op->GetFuture();
   }

--- a/google/cloud/internal/async_connection_ready.cc
+++ b/google/cloud/internal/async_connection_ready.cc
@@ -85,7 +85,7 @@ future<bool> NotifyOnStateChange::Start(
     grpc_connectivity_state last_observed) {
   auto op = std::make_shared<NotifyOnStateChange>();
   cq->StartOperation(op, [&](void* tag) {
-    channel->NotifyOnStateChange(last_observed, deadline, &cq->cq(), tag);
+    channel->NotifyOnStateChange(last_observed, deadline, cq->cq(), tag);
   });
   return op->promise_.get_future();
 }

--- a/google/cloud/internal/async_read_stream_impl.h
+++ b/google/cloud/internal/async_read_stream_impl.h
@@ -167,7 +167,7 @@ class AsyncReadStreamImpl
       //     never called. We leave `reader_` null in this case; other methods
       //     must make the same `tag != nullptr` check prior to accessing
       //     `reader_`.  This is safe since `Shutdown()` cannot be undone.
-      reader_ = async_call(context_.get(), request, &cq_->cq());
+      reader_ = async_call(context_.get(), request, cq_->cq());
       reader_->StartCall(tag);
     });
   }

--- a/google/cloud/internal/async_read_write_stream_impl.h
+++ b/google/cloud/internal/async_read_write_stream_impl.h
@@ -172,7 +172,7 @@ MakeStreamingReadWriteRpc(
     CompletionQueue const& cq, std::unique_ptr<grpc::ClientContext> context,
     PrepareAsyncReadWriteRpc<Request, Response> async_call) {
   auto cq_impl = GetCompletionQueueImpl(cq);
-  auto stream = async_call(context.get(), &cq_impl->cq());
+  auto stream = async_call(context.get(), cq_impl->cq());
   return absl::make_unique<AsyncStreamingReadWriteRpcImpl<Request, Response>>(
       std::move(cq_impl), std::move(context), std::move(stream));
 }

--- a/google/cloud/internal/async_read_write_stream_impl_test.cc
+++ b/google/cloud/internal/async_read_write_stream_impl_test.cc
@@ -32,7 +32,7 @@ namespace {
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::testing::_;
-using ::testing::ReturnRef;
+using ::testing::Return;
 
 struct FakeRequest {
   std::string key;
@@ -96,7 +96,7 @@ TEST(AsyncReadWriteStreamingRpcTest, Basic) {
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok = true) {

--- a/google/cloud/internal/async_read_write_stream_impl_test.cc
+++ b/google/cloud/internal/async_read_write_stream_impl_test.cc
@@ -95,8 +95,7 @@ TEST(AsyncReadWriteStreamingRpcTest, Basic) {
       });
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
-  grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(nullptr));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok = true) {

--- a/google/cloud/internal/async_streaming_read_rpc_impl.h
+++ b/google/cloud/internal/async_streaming_read_rpc_impl.h
@@ -137,7 +137,7 @@ std::unique_ptr<AsyncStreamingReadRpc<Response>> MakeStreamingReadRpc(
     CompletionQueue const& cq, std::unique_ptr<grpc::ClientContext> context,
     Request const& request, PrepareAsyncReadRpc<Request, Response> async_call) {
   auto cq_impl = GetCompletionQueueImpl(cq);
-  auto stream = async_call(context.get(), request, &cq_impl->cq());
+  auto stream = async_call(context.get(), request, cq_impl->cq());
   return absl::make_unique<AsyncStreamingReadRpcImpl<Response>>(
       std::move(cq_impl), std::move(context), std::move(stream));
 }

--- a/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
@@ -31,7 +31,7 @@ namespace {
 
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
-using ::testing::ReturnRef;
+using ::testing::Return;
 
 struct FakeRequest {
   std::string key;
@@ -82,7 +82,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok = true) {

--- a/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
@@ -81,8 +81,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
       });
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
-  grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(nullptr));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok = true) {

--- a/google/cloud/internal/async_streaming_write_rpc_impl.h
+++ b/google/cloud/internal/async_streaming_write_rpc_impl.h
@@ -162,7 +162,7 @@ MakeStreamingWriteRpc(CompletionQueue const& cq,
                       PrepareAsyncWriteRpc<Request, Response> async_call) {
   auto cq_impl = GetCompletionQueueImpl(cq);
   auto response = absl::make_unique<Response>();
-  auto stream = async_call(context.get(), response.get(), &cq_impl->cq());
+  auto stream = async_call(context.get(), response.get(), cq_impl->cq());
   return absl::make_unique<AsyncStreamingWriteRpcImpl<Request, Response>>(
       std::move(cq_impl), std::move(context), std::move(response),
       std::move(stream));

--- a/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
@@ -85,8 +85,7 @@ TEST(AsyncStreamingWriteRpcTest, Basic) {
       });
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
-  grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(nullptr));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok = true) {

--- a/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
@@ -32,7 +32,7 @@ namespace {
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::testing::_;
-using ::testing::ReturnRef;
+using ::testing::Return;
 
 struct FakeRequest {
   std::string key;
@@ -86,7 +86,7 @@ TEST(AsyncStreamingWriteRpcTest, Basic) {
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
-  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(&grpc_cq));
 
   std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
   auto notify_next_op = [&](bool ok = true) {

--- a/google/cloud/internal/completion_queue_impl.h
+++ b/google/cloud/internal/completion_queue_impl.h
@@ -72,7 +72,7 @@ class CompletionQueueImpl {
                               absl::FunctionRef<void(void*)> start) = 0;
 
   /// The underlying gRPC completion queue, if it exists.
-  virtual grpc::CompletionQueue* cq() { return nullptr; }
+  virtual grpc::CompletionQueue* cq() = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/completion_queue_impl.h
+++ b/google/cloud/internal/completion_queue_impl.h
@@ -71,8 +71,8 @@ class CompletionQueueImpl {
   virtual void StartOperation(std::shared_ptr<AsyncGrpcOperation> op,
                               absl::FunctionRef<void(void*)> start) = 0;
 
-  /// The underlying gRPC completion queue.
-  virtual grpc::CompletionQueue& cq() = 0;
+  /// The underlying gRPC completion queue, if it exists.
+  virtual grpc::CompletionQueue* cq() { return nullptr; }
 };
 
 }  // namespace internal

--- a/google/cloud/internal/default_completion_queue_impl.cc
+++ b/google/cloud/internal/default_completion_queue_impl.cc
@@ -217,6 +217,7 @@ DefaultCompletionQueueImpl::MakeDeadlineTimer(
     std::chrono::system_clock::time_point deadline) {
   auto p = AsyncTimerFuture::Create();
   auto op = std::move(p.first);
+  // We know *cq() is always valid as it's implemented in this class.
   StartOperation(op, [&](void* tag) { op->Set(*cq(), deadline, tag); });
   return std::move(p.second);
 }

--- a/google/cloud/internal/default_completion_queue_impl.h
+++ b/google/cloud/internal/default_completion_queue_impl.h
@@ -31,7 +31,7 @@ namespace internal {
 /**
  * The default implementation for `CompletionQueue`.
  */
-class DefaultCompletionQueueImpl
+class DefaultCompletionQueueImpl final
     : public CompletionQueueImpl,
       public std::enable_shared_from_this<DefaultCompletionQueueImpl> {
  public:

--- a/google/cloud/internal/default_completion_queue_impl.h
+++ b/google/cloud/internal/default_completion_queue_impl.h
@@ -63,7 +63,7 @@ class DefaultCompletionQueueImpl
                       absl::FunctionRef<void(void*)> start) override;
 
   /// The underlying gRPC completion queue.
-  grpc::CompletionQueue& cq() override;
+  grpc::CompletionQueue* cq() override;
 
   /// Some counters for testing and debugging.
   std::int64_t notify_counter() const { return notify_counter_.load(); }

--- a/google/cloud/testing_util/fake_completion_queue_impl.h
+++ b/google/cloud/testing_util/fake_completion_queue_impl.h
@@ -39,7 +39,7 @@ class FakeCompletionQueueImpl
   void Run() override;
   void Shutdown() override;
   void CancelAll() override;
-  grpc::CompletionQueue& cq() override { return cq_; }
+  grpc::CompletionQueue* cq() override { return &cq_; }
 
   future<StatusOr<std::chrono::system_clock::time_point>> MakeDeadlineTimer(
       std::chrono::system_clock::time_point deadline) override;

--- a/google/cloud/testing_util/mock_completion_queue_impl.h
+++ b/google/cloud/testing_util/mock_completion_queue_impl.h
@@ -43,7 +43,7 @@ class MockCompletionQueueImpl : public internal::CompletionQueueImpl {
                absl::FunctionRef<void(void*)>),
               (override));
 
-  MOCK_METHOD(grpc::CompletionQueue&, cq, (), (override));
+  MOCK_METHOD(grpc::CompletionQueue*, cq, (), (override));
 };
 
 }  // namespace testing_util


### PR DESCRIPTION
This change is in preparation for adding derivations of `CompletionQueueImpl` that do not contain a `grpc::CompletionQueue`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10451)
<!-- Reviewable:end -->
