### PR TITLE
impl(generator): backwards compat using declarations are deprecated

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -27,6 +27,7 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1::GoldenKitchenSinkClient directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkClient;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -27,10 +27,19 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1::MakeGoldenKitchenSinkConnection directly.
 using ::google::cloud::golden_v1::MakeGoldenKitchenSinkConnection;
+
+/// @deprecated Use golden_v1::GoldenKitchenSinkConnection directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkConnection;
+
+/// @deprecated Use golden_v1::GoldenKitchenSinkLimitedErrorCountRetryPolicy directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkLimitedErrorCountRetryPolicy;
+
+/// @deprecated Use golden_v1::GoldenKitchenSinkLimitedTimeRetryPolicy directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkLimitedTimeRetryPolicy;
+
+/// @deprecated Use golden_v1::GoldenKitchenSinkRetryPolicy directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkRetryPolicy;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
@@ -26,7 +26,10 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1::MakeDefaultGoldenKitchenSinkConnectionIdempotencyPolicy directly.
 using ::google::cloud::golden_v1::MakeDefaultGoldenKitchenSinkConnectionIdempotencyPolicy;
+
+/// @deprecated Use golden_v1::GoldenKitchenSinkConnectionIdempotencyPolicy directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkConnectionIdempotencyPolicy;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_kitchen_sink_options.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_options.h
@@ -28,9 +28,16 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1::GoldenKitchenSinkBackoffPolicyOption directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkBackoffPolicyOption;
+
+/// @deprecated Use golden_v1::GoldenKitchenSinkConnectionIdempotencyPolicyOption directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkConnectionIdempotencyPolicyOption;
+
+/// @deprecated Use golden_v1::GoldenKitchenSinkPolicyOptionList directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkPolicyOptionList;
+
+/// @deprecated Use golden_v1::GoldenKitchenSinkRetryPolicyOption directly.
 using ::google::cloud::golden_v1::GoldenKitchenSinkRetryPolicyOption;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -27,6 +27,7 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1::GoldenThingAdminClient directly.
 using ::google::cloud::golden_v1::GoldenThingAdminClient;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -27,10 +27,19 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1::MakeGoldenThingAdminConnection directly.
 using ::google::cloud::golden_v1::MakeGoldenThingAdminConnection;
+
+/// @deprecated Use golden_v1::GoldenThingAdminConnection directly.
 using ::google::cloud::golden_v1::GoldenThingAdminConnection;
+
+/// @deprecated Use golden_v1::GoldenThingAdminLimitedErrorCountRetryPolicy directly.
 using ::google::cloud::golden_v1::GoldenThingAdminLimitedErrorCountRetryPolicy;
+
+/// @deprecated Use golden_v1::GoldenThingAdminLimitedTimeRetryPolicy directly.
 using ::google::cloud::golden_v1::GoldenThingAdminLimitedTimeRetryPolicy;
+
+/// @deprecated Use golden_v1::GoldenThingAdminRetryPolicy directly.
 using ::google::cloud::golden_v1::GoldenThingAdminRetryPolicy;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
@@ -26,7 +26,10 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1::MakeDefaultGoldenThingAdminConnectionIdempotencyPolicy directly.
 using ::google::cloud::golden_v1::MakeDefaultGoldenThingAdminConnectionIdempotencyPolicy;
+
+/// @deprecated Use golden_v1::GoldenThingAdminConnectionIdempotencyPolicy directly.
 using ::google::cloud::golden_v1::GoldenThingAdminConnectionIdempotencyPolicy;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_thing_admin_options.h
+++ b/generator/integration_tests/golden/golden_thing_admin_options.h
@@ -28,10 +28,19 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1::GoldenThingAdminPollingPolicyOption directly.
 using ::google::cloud::golden_v1::GoldenThingAdminPollingPolicyOption;
+
+/// @deprecated Use golden_v1::GoldenThingAdminBackoffPolicyOption directly.
 using ::google::cloud::golden_v1::GoldenThingAdminBackoffPolicyOption;
+
+/// @deprecated Use golden_v1::GoldenThingAdminConnectionIdempotencyPolicyOption directly.
 using ::google::cloud::golden_v1::GoldenThingAdminConnectionIdempotencyPolicyOption;
+
+/// @deprecated Use golden_v1::GoldenThingAdminPolicyOptionList directly.
 using ::google::cloud::golden_v1::GoldenThingAdminPolicyOptionList;
