### PR TITLE
refactor(generator): consolidate some stub member functions

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -83,6 +83,8 @@ add_library(
     internal/stub_factory_rest_generator.h
     internal/stub_generator.cc
     internal/stub_generator.h
+    internal/stub_generator_base.cc
+    internal/stub_generator_base.h
     internal/stub_rest_generator.cc
     internal/stub_rest_generator.h)
 target_include_directories(google_cloud_cpp_generator

--- a/generator/google_cloud_cpp_generator.bzl
+++ b/generator/google_cloud_cpp_generator.bzl
@@ -48,6 +48,7 @@ google_cloud_cpp_generator_hdrs = [
     "internal/stub_factory_generator.h",
     "internal/stub_factory_rest_generator.h",
     "internal/stub_generator.h",
+    "internal/stub_generator_base.h",
     "internal/stub_rest_generator.h",
 ]
 
@@ -81,5 +82,6 @@ google_cloud_cpp_generator_srcs = [
     "internal/stub_factory_generator.cc",
     "internal/stub_factory_rest_generator.cc",
     "internal/stub_generator.cc",
+    "internal/stub_generator_base.cc",
     "internal/stub_rest_generator.cc",
 ]

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
@@ -39,38 +39,37 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
                        std::set<std::string> components);
 
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListLogsResponse> ListLogs(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListLogsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListLogsRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
   Status DoNothing(
-    grpc::ClientContext& context,
-    google::protobuf::Empty const& request) override;
+      grpc::ClientContext& context,
+      google::protobuf::Empty const& request) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::Request const& request) override;
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>>
-   StreamingWrite(
+      google::test::admin::database::v1::Response>> StreamingWrite(
       std::unique_ptr<grpc::ClientContext> context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -81,12 +80,12 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
       std::unique_ptr<grpc::ClientContext> context) override;
 
   Status ExplicitRouting1(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   Status ExplicitRouting2(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::test::admin::database::v1::Response>>

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -35,38 +35,37 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
   explicit GoldenKitchenSinkMetadata(std::shared_ptr<GoldenKitchenSinkStub> child);
 
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListLogsResponse> ListLogs(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListLogsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListLogsRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
   Status DoNothing(
-    grpc::ClientContext& context,
-    google::protobuf::Empty const& request) override;
+      grpc::ClientContext& context,
+      google::protobuf::Empty const& request) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
-    StreamingRead(
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::Request const& request) override;
+  StreamingRead(
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>>
-  StreamingWrite(
+      google::test::admin::database::v1::Response>> StreamingWrite(
       std::unique_ptr<grpc::ClientContext> context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -77,12 +76,12 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
       std::unique_ptr<grpc::ClientContext> context) override;
 
   Status ExplicitRouting1(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   Status ExplicitRouting2(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::test::admin::database::v1::Response>>

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
@@ -65,13 +65,12 @@ class GoldenKitchenSinkRoundRobin : public GoldenKitchenSinkStub {
       std::unique_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::Request const& request) override;
 
-  std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>>
-  StreamingWrite(
+      google::test::admin::database::v1::Response>> StreamingWrite(
       std::unique_ptr<grpc::ClientContext> context) override;
 
-  std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,
       google::test::admin::database::v1::Response>>
   AsyncStreamingReadWrite(
@@ -86,16 +85,15 @@ class GoldenKitchenSinkRoundRobin : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
-  std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::test::admin::database::v1::Response>>
   AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::Request const& request) override;
 
-  std::unique_ptr<google::cloud::internal::AsyncStreamingWriteRpc<
-      google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>>
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
+      google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_auth_decorator.h
@@ -135,6 +135,7 @@ class GoldenThingAdminAuth : public GoldenThingAdminStub {
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::longrunning::CancelOperationRequest const& request) override;
+
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<GoldenThingAdminStub> child_;

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_logging_decorator.h
@@ -40,8 +40,8 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
                        std::set<std::string> components);
 
   StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
@@ -49,8 +49,8 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
       google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Database> GetDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
       google::cloud::CompletionQueue& cq,
@@ -58,24 +58,24 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
   Status DropDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
 
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-    grpc::ClientContext& context,
-    google::iam::v1::SetIamPolicyRequest const& request) override;
+      grpc::ClientContext& context,
+      google::iam::v1::SetIamPolicyRequest const& request) override;
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-    grpc::ClientContext& context,
-    google::iam::v1::GetIamPolicyRequest const& request) override;
+      grpc::ClientContext& context,
+      google::iam::v1::GetIamPolicyRequest const& request) override;
 
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-    grpc::ClientContext& context,
-    google::iam::v1::TestIamPermissionsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::iam::v1::TestIamPermissionsRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
       google::cloud::CompletionQueue& cq,
@@ -83,20 +83,20 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
       google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Backup> GetBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GetBackupRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GetBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Backup> UpdateBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::UpdateBackupRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::UpdateBackupRequest const& request) override;
 
   Status DeleteBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::DeleteBackupRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::DeleteBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListBackupsResponse> ListBackups(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListBackupsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
       google::cloud::CompletionQueue& cq,
@@ -104,12 +104,12 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncLongRunningWithoutRouting(
       google::cloud::CompletionQueue& cq,
@@ -117,24 +117,24 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::longrunning::GetOperationRequest const& request) override;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::longrunning::GetOperationRequest const& request) override;
 
   future<Status> AsyncCancelOperation(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::longrunning::CancelOperationRequest const& request) override;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::longrunning::CancelOperationRequest const& request) override;
 
  private:
   std::shared_ptr<GoldenThingAdminStub> child_;

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h
@@ -36,8 +36,8 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
   explicit GoldenThingAdminMetadata(std::shared_ptr<GoldenThingAdminStub> child);
 
   StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
@@ -45,8 +45,8 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
       google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Database> GetDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
       google::cloud::CompletionQueue& cq,
@@ -54,24 +54,24 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
   Status DropDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
 
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-    grpc::ClientContext& context,
-    google::iam::v1::SetIamPolicyRequest const& request) override;
+      grpc::ClientContext& context,
+      google::iam::v1::SetIamPolicyRequest const& request) override;
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-    grpc::ClientContext& context,
-    google::iam::v1::GetIamPolicyRequest const& request) override;
+      grpc::ClientContext& context,
+      google::iam::v1::GetIamPolicyRequest const& request) override;
 
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-    grpc::ClientContext& context,
-    google::iam::v1::TestIamPermissionsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::iam::v1::TestIamPermissionsRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
       google::cloud::CompletionQueue& cq,
