### PR TITLE
cleanup(storage): stop using XML for uploads and downloads

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -266,11 +266,6 @@ DownloadDetail DownloadOneObject(
 
   std::vector<char> buffer(options.read_buffer_size);
   auto const buffer_size = static_cast<std::streamsize>(buffer.size());
-  // Using IfGenerationNotMatch(0) triggers JSON, as this feature is not
-  // supported by XML.  Using IfGenerationNotMatch() -- without a value -- has
-  // no effect.
-  auto xml_hack = options.api == "JSON" ? gcs::IfGenerationNotMatch(0)
-                                        : gcs::IfGenerationNotMatch();
   auto const object_start = clock::now();
   auto const start = std::chrono::system_clock::now();
   auto object_bytes = std::uint64_t{0};
@@ -281,9 +276,8 @@ DownloadDetail DownloadOneObject(
         0, object_size - options.read_size);
     range = gcs::ReadRange(read_start(generator), options.read_size);
   }
-  auto stream =
-      client.ReadObject(object.bucket(), object.name(),
-                        gcs::Generation(object.generation()), range, xml_hack);
+  auto stream = client.ReadObject(object.bucket(), object.name(),
+                                  gcs::Generation(object.generation()), range);
   while (stream.read(buffer.data(), buffer_size)) {
     object_bytes += stream.gcount();
   }

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
@@ -106,7 +106,7 @@ ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
        [&options](std::string const& val) {
          options.read_buffer_size = ParseBufferSize(val);
        }},
