### PR TITLE
ci: faster checkers build

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -56,9 +56,9 @@ function sed_edit() {
 }
 export -f sed_edit
 
-# The list of files to format.
+# The list of files to check.
 #
-# By default, we format all files in the repository tracked by `git`. To format
+# By default, we check all files in the repository tracked by `git`. To check
 # only the files that have changed in a development branch, set
 # `GOOGLE_CLOUD_CPP_FAST_CHECKERS=1`.
 git_files() {


### PR DESCRIPTION
Make `checkers` only run on files that have diverged from `upstream/main`, if `GOOGLE_CLOUD_CPP_FAST_CHECKERS` is set.

This is a convenience for developers (especially those who run `checkers` on a laptop). We should not change our CI... but I am sure there are some how-to instructions that could benefit from a faster `checkers` build. If no one else sees the utility in this, I will painstakingly maintain it locally.

## Results

From a repo that only has changes to `checkers.sh`, on my gLaptop.

```sh
$ ci/cloudbuild/build.sh -t checkers-pr

Running typos:                                    ... 1.436 seconds
Running check-include-guards:                     ... 0.220 seconds
Running Abseil header fixes:                      ... 3.125 seconds
Running include fixes:                            ... 4.648 seconds
Running whitespace fixes:                         ... 6.291 seconds
Running buildifier:                               ... 0.161 seconds
Running black:                                    ... 0.219 seconds
Running shfmt:                                    ... 0.028 seconds
Running shellcheck:                               ... 0.692 seconds
Running clang-format:                             ... 46.427 seconds
Running cmake-format:                             ... 28.773 seconds
Running markdown generators:                      ... 5.092 seconds
Running markdown formatter:                       ... 23.840 seconds
Running doxygen landing-page updates:             ... 5.956 seconds
==> 🕑 checkers completed in 127.019 seconds
```

```sh
$ env GOOGLE_CLOUD_CPP_FAST_CHECKERS=1 ci/cloudbuild/build.sh -t checkers-pr

Running typos:                                    ... 1.725 seconds
Running check-include-guards:                     ... 0.008 seconds
Running Abseil header fixes:                      ... 0.013 seconds
Running include fixes:                            ... 0.012 seconds
Running whitespace fixes:                         ... 0.022 seconds
Running buildifier:                               ... 0.009 seconds
Running black:                                    ... 0.008 seconds
Running shfmt:                                    ... 0.023 seconds
Running shellcheck:                               ... 0.150 seconds
Running clang-format:                             ... 0.009 seconds
Running cmake-format:                             ... 0.008 seconds
Running markdown generators:                      ... 3.777 seconds
Running markdown formatter:                       ... 0.582 seconds
Running doxygen landing-page updates:             ... 5.180 seconds
==> 🕑 checkers completed in 11.620 seconds
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10495)
<!-- Reviewable:end -->
