### PR TITLE
impl(oauth2): content-type header in token exchange

### DIFF
--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -141,7 +141,9 @@ StatusOr<internal::AccessToken> ExternalAccountCredentials::GetToken(
       {"subject_token_type", info_.subject_token_type},
       {"subject_token", subject_token->token},
   };
-  auto request = rest_internal::RestRequest(info_.token_url);
+  auto request =
+      rest_internal::RestRequest(info_.token_url)
+          .AddHeader("content-type", "application/x-www-form-urlencoded");
 
   auto client = client_factory_(options_);
   auto response = client->Post(request, form_data);


### PR DESCRIPTION
Use the right content-type header during the token exchange. At this time, Google's Security Token Service seems to work fine without it. It seems better to use the right header though.

I took the opportunity to clean up the tests.

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10453)
<!-- Reviewable:end -->
