### PR TITLE
cleanup(bigtable): deflake integration test

### DIFF
--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -433,10 +433,8 @@ TEST_F(InstanceAdminIntegrationTest, CustomWorkers) {
   CompletionQueue cq;
   auto instance_admin_client = bigtable::MakeInstanceAdminClient(
       project_id_, Options{}.set<GrpcCompletionQueueOption>(cq));
-  instance_admin_ = absl::make_unique<bigtable::InstanceAdmin>(
-      instance_admin_client,
-      *DefaultRPCRetryPolicy({std::chrono::seconds(1), std::chrono::seconds(1),
-                              std::chrono::seconds(1)}));
+  instance_admin_ =
+      absl::make_unique<bigtable::InstanceAdmin>(instance_admin_client);
 
   // CompletionQueue `cq` is not being `Run()`, so this should never finish.
   auto const instance_id = RandomInstanceId(generator_);


### PR DESCRIPTION
This test has flaked a few times recently. We do not need to be setting a strict deadline here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10503)
<!-- Reviewable:end -->
