### PR TITLE
impl(oauth2): create AWS V4 signed request

### DIFF
--- a/google/cloud/internal/external_account_token_source_aws.h
+++ b/google/cloud/internal/external_account_token_source_aws.h
@@ -98,6 +98,20 @@ StatusOr<ExternalAccountTokenSourceAwsSecrets> FetchSecrets(
     std::string const& metadata_token, HttpClientFactory const& cf,
     Options const& opts, internal::ErrorContext const& ec);
 
+/**
+ * Compute the subject token using the fetched region and secrets.
+ *
+ * The subject token will be url-encoded and then passed to Google's STS
+ * (Security Token Service) to exchange for an access token. Embedded in this
+ * JSON object is a signed request to AWS.  Presumably Google's STS uses this
+ * signed request to contact AWS.
+ */
+nlohmann::json ComputeSubjectToken(
+    ExternalAccountTokenSourceAwsInfo const& info, std::string const& region,
+    ExternalAccountTokenSourceAwsSecrets const& secrets,
+    std::chrono::system_clock::time_point now, std::string const& target,
+    bool debug);
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal
 }  // namespace cloud

--- a/google/cloud/internal/external_account_token_source_aws_test.cc
+++ b/google/cloud/internal/external_account_token_source_aws_test.cc
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 #include "google/cloud/internal/external_account_token_source_aws.h"
+#include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/testing_util/mock_http_payload.h"
 #include "google/cloud/testing_util/mock_rest_client.h"
 #include "google/cloud/testing_util/mock_rest_response.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
 #include <algorithm>
 
@@ -45,6 +47,7 @@ using ::testing::Pair;
 using ::testing::Property;
 using ::testing::ResultOf;
 using ::testing::Return;