-      {"--api", "select the API (JSON, XML, or GRPC) for the benchmark",
+      {"--api", "select the API (JSON, or GRPC) for the benchmark",
        [&options](std::string const& val) { options.api = val; }},
       {"--client-per-thread",
        "use a different storage::Client object in each thread",

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options_test.cc
@@ -38,7 +38,7 @@ TEST(AggregateDownloadThroughputOptions, Basic) {
           "--repeats-per-iteration=2",
           "--read-size=4MiB",
           "--read-buffer-size=1MiB",
-          "--api=XML",
+          "--api=JSON",
           "--client-per-thread",
           "--grpc-channel-count=16",
           "--rest-http-version=1.1",
@@ -60,7 +60,7 @@ TEST(AggregateDownloadThroughputOptions, Basic) {
   EXPECT_EQ(2, options->repeats_per_iteration);
   EXPECT_EQ(4 * kMiB, options->read_size);
   EXPECT_EQ(1 * kMiB, options->read_buffer_size);
-  EXPECT_EQ("XML", options->api);
+  EXPECT_EQ("JSON", options->api);
   EXPECT_EQ(true, options->client_per_thread);
   EXPECT_EQ(16, options->client_options.get<GrpcNumChannelsOption>());
   EXPECT_EQ("1.1", options->client_options.get<gcs_ex::HttpVersionOption>());

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
@@ -312,16 +312,10 @@ UploadDetail UploadOneObject(gcs::Client& client,
   using std::chrono::microseconds;
 
   auto const buffer_size = static_cast<std::streamsize>(write_block.size());
-  // The JSON API returns the object metadata after an insert, while the XML API
-  // does not. If the application explicitly requests "filter out all the
-  // fields" from the response, then both APIs are equivalent and the library
-  // prefers XML in that case. Using gcs::Fields() has no effect.
-  auto xml_hack = options.api == "XML" ? gcs::Fields("") : gcs::Fields();
   auto const object_start = clock::now();
   auto const start = std::chrono::system_clock::now();
 
-  auto stream =
-      client.WriteObject(options.bucket_name, upload.object_name, xml_hack);
+  auto stream = client.WriteObject(options.bucket_name, upload.object_name);
   auto object_bytes = std::uint64_t{0};
   while (object_bytes < upload.object_size) {
     auto n = std::min(static_cast<std::uint64_t>(buffer_size),

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
@@ -118,7 +118,7 @@ ParseAggregateUploadThroughputOptions(std::vector<std::string> const& argv,
        [&options](std::string const& val) {
          options.iteration_count = std::stoi(val);
        }},
-      {"--api", "select the API (JSON, XML, or GRPC) for the benchmark",
+      {"--api", "select the API (JSON, or GRPC) for the benchmark",
        [&options](std::string const& val) { options.api = val; }},
       {"--client-per-thread",
        "use a different storage::Client object in each thread",

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_options_test.cc
@@ -40,7 +40,7 @@ TEST(AggregateUploadThroughputOptions, Basic) {
           "--resumable-upload-chunk-size=4MiB",
           "--thread-count=42",
           "--iteration-count=10",
-          "--api=XML",
+          "--api=JSON",
           "--client-per-thread",
           "--grpc-channel-count=16",
           "--rest-http-version=1.1",
@@ -62,7 +62,7 @@ TEST(AggregateUploadThroughputOptions, Basic) {
   EXPECT_EQ(32 * kMiB, options->maximum_object_size);
   EXPECT_EQ(42, options->thread_count);
   EXPECT_EQ(10, options->iteration_count);
-  EXPECT_EQ("XML", options->api);
+  EXPECT_EQ("JSON", options->api);
   EXPECT_EQ(true, options->client_per_thread);
   EXPECT_EQ(16, options->client_options.get<GrpcNumChannelsOption>());
   EXPECT_EQ("1.1", options->client_options.get<gcs_ex::HttpVersionOption>());

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -91,8 +91,6 @@ char const* ToString(ApiName api) {
   switch (api) {
     case ApiName::kApiJson:
       return "JSON";
-    case ApiName::kApiXml:
-      return "XML";
     case ApiName::kApiGrpc:
       return "GRPC";
   }
@@ -100,7 +98,7 @@ char const* ToString(ApiName api) {
 }
 
 StatusOr<ApiName> ParseApiName(std::string const& val) {
-  for (auto a : {ApiName::kApiJson, ApiName::kApiXml, ApiName::kApiGrpc}) {
+  for (auto a : {ApiName::kApiJson, ApiName::kApiGrpc}) {
     if (val == ToString(a)) return a;
   }
   return Status{StatusCode::kInvalidArgument, "unknown ApiName " + val};
@@ -116,8 +114,7 @@ StatusOr<ExperimentLibrary> ParseExperimentLibrary(std::string const& val) {
 
 StatusOr<ExperimentTransport> ParseExperimentTransport(std::string const& val) {
   for (auto v : {ExperimentTransport::kDirectPath, ExperimentTransport::kGrpc,
-                 ExperimentTransport::kJson, ExperimentTransport::kXml,
-                 ExperimentTransport::kJsonV2, ExperimentTransport::kXmlV2}) {
+                 ExperimentTransport::kJson, ExperimentTransport::kJsonV2}) {
     if (val == ToString(v)) return v;
   }
   return Status{StatusCode::kInvalidArgument,
@@ -142,12 +139,8 @@ std::string ToString(ExperimentTransport v) {
       return "Grpc";
     case ExperimentTransport::kJson:
       return "Json";
-    case ExperimentTransport::kXml:
-      return "Xml";
     case ExperimentTransport::kJsonV2:
       return "JsonV2";
-    case ExperimentTransport::kXmlV2:
-      return "XmlV2";
   }
   return "";
 }

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -59,7 +59,6 @@ void DeleteAllObjects(google::cloud::storage::Client client,
 // protocol, but it is easier to represent it as such in the benchmark.
 enum class ApiName {
   kApiJson,
-  kApiXml,
   kApiGrpc,
 };
 char const* ToString(ApiName api);
@@ -69,11 +68,9 @@ StatusOr<ApiName> ParseApiName(std::string const& val);
 // We want to compare the following alternatives.
 //
 // - Raw (no C++ client library) JSON Download
-// - Raw XML Download
 // - Raw gRPC Download
 // - Raw gRPC+DirectPath Download
 // - JSON Download
-// - XML Download
 // - gRPC Download
 // - gRPC+DirectPath Download
 // - JSON Upload
@@ -83,7 +80,7 @@ StatusOr<ApiName> ParseApiName(std::string const& val);
 // We will model this with 3 dimensions for each experiment:
 // - Direction: Upload vs. Download
 // - Library: Raw vs. Client library
-// - Transport: XML vs. JSON vs. gRPC vs. gRPC+DirectPath
+// - Transport: JSON vs. gRPC vs. gRPC+DirectPath
 //
 // Some combinations are simply not implemented and ignored when building the
 // set of experiments.
@@ -92,9 +89,7 @@ enum class ExperimentTransport {
   kDirectPath,
   kGrpc,
   kJson,
-  kXml,
   kJsonV2,
-  kXmlV2,
 };
 
 StatusOr<ExperimentLibrary> ParseExperimentLibrary(std::string const& val);

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -62,8 +62,8 @@ via the command line, to obtain more samples in parallel. Configure this value
 with a small enough number of threads such that you do not saturate the CPU.
 
 Each thread creates C++ objects to perform the "upload experiments". Each one
-of these objects represents the "api" used to perform the upload, that is XML,
-JSON and/or gRPC (though technically gRPC is just another protocol for the JSON
+of these objects represents the "api" used to perform the upload, that is JSON
+and/or gRPC (though technically gRPC is just another protocol for the JSON
 API). Likewise, the thread creates a number of "download experiments", also
 based on the APIs configured via the command-line.
 
@@ -309,7 +309,7 @@ gcs_bm::ClientProvider BaseProvider(ThroughputOptions const& options) {
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
     opts = google::cloud::internal::MergeOptions(options.rest_options,
                                                  std::move(opts));
-    if (t == ExperimentTransport::kJsonV2 || t == ExperimentTransport::kXmlV2) {
+    if (t == ExperimentTransport::kJsonV2) {
       opts.set<gcs::internal::UseRestClientOption>(true);
     }
     return gcs::Client(std::move(opts));
@@ -474,7 +474,7 @@ google::cloud::StatusOr<ThroughputOptions> SelfTest(char const* argv0) {
           "--duration=1s",
           "--minimum-sample-count=4",
           "--maximum-sample-count=10",
-          "--enabled-transports=Json,Xml",
+          "--enabled-transports=Json",
           "--enabled-crc32c=enabled",
           "--enabled-md5=disabled",
       },

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -44,7 +44,7 @@ struct ThroughputExperimentConfig {
  *
  * Throughput benchmarks typically repeat the same "experiment" multiple times,
  * sometimes choosing at random which experiment to run, and which parameters to
- * use. An experiment might be "upload an object using XML" or "download an
+ * use. An experiment might be "upload an object using JSON" or "download an
  * an object using raw libcurl calls".
  */
 class ThroughputExperiment {

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -123,22 +123,12 @@ INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestJson,
                          ::testing::Values(TestParam{
                              ExperimentLibrary::kCppClient,
                              ExperimentTransport::kJson}));
-INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestXml,
-                         ThroughputExperimentIntegrationTest,
-                         ::testing::Values(TestParam{
-                             ExperimentLibrary::kCppClient,
-                             ExperimentTransport::kXml}));
 INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestGrpc,
                          ThroughputExperimentIntegrationTest,
                          ::testing::Values(TestParam{
                              ExperimentLibrary::kCppClient,
                              ExperimentTransport::kGrpc}));
 INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawJson,
-                         ThroughputExperimentIntegrationTest,
-                         ::testing::Values(TestParam{
-                             ExperimentLibrary::kRaw,
-                             ExperimentTransport::kJson}));
-INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawXml,
                          ThroughputExperimentIntegrationTest,
                          ::testing::Values(TestParam{
                              ExperimentLibrary::kRaw,

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -322,7 +322,7 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
          options.libs = ParseLibraries(val);
        }},
       {"--enabled-transports",
-       "enable a subset of the transports (DirectPath, Grpc, Json, Xml)",
+       "enable a subset of the transports (DirectPath, Grpc, Json)",
        [&options](std::string const& val) {
          options.transports = ParseTransports(val);
        }},

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -49,9 +49,9 @@ struct ThroughputOptions {
       ExperimentLibrary::kCppClient,
   };
   std::vector<ExperimentTransport> transports = {
-      ExperimentTransport::kGrpc,  ExperimentTransport::kJson,
-      ExperimentTransport::kXml,   ExperimentTransport::kJsonV2,
-      ExperimentTransport::kXmlV2,
+      ExperimentTransport::kGrpc,
+      ExperimentTransport::kJson,
+      ExperimentTransport::kJsonV2,
   };
   std::vector<std::string> upload_functions = {"InsertObject", "WriteObject"};
   std::vector<bool> enabled_crc32c = {false, true};

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -50,7 +50,7 @@ TEST(ThroughputOptions, Basic) {
       "--minimum-sample-count=1",
       "--maximum-sample-count=2",
       "--enabled-libs=Raw,CppClient",
-      "--enabled-transports=DirectPath,Grpc,Json,Xml",
+      "--enabled-transports=DirectPath,Grpc,Json",
       "--upload-functions=WriteObject",
       "--enabled-crc32c=enabled",
       "--enabled-md5=disabled",
@@ -95,9 +95,9 @@ TEST(ThroughputOptions, Basic) {
               UnorderedElementsAre(ExperimentLibrary::kRaw,
                                    ExperimentLibrary::kCppClient));
   EXPECT_THAT(options->transports,
-              UnorderedElementsAre(
-                  ExperimentTransport::kDirectPath, ExperimentTransport::kGrpc,
-                  ExperimentTransport::kJson, ExperimentTransport::kXml));
+              UnorderedElementsAre(ExperimentTransport::kDirectPath,
+                                   ExperimentTransport::kGrpc,
+                                   ExperimentTransport::kJson));
   EXPECT_THAT(options->upload_functions, UnorderedElementsAre("WriteObject"));
   EXPECT_THAT(options->enabled_crc32c, ElementsAre(true));
   EXPECT_THAT(options->enabled_md5, ElementsAre(false));

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -71,9 +71,7 @@ which should give you a taste of the Cloud Storage C++ client library API.
 ### Experimental
 
 - `GOOGLE_CLOUD_CPP_STORAGE_REST_CONFIG=...` configuration for the REST
-  protocol, currently only the `disable-xml` value has any effect. Sometimes
-  the application developer may want to test using an emulator that does not
-  support XML, while the library defaults to XML for some media operations.
+  protocol, currently unused.
 
 - `GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=...` used with
   `google::cloud::storage_experimental::DefaultGrpcClient()` to configure

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -192,11 +192,6 @@ class CurlClient : public RawClient,
   Status SetupBuilder(CurlRequestBuilder& builder, Request const& request,
                       char const* method);
 
-  StatusOr<ObjectMetadata> InsertObjectMediaXml(
-      InsertObjectMediaRequest const& request);
-  StatusOr<std::unique_ptr<ObjectReadSource>> ReadObjectXml(
-      ReadObjectRangeRequest const& request);
-
   /// Insert an object using uploadType=multipart.
   StatusOr<ObjectMetadata> InsertObjectMediaMultipart(
       InsertObjectMediaRequest const& request);
@@ -213,7 +208,6 @@ class CurlClient : public RawClient,
   std::string const upload_endpoint_;
   std::string const xml_endpoint_;
   std::string const iam_endpoint_;
-  bool const xml_enabled_;
 
   std::mutex mu_;
   google::cloud::internal::DefaultPRNG generator_;  // GUARDED_BY(mu_);

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -266,29 +266,11 @@ TEST_P(CurlClientTest, InsertObjectMediaMultipart) {
   CheckStatus(actual);
 }
 
-TEST_P(CurlClientTest, InsertObjectMediaXml) {
-  OptionsSpan const span(client_->options());
-  auto actual =
-      client_
-          ->InsertObjectMedia(InsertObjectMediaRequest("bkt", "obj", "contents")
-                                  .set_multiple_options(Fields("")))
-          .status();
-  CheckStatus(actual);
-}
-
 TEST_P(CurlClientTest, GetObjectMetadata) {
   OptionsSpan const span(client_->options());
   auto actual =
       client_->GetObjectMetadata(GetObjectMetadataRequest("bkt", "obj"))
           .status();
-  CheckStatus(actual);
-}
-
-TEST_P(CurlClientTest, ReadObjectXml) {
-  OptionsSpan const span(client_->options());
-  if (GetParam() == "libcurl-failure") GTEST_SKIP();
-  auto actual =
-      client_->ReadObject(ReadObjectRangeRequest("bkt", "obj")).status();
   CheckStatus(actual);
 }
 

--- a/google/cloud/storage/internal/grpc_client_failures_test.cc
+++ b/google/cloud/storage/internal/grpc_client_failures_test.cc
@@ -155,7 +155,7 @@ TEST_P(GrpcClientFailuresTest, InsertObjectMediaMultipart) {
   EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable));
 }
 
-TEST_P(GrpcClientFailuresTest, InsertObjectMediaXml) {
+TEST_P(GrpcClientFailuresTest, InsertObjectMedia) {
   OptionsSpan const span(client_->options());
   auto actual = client_->InsertObjectMedia(
       InsertObjectMediaRequest("bkt", "obj", "contents")

--- a/google/cloud/storage/internal/rest_client.h
+++ b/google/cloud/storage/internal/rest_client.h
@@ -177,20 +177,14 @@ class RestClient : public RawClient,
   StatusOr<ObjectMetadata> InsertObjectMediaMultipart(
       InsertObjectMediaRequest const& request);
 
-  StatusOr<ObjectMetadata> InsertObjectMediaXml(
-      InsertObjectMediaRequest const& request);
-
   StatusOr<ObjectMetadata> InsertObjectMediaSimple(
       InsertObjectMediaRequest const& request);
 
   std::string MakeBoundary();
-  StatusOr<std::unique_ptr<ObjectReadSource>> ReadObjectXml(
-      ReadObjectRangeRequest const& request);
 
   std::shared_ptr<google::cloud::rest_internal::RestClient>
       storage_rest_client_;
   std::shared_ptr<google::cloud::rest_internal::RestClient> iam_rest_client_;
-  bool const xml_enabled_;
   std::mutex mu_;
   google::cloud::internal::DefaultPRNG generator_;  // GUARDED_BY(mu_);
   google::cloud::Options options_;

--- a/google/cloud/storage/object_read_stream.h
+++ b/google/cloud/storage/object_read_stream.h
@@ -125,12 +125,9 @@ class ObjectReadStream : public std::basic_istream<char> {
    *
    * @warning The contents of these headers may change without notice. Unless
    *     documented in the API, headers may be removed or added by the service.
-   *     Also note that the client library uses both the XML and JSON API,
-   *     choosing between them based on the feature set (some functionality is
-   *     only available through the JSON API), and performance.  Consequently,
-   *     the headers may be different on requests using different features.
-   *     Likewise, the headers may change from one version of the library to the
-   *     next, as we find more (or different) opportunities for optimization.
+   *     Furthermore, the headers may change from one version of the library to
+   *     the next, as we find more (or different) opportunities for
+   *     optimization.
    */
   HeadersMap const& headers() const { return buf_->headers(); }
 

--- a/google/cloud/storage/object_write_stream.h
+++ b/google/cloud/storage/object_write_stream.h
@@ -232,12 +232,9 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    *
    * @warning The contents of these headers may change without notice. Unless
    *     documented in the API, headers may be removed or added by the service.
-   *     Also note that the client library uses both the XML and JSON API,
-   *     choosing between them based on the feature set (some functionality is
-   *     only available through the JSON API), and performance.  Consequently,
-   *     the headers may be different on requests using different features.
-   *     Likewise, the headers may change from one version of the library to the
-   *     next, as we find more (or different) opportunities for optimization.
+   *     Furthermore, he headers may change from one version of the library to
+   *     the next, as we find more (or different) opportunities for
+   *     optimization.
    */
   HeadersMap const& headers() const { return headers_; }
 

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -109,30 +109,6 @@ class StorageIntegrationTest
     buckets_to_delete_.push_back(std::move(meta));
   }
 
-  struct ApiSwitch {
-    Fields for_insert;
-    IfMetagenerationNotMatch for_streaming_read;
-  };
-
-  static ApiSwitch RestApiFlags(std::string const& api) {
-    if (api == "XML") {
-      return ApiSwitch{
-          // enables XML: this filters-out all metadata fields from
-          // the InsertObject() response. JSON and XML are equivalent when no
-          // metadata fields are requested, and we default to XML in that case.
-          Fields(""),
-          // empty option has no effect, and the default is XML
-          IfMetagenerationNotMatch()};
-    }
-    return ApiSwitch{
-        // empty option has no effect, and the default is JSON since only JSON
-        // can provide all metadata fields.
-        Fields(),
-        // disables XML (the default) as it does not support
-        // metageneration-not-match
-        IfMetagenerationNotMatch(0)};
-  }
-
   /**
    * Retry test configuration for a single RPC.
    *

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -175,21 +175,6 @@ TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointInsertJSON) {
 }
 
 /// @test Verify that the client works with non-default endpoints.
-TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointInsertXml) {
-  auto client = CreateNonDefaultClient();
-  auto object_name = MakeRandomObjectName();
-  auto const expected = LoremIpsum();
-  auto insert =
-      client.InsertObject(bucket_name_, object_name, expected, Fields(""));
-  ASSERT_STATUS_OK(insert);
-  ScheduleForDelete(*insert);
-  auto stream = client.ReadObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(stream.status());
-  std::string const actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(expected, actual);
-}
-
-/// @test Verify that the client works with non-default endpoints.
 TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointWriteJSON) {
   auto client = CreateNonDefaultClient();
   auto object_name = MakeRandomObjectName();
@@ -201,22 +186,6 @@ TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointWriteJSON) {
   ScheduleForDelete(*writer.metadata());
   auto stream =
       client.ReadObject(bucket_name_, object_name, IfGenerationNotMatch(0));
-  EXPECT_STATUS_OK(stream.status());
-  std::string const actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(expected, actual);
-}
-
-/// @test Verify that the client works with non-default endpoints.
-TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointWriteXml) {
-  auto client = CreateNonDefaultClient();
-  auto object_name = MakeRandomObjectName();
-  auto const expected = LoremIpsum();
-  auto writer = client.WriteObject(bucket_name_, object_name, Fields(""));
-  writer << expected;
-  writer.Close();
-  ASSERT_STATUS_OK(writer.metadata());
-  ScheduleForDelete(*writer.metadata());
-  auto stream = client.ReadObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(stream.status());
   std::string const actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);

--- a/google/cloud/storage/tests/object_insert_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_preconditions_integration_test.cc
@@ -34,18 +34,10 @@ using ::testing::AnyOf;
 using ::testing::IsEmpty;
 using ::testing::Not;
 
-struct TestParam {
-  absl::optional<std::string> rest_config;
-  Fields fields;
-};
-
 class ObjectInsertPreconditionsIntegrationTest
-    : public ::google::cloud::storage::testing::StorageIntegrationTest,
-      public ::testing::WithParamInterface<TestParam> {
+    : public ::google::cloud::storage::testing::StorageIntegrationTest {
  protected:
-  ObjectInsertPreconditionsIntegrationTest()
-      : config_("GOOGLE_CLOUD_CPP_STORAGE_REST_CONFIG",
-                GetParam().rest_config) {}
+  ObjectInsertPreconditionsIntegrationTest() = default;
 
   void SetUp() override {
     bucket_name_ =
@@ -58,10 +50,9 @@ class ObjectInsertPreconditionsIntegrationTest
 
  private:
   std::string bucket_name_;
-  google::cloud::testing_util::ScopedEnvironment config_;
 };
 
-TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
+TEST_F(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -73,13 +64,12 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
   ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
-                                     GetParam().fields,
                                      IfGenerationMatch(meta->generation()));
   ASSERT_THAT(insert, IsOk());
   ScheduleForDelete(*insert);
 }
 
-TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchFailure) {
+TEST_F(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -91,12 +81,12 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchFailure) {
   ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
-                                     GetParam().fields,
+
                                      IfGenerationMatch(meta->generation() + 1));
   ASSERT_THAT(insert, StatusIs(StatusCode::kFailedPrecondition));
 }
 
-TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
+TEST_F(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -107,14 +97,14 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
   ASSERT_THAT(meta, IsOk());
   ScheduleForDelete(*meta);
 
-  auto insert = client->InsertObject(
-      bucket_name(), object_name, expected_text, GetParam().fields,
-      IfGenerationNotMatch(meta->generation() + 1));
+  auto insert =
+      client->InsertObject(bucket_name(), object_name, expected_text,
+                           IfGenerationNotMatch(meta->generation() + 1));
   ASSERT_THAT(insert, IsOk());
   ScheduleForDelete(*insert);
 }
 
-TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
+TEST_F(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -126,13 +116,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
   ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
-                                     GetParam().fields,
+
                                      IfGenerationNotMatch(meta->generation()));
   ASSERT_THAT(insert, StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                      StatusCode::kAborted)));
 }
 
-TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
+TEST_F(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -143,14 +133,14 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
   ASSERT_THAT(meta, IsOk());
   ScheduleForDelete(*meta);
 
-  auto insert = client->InsertObject(
-      bucket_name(), object_name, expected_text, GetParam().fields,
-      IfMetagenerationMatch(meta->metageneration()));
+  auto insert =
+      client->InsertObject(bucket_name(), object_name, expected_text,
+                           IfMetagenerationMatch(meta->metageneration()));
   ASSERT_THAT(insert, IsOk());
   ScheduleForDelete(*insert);
 }
 
-TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
+TEST_F(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -161,13 +151,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
   ASSERT_THAT(meta, IsOk());
   ScheduleForDelete(*meta);
 
-  auto insert = client->InsertObject(
-      bucket_name(), object_name, expected_text, GetParam().fields,
-      IfMetagenerationMatch(meta->metageneration() + 1));
+  auto insert =
+      client->InsertObject(bucket_name(), object_name, expected_text,
+                           IfMetagenerationMatch(meta->metageneration() + 1));
   ASSERT_THAT(insert, StatusIs(StatusCode::kFailedPrecondition));
 }
 
-TEST_P(ObjectInsertPreconditionsIntegrationTest,
+TEST_F(ObjectInsertPreconditionsIntegrationTest,
        IfMetagenerationNotMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -180,13 +170,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest,
   ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(
-      bucket_name(), object_name, expected_text, GetParam().fields,
+      bucket_name(), object_name, expected_text,
       IfMetagenerationNotMatch(meta->metageneration() + 1));
   ASSERT_THAT(insert, IsOk());
   ScheduleForDelete(*insert);
 }
 
-TEST_P(ObjectInsertPreconditionsIntegrationTest,
+TEST_F(ObjectInsertPreconditionsIntegrationTest,
        IfMetagenerationNotMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -198,22 +188,12 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest,
   ASSERT_THAT(meta, IsOk());
   ScheduleForDelete(*meta);
 
-  auto insert = client->InsertObject(
-      bucket_name(), object_name, expected_text, GetParam().fields,
-      IfMetagenerationNotMatch(meta->metageneration()));
+  auto insert =
+      client->InsertObject(bucket_name(), object_name, expected_text,
+                           IfMetagenerationNotMatch(meta->metageneration()));
   ASSERT_THAT(insert, StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                      StatusCode::kAborted)));
 }
-
-INSTANTIATE_TEST_SUITE_P(XmlEnabledAndUsed,
-                         ObjectInsertPreconditionsIntegrationTest,
-                         ::testing::Values(TestParam{absl::nullopt,
-                                                     Fields("")}));
-INSTANTIATE_TEST_SUITE_P(XmlEnabledNotUsed,
-                         ObjectInsertPreconditionsIntegrationTest,
-                         ::testing::Values(TestParam{absl::nullopt, Fields()}));
-INSTANTIATE_TEST_SUITE_P(XmlDisabled, ObjectInsertPreconditionsIntegrationTest,
-                         ::testing::Values(TestParam{"disable-xml", Fields()}));
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
@@ -34,17 +34,10 @@ using ::testing::AnyOf;
 using ::testing::IsEmpty;
 using ::testing::Not;
 
-struct TestParam {
-  absl::optional<std::string> rest_config;
-};
-
 class ObjectReadPreconditionsIntegrationTest
-    : public ::google::cloud::storage::testing::StorageIntegrationTest,
-      public ::testing::WithParamInterface<TestParam> {
+    : public ::google::cloud::storage::testing::StorageIntegrationTest {
  protected:
-  ObjectReadPreconditionsIntegrationTest()
-      : config_("GOOGLE_CLOUD_CPP_STORAGE_REST_CONFIG",
-                GetParam().rest_config) {}
+  ObjectReadPreconditionsIntegrationTest() = default;
 
   void SetUp() override {
     bucket_name_ =
@@ -57,10 +50,9 @@ class ObjectReadPreconditionsIntegrationTest
 
  private:
   std::string bucket_name_;
-  google::cloud::testing_util::ScopedEnvironment config_;
 };
 
-TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
+TEST_F(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -77,7 +69,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
   EXPECT_THAT(reader.status(), IsOk());
 }
 
-TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchFailure) {
+TEST_F(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -94,7 +86,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchFailure) {
   EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
 }
 
-TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
+TEST_F(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -111,7 +103,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
   EXPECT_THAT(reader.status(), IsOk());
 }
 
-TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
+TEST_F(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -133,7 +125,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
                                               StatusCode::kAborted)));
 }
 
-TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
+TEST_F(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -151,7 +143,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
   EXPECT_THAT(reader.status(), IsOk());
 }
 
-TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
+TEST_F(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -169,7 +161,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
   EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
 }
 
-TEST_P(ObjectReadPreconditionsIntegrationTest,
+TEST_F(ObjectReadPreconditionsIntegrationTest,
        IfMetagenerationNotMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -188,7 +180,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest,
   EXPECT_THAT(reader.status(), IsOk());
 }
 
-TEST_P(ObjectReadPreconditionsIntegrationTest,
+TEST_F(ObjectReadPreconditionsIntegrationTest,
        IfMetagenerationNotMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -211,11 +203,6 @@ TEST_P(ObjectReadPreconditionsIntegrationTest,
   EXPECT_THAT(reader.status(), StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                               StatusCode::kAborted)));
 }
-
-INSTANTIATE_TEST_SUITE_P(XmlDisabled, ObjectReadPreconditionsIntegrationTest,
-                         ::testing::Values(TestParam{"disable-xml"}));
-INSTANTIATE_TEST_SUITE_P(XmlEnabled, ObjectReadPreconditionsIntegrationTest,
-                         ::testing::Values(TestParam{absl::nullopt}));
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
We no longer have reason to believe that XML is faster than JSON for uploads and/or downloads. The extra code carries significant complexity, which is no longer justified. Removing this code is non-breaking, as the API is the same, in fact, we already had support to "fallback" to JSON when using features that XML does not support.

Fixes #10471

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10472)
<!-- Reviewable:end -->
