### PR TITLE
impl(oauth2): fix AWS subject token generation

### DIFF
--- a/google/cloud/internal/external_account_token_source_aws_test.cc
+++ b/google/cloud/internal/external_account_token_source_aws_test.cc
@@ -44,6 +44,7 @@ using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::IsSupersetOf;
+using ::testing::Not;
 using ::testing::Pair;
 using ::testing::Property;
 using ::testing::ResultOf;
@@ -132,8 +133,8 @@ TEST(ExternalAccountTokenSource, SourceWorking) {
       // {"imdsv2_session_token_url", kTestImdsv2Url},
   };
   auto const target = std::string{
-      "//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/"
-      "workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID"};
+      "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/"
+      "workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"};
   auto const source = MakeExternalAccountTokenSourceAws(
       credentials_source, target, MakeTestErrorContext());
   ASSERT_STATUS_OK(source);
@@ -143,16 +144,9 @@ TEST(ExternalAccountTokenSource, SourceWorking) {
 
   auto subject_token = (*source)(client_factory.AsStdFunction(), Options{});
   ASSERT_STATUS_OK(subject_token);
-  // Verify some simple cases. We make a full test in ComputeSubjectToken().
-  EXPECT_THAT(subject_token->token, HasSubstr(nlohmann::json{
-                                        {"key", "x-goog-cloud-target-resource"},
-                                        {"value",
-                                         target}}.dump()));
-  EXPECT_THAT(
-      subject_token->token,
-      HasSubstr(nlohmann::json{{"key", "host"},
-                               {"value", "sts.expected-region.amazonaws.com"}}
-                    .dump()));
+  EXPECT_THAT(subject_token->token,
+              HasSubstr("%22key%22%3A%22host%22%2C%22value%22%3A"
+                        "%22sts.expected-region.amazonaws.com%22"));
 }
 
 TEST(ExternalAccountTokenSource, SourceImdsv2Failure) {
@@ -838,6 +832,181 @@ TEST(ExternalAccountTokenSource, ComputeSubjectToken) {
   auto constexpr kTestRegion = "us-central1";
   auto constexpr kTestKeyId = "TESTKEYID123";
   auto constexpr kTestSecretAccessKey = "test/secret/access/key";
+  auto constexpr kTestSessionToken = "";
+  auto constexpr kRegionalCredUrl =
+      "https://sts.{region}.example.com"
+      "?Action=GetCallerIdentity&Version=2011-06-15&Test=Only";
+  auto const secrets = ExternalAccountTokenSourceAwsSecrets{
+      /*access_key_id=*/kTestKeyId,
+      /*secret_access_key=*/kTestSecretAccessKey,
+      /*session_token=*/kTestSessionToken};
+  auto const info = ExternalAccountTokenSourceAwsInfo{
+      /*environment_id=*/"aws1",
+      /*region_url=*/kTestRegionUrl,
+      /*url=*/kTestMetadataUrl,
+      /*regional_cred_verification_url=*/kRegionalCredUrl,
+      /*imdsv2_session_token_url=*/std::string{}};
+
+  // Use a fixed timestamp to make the expected output more predictable.
+  auto const tp =
+      google::cloud::internal::ParseRfc3339("2022-12-15T01:02:03.123456789Z")
+          .value();
+
+  auto const target = std::string{
+      "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/"
+      "workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"};
+
+  auto const actual =
+      ComputeSubjectToken(info, kTestRegion, secrets, tp, target);
+  auto const subject =
+      ComputeSubjectToken(info, kTestRegion, secrets, tp, target, true);
+  // Verify that the debug version only adds a few values.
+  auto expected = [](nlohmann::json json) {
+    for (auto const* k :
+         {"body_hash", "canonical_request", "canonical_request_hash",
+          "string_to_sign", "k1", "k2", "k3", "k4", "signature"}) {
+      json.erase(k);
+    }
+    return json;
+  }(subject);
+
+  EXPECT_EQ(expected, actual);
+  EXPECT_EQ(subject.value("url", ""),
+            "https://sts.us-central1.example.com"
+            "?Action=GetCallerIdentity&Version=2011-06-15&Test=Only");
+  EXPECT_THAT(subject.value("method", ""), "POST");
+  EXPECT_TRUE(subject.contains("body"));
+  EXPECT_THAT(subject.value("body", ""), IsEmpty());
+  auto const headers = subject.value("headers", std::vector<nlohmann::json>{});
+  // Most headers are easy to predict.
+  EXPECT_THAT(headers, Contains(nlohmann::json{
+                           {"key", "x-goog-cloud-target-resource"},
+                           {"value", target},
+                       }));
+  EXPECT_THAT(headers, Contains(nlohmann::json{
+                           {"key", "x-amz-date"},
+                           {"value", "20221215T010203Z"},
+                       }));
+  EXPECT_THAT(headers, Contains(nlohmann::json{
+                           {"key", "host"},
+                           {"value", "sts.us-central1.amazonaws.com"},
+                       }));
+  EXPECT_THAT(headers, Not(Contains(nlohmann::json{
+                           {"key", "x-amz-security-token"},
+                           {"value", kTestSessionToken},
+                       })));
+
+  auto const authorization = [&] {
+    for (auto const& j : headers) {
+      if (j.value("key", "") == "authorization") return j.value("value", "");
+    }
+    return std::string{};
+  }();
+  EXPECT_THAT(authorization, StartsWith("AWS4-HMAC-SHA256 "));
+  auto fields = std::map<std::string, std::string>{};
+  for (auto text : absl::StrSplit(
+           absl::StripPrefix(authorization, "AWS4-HMAC-SHA256 "), ',')) {
+    fields.insert(absl::StrSplit(text, absl::MaxSplits('=', 1)));
+  }
+  EXPECT_THAT(fields,
+              Contains(Pair("Credential",
+                            secrets.access_key_id +
+                                "/20221215/us-central1/sts/aws4_request")));
+  EXPECT_THAT(fields,
+              Contains(Pair("SignedHeaders",
+                            "host;x-amz-date;x-goog-cloud-target-resource")));
+  EXPECT_THAT(
+      fields,
+      Contains(Pair(
+          "Signature",
+          "e3d3681f82032cc2d5772173ca3f63ed1a1b5ae89f5a3c24dae5c29edb62f298")));
+
+  // To obtain the signature we use a fairly complicated pipeline.
+  // clang-format off
+  /**
+      # body_hash
+      EH=$(printf "" | sha256sum | cut -f1 -d ' ')
+      K1=$(echo -n "20221215"     | openssl  dgst -sha256 -mac HMAC -macopt key:AWS4test/secret/access/key | cut -f2 -d' ')
+      K2=$(echo -n "us-central1"  | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K1} | cut -f2 -d' ')
+      K3=$(echo -n "sts"          | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K2} | cut -f2 -d' ')
+      K4=$(echo -n "aws4_request" | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K3} | cut -f2 -d' ')
+      # canonical_request_hash
+      RH=$( (echo "POST" ;
+             echo "/" ;
+             echo "Action=GetCallerIdentity&Version=2011-06-15&Test=Only" ;
+             echo "host:sts.us-central1.amazonaws.com" ;
+             echo "x-amz-date:20221215T010203Z" ;
+             echo "x-goog-cloud-target-resource://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID" ;
+             echo "" ;
+             echo "host;x-amz-date;x-goog-cloud-target-resource" ;
+             printf "${EH}"
+             ) | sha256sum | cut -f1 -d ' ')
+      # signature
+      S=$( (echo "AWS4-HMAC-SHA256";
+            echo "20221215T010203Z";
+            echo "20221215/us-central1/sts/aws4_request";
+            printf "${RH}"
+            ) |
+            openssl dgst -sha256 -mac HMAC -macopt hexkey:${K4} | cut -f2 -d' ')
+
+      EH=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      K1=29e98e306cb1b36b91ac7f41b613d2836ad7c34dcbef0b4ba5c1fedab921f1a2
+      K2=fddbd9a610661ec06144237e777bbca4b2da50b7f214cec6a929e3e9cf20779f
+      K3=b4aa191870313f880efeb84203e140214e7a1eaa8bf199c34d26519007fc3305
+      K4=fe95b5bac5f243cd7c77fb4f2b143377d9cdd42e6ef1a7ef4d68bb2526dbe414
+      RH=27d7c240af4b780c8e9380e7e57bea58802b8488f776fc260510041de294727a
+      S=e3d3681f82032cc2d5772173ca3f63ed1a1b5ae89f5a3c24dae5c29edb62f298
+  */
+  // clang-format on
+
+  auto constexpr kStringToSign = R"""(AWS4-HMAC-SHA256
+20221215T010203Z
+20221215/us-central1/sts/aws4_request
+27d7c240af4b780c8e9380e7e57bea58802b8488f776fc260510041de294727a)""";
+
+  auto constexpr kCanonicalRequest = R"""(POST
+/
+Action=GetCallerIdentity&Version=2011-06-15&Test=Only
+host:sts.us-central1.amazonaws.com
+x-amz-date:20221215T010203Z
+x-goog-cloud-target-resource://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+
+host;x-amz-date;x-goog-cloud-target-resource
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855)""";
+
+  struct ExpectedDebug {
+    std::string name;
+    std::string value;
+  } const expected_values[] = {
+      {"body_hash",
+       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+      {"canonical_request_hash",
+       "27d7c240af4b780c8e9380e7e57bea58802b8488f776fc260510041de294727a"},
+      {"string_to_sign", kStringToSign},
+      {"canonical_request", kCanonicalRequest},
+      {"k1",
+       "29e98e306cb1b36b91ac7f41b613d2836ad7c34dcbef0b4ba5c1fedab921f1a2"},
+      {"k2",
+       "fddbd9a610661ec06144237e777bbca4b2da50b7f214cec6a929e3e9cf20779f"},
+      {"k3",
+       "b4aa191870313f880efeb84203e140214e7a1eaa8bf199c34d26519007fc3305"},
+      {"k4",
+       "fe95b5bac5f243cd7c77fb4f2b143377d9cdd42e6ef1a7ef4d68bb2526dbe414"},
+      {"signature",
+       "e3d3681f82032cc2d5772173ca3f63ed1a1b5ae89f5a3c24dae5c29edb62f298"},
+  };
+
+  for (auto const& e : expected_values) {
+    EXPECT_EQ(subject.value(e.name, ""), e.value) << "name=" << e.name;
+  }
+}
+
+TEST(ExternalAccountTokenSource, ComputeSubjectTokenWithSessionToken) {
+  // Put the test values inline because it is hard to see how they are affected
+  // otherwise.
+  auto constexpr kTestRegion = "us-central1";
+  auto constexpr kTestKeyId = "TESTKEYID123";
+  auto constexpr kTestSecretAccessKey = "test/secret/access/key";
   auto constexpr kTestSessionToken = "test-session-token";
   auto constexpr kRegionalCredUrl =
       "https://sts.{region}.example.com"
@@ -859,8 +1028,8 @@ TEST(ExternalAccountTokenSource, ComputeSubjectToken) {
           .value();
 
   auto const target = std::string{
-      "//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/"
-      "workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID"};
+      "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/"
+      "workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"};
 
   auto const actual =
       ComputeSubjectToken(info, kTestRegion, secrets, tp, target);
@@ -908,38 +1077,46 @@ TEST(ExternalAccountTokenSource, ComputeSubjectToken) {
     }
     return std::string{};
   }();
-  EXPECT_THAT(authorization, StartsWith("AWS-HMAC-SHA256 "));
+  EXPECT_THAT(authorization, StartsWith("AWS4-HMAC-SHA256 "));
   auto fields = std::map<std::string, std::string>{};
   for (auto text : absl::StrSplit(
-           absl::StripPrefix(authorization, "AWS-HMAC-SHA256 "), ',')) {
+           absl::StripPrefix(authorization, "AWS4-HMAC-SHA256 "), ',')) {
     fields.insert(absl::StrSplit(text, absl::MaxSplits('=', 1)));
   }
-  EXPECT_THAT(fields, Contains(Pair("Credential", secrets.access_key_id)));
-  EXPECT_THAT(fields, Contains(Pair("SignedHeaders", "host;x-amz-date")));
+  EXPECT_THAT(fields,
+              Contains(Pair("Credential",
+                            secrets.access_key_id +
+                                "/20221215/us-central1/sts/aws4_request")));
+  EXPECT_THAT(fields, Contains(Pair("SignedHeaders",
+                                    "host;x-amz-date;x-amz-security-token;x-"
+                                    "goog-cloud-target-resource")));
   EXPECT_THAT(
       fields,
       Contains(Pair(
           "Signature",
-          "2b7ed7cf9ee442a9d2b4ae1241cd546686736216fdaf435b5b1b39d7d923c8bc")));
+          "c7e686c23990b72ea77d0163651ab0d087ecdb43d8dde1499387d7c24fdc92eb")));
 
   // To obtain the signature we use a fairly complicated pipeline.
   // clang-format off
   /**
       # body_hash
       EH=$(printf "" | sha256sum | cut -f1 -d ' ')
+      K1=$(echo -n "20221215"     | openssl  dgst -sha256 -mac HMAC -macopt key:AWS4test/secret/access/key | cut -f2 -d' ')
+      K2=$(echo -n "us-central1"  | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K1} | cut -f2 -d' ')
+      K3=$(echo -n "sts"          | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K2} | cut -f2 -d' ')
+      K4=$(echo -n "aws4_request" | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K3} | cut -f2 -d' ')
       # canonical_request_hash
       RH=$( (echo "POST" ;
              echo "/" ;
              echo "Action=GetCallerIdentity&Version=2011-06-15&Test=Only" ;
              echo "host:sts.us-central1.amazonaws.com" ;
              echo "x-amz-date:20221215T010203Z" ;
-             echo "host;x-amz-date" ;
+             echo "x-amz-security-token:test-session-token" ;
+             echo "x-goog-cloud-target-resource://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID" ;
+             echo "" ;
+             echo "host;x-amz-date;x-amz-security-token;x-goog-cloud-target-resource" ;
              printf "${EH}"
              ) | sha256sum | cut -f1 -d ' ')
-      K1=$(echo -n "20221215T010203Z" | openssl  dgst -sha256 -mac HMAC -macopt key:AWS4test/secret/access/key | cut -f2 -d' ')
-      K2=$(echo -n "us-central1"      | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K1} | cut -f2 -d' ')
-      K3=$(echo -n "sts"              | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K2} | cut -f2 -d' ')
-      K4=$(echo -n "aws4_request"     | openssl  dgst -sha256 -mac HMAC -macopt hexkey:${K3} | cut -f2 -d' ')
       # signature
       S=$( (echo "AWS4-HMAC-SHA256";
             echo "20221215T010203Z";
@@ -949,19 +1126,30 @@ TEST(ExternalAccountTokenSource, ComputeSubjectToken) {
             openssl dgst -sha256 -mac HMAC -macopt hexkey:${K4} | cut -f2 -d' ')
 
       EH=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      RH=12ab54ea41075d16644647d7698756fbef68de19f0cac33a8b782577e0ca232a
-      K1=2bed839a35135b5a8c16ab11fc1725cd728f08047ae4d27dfa8f72e208211dad
-      K2=9a297c109206024d848266604017d555e468b180e7adf13af3784573ec61cb41
-      K3=6fb195618a3e74d3604c43f1b5d6f2ef1640cb40cd179fce05036f2b560ae99f
-      K4=42119734b74396470dbfe29dd56f529528154131ce5ad052e7633bd6994ef4ec
-      S=2b7ed7cf9ee442a9d2b4ae1241cd546686736216fdaf435b5b1b39d7d923c8bc
+      K1=29e98e306cb1b36b91ac7f41b613d2836ad7c34dcbef0b4ba5c1fedab921f1a2
+      K2=fddbd9a610661ec06144237e777bbca4b2da50b7f214cec6a929e3e9cf20779f
+      K3=b4aa191870313f880efeb84203e140214e7a1eaa8bf199c34d26519007fc3305
+      K4=fe95b5bac5f243cd7c77fb4f2b143377d9cdd42e6ef1a7ef4d68bb2526dbe414
+      RH=6b0a92261314977c6befef7b6899a60db5b8bce3ea78bb8b455ce53242bf3a9c
+      S=c7e686c23990b72ea77d0163651ab0d087ecdb43d8dde1499387d7c24fdc92eb
   */
   // clang-format on
 
   auto constexpr kStringToSign = R"""(AWS4-HMAC-SHA256
 20221215T010203Z
 20221215/us-central1/sts/aws4_request
-12ab54ea41075d16644647d7698756fbef68de19f0cac33a8b782577e0ca232a)""";
+6b0a92261314977c6befef7b6899a60db5b8bce3ea78bb8b455ce53242bf3a9c)""";
+
+  auto constexpr kCanonicalRequest = R"""(POST
+/
+Action=GetCallerIdentity&Version=2011-06-15&Test=Only
+host:sts.us-central1.amazonaws.com
+x-amz-date:20221215T010203Z
+x-amz-security-token:test-session-token
+x-goog-cloud-target-resource://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+
+host;x-amz-date;x-amz-security-token;x-goog-cloud-target-resource
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855)""";
 
   struct ExpectedDebug {
     std::string name;
@@ -970,19 +1158,19 @@ TEST(ExternalAccountTokenSource, ComputeSubjectToken) {
       {"body_hash",
        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
       {"canonical_request_hash",
-       "12ab54ea41075d16644647d7698756fbef68de19f0cac33a8b782577e0ca232a"},
+       "6b0a92261314977c6befef7b6899a60db5b8bce3ea78bb8b455ce53242bf3a9c"},
       {"string_to_sign", kStringToSign},
+      {"canonical_request", kCanonicalRequest},
       {"k1",
-       "2bed839a35135b5a8c16ab11fc1725cd728f08047ae4d27dfa8f72e208211dad"},
+       "29e98e306cb1b36b91ac7f41b613d2836ad7c34dcbef0b4ba5c1fedab921f1a2"},
       {"k2",
-       "9a297c109206024d848266604017d555e468b180e7adf13af3784573ec61cb41"},
+       "fddbd9a610661ec06144237e777bbca4b2da50b7f214cec6a929e3e9cf20779f"},
       {"k3",
-       "6fb195618a3e74d3604c43f1b5d6f2ef1640cb40cd179fce05036f2b560ae99f"},
+       "b4aa191870313f880efeb84203e140214e7a1eaa8bf199c34d26519007fc3305"},
       {"k4",
-       "42119734b74396470dbfe29dd56f529528154131ce5ad052e7633bd6994ef4ec"},
+       "fe95b5bac5f243cd7c77fb4f2b143377d9cdd42e6ef1a7ef4d68bb2526dbe414"},
       {"signature",
-       "2b7ed7cf9ee442a9d2b4ae1241cd546686736216fdaf435b5b1b39d7d923c8bc"},
-
+       "c7e686c23990b72ea77d0163651ab0d087ecdb43d8dde1499387d7c24fdc92eb"},
   };
 
   for (auto const& e : expected_values) {

--- a/google/cloud/internal/oauth2_external_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials_test.cc
@@ -183,9 +183,8 @@ TEST(ExternalAccount, ParseAwsSuccess) {
       actual->token_source(client_factory.AsStdFunction(), Options{});
   ASSERT_STATUS_OK(subject);
   EXPECT_THAT(subject->token,
-              HasSubstr(nlohmann::json{{"key", "x-goog-cloud-target-resource"},
-                                       {"value", kTestAudience}}
-                            .dump()));
+              HasSubstr("%22key%22%3A%22host%22%2C%22value%22%3A"
+                        "%22sts.expected-region.amazonaws.com%22"));
 }
 
 TEST(ExternalAccount, ParseUrlSuccess) {


### PR DESCRIPTION
This fixes a number of mistakes in the AWS subject token generation. I was able to test these changes manually using a VM in AWS.

The largest changes are:

- If present, the `x-amz-security-token` header must be signed, this required a new test
- It is also a recommended that the `x-goog-cloud-target-resource` header is signed too
- The subject token must be URL-encoded. Effectively this URL-encodes the subject token twice, as it is included in form payload.
- The signature should be based on the `YYYYMMDD` date, not the `YYYYMMDDTHHMMSSZ` timestamp
- I was missing a separator line for the canonical request
- s/AWS/AWS4/

Part of the work for #5915

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10464)
<!-- Reviewable:end -->
