### PR TITLE
impl: benchmark client call round trip

### DIFF
--- a/generator/integration_tests/BUILD.bazel
+++ b/generator/integration_tests/BUILD.bazel
@@ -145,3 +145,16 @@ filegroup(
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
 ) for sample in glob(["golden/v1/samples/*.cc"])]
+
+[cc_test(
+    name = benchmark.replace("/", "_").replace(".cc", ""),
+    srcs = [benchmark],
+    copts = [
+        "-I$(BINDIR)",
+    ],
+    tags = ["benchmark"],
+    deps = [
+        ":google_cloud_cpp_generator_golden",
+        "@com_google_benchmark//:benchmark_main",
+    ],
+) for benchmark in glob(["benchmarks/*.cc"])]

--- a/generator/integration_tests/CMakeLists.txt
+++ b/generator/integration_tests/CMakeLists.txt
@@ -179,3 +179,15 @@ foreach (fname IN LISTS samples_cc)
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties("${target}" PROPERTIES LABELS "integration-test")
 endforeach ()
+
+file(
+    GLOB benchmarks_cc
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "benchmarks/*.cc")
+foreach (fname IN LISTS benchmarks_cc)
+    google_cloud_cpp_add_executable(target "generator" "${fname}")
+    add_test(NAME ${target} COMMAND ${target})
+    target_link_libraries(${target} PRIVATE google_cloud_cpp_generator_golden
+                                            benchmark::benchmark_main)
+    google_cloud_cpp_add_common_options(${target})
+endforeach ()

--- a/generator/integration_tests/CMakeLists.txt
+++ b/generator/integration_tests/CMakeLists.txt
@@ -180,6 +180,7 @@ foreach (fname IN LISTS samples_cc)
     set_tests_properties("${target}" PROPERTIES LABELS "integration-test")
 endforeach ()
 
