### PR TITLE
test(bigtable): refactor CheckEqualUnordered

### DIFF
--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -131,8 +131,8 @@ class TableIntegrationTest
    * Compare two sets of cells.
    * Unordered because ReadRows does not guarantee a particular order.
    */
-  static void CheckEqualUnordered(std::vector<bigtable::Cell> expected,
-                                  std::vector<bigtable::Cell> actual);
+  static void CheckEqualUnordered(std::vector<bigtable::Cell> const& expected,
+                                  std::vector<bigtable::Cell> const& actual);
 
   /**
    * Generate a random table id.


### PR DESCRIPTION
use a `::testing::Matcher` instead of defining `operator==` and such for `bigtable::Cell`. Motivated by cl/499097840.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10482)
<!-- Reviewable:end -->
