### PR TITLE
cleanup: automate scaffold WORKSPACE file

### DIFF
--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -230,15 +230,6 @@ arguments in the CI builds.
 
 - `google/cloud/${library}/CMakeLists.txt`
 
-The scaffold generator does not know the current version of `google-cloud-cpp`.
-We can copy it from a library that should be up-to-date.
-
-```sh
-sed -i '/workspace(/q' google/cloud/${library}/quickstart/WORKSPACE.bazel
-sed '1,/workspace(/d' google/cloud/accessapproval/quickstart/WORKSPACE.bazel \
-    >> google/cloud/${library}/quickstart/WORKSPACE.bazel
-```
-
 ## Update the README files
 
 The following files probably need some light copy-editing to read less like they

--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -121,6 +121,7 @@ bazel run \
   --googleapis_proto_path="${bazel_output_base}"/external/com_google_googleapis \
   --output_path="${PWD}" \
   --config_file="${PWD}/generator/generator_config.textproto" \
+  --scaffold_templates_path="${PWD}/generator/templates/" \
   --scaffold="google/cloud/${library}/"
 ```
 

--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -68,7 +68,8 @@ std::map<std::string, std::string> ScaffoldVars(
 void MakeDirectory(std::string const& path);
 
 void GenerateScaffold(
-    std::string const& googleapis_path, std::string const& output_path,
+    std::string const& googleapis_path,
+    std::string const& scaffold_templates_path, std::string const& output_path,
     google::cloud::cpp::generator::ServiceConfiguration const& service,
     bool experimental);
 
@@ -93,15 +94,12 @@ void GenerateQuickstartCMake(
 void GenerateQuickstartMakefile(
     std::ostream& os, std::map<std::string, std::string> const& variables);
 void GenerateQuickstartWorkspace(
-    std::ostream& os, std::map<std::string, std::string> const& variables);
+    std::ostream& os, std::map<std::string, std::string> const& variables,
+    std::string const& contents);
 void GenerateQuickstartBuild(
     std::ostream& os, std::map<std::string, std::string> const& variables);
 void GenerateQuickstartBazelrc(
     std::ostream& os, std::map<std::string, std::string> const& variables);
-void GenerateSamplesBuild(std::ostream& os,
-                          std::map<std::string, std::string> const& variables);
-void GenerateSamplesCMake(std::ostream& os,
-                          std::map<std::string, std::string> const& variables);
 
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -326,12 +326,24 @@ TEST_F(ScaffoldGenerator, QuickstartMakefile) {
 }
 
 TEST_F(ScaffoldGenerator, QuickstartWorkspace) {
+  auto constexpr kContents = R"""(# Copyright $copyright_year$ Google LLC
+
+# A minimal WORKSPACE file showing how to use the $title$
+# C++ client library in Bazel-based projects.
+workspace(name = "qs")
+)""";
+
   auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
-  GenerateQuickstartWorkspace(os, vars);
+  GenerateQuickstartWorkspace(os, vars, kContents);
   auto const actual = std::move(os).str();
-  EXPECT_THAT(actual, HasSubstr("2034"));
+  EXPECT_THAT(actual, HasSubstr("# Copyright 2034 Google LLC"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
+  EXPECT_THAT(
+      actual,
+      HasSubstr(
+          "A minimal WORKSPACE file showing how to use the Test Only API"));
+  EXPECT_THAT(actual, Not(HasSubstr("$title$")));
 }
 
 TEST_F(ScaffoldGenerator, QuickstartBuild) {

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -38,6 +38,8 @@ ABSL_FLAG(std::string, golden_proto_path, "",
           "Path to root dir of protos distributed with googleapis.");
 ABSL_FLAG(std::string, output_path, ".",
           "Path to root dir where code is emitted.");
+ABSL_FLAG(std::string, scaffold_templates_path, ".",
+          "Path to directory where we store scaffold templates.");
 ABSL_FLAG(std::string, scaffold, "",
           "Generate the library support files for the given directory.");
 ABSL_FLAG(bool, experimental_scaffold, false,
@@ -181,6 +183,7 @@ int main(int argc, char** argv) {
   auto config_file = absl::GetFlag(FLAGS_config_file);
   auto output_path = absl::GetFlag(FLAGS_output_path);
   auto scaffold = absl::GetFlag(FLAGS_scaffold);
+  auto scaffold_templates_path = absl::GetFlag(FLAGS_scaffold_templates_path);
   auto experimental_scaffold = absl::GetFlag(FLAGS_experimental_scaffold);
 
   GCP_LOG(INFO) << "proto_path = " << proto_path << "\n";
@@ -203,8 +206,8 @@ int main(int argc, char** argv) {
   std::vector<std::future<google::cloud::Status>> tasks;
   for (auto const& service : config->service()) {
     if (LibraryPath(service.product_path()) == scaffold) {
-      GenerateScaffold(googleapis_path, output_path, service,
-                       experimental_scaffold);
+      GenerateScaffold(googleapis_path, scaffold_templates_path, output_path,
+                       service, experimental_scaffold);
     }
     std::vector<std::string> args;
     // empty arg prevents first real arg from being ignored.

--- a/generator/templates/WORKSPACE.bazel
+++ b/generator/templates/WORKSPACE.bazel
@@ -1,0 +1,51 @@
+# Copyright $copyright_year$ Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A minimal WORKSPACE file showing how to use the $title$
+# C++ client library in Bazel-based projects.
+workspace(name = "qs")
+
+# Add the necessary Starlark functions to fetch google-cloud-cpp.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Fetch the Google Cloud C++ libraries.
+# NOTE: Update this version and SHA256 as needed.
+http_archive(
+    name = "google_cloud_cpp",
+    sha256 = "ac93ef722d08bfb220343bde2f633c7c11f15e34ec3ecd0a57dbd3ff729cc3a6",
+    strip_prefix = "google-cloud-cpp-2.5.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.5.0.tar.gz",
+)
+
+# Load indirect dependencies due to
+#     https://github.com/bazelbuild/bazel/issues/1943
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+
+google_cloud_cpp_deps()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()


### PR DESCRIPTION
The generated `${library}/quickstart/WORKSPACE.bazel` are often out of date as soon as they are generated. To solve this, I moved the template for this generated file to a separate file, where renovate bot will keep it up to date.

Fixes #9825

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10493)
<!-- Reviewable:end -->