@@ -79,20 +79,20 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
       google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Backup> GetBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::GetBackupRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::GetBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Backup> UpdateBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::UpdateBackupRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::UpdateBackupRequest const& request) override;
 
   Status DeleteBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::DeleteBackupRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::DeleteBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListBackupsResponse> ListBackups(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListBackupsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
       google::cloud::CompletionQueue& cq,
@@ -100,12 +100,12 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncLongRunningWithoutRouting(
       google::cloud::CompletionQueue& cq,
@@ -113,14 +113,14 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_round_robin_decorator.h
@@ -113,10 +113,10 @@ class GoldenThingAdminRoundRobin : public GoldenThingAdminStub {
       std::unique_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
-future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+  future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/internal/auth_decorator_generator.h
+++ b/generator/internal/auth_decorator_generator.h
@@ -17,7 +17,7 @@
 
 #include "google/cloud/status.h"
 #include "generator/internal/printer.h"
-#include "generator/internal/service_code_generator.h"
+#include "generator/internal/stub_generator_base.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>
@@ -31,7 +31,7 @@ namespace generator_internal {
 /**
  * Generates the Auth decorator for a particular service.
  */
-class AuthDecoratorGenerator : public ServiceCodeGenerator {
+class AuthDecoratorGenerator : public StubGeneratorBase {
  public:
   AuthDecoratorGenerator(
       google::protobuf::ServiceDescriptor const* service_descriptor,

--- a/generator/internal/logging_decorator_generator.h
+++ b/generator/internal/logging_decorator_generator.h
@@ -17,7 +17,7 @@
 
 #include "google/cloud/status.h"
 #include "generator/internal/printer.h"
-#include "generator/internal/service_code_generator.h"
+#include "generator/internal/stub_generator_base.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>
@@ -32,7 +32,7 @@ namespace generator_internal {
  * Generates the header file and cc file for the Logging decorator for a
  * particular service.
  */
-class LoggingDecoratorGenerator : public ServiceCodeGenerator {
+class LoggingDecoratorGenerator : public StubGeneratorBase {
  public:
   LoggingDecoratorGenerator(
       google::protobuf::ServiceDescriptor const* service_descriptor,

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -103,9 +103,9 @@ MetadataDecoratorGenerator::MetadataDecoratorGenerator(
     VarsDictionary service_vars,
     std::map<std::string, VarsDictionary> service_method_vars,
     google::protobuf::compiler::GeneratorContext* context)
-    : ServiceCodeGenerator("metadata_header_path", "metadata_cc_path",
-                           service_descriptor, std::move(service_vars),
-                           std::move(service_method_vars), context) {}
+    : StubGeneratorBase("metadata_header_path", "metadata_cc_path",
+                        service_descriptor, std::move(service_vars),
+                        std::move(service_method_vars), context) {}
 
 Status MetadataDecoratorGenerator::GenerateHeader() {
   HeaderPrint(CopyrightLicenseFileHeader());
@@ -138,115 +138,7 @@ Status MetadataDecoratorGenerator::GenerateHeader() {
     "  explicit $metadata_class_name$(std::shared_ptr<$stub_class_name$> child);\n");
   // clang-format on
 
-  for (auto const& method : methods()) {
-    if (IsStreamingWrite(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__,
-                        R"""(
-  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
-      $request_type$,
-      $response_type$>>
-  $method_name$(
-      std::unique_ptr<grpc::ClientContext> context) override;
-)""");
-      continue;
-    }
-    if (IsBidirStreaming(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__,
-                        R"""(
-  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      $request_type$,
-      $response_type$>>
-  Async$method_name$(
-      google::cloud::CompletionQueue const& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
-)""");
-      continue;
-    }
-    HeaderPrintMethod(
-        method,
-        {MethodPattern({{IsResponseTypeEmpty,
-                         // clang-format off
-    "\n  Status $method_name$(\n",
-    "\n  StatusOr<$response_type$> $method_name$(\n"},
-   {"    grpc::ClientContext& context,\n"
-    "    $request_type$ const& request) override;\n"
-                            // clang-format on
-                        }},
-                       And(IsNonStreaming, Not(IsLongrunningOperation))),
-         MethodPattern({{R"""(
-  future<StatusOr<google::longrunning::Operation>> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      $request_type$ const& request) override;
-)"""}},
-                       IsLongrunningOperation),
-         MethodPattern(
-             {    // clang-format off
-   {"\n"
-    "  std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>\n"
-    "    $method_name$(\n"
-    "    std::unique_ptr<grpc::ClientContext> context,\n"
-    "    $request_type$ const& request) override;\n"
-                  // clang-format on
-              }},
-             IsStreamingRead)},
-        __FILE__, __LINE__);
-  }
-
-  for (auto const& method : async_methods()) {
-    if (IsStreamingRead(method)) {
-      auto constexpr kDeclaration = R"""(
-  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      $response_type$>>
-  Async$method_name$(
-      google::cloud::CompletionQueue const& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      $request_type$ const& request) override;
-)""";
-      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
-      continue;
-    }
-    if (IsStreamingWrite(method)) {
-      auto constexpr kDeclaration = R"""(
-  std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
-      $request_type$, $response_type$>>
-  Async$method_name$(
-      google::cloud::CompletionQueue const& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
-)""";
-      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
-      continue;
-    }
-    HeaderPrintMethod(
-        method,
-        {MethodPattern(
-            {{IsResponseTypeEmpty,
-              // clang-format off
-    "\n  future<Status> Async$method_name$(\n",
-    "\n  future<StatusOr<$response_type$>> Async$method_name$(\n"},
-   {"    google::cloud::CompletionQueue& cq,\n"
-    "    std::unique_ptr<grpc::ClientContext> context,\n"
-    "    $request_type$ const& request) override;\n"
-                 // clang-format on
-             }},
-            And(IsNonStreaming, Not(IsLongrunningOperation)))},
-        __FILE__, __LINE__);
-  }
-
-  if (HasLongrunningMethod()) {
-    HeaderPrint(
-        R"""(
-  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::longrunning::GetOperationRequest const& request) override;
-
-  future<Status> AsyncCancelOperation(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::longrunning::CancelOperationRequest const& request) override;
-)""");
-  }
+  HeaderPrintPublicMethods();
 
   HeaderPrint(R"""(
  private:

--- a/generator/internal/metadata_decorator_generator.h
+++ b/generator/internal/metadata_decorator_generator.h
@@ -17,7 +17,7 @@
 
 #include "google/cloud/status.h"
 #include "generator/internal/printer.h"
-#include "generator/internal/service_code_generator.h"
+#include "generator/internal/stub_generator_base.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>
@@ -32,7 +32,7 @@ namespace generator_internal {
  * Generates the header file and cc file for the Metadata decorator for a
  * particular service.
  */
-class MetadataDecoratorGenerator : public ServiceCodeGenerator {
+class MetadataDecoratorGenerator : public StubGeneratorBase {
  public:
   MetadataDecoratorGenerator(
       google::protobuf::ServiceDescriptor const* service_descriptor,

--- a/generator/internal/stub_generator_base.cc
+++ b/generator/internal/stub_generator_base.cc
@@ -1,0 +1,148 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "generator/internal/stub_generator_base.h"
+#include "generator/internal/predicate_utils.h"
+#include <google/protobuf/descriptor.h>
+
+namespace google {
+namespace cloud {
+namespace generator_internal {
+
+StubGeneratorBase::StubGeneratorBase(
+    std::string const& header_path_key, std::string const& cc_path_key,
+    google::protobuf::ServiceDescriptor const* service_descriptor,
+    VarsDictionary service_vars,
+    std::map<std::string, VarsDictionary> service_method_vars,
+    google::protobuf::compiler::GeneratorContext* context)
+    : ServiceCodeGenerator(header_path_key, cc_path_key, service_descriptor,
+                           std::move(service_vars),
+                           std::move(service_method_vars), context) {}
+
+void StubGeneratorBase::HeaderPrintPublicMethods() {
+  for (auto const& method : methods()) {
+    if (IsStreamingWrite(method)) {
+      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      $request_type$,
+      $response_type$>> $method_name$(
+      std::unique_ptr<grpc::ClientContext> context) override;
+)""");
+      continue;
+    }
+    if (IsBidirStreaming(method)) {
+      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      $request_type$,
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+)""");
+      continue;
+    }
+    HeaderPrintMethod(
+        method,
+        {MethodPattern({{IsResponseTypeEmpty,
+                         R"""(
+  Status $method_name$(
+      grpc::ClientContext& context,
+      $request_type$ const& request) override;
+)""",
+                         R"""(
+  StatusOr<$response_type$> $method_name$(
+      grpc::ClientContext& context,
+      $request_type$ const& request) override;
+)"""},
+                        {""}},
+                       And(IsNonStreaming, Not(IsLongrunningOperation))),
+         MethodPattern({{R"""(
+  future<StatusOr<google::longrunning::Operation>> Async$method_name$(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      $request_type$ const& request) override;
+)"""}},
+                       IsLongrunningOperation),
+         MethodPattern({{R"""(
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
+  $method_name$(
+      std::unique_ptr<grpc::ClientContext> context,
+      $request_type$ const& request) override;
+)"""}},
+                       IsStreamingRead)},
+        __FILE__, __LINE__);
+  }
+
+  for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) {
+      auto constexpr kDeclaration = R"""(
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      $request_type$ const& request) override;
+)""";
+      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+      continue;
+    }
+    if (IsStreamingWrite(method)) {
+      auto constexpr kDeclaration = R"""(
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
+      $request_type$, $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+)""";
+      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+      continue;
+    }
+    HeaderPrintMethod(
+        method,
+        {MethodPattern({{IsResponseTypeEmpty,
+                         R"""(
+  future<Status> Async$method_name$(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      $request_type$ const& request) override;
+)""",
+                         R"""(
+  future<StatusOr<$response_type$>> Async$method_name$(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      $request_type$ const& request) override;
+)"""},
+                        {""}},
+                       And(IsNonStreaming, Not(IsLongrunningOperation)))},
+        __FILE__, __LINE__);
+  }
+
+  if (HasLongrunningMethod()) {
+    HeaderPrint(R"""(
+  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::longrunning::GetOperationRequest const& request) override;
+
+  future<Status> AsyncCancelOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::longrunning::CancelOperationRequest const& request) override;
+)""");
+  }
+}
+
+}  // namespace generator_internal
+}  // namespace cloud
+}  // namespace google

--- a/generator/internal/stub_generator_base.h
+++ b/generator/internal/stub_generator_base.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_ROUND_ROBIN_DECORATOR_GENERATOR_H
-#define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_ROUND_ROBIN_DECORATOR_GENERATOR_H
+#ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_GENERATOR_BASE_H
+#define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_GENERATOR_BASE_H
 
 #include "google/cloud/status.h"
 #include "generator/internal/printer.h"
-#include "generator/internal/stub_generator_base.h"
+#include "generator/internal/service_code_generator.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>
@@ -28,33 +28,22 @@ namespace google {
 namespace cloud {
 namespace generator_internal {
 
-/**
- * Generates the RoundRobin decorator for a particular service.
- */
-class RoundRobinDecoratorGenerator : public StubGeneratorBase {
+/// Base class that knows how to print Stub member function signatures.
+class StubGeneratorBase : public ServiceCodeGenerator {
  public:
-  RoundRobinDecoratorGenerator(
+  StubGeneratorBase(
+      std::string const& header_path_key, std::string const& cc_path_key,
       google::protobuf::ServiceDescriptor const* service_descriptor,
       VarsDictionary service_vars,
       std::map<std::string, VarsDictionary> service_method_vars,
       google::protobuf::compiler::GeneratorContext* context);
 
-  ~RoundRobinDecoratorGenerator() override = default;
-
-  RoundRobinDecoratorGenerator(RoundRobinDecoratorGenerator const&) = delete;
-  RoundRobinDecoratorGenerator& operator=(RoundRobinDecoratorGenerator const&) =
-      delete;
-  RoundRobinDecoratorGenerator(RoundRobinDecoratorGenerator&&) = default;
-  RoundRobinDecoratorGenerator& operator=(RoundRobinDecoratorGenerator&&) =
-      default;
-
- private:
-  Status GenerateHeader() override;
-  Status GenerateCc() override;
+ protected:
+  void HeaderPrintPublicMethods();
 };
 
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_ROUND_ROBIN_DECORATOR_GENERATOR_H
+#endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_GENERATOR_BASE_H

--- a/google/cloud/bigtable/internal/bigtable_round_robin_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_round_robin_decorator.h
@@ -68,13 +68,13 @@ class BigtableRoundRobin : public BigtableStub {
       grpc::ClientContext& context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
-  std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::unique_ptr<grpc::ClientContext> context,
                 google::bigtable::v2::ReadRowsRequest const& request) override;
 
-  std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
@@ -86,7 +86,7 @@ class BigtableRoundRobin : public BigtableStub {
       std::unique_ptr<grpc::ClientContext> context,
       google::bigtable::v2::MutateRowRequest const& request) override;
 
-  std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   AsyncMutateRows(
       google::cloud::CompletionQueue const& cq,

--- a/google/cloud/pubsub/internal/subscriber_round_robin_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_round_robin_decorator.h
@@ -60,7 +60,7 @@ class SubscriberRoundRobin : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::PullRequest const& request) override;
 
-  std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::pubsub::v1::StreamingPullRequest,
       google::pubsub::v1::StreamingPullResponse>>
   AsyncStreamingPull(google::cloud::CompletionQueue const& cq,


### PR DESCRIPTION
All gRPC stubs have the same public methods. I think there are enough stubs to justify this consolidation.

It would be nice if we could do something similar for the method signatures in the `.cc` files... but I have not thought that far ahead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10473)
<!-- Reviewable:end -->