+using ::testing::StartsWith;
 
 using MockClientFactory =
     ::testing::MockFunction<std::unique_ptr<rest_internal::RestClient>(
@@ -659,6 +662,164 @@ TEST(ExternalAccountTokenSource, FetchSecretsFromUrlV2) {
   EXPECT_EQ(actual->access_key_id, "test-access-key-id");
   EXPECT_EQ(actual->secret_access_key, "test-secret-access-key");
   EXPECT_EQ(actual->session_token, "test-token");
+}
+
+TEST(ExternalAccountTokenSource, ComputeSubjectToken) {
+  // Put the test values inline because it is hard to see how they are affected
+  // otherwise.
+  auto constexpr kTestRegion = "us-central1";
+  auto constexpr kTestKeyId = "TESTKEYID123";
+  auto constexpr kTestSecretAccessKey = "test/secret/access/key";
+  auto constexpr kTestSessionToken = "test-session-token";
+  auto constexpr kRegionalCredUrl =
+      "https://sts.{region}.example.com"
+      "?Action=GetCallerIdentity&Version=2011-06-15&Test=Only";
+  auto const secrets = ExternalAccountTokenSourceAwsSecrets{
+      /*access_key_id=*/kTestKeyId,
+      /*secret_access_key=*/kTestSecretAccessKey,
+      /*session_token=*/kTestSessionToken};
+  auto const info = ExternalAccountTokenSourceAwsInfo{
+      /*environment_id=*/"aws1",
+      /*region_url=*/kTestRegionUrl,
+      /*url=*/kTestMetadataUrl,
+      /*regional_cred_verification_url=*/kRegionalCredUrl,
+      /*imdsv2_session_token_url=*/std::string{}};
+
+  // Use a fixed timestamp to make the expected output more predictable.
+  auto const tp =
+      google::cloud::internal::ParseRfc3339("2022-12-15T01:02:03.123456789Z")
+          .value();
+
+  auto const target = std::string{
+      "//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/"
+      "workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID"};
+
+  auto const actual =
+      ComputeSubjectToken(info, kTestRegion, secrets, tp, target, false);
+  auto const subject =
+      ComputeSubjectToken(info, kTestRegion, secrets, tp, target, true);
+  // Verify that the debug version only adds a few values.
+  auto expected = [](nlohmann::json json) {
+    for (auto const* k :
+         {"body_hash", "canonical_request", "canonical_request_hash",
+          "string_to_sign", "k1", "k2", "k3", "k4", "signature"}) {
+      json.erase(k);
+    }
+    return json;
+  }(subject);
+
+  EXPECT_EQ(expected, actual);
+  EXPECT_EQ(subject.value("url", ""),
+            "https://sts.us-central1.example.com"
+            "?Action=GetCallerIdentity&Version=2011-06-15&Test=Only");
+  EXPECT_THAT(subject.value("method", ""), "POST");
+  EXPECT_TRUE(subject.contains("body"));
+  EXPECT_THAT(subject.value("body", ""), IsEmpty());
+  auto const headers = subject.value("headers", std::vector<nlohmann::json>{});
+  // Most headers are easy to predict.
+  EXPECT_THAT(headers, Contains(nlohmann::json{
+                           {"key", "x-goog-cloud-target-resource"},
+                           {"value", target},
+                       }));
+  EXPECT_THAT(headers, Contains(nlohmann::json{
+                           {"key", "x-amz-date"},
+                           {"value", "20221215T010203Z"},
+                       }));
+  EXPECT_THAT(headers, Contains(nlohmann::json{
+                           {"key", "host"},
+                           {"value", "sts.us-central1.amazonaws.com"},
+                       }));
+  EXPECT_THAT(headers, Contains(nlohmann::json{
+                           {"key", "x-amz-security-token"},
+                           {"value", kTestSessionToken},
+                       }));
+
+  auto const authorization = [&] {
+    for (auto const& j : headers) {
+      if (j.value("key", "") == "authorization") return j.value("value", "");
+    }
+    return std::string{};
+  }();
+  EXPECT_THAT(authorization, StartsWith("AWS-HMAC-SHA256 "));
+  auto fields = std::map<std::string, std::string>{};
+  for (auto text : absl::StrSplit(
+           absl::StripPrefix(authorization, "AWS-HMAC-SHA256 "), ',')) {
+    fields.insert(absl::StrSplit(text, absl::MaxSplits('=', 1)));
+  }
+  EXPECT_THAT(fields, Contains(Pair("Credential", secrets.access_key_id)));
+  EXPECT_THAT(fields, Contains(Pair("SignedHeaders", "host;x-amz-date")));
+  EXPECT_THAT(
+      fields,
+      Contains(Pair(
+          "Signature",
+          "2b7ed7cf9ee442a9d2b4ae1241cd546686736216fdaf435b5b1b39d7d923c8bc")));
+
+  // To obtain the signature we use a fairly complicated pipeline.
+  // clang-format off
+  /**
+      # body_hash
+      EH=$(printf "" | sha256sum | cut -f1 -d ' ')
+      # canonical_request_hash
+      RH=$( (echo "POST" ;
+             echo "/" ;
+             echo "Action=GetCallerIdentity&Version=2011-06-15&Test=Only" ;
+             echo "host:sts.us-central1.amazonaws.com" ;
+             echo "x-amz-date:20221215T010203Z" ;
+             echo "host;x-amz-date" ;
+             printf "${EH}"
+             ) | sha256sum | cut -f1 -d ' ')
+      K1=$(echo -n "20221215T010203Z" | openssl  dgst -sha256 -mac HMAC -macopt key:AWS4test/secret/access/key | cut -f2 -d' ')
+      K2=$(echo -n "us-central1"      | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K1} | cut -f2 -d' ')
+      K3=$(echo -n "sts"              | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K2} | cut -f2 -d' ')
+      K4=$(echo -n "aws4_request"     | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K3} | cut -f2 -d' ')
+      # signature
+      S=$( (echo "AWS4-HMAC-SHA256";
+            echo "20221215T010203Z";
+            echo "20221215/us-central1/sts/aws4_request";
+            printf "${RH}"
+            ) |
+            openssl dgst -sha256 -mac HMAC -macopt hexkey:${K4} | cut -f2 -d' ')
+
+      EH=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      RH=12ab54ea41075d16644647d7698756fbef68de19f0cac33a8b782577e0ca232a
+      K1=2bed839a35135b5a8c16ab11fc1725cd728f08047ae4d27dfa8f72e208211dad
+      K2=9a297c109206024d848266604017d555e468b180e7adf13af3784573ec61cb41
+      K3=6fb195618a3e74d3604c43f1b5d6f2ef1640cb40cd179fce05036f2b560ae99f
+      K4=42119734b74396470dbfe29dd56f529528154131ce5ad052e7633bd6994ef4ec
+      S=2b7ed7cf9ee442a9d2b4ae1241cd546686736216fdaf435b5b1b39d7d923c8bc
+  */
+  // clang-format on
+
+  auto constexpr kStringToSign = R"""(AWS4-HMAC-SHA256
+20221215T010203Z
+20221215/us-central1/sts/aws4_request
+12ab54ea41075d16644647d7698756fbef68de19f0cac33a8b782577e0ca232a)""";
+
+  struct ExpectedDebug {
+    std::string name;
+    std::string value;
+  } const expected_values[] = {
+      {"body_hash",
+       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+      {"canonical_request_hash",
+       "12ab54ea41075d16644647d7698756fbef68de19f0cac33a8b782577e0ca232a"},
+      {"string_to_sign", kStringToSign},
+      {"k1",
+       "2bed839a35135b5a8c16ab11fc1725cd728f08047ae4d27dfa8f72e208211dad"},
+      {"k2",
+       "9a297c109206024d848266604017d555e468b180e7adf13af3784573ec61cb41"},
+      {"k3",
+       "6fb195618a3e74d3604c43f1b5d6f2ef1640cb40cd179fce05036f2b560ae99f"},
+      {"k4",
+       "42119734b74396470dbfe29dd56f529528154131ce5ad052e7633bd6994ef4ec"},
+      {"signature",
+       "2b7ed7cf9ee442a9d2b4ae1241cd546686736216fdaf435b5b1b39d7d923c8bc"},
+
+  };
+
+  for (auto const& e : expected_values) {
+    EXPECT_EQ(subject.value(e.name, ""), e.value) << "name=" << e.name;
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Create the AWS V4 signed request as a JSON object because it is easier to test. In the actual implementation this becomes a string, that is then URL-encoded (yikes!) and passed to Google's Security Token Service.

Part of the work for #5915 

