### PR TITLE
test(spanner): enable testing of PG JSONB[] support

### DIFF
--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -417,16 +417,6 @@ TEST_F(PgDataTypeIntegrationTest, WriteReadArrayJson) {
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayJsonValue");
-  {
-    // TODO(#10095): Remove this when JSONB[] is supported.
-    auto matcher = StatusIs(StatusCode::kNotFound,
-                            AnyOf(HasSubstr("Column not found in table"),
-                                  HasSubstr("is not a column in")));
-    testing::StringMatchResultListener listener;
-    if (matcher.impl().MatchAndExplain(result, &listener)) {
-      GTEST_SKIP();
-    }
-  }
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(*result, UnorderedElementsAreArray(data));
 }

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -215,7 +215,7 @@ void PgDatabaseIntegrationTest::SetUpTestSuite() {
           ArrayBytesValue BYTEA[],
           ArrayTimestampValue TIMESTAMP WITH TIME ZONE[],
           ArrayDateValue DATE[],
-          -- TODO(#10095): ArrayJsonValue JSONB[],
+          ArrayJsonValue JSONB[],
           ArrayNumericValue NUMERIC[],
           PRIMARY KEY(Id)
         )


### PR DESCRIPTION
The backend now supports PG JSONB arrays.  Fixes #10095.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10475)
<!-- Reviewable:end -->
