### PR TITLE
chore(otel): patch bazel

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -191,9 +191,9 @@ def google_cloud_cpp_deps():
     if "io_opentelemetry_cpp" not in native.existing_rules():
         http_archive(
             name = "io_opentelemetry_cpp",
-            strip_prefix = "opentelemetry-cpp-1.8.1",
+            strip_prefix = "opentelemetry-cpp-d5571916e18abbd994373cdb633be0815deda319",
             urls = [
-                "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.1.tar.gz",
+                "https://github.com/open-telemetry/opentelemetry-cpp/archive/d5571916e18abbd994373cdb633be0815deda319.tar.gz",
             ],
-            sha256 = "3d640201594b07f08dade9cd1017bd0b59674daca26223b560b9bb6bf56264c2",
+            sha256 = "051cbbc3b76e0459371cdcf4044a1e5182a686a443d03f9dbcec6bb7d4e2aa46",
         )


### PR DESCRIPTION
Manually update `opentelemetry-cpp` to a commit that includes https://github.com/open-telemetry/opentelemetry-cpp/pull/1873

Otherwise the SDK will not build with bazel 6.0, which we need to use in our tests.

I do not want to wait on OpenTelemetry's release schedule. Also, I do not know how the bots will react. :shrug:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10498)
<!-- Reviewable:end -->
