### PR TITLE
ci: fix `demo-rockylinux-9` builds

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -25,7 +25,7 @@ RUN dnf makecache && \
     dnf update -y && \
     dnf install -y epel-release && \
     dnf makecache && \
-    dnf install -y ccache cmake curl findutils gcc-c++ git make openssl-devel \
+    dnf install -y ccache cmake findutils gcc-c++ git make openssl-devel \
         patch re2-devel zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -1513,7 +1513,7 @@ sudo dnf makecache && \
 sudo dnf update -y && \
 sudo dnf install -y epel-release && \
 sudo dnf makecache && \
-sudo dnf install -y ccache cmake curl findutils gcc-c++ git make openssl-devel \
+sudo dnf install -y ccache cmake findutils gcc-c++ git make openssl-devel \
         patch re2-devel zlib-devel libcurl-devel c-ares-devel tar wget which
 ```
 


### PR DESCRIPTION
Installing `curl` conflicts with a pre-installed `curl-minimal` package. It seems that `curl-minimal` is all we need.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10481)
<!-- Reviewable:end -->