+include(FindBenchmarkWithWorkarounds)
 file(
     GLOB benchmarks_cc
     RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/make_status.h"
+#include "google/cloud/log.h"
 #include "google/cloud/version.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_client.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
@@ -42,10 +43,10 @@ namespace {
 // ----------------------------------------------------------------------------
 // Benchmark                                  Time             CPU   Iterations
 // ----------------------------------------------------------------------------
-// BM_ClientRoundTripStubOnly              2330 ns         2329 ns       293640
-// BM_ClientRoundTripMetadata              2693 ns         2693 ns       253897
-// BM_ClientRoundTripLogging               5551 ns         5551 ns       126334
-// BM_ClientRoundTripTenExtraOptions       5352 ns         5351 ns       131036
+// BM_ClientRoundTripStubOnly              2384 ns         2384 ns       291682
+// BM_ClientRoundTripMetadata              2808 ns         2808 ns       248738
+// BM_ClientRoundTripLogging               2420 ns         2419 ns       288583
+// BM_ClientRoundTripTenExtraOptions       5070 ns         5069 ns       138898
 
 using ::google::cloud::golden_v1_internal::GoldenKitchenSinkConnectionImpl;
 using ::google::cloud::golden_v1_internal::GoldenKitchenSinkDefaultOptions;
@@ -192,7 +193,13 @@ void BM_ClientRoundTripMetadata(benchmark::State& state) {
 }
 BENCHMARK(BM_ClientRoundTripMetadata);
 
+/**
+ * Measure the cost of logging, when the logging decorator is present, but the
+ * log severity is set above that which the logging decorator uses.
+ */
 void BM_ClientRoundTripLogging(benchmark::State& state) {
+  google::cloud::LogSink::Instance().set_minimum_severity(
+      google::cloud::Severity::GCP_LS_WARNING);
   auto options = Options{};
   std::shared_ptr<GoldenKitchenSinkStub> stub = std::make_shared<TestStub>();
   stub = std::make_shared<GoldenKitchenSinkLogging>(

--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -163,7 +163,7 @@ std::shared_ptr<GoldenKitchenSinkConnection> MakeTestConnection(
 void BM_ClientRoundTripStubOnly(benchmark::State& state) {
   auto options = Options{};
   auto stub = std::make_shared<TestStub>();
-  auto conn = MakeTestConnection(stub, std::move(options));
+  auto conn = MakeTestConnection(std::move(stub), std::move(options));
   auto client = GoldenKitchenSinkClient(std::move(conn));
 
   for (auto _ : state) {
@@ -177,7 +177,7 @@ void BM_ClientRoundTripMetadata(benchmark::State& state) {
   auto options = Options{};
   std::shared_ptr<GoldenKitchenSinkStub> stub = std::make_shared<TestStub>();
   stub = std::make_shared<GoldenKitchenSinkMetadata>(std::move(stub));
-  auto conn = MakeTestConnection(stub, std::move(options));
+  auto conn = MakeTestConnection(std::move(stub), std::move(options));
   auto client = GoldenKitchenSinkClient(std::move(conn));
 
   for (auto _ : state) {
@@ -227,7 +227,7 @@ void BM_ClientRoundTripTenExtraOptions(benchmark::State& state) {
                      .set<ExtraOption8>(8)
                      .set<ExtraOption9>(9);
   auto stub = std::make_shared<TestStub>();
-  auto conn = MakeTestConnection(stub, std::move(options));
+  auto conn = MakeTestConnection(std::move(stub), std::move(options));
   auto client = GoldenKitchenSinkClient(std::move(conn));
 
   for (auto _ : state) {
@@ -236,8 +236,6 @@ void BM_ClientRoundTripTenExtraOptions(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_ClientRoundTripTenExtraOptions);
-
-BENCHMARK_MAIN();
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -1,0 +1,246 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/common_options.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/version.h"
+#include "generator/integration_tests/golden/v1/golden_kitchen_sink_client.h"
+#include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
+#include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h"
+#include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h"
+#include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h"
+#include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h"
+#include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
+#include <benchmark/benchmark.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace golden_v1 {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+// Run on (96 X 2000 MHz CPU s)
+// CPU Caches:
+//   L1 Data 32 KiB (x48)
+//   L1 Instruction 32 KiB (x48)
+//   L2 Unified 1024 KiB (x48)
+//   L3 Unified 39424 KiB (x2)
+// Load Average: 0.38, 0.38, 0.73
+// ----------------------------------------------------------------------------
+// Benchmark                                  Time             CPU   Iterations
+// ----------------------------------------------------------------------------
+// BM_ClientRoundTripStubOnly              2330 ns         2329 ns       293640
+// BM_ClientRoundTripMetadata              2693 ns         2693 ns       253897
+// BM_ClientRoundTripLogging               5551 ns         5551 ns       126334
+// BM_ClientRoundTripTenExtraOptions       5352 ns         5351 ns       131036
+
+using ::google::cloud::golden_v1_internal::GoldenKitchenSinkConnectionImpl;
+using ::google::cloud::golden_v1_internal::GoldenKitchenSinkDefaultOptions;
+using ::google::cloud::golden_v1_internal::GoldenKitchenSinkLogging;
+using ::google::cloud::golden_v1_internal::GoldenKitchenSinkMetadata;
+using ::google::cloud::golden_v1_internal::GoldenKitchenSinkStub;
+
+class TestStub : public GoldenKitchenSinkStub {
+ public:
+  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
+  GenerateAccessToken(
+      grpc::ClientContext&,
+      google::test::admin::database::v1::GenerateAccessTokenRequest const&)
+      override {
+    return internal::UnimplementedError("unimplemented");
+  }
+
+  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
+  GenerateIdToken(
+      grpc::ClientContext&,
+      google::test::admin::database::v1::GenerateIdTokenRequest const&)
+      override {
+    return internal::UnimplementedError("unimplemented");
+  }
+
+  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
+  WriteLogEntries(
+      grpc::ClientContext&,
+      google::test::admin::database::v1::WriteLogEntriesRequest const&)
+      override {
+    return internal::UnimplementedError("unimplemented");
+  }
+
+  StatusOr<google::test::admin::database::v1::ListLogsResponse> ListLogs(
+      grpc::ClientContext&,
+      google::test::admin::database::v1::ListLogsRequest const&) override {
+    return internal::UnimplementedError("unimplemented");
+  }
+
+  StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
+  ListServiceAccountKeys(
+      grpc::ClientContext&,
+      google::test::admin::database::v1::ListServiceAccountKeysRequest const&)
+      override {
+    return internal::UnimplementedError("unimplemented");
+  }
+
+  Status DoNothing(grpc::ClientContext&,
+                   google::protobuf::Empty const&) override {
+    return Status();
+  }
+
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+      google::test::admin::database::v1::Response>>
+  StreamingRead(std::unique_ptr<grpc::ClientContext>,
+                google::test::admin::database::v1::Request const&) override {
+    return nullptr;
+  }
+
+  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(std::unique_ptr<grpc::ClientContext>) override {
+    return nullptr;
+  }
+
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingReadWrite(google::cloud::CompletionQueue const&,
+                          std::unique_ptr<grpc::ClientContext>) override {
+    return nullptr;
+  }
+
+  Status ExplicitRouting1(
+      grpc::ClientContext&,
+      google::test::admin::database::v1::ExplicitRoutingRequest const&)
+      override {
+    return Status();
+  }
+
+  Status ExplicitRouting2(
+      grpc::ClientContext&,
+      google::test::admin::database::v1::ExplicitRoutingRequest const&)
+      override {
+    return Status();
+  }
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingRead(
+      google::cloud::CompletionQueue const&,
+      std::unique_ptr<grpc::ClientContext>,
+      google::test::admin::database::v1::Request const&) override {
+    return nullptr;
+  }
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
+      google::test::admin::database::v1::Request,
+      google::test::admin::database::v1::Response>>
+  AsyncStreamingWrite(google::cloud::CompletionQueue const&,
+                      std::unique_ptr<grpc::ClientContext>) override {
+    return nullptr;
+  }
+};
+
+std::shared_ptr<GoldenKitchenSinkConnection> MakeTestConnection(
+    std::shared_ptr<GoldenKitchenSinkStub> stub, Options options) {
+  options = GoldenKitchenSinkDefaultOptions(std::move(options));
+  auto background = internal::MakeBackgroundThreadsFactory(options)();
+  return std::make_shared<GoldenKitchenSinkConnectionImpl>(
+      std::move(background), std::move(stub), std::move(options));
+}
+
+void BM_ClientRoundTripStubOnly(benchmark::State& state) {
+  auto options = Options{};
+  auto stub = std::make_shared<TestStub>();
+  auto conn = MakeTestConnection(stub, std::move(options));
+  auto client = GoldenKitchenSinkClient(std::move(conn));
+
+  for (auto _ : state) {
+    auto status = client.DoNothing();
+    benchmark::DoNotOptimize(status);
+  }
+}
+BENCHMARK(BM_ClientRoundTripStubOnly);
+
+void BM_ClientRoundTripMetadata(benchmark::State& state) {
+  auto options = Options{};
+  std::shared_ptr<GoldenKitchenSinkStub> stub = std::make_shared<TestStub>();
+  stub = std::make_shared<GoldenKitchenSinkMetadata>(std::move(stub));
+  auto conn = MakeTestConnection(stub, std::move(options));
+  auto client = GoldenKitchenSinkClient(std::move(conn));
+
+  for (auto _ : state) {
+    auto status = client.DoNothing();
+    benchmark::DoNotOptimize(status);
+  }
+}
+BENCHMARK(BM_ClientRoundTripMetadata);
+
+void BM_ClientRoundTripLogging(benchmark::State& state) {
+  auto options = Options{};
+  std::shared_ptr<GoldenKitchenSinkStub> stub = std::make_shared<TestStub>();
+  stub = std::make_shared<GoldenKitchenSinkLogging>(
+      std::move(stub), TracingOptions{}, std::set<std::string>{"rpc"});
+  auto conn = MakeTestConnection(std::move(stub), std::move(options));
+  auto client = GoldenKitchenSinkClient(std::move(conn));
+
+  for (auto _ : state) {
+    auto status = client.DoNothing();
+    benchmark::DoNotOptimize(status);
+  }
+}
+BENCHMARK(BM_ClientRoundTripLogging);
+
+void BM_ClientRoundTripTenExtraOptions(benchmark::State& state) {
+  // clang-format off
+  struct ExtraOption0 { using Type = int; };
+  struct ExtraOption1 { using Type = int; };
+  struct ExtraOption2 { using Type = int; };
+  struct ExtraOption3 { using Type = int; };
+  struct ExtraOption4 { using Type = int; };
+  struct ExtraOption5 { using Type = int; };
+  struct ExtraOption6 { using Type = int; };
+  struct ExtraOption7 { using Type = int; };
+  struct ExtraOption8 { using Type = int; };
+  struct ExtraOption9 { using Type = int; };
+  // clang-format on
+  auto options = Options{}
+                     .set<ExtraOption0>(0)
+                     .set<ExtraOption1>(1)
+                     .set<ExtraOption2>(2)
+                     .set<ExtraOption3>(3)
+                     .set<ExtraOption4>(4)
+                     .set<ExtraOption5>(5)
+                     .set<ExtraOption6>(6)
+                     .set<ExtraOption7>(7)
+                     .set<ExtraOption8>(8)
+                     .set<ExtraOption9>(9);
+  auto stub = std::make_shared<TestStub>();
+  auto conn = MakeTestConnection(stub, std::move(options));
+  auto client = GoldenKitchenSinkClient(std::move(conn));
+
+  for (auto _ : state) {
+    auto status = client.DoNothing();
+    benchmark::DoNotOptimize(status);
+  }
+}
+BENCHMARK(BM_ClientRoundTripTenExtraOptions);
+
+BENCHMARK_MAIN();
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace golden_v1
+}  // namespace cloud
+}  // namespace google

--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -160,6 +160,11 @@ std::shared_ptr<GoldenKitchenSinkConnection> MakeTestConnection(
       std::move(background), std::move(stub), std::move(options));
 }
 
+template <int N>
+struct ExtraOption {
+  using Type = int;
+};
+
 void BM_ClientRoundTripStubOnly(benchmark::State& state) {
   auto options = Options{};
   auto stub = std::make_shared<TestStub>();
@@ -203,29 +208,17 @@ void BM_ClientRoundTripLogging(benchmark::State& state) {
 BENCHMARK(BM_ClientRoundTripLogging);
 
 void BM_ClientRoundTripTenExtraOptions(benchmark::State& state) {
-  // clang-format off
-  struct ExtraOption0 { using Type = int; };
-  struct ExtraOption1 { using Type = int; };
-  struct ExtraOption2 { using Type = int; };
-  struct ExtraOption3 { using Type = int; };
-  struct ExtraOption4 { using Type = int; };
-  struct ExtraOption5 { using Type = int; };
-  struct ExtraOption6 { using Type = int; };
-  struct ExtraOption7 { using Type = int; };
-  struct ExtraOption8 { using Type = int; };
-  struct ExtraOption9 { using Type = int; };
-  // clang-format on
   auto options = Options{}
-                     .set<ExtraOption0>(0)
-                     .set<ExtraOption1>(1)
-                     .set<ExtraOption2>(2)
-                     .set<ExtraOption3>(3)
-                     .set<ExtraOption4>(4)
-                     .set<ExtraOption5>(5)
-                     .set<ExtraOption6>(6)
-                     .set<ExtraOption7>(7)
-                     .set<ExtraOption8>(8)
-                     .set<ExtraOption9>(9);
+                     .set<ExtraOption<0>>(0)
+                     .set<ExtraOption<1>>(1)
+                     .set<ExtraOption<2>>(2)
+                     .set<ExtraOption<3>>(3)
+                     .set<ExtraOption<4>>(4)
+                     .set<ExtraOption<5>>(5)
+                     .set<ExtraOption<6>>(6)
+                     .set<ExtraOption<7>>(7)
+                     .set<ExtraOption<8>>(8)
+                     .set<ExtraOption<9>>(9);
   auto stub = std::make_shared<TestStub>();
   auto conn = MakeTestConnection(std::move(stub), std::move(options));
   auto client = GoldenKitchenSinkClient(std::move(conn));


### PR DESCRIPTION
Motivated by #10407 and other observability efforts.

Add a benchmark to measure the round trip time of a client call (where the server responds instantaneously).

If the cost incurred by logging is < X, we can justify always logging. Especially when compared with the time it takes to serialize/deserialize a message and send it over the wire.

What is X? Probably greater than 1 microsecond.

Also, for the record, the results look different on my laptop. The ratios are very similar though.
```
Run on (8 X 4900 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.61, 3.36, 5.01
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_ClientRoundTripStubOnly              1569 ns         1569 ns       372348
BM_ClientRoundTripMetadata              1720 ns         1720 ns       397493
BM_ClientRoundTripLogging               3313 ns         3313 ns       207672
BM_ClientRoundTripTenExtraOptions       3226 ns         3226 ns       215489
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10467)
<!-- Reviewable:end -->