+
+/// @deprecated Use golden_v1::GoldenThingAdminRetryPolicyOption directly.
 using ::google::cloud::golden_v1::GoldenThingAdminRetryPolicyOption;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -27,6 +27,7 @@ namespace cloud {
 namespace golden_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1_mocks::MockGoldenKitchenSinkConnection directly.
 using ::google::cloud::golden_v1_mocks::MockGoldenKitchenSinkConnection;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
@@ -27,6 +27,7 @@ namespace cloud {
 namespace golden_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// @deprecated Use golden_v1_mocks::MockGoldenThingAdminConnection directly.
 using ::google::cloud::golden_v1_mocks::MockGoldenThingAdminConnection;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/internal/forwarding_client_generator.cc
+++ b/generator/internal/forwarding_client_generator.cc
@@ -51,6 +51,7 @@ Status ForwardingClientGenerator::GenerateHeader() {
   // forwards
   HeaderPrint(
       R"""(
+/// @deprecated Use $product_namespace$::$client_class_name$ directly.
 using ::google::cloud::$product_namespace$::$client_class_name$;
 )""");
 

--- a/generator/internal/forwarding_connection_generator.cc
+++ b/generator/internal/forwarding_connection_generator.cc
@@ -50,10 +50,19 @@ Status ForwardingConnectionGenerator::GenerateHeader() {
 
   HeaderPrint(
       R"""(
+/// @deprecated Use $product_namespace$::Make$connection_class_name$ directly.
 using ::google::cloud::$product_namespace$::Make$connection_class_name$;
+
+/// @deprecated Use $product_namespace$::$connection_class_name$ directly.
 using ::google::cloud::$product_namespace$::$connection_class_name$;
+
+/// @deprecated Use $product_namespace$::$limited_error_count_retry_policy_name$ directly.
 using ::google::cloud::$product_namespace$::$limited_error_count_retry_policy_name$;
+
+/// @deprecated Use $product_namespace$::$limited_time_retry_policy_name$ directly.
 using ::google::cloud::$product_namespace$::$limited_time_retry_policy_name$;
+
+/// @deprecated Use $product_namespace$::$retry_policy_name$ directly.
 using ::google::cloud::$product_namespace$::$retry_policy_name$;
 )""");
 

--- a/generator/internal/forwarding_idempotency_policy_generator.cc
+++ b/generator/internal/forwarding_idempotency_policy_generator.cc
@@ -50,7 +50,10 @@ Status ForwardingIdempotencyPolicyGenerator::GenerateHeader() {
   // forwards
   HeaderPrint(
       R"""(
+/// @deprecated Use $product_namespace$::MakeDefault$idempotency_class_name$ directly.
 using ::google::cloud::$product_namespace$::MakeDefault$idempotency_class_name$;
+
+/// @deprecated Use $product_namespace$::$idempotency_class_name$ directly.
 using ::google::cloud::$product_namespace$::$idempotency_class_name$;
 )""");
 

--- a/generator/internal/forwarding_mock_connection_generator.cc
+++ b/generator/internal/forwarding_mock_connection_generator.cc
@@ -50,6 +50,7 @@ Status ForwardingMockConnectionGenerator::GenerateHeader() {
 
   HeaderPrint(
       R"""(
+/// @deprecated Use $product_namespace$_mocks::$mock_connection_class_name$ directly.
 using ::google::cloud::$product_namespace$_mocks::$mock_connection_class_name$;
 )""");
 

--- a/generator/internal/forwarding_options_generator.cc
+++ b/generator/internal/forwarding_options_generator.cc
@@ -52,12 +52,21 @@ Status ForwardingOptionsGenerator::GenerateHeader() {
   // forwards
   if (HasLongrunningMethod()) {
     HeaderPrint(R"""(
-using ::google::cloud::$product_namespace$::$service_name$PollingPolicyOption;)""");
+/// @deprecated Use $product_namespace$::$service_name$PollingPolicyOption directly.
+using ::google::cloud::$product_namespace$::$service_name$PollingPolicyOption;
+)""");
   }
   HeaderPrint(R"""(
+/// @deprecated Use $product_namespace$::$service_name$BackoffPolicyOption directly.
 using ::google::cloud::$product_namespace$::$service_name$BackoffPolicyOption;
+
+/// @deprecated Use $product_namespace$::$service_name$ConnectionIdempotencyPolicyOption directly.
 using ::google::cloud::$product_namespace$::$service_name$ConnectionIdempotencyPolicyOption;
+
+/// @deprecated Use $product_namespace$::$service_name$PolicyOptionList directly.
 using ::google::cloud::$product_namespace$::$service_name$PolicyOptionList;
+
+/// @deprecated Use $product_namespace$::$service_name$RetryPolicyOption directly.
 using ::google::cloud::$product_namespace$::$service_name$RetryPolicyOption;
 )""");
 


### PR DESCRIPTION
Part of the work for #10170 

In response to: https://github.com/googleapis/google-cloud-cpp/pull/10463#discussion_r1052997265

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10466)
<!-- Reviewable:end -->
