### PR TITLE
cleanup(grafeas): fix path to find proto{deps,list}

### DIFF
--- a/google/cloud/grafeas/CMakeLists.txt
+++ b/google/cloud/grafeas/CMakeLists.txt
@@ -38,10 +38,10 @@ endif ()
 include(CompileProtos)
 google_cloud_cpp_load_protolist(
     grafeas_list
-    "${CMAKE_SOURCE_DIR}/external/googleapis/protolists/grafeas.list")
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/grafeas.list")
 google_cloud_cpp_load_protodeps(
     grafeas_deps
-    "${CMAKE_SOURCE_DIR}/external/googleapis/protodeps/grafeas.deps")
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/grafeas.deps")
 google_cloud_cpp_grpcpp_library(
     google_cloud_cpp_grafeas_protos ${grafeas_list} PROTO_PATH_DIRECTORIES
     "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")


### PR DESCRIPTION
We should use ${PROJECT_SOURCE_DIR}, as we do in all the other libraries, because that works even if `google-cloud-cpp` is used via `add_subdirectory()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10469)
<!-- Reviewable:end -->
