### PR TITLE
doc(spanner): use real Doxygen groups

### DIFF
--- a/google/cloud/spanner/backup.h
+++ b/google/cloud/spanner/backup.h
@@ -45,12 +45,12 @@ class Backup {
   Backup(Instance instance, std::string backup_id);
 
   /// @name Copy and move
-  //@{
+  ///@{
   Backup(Backup const&) = default;
   Backup& operator=(Backup const&) = default;
   Backup(Backup&&) = default;
   Backup& operator=(Backup&&) = default;
-  //@}
+  ///@}
 
   /// Returns the `Instance` containing this backup.
   Instance const& instance() const { return instance_; }
@@ -65,10 +65,10 @@ class Backup {
   std::string FullName() const;
 
   /// @name Equality operators
-  //@{
+  ///@{
   friend bool operator==(Backup const& a, Backup const& b);
   friend bool operator!=(Backup const& a, Backup const& b);
-  //@}
+  ///@}
 
   /// Output the `FullName()` format.
   friend std::ostream& operator<<(std::ostream&, Backup const&);

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -134,7 +134,7 @@ class Client {
       : conn_(std::move(conn)),
         opts_(internal::MergeOptions(std::move(opts), conn_->options())) {}
 
-  /// @name Backwards compatibility for `ClientOptions`.
+  /// @name Backwards compatibility for ClientOptions.
   ///@{
   explicit Client(std::shared_ptr<Connection> conn, ClientOptions const& opts)
       : Client(std::move(conn), Options(opts)) {}
@@ -146,23 +146,22 @@ class Client {
   /// No default construction.
   Client() = delete;
 
-  //@{
-  // @name Copy and move support
+  ///@{
+  /// @name Copy and move support
   Client(Client const&) = default;
   Client& operator=(Client const&) = default;
   Client(Client&&) = default;
   Client& operator=(Client&&) = default;
-  //@}
+  ///@}
 
-  //@{
-  // @name Equality
+  ///@{
+  /// @name Equality
   friend bool operator==(Client const& a, Client const& b) {
     return a.conn_ == b.conn_;
   }
   friend bool operator!=(Client const& a, Client const& b) { return !(a == b); }
-  //@}
+  ///@}
 
-  //@{
   /**
    * Reads rows from the database using key lookups and scans, as a simple
    * key/value style alternative to `ExecuteQuery()`.
@@ -207,21 +206,32 @@ class Client {
    */
   RowStream Read(Transaction transaction, std::string table, KeySet keys,
                  std::vector<std::string> columns, Options opts = {});
-  //@}
 
-  /// @name Backwards compatibility for `ReadOptions`.
   ///@{
+  /// @name Backwards compatibility for ReadOptions.
+  /**
+   * @copybrief Read(std::string,KeySet,std::vector<std::string>,Options)
+   * @see Read(std::string,KeySet,std::vector<std::string>,Options)
+   */
   RowStream Read(std::string table, KeySet keys,
                  std::vector<std::string> columns,
                  ReadOptions const& read_options) {
     return Read(std::move(table), std::move(keys), std::move(columns),
                 ToOptions(read_options));
   }
+  /**
+   * @copybrief Read(std::string,KeySet,std::vector<std::string>,Options)
+   * @see Read(std::string,KeySet,std::vector<std::string>,Options)
+   */
   RowStream Read(std::string table, KeySet keys,
                  std::vector<std::string> columns,
                  std::initializer_list<internal::NonConstructible>) {
     return Read(std::move(table), std::move(keys), std::move(columns));
   }
+  /**
+   * @copybrief Read(Transaction::SingleUseOptions,std::string,KeySet,std::vector<std::string>,Options)
+   * @see Read(Transaction::SingleUseOptions,std::string,KeySet,std::vector<std::string>,Options)
+   */
   RowStream Read(Transaction::SingleUseOptions transaction_options,
                  std::string table, KeySet keys,
                  std::vector<std::string> columns,
@@ -229,6 +239,10 @@ class Client {
     return Read(std::move(transaction_options), std::move(table),
                 std::move(keys), std::move(columns), ToOptions(read_options));
   }
+  /**
+   * @copybrief Read(Transaction::SingleUseOptions,std::string,KeySet,std::vector<std::string>,Options)
+   * @see Read(Transaction::SingleUseOptions,std::string,KeySet,std::vector<std::string>,Options)
+   */
   RowStream Read(Transaction::SingleUseOptions transaction_options,
                  std::string table, KeySet keys,
                  std::vector<std::string> columns,
@@ -236,12 +250,20 @@ class Client {
     return Read(std::move(transaction_options), std::move(table),
                 std::move(keys), std::move(columns));
   }
+  /**
+   * @copybrief Read(Transaction,std::string,KeySet,std::vector<std::string>,Options)
+   * @see Read(Transaction,std::string,KeySet,std::vector<std::string>,Options)
+   */
   RowStream Read(Transaction transaction, std::string table, KeySet keys,
                  std::vector<std::string> columns,
                  ReadOptions const& read_options) {
     return Read(std::move(transaction), std::move(table), std::move(keys),
                 std::move(columns), ToOptions(read_options));
   }
+  /**
+   * @copybrief Read(Transaction,std::string,KeySet,std::vector<std::string>,Options)
+   * @see Read(Transaction,std::string,KeySet,std::vector<std::string>,Options)
+   */
   RowStream Read(Transaction transaction, std::string table, KeySet keys,
                  std::vector<std::string> columns,
                  std::initializer_list<internal::NonConstructible>) {
@@ -301,8 +323,12 @@ class Client {
       Transaction transaction, std::string table, KeySet keys,
       std::vector<std::string> columns, Options opts = {});
 
-  /// @name Backwards compatibility for `ReadOptions` and `PartitionOptions`.
   ///@{
+  /// @name Backwards compatibility for ReadOptions and PartitionOptions.
+  /**
+   * @copybrief PartitionRead(Transaction,std::string,KeySet,std::vector<std::string>,Options)
+   * @see PartitionRead(Transaction,std::string,KeySet,std::vector<std::string>,Options)
+   */
   StatusOr<std::vector<ReadPartition>> PartitionRead(
       Transaction transaction, std::string table, KeySet keys,
       std::vector<std::string> columns, ReadOptions const& read_options,
@@ -312,6 +338,10 @@ class Client {
                          internal::MergeOptions(ToOptions(read_options),
                                                 ToOptions(partition_options)));
   }
+  /**
+   * @copybrief PartitionRead(Transaction,std::string,KeySet,std::vector<std::string>,Options)
+   * @see PartitionRead(Transaction,std::string,KeySet,std::vector<std::string>,Options)
+   */
   StatusOr<std::vector<ReadPartition>> PartitionRead(
       Transaction transaction, std::string table, KeySet keys,
       std::vector<std::string> columns,
@@ -321,7 +351,7 @@ class Client {
   }
   ///@}
 
-  //@{
+  ///@{
   /**
    * Executes a SQL query.
    *
@@ -397,47 +427,79 @@ class Client {
    * @snippet samples.cc execute-sql-query-partition
    */
   RowStream ExecuteQuery(QueryPartition const& partition, Options opts = {});
-  //@}
+  ///@}
 
-  /// @name Backwards compatibility for `QueryOptions`.
   ///@{
+  /// @name Backwards compatibility for QueryOptions.
+  /**
+   * @copybrief ExecuteQuery(SqlStatement,Options)
+   * @see ExecuteQuery(SqlStatement,Options)
+   */
   RowStream ExecuteQuery(SqlStatement statement, QueryOptions const& opts) {
     return ExecuteQuery(std::move(statement), Options(opts));
   }
+  /**
+   * @copybrief ExecuteQuery(SqlStatement,Options)
+   * @see ExecuteQuery(SqlStatement,Options)
+   */
   RowStream ExecuteQuery(SqlStatement statement,
                          std::initializer_list<internal::NonConstructible>) {
     return ExecuteQuery(std::move(statement));
   }
+  /**
+   * @copybrief ExecuteQuery(Transaction::SingleUseOptions,SqlStatement,Options)
+   * @see ExecuteQuery(Transaction::SingleUseOptions,SqlStatement,Options)
+   */
   RowStream ExecuteQuery(Transaction::SingleUseOptions transaction_options,
                          SqlStatement statement, QueryOptions const& opts) {
     return ExecuteQuery(std::move(transaction_options), std::move(statement),
                         Options(opts));
   }
+  /**
+   * @copybrief ExecuteQuery(Transaction::SingleUseOptions,SqlStatement,Options)
+   * @see ExecuteQuery(Transaction::SingleUseOptions,SqlStatement,Options)
+   */
   RowStream ExecuteQuery(Transaction::SingleUseOptions transaction_options,
                          SqlStatement statement,
                          std::initializer_list<internal::NonConstructible>) {
     return ExecuteQuery(std::move(transaction_options), std::move(statement));
   }
+  /**
+   * @copybrief ExecuteQuery(Transaction,SqlStatement,Options)
+   * @see ExecuteQuery(Transaction,SqlStatement,Options)
+   */
   RowStream ExecuteQuery(Transaction transaction, SqlStatement statement,
                          QueryOptions const& opts) {
     return ExecuteQuery(std::move(transaction), std::move(statement),
                         Options(opts));
   }
+  /**
+   * @copybrief ExecuteQuery(Transaction,SqlStatement,Options)
+   * @see ExecuteQuery(Transaction,SqlStatement,Options)
+   */
   RowStream ExecuteQuery(Transaction transaction, SqlStatement statement,
                          std::initializer_list<internal::NonConstructible>) {
     return ExecuteQuery(std::move(transaction), std::move(statement));
   }
+  /**
+   * @copybrief ExecuteQuery(QueryPartition const&,Options)
+   * @see ExecuteQuery(QueryPartition const&,Options)
+   */
   RowStream ExecuteQuery(QueryPartition const& partition,
                          QueryOptions const& opts) {
     return ExecuteQuery(partition, Options(opts));
   }
+  /**
+   * @copybrief ExecuteQuery(QueryPartition const&,Options)
+   * @see ExecuteQuery(QueryPartition const&,Options)
+   */
   RowStream ExecuteQuery(QueryPartition const& partition,
                          std::initializer_list<internal::NonConstructible>) {
     return ExecuteQuery(partition);
   }
   ///@}
 
-  //@{
+  ///@{
   /**
    * Profiles a SQL query.
    *
@@ -485,36 +547,60 @@ class Client {
    */
   ProfileQueryResult ProfileQuery(Transaction transaction,
                                   SqlStatement statement, Options opts = {});
-  //@}
+  ///@}
 
-  /// @name Backwards compatibility for `QueryOptions`.
   ///@{
+  /// @name Backwards compatibility for QueryOptions.
+  /**
+   * @copybrief ProfileQuery(SqlStatement,Options)
+   * @see ProfileQuery(SqlStatement,Options)
+   */
   ProfileQueryResult ProfileQuery(SqlStatement statement,
                                   QueryOptions const& opts) {
     return ProfileQuery(std::move(statement), Options(opts));
   }
+  /**
+   * @copybrief ProfileQuery(SqlStatement,Options)
+   * @see ProfileQuery(SqlStatement,Options)
+   */
   ProfileQueryResult ProfileQuery(
       SqlStatement statement,
       std::initializer_list<internal::NonConstructible>) {
     return ProfileQuery(std::move(statement));
   }
+  /**
+   * @copybrief ProfileQuery(Transaction::SingleUseOptions,SqlStatement,Options)
+   * @see ProfileQuery(Transaction::SingleUseOptions,SqlStatement,Options)
+   */
   ProfileQueryResult ProfileQuery(
       Transaction::SingleUseOptions transaction_options, SqlStatement statement,
       QueryOptions const& opts) {
     return ProfileQuery(std::move(transaction_options), std::move(statement),
                         Options(opts));
   }
+  /**
+   * @copybrief ProfileQuery(Transaction::SingleUseOptions,SqlStatement,Options)
+   * @see ProfileQuery(Transaction::SingleUseOptions,SqlStatement,Options)
+   */
   ProfileQueryResult ProfileQuery(
       Transaction::SingleUseOptions transaction_options, SqlStatement statement,
       std::initializer_list<internal::NonConstructible>) {
     return ProfileQuery(std::move(transaction_options), std::move(statement));
   }
+  /**
+   * @copybrief ProfileQuery(Transaction,SqlStatement,Options)
+   * @see ProfileQuery(Transaction,SqlStatement,Options)
+   */
   ProfileQueryResult ProfileQuery(Transaction transaction,
                                   SqlStatement statement,
                                   QueryOptions const& opts) {
     return ProfileQuery(std::move(transaction), std::move(statement),
                         Options(opts));
   }
+  /**
+   * @copybrief ProfileQuery(Transaction,SqlStatement,Options)
+   * @see ProfileQuery(Transaction,SqlStatement,Options)
+   */
   ProfileQueryResult ProfileQuery(
       Transaction transaction, SqlStatement statement,
       std::initializer_list<internal::NonConstructible>) {
@@ -547,14 +633,22 @@ class Client {
       Transaction transaction, SqlStatement statement,
       Options opts = Options{});
 
-  /// @name Backwards compatibility for `PartitionOptions`.
   ///@{
+  /// @name Backwards compatibility for PartitionOptions.
+  /**
+   * @copybrief PartitionQuery(Transaction,SqlStatement,Options)
+   * @see PartitionQuery(Transaction,SqlStatement,Options)
+   */
   StatusOr<std::vector<QueryPartition>> PartitionQuery(
       Transaction transaction, SqlStatement statement,
       PartitionOptions const& partition_options) {
     return PartitionQuery(std::move(transaction), std::move(statement),
                           ToOptions(partition_options));
   }
+  /**
+   * @copybrief PartitionQuery(Transaction,SqlStatement,Options)
+   * @see PartitionQuery(Transaction,SqlStatement,Options)
+   */
   StatusOr<std::vector<QueryPartition>> PartitionQuery(
       Transaction transaction, SqlStatement statement,
       std::initializer_list<internal::NonConstructible>) {
@@ -582,14 +676,22 @@ class Client {
   StatusOr<DmlResult> ExecuteDml(Transaction transaction,
                                  SqlStatement statement, Options opts = {});
 
-  /// @name Backwards compatibility for `QueryOptions`.
   ///@{
+  /// @name Backwards compatibility for QueryOptions.
+  /**
+   * @copybrief ExecuteDml(Transaction,SqlStatement,Options)
+   * @see ExecuteDml(Transaction,SqlStatement,Options)
+   */
   StatusOr<DmlResult> ExecuteDml(Transaction transaction,
                                  SqlStatement statement,
                                  QueryOptions const& opts) {
     return ExecuteDml(std::move(transaction), std::move(statement),
                       Options(opts));
   }
+  /**
+   * @copybrief ExecuteDml(Transaction,SqlStatement,Options)
+   * @see ExecuteDml(Transaction,SqlStatement,Options)
+   */
   StatusOr<DmlResult> ExecuteDml(
       Transaction transaction, SqlStatement statement,
       std::initializer_list<internal::NonConstructible>) {
@@ -621,8 +723,8 @@ class Client {
                                         SqlStatement statement,
                                         Options opts = {});
 
-  /// @name Backwards compatibility for `QueryOptions`.
   ///@{
+  /// @name Backwards compatibility for QueryOptions.
   StatusOr<ProfileDmlResult> ProfileDml(Transaction transaction,
                                         SqlStatement statement,
                                         QueryOptions const& opts) {
@@ -659,14 +761,24 @@ class Client {
   StatusOr<ExecutionPlan> AnalyzeSql(Transaction transaction,
                                      SqlStatement statement, Options opts = {});
 
-  /// @name Backwards compatibility for `QueryOptions`.
   ///@{
+  /// @name Backwards compatibility for QueryOptions.
+  /**
+   * @copybrief AnalyzeSql(Transaction,SqlStatement,Options)
+   *
+   * @see AnalyzeSql(Transaction,SqlStatement,Options)
+   */
   StatusOr<ExecutionPlan> AnalyzeSql(Transaction transaction,
                                      SqlStatement statement,
                                      QueryOptions const& opts) {
     return AnalyzeSql(std::move(transaction), std::move(statement),
                       Options(opts));
   }
+  /**
+   * @copybrief AnalyzeSql(Transaction,SqlStatement,Options)
+   *
+   * @see AnalyzeSql(Transaction,SqlStatement,Options)
+   */
   StatusOr<ExecutionPlan> AnalyzeSql(
       Transaction transaction, SqlStatement statement,
       std::initializer_list<internal::NonConstructible>) {
@@ -755,8 +867,12 @@ class Client {
       std::unique_ptr<TransactionRerunPolicy> rerun_policy,
       std::unique_ptr<BackoffPolicy> backoff_policy, Options opts = {});
 
-  /// @name Backwards compatibility for `CommitOptions`.
   ///@{
+  /// @name Backwards compatibility for CommitOptions.
+  /**
+   * @copybrief Commit(std::function<StatusOr<Mutations>(Transaction)> const&,std::unique_ptr<TransactionRerunPolicy>,std::unique_ptr<BackoffPolicy>,Options)
+   * @see Commit(std::function<StatusOr<Mutations>(Transaction)> const&,std::unique_ptr<TransactionRerunPolicy>,std::unique_ptr<BackoffPolicy>,Options)
+   */
   StatusOr<CommitResult> Commit(
       std::function<StatusOr<Mutations>(Transaction)> const& mutator,
       std::unique_ptr<TransactionRerunPolicy> rerun_policy,
@@ -765,6 +881,10 @@ class Client {
     return Commit(mutator, std::move(rerun_policy), std::move(backoff_policy),
                   Options(commit_options));
   }
+  /**
+   * @copybrief Commit(std::function<StatusOr<Mutations>(Transaction)> const&,std::unique_ptr<TransactionRerunPolicy>,std::unique_ptr<BackoffPolicy>,Options)
+   * @see Commit(std::function<StatusOr<Mutations>(Transaction)> const&,std::unique_ptr<TransactionRerunPolicy>,std::unique_ptr<BackoffPolicy>,Options)
+   */
   StatusOr<CommitResult> Commit(
       std::function<StatusOr<Mutations>(Transaction)> const& mutator,
       std::unique_ptr<TransactionRerunPolicy> rerun_policy,
@@ -789,13 +909,19 @@ class Client {
       std::function<StatusOr<Mutations>(Transaction)> const& mutator,
       Options opts = {});
 
-  /// @name Backwards compatibility for `CommitOptions`.
   ///@{
+  /// @name Backwards compatibility for CommitOptions.
+  /**
+   * @copybrief Commit(std::function<StatusOr<Mutations>(Transaction)> const&,Options)
+   */
   StatusOr<CommitResult> Commit(
       std::function<StatusOr<Mutations>(Transaction)> const& mutator,
       CommitOptions const& commit_options) {
     return Commit(mutator, Options(commit_options));
   }
+  /**
+   * @see Commit(std::function<StatusOr<Mutations>(Transaction)> const&,Options)
+   */
   StatusOr<CommitResult> Commit(
       std::function<StatusOr<Mutations>(Transaction)> const& mutator,
       std::initializer_list<internal::NonConstructible>) {
@@ -814,12 +940,20 @@ class Client {
    */
   StatusOr<CommitResult> Commit(Mutations mutations, Options opts = {});
 
-  /// @name Backwards compatibility for `CommitOptions`.
   ///@{
+  /// @name Backwards compatibility for CommitOptions.
+  /**
+   * @copybrief Commit(Mutations,Options)
+   * @see Commit(Mutations,Options)
+   */
   StatusOr<CommitResult> Commit(Mutations mutations,
                                 CommitOptions const& commit_options) {
     return Commit(std::move(mutations), Options(commit_options));
   }
+  /**
+   * @copybrief Commit(Mutations,Options)
+   * @see Commit(Mutations,Options)
+   */
   StatusOr<CommitResult> Commit(
       Mutations mutations, std::initializer_list<internal::NonConstructible>) {
     return Commit(std::move(mutations));
@@ -854,13 +988,21 @@ class Client {
   StatusOr<CommitResult> Commit(Transaction transaction, Mutations mutations,
                                 Options opts = {});
 
-  /// @name Backwards compatibility for `CommitOptions`.
   ///@{
+  /// @name Backwards compatibility for CommitOptions.
+  /**
+   * @copybrief Commit(Transaction,Mutations,Options)
+   * @see Commit(Transaction,Mutations,Options)
+   */
   StatusOr<CommitResult> Commit(Transaction transaction, Mutations mutations,
                                 CommitOptions const& commit_options) {
     return Commit(std::move(transaction), std::move(mutations),
                   Options(commit_options));
   }
+  /**
+   * @copybrief Commit(Transaction,Mutations,Options)
+   * @see Commit(Transaction,Mutations,Options)
+   */
   StatusOr<CommitResult> Commit(
       Transaction transaction, Mutations mutations,
       std::initializer_list<internal::NonConstructible>) {
@@ -909,12 +1051,20 @@ class Client {
   StatusOr<PartitionedDmlResult> ExecutePartitionedDml(SqlStatement statement,
                                                        Options opts = {});
 
-  /// @name Backwards compatibility for `QueryOptions`.
   ///@{
+  /// @name Backwards compatibility for QueryOptions.
+  /**
+   * @copybrief ExecutePartitionedDml(SqlStatement,Options)
+   * @see ExecutePartitionedDml(SqlStatement,Options)
+   */
   StatusOr<PartitionedDmlResult> ExecutePartitionedDml(
       SqlStatement statement, QueryOptions const& opts) {
     return ExecutePartitionedDml(std::move(statement), Options(opts));
   }
+  /**
+   * @copybrief ExecutePartitionedDml(SqlStatement,Options)
+   * @see ExecutePartitionedDml(SqlStatement,Options)
+   */
   StatusOr<PartitionedDmlResult> ExecutePartitionedDml(
       SqlStatement statement,
       std::initializer_list<internal::NonConstructible>) {

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -60,7 +60,7 @@ class Connection {
  public:
   virtual ~Connection() = default;
 
-  //@{
+  ///@{
   /**
    * @name Defines the arguments for each member function.
    *
@@ -126,7 +126,7 @@ class Connection {
   struct RollbackParams {
     Transaction transaction;
   };
-  //@}
+  ///@}
 
   /// Returns the options used by the Connection.
   virtual Options options() { return Options{}; }

--- a/google/cloud/spanner/database.h
+++ b/google/cloud/spanner/database.h
@@ -59,12 +59,12 @@ class Database {
            std::string database_id);
 
   /// @name Copy and move
-  //@{
+  ///@{
   Database(Database const&) = default;
   Database& operator=(Database const&) = default;
   Database(Database&&) = default;
   Database& operator=(Database&&) = default;
-  //@}
+  ///@}
 
   /// Returns the `Instance` containing this database.
   Instance const& instance() const { return instance_; }
@@ -79,10 +79,10 @@ class Database {
   std::string FullName() const;
 
   /// @name Equality operators
-  //@{
+  ///@{
   friend bool operator==(Database const& a, Database const& b);
   friend bool operator!=(Database const& a, Database const& b);
-  //@}
+  ///@}
 
   /// Output the `FullName()` format.
   friend std::ostream& operator<<(std::ostream&, Database const&);

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -103,7 +103,7 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("DatabaseAdminConnection")
  public:
   virtual ~DatabaseAdminConnection() = 0;
 
-  //@{
+  ///@{
   /**
    * @name Define the arguments for each member function.
    *
@@ -239,7 +239,7 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("DatabaseAdminConnection")
     Instance instance;
     std::string filter;
   };
-  //@}
+  ///@}
 
   virtual Options options() { return Options{}; }
 

--- a/google/cloud/spanner/instance.h
+++ b/google/cloud/spanner/instance.h
@@ -57,12 +57,12 @@ class Instance {
   Instance(std::string project_id, std::string instance_id);
 
   /// @name Copy and move
-  //@{
+  ///@{
   Instance(Instance const&) = default;
   Instance& operator=(Instance const&) = default;
   Instance(Instance&&) = default;
   Instance& operator=(Instance&&) = default;
-  //@}
+  ///@}
 
   /// Returns the `Project` containing this instance.
   Project const& project() const { return project_; }
@@ -78,10 +78,10 @@ class Instance {
   std::string FullName() const;
 
   /// @name Equality operators
-  //@{
+  ///@{
   friend bool operator==(Instance const& a, Instance const& b);
   friend bool operator!=(Instance const& a, Instance const& b);
-  //@}
+  ///@}
 
   /// Output the `FullName()` format.
   friend std::ostream& operator<<(std::ostream&, Instance const&);

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -71,16 +71,16 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("InstanceAdminClient")
   /// Use `InstanceAdminClient(std::shared_ptr<InstanceAdminConnection>)`
   InstanceAdminClient() = delete;
 
-  //@{
-  // @name Copy and move support
+  ///@{
+  /// @name Copy and move support
   InstanceAdminClient(InstanceAdminClient const&) = default;
   InstanceAdminClient& operator=(InstanceAdminClient const&) = default;
   InstanceAdminClient(InstanceAdminClient&&) = default;
   InstanceAdminClient& operator=(InstanceAdminClient&&) = default;
-  //@}
+  ///@}
 
-  //@{
-  // @name Equality
+  ///@{
+  /// @name Equality
   friend bool operator==(InstanceAdminClient const& a,
                          InstanceAdminClient const& b) {
     return a.conn_ == b.conn_;
@@ -89,7 +89,7 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("InstanceAdminClient")
                          InstanceAdminClient const& b) {
     return !(a == b);
   }
-  //@}
+  ///@}
 
   /**
    * Retrieve metadata information about a Cloud Spanner Instance.

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -73,7 +73,7 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("InstanceAdminConnection")
  public:
   virtual ~InstanceAdminConnection() = 0;
 
-  //@{
+  ///@{
   /**
    * @name Define the arguments for each member function.
    *
@@ -155,7 +155,7 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("InstanceAdminConnection")
     std::string instance_name;
     std::vector<std::string> permissions;
   };
-  //@}
+  ///@}
 
   virtual Options options() { return Options{}; }
 

--- a/google/cloud/spanner/internal/database_admin_logging.h
+++ b/google/cloud/spanner/internal/database_admin_logging.h
@@ -38,13 +38,12 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
 
   ~DatabaseAdminLogging() override = default;
 
-  //@{
+  ///@{
   /**
    * @name Override the functions from `DatabaseAdminStub`.
    *
    * Run the logging loop (if appropriate) for the child DatabaseAdminStub.
    */
-  ///
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::spanner::admin::database::v1::CreateDatabaseRequest const&)
@@ -136,7 +135,7 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
   future<Status> AsyncCancelOperation(
       CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::longrunning::CancelOperationRequest const&) override;
-  //@}
+  ///@}
 
  private:
   std::shared_ptr<DatabaseAdminStub> child_;

--- a/google/cloud/spanner/internal/database_admin_metadata.h
+++ b/google/cloud/spanner/internal/database_admin_metadata.h
@@ -33,10 +33,8 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
 
   ~DatabaseAdminMetadata() override = default;
 
-  //@{
-  /**
-   * @name Override the functions from `DatabaseAdminStub`.
-   */
+  ///@{
+  /// @name Override the functions from `DatabaseAdminStub`.
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::spanner::admin::database::v1::CreateDatabaseRequest const&)
@@ -129,7 +127,7 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
   future<Status> AsyncCancelOperation(
       CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::longrunning::CancelOperationRequest const&) override;
-  //@}
+  ///@}
 
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -38,13 +38,12 @@ class InstanceAdminLogging : public InstanceAdminStub {
 
   ~InstanceAdminLogging() override = default;
 
-  //@{
+  ///@{
   /**
    * @name Override the functions from `InstanceAdminStub`.
    *
    * Run the logging loop (if appropriate) for the child InstanceAdminStub.
    */
-  ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       grpc::ClientContext&,
       google::spanner::admin::instance::v1::GetInstanceRequest const&) override;
@@ -101,7 +100,7 @@ class InstanceAdminLogging : public InstanceAdminStub {
   future<Status> AsyncCancelOperation(
       CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::longrunning::CancelOperationRequest const&) override;
-  //@}
+  ///@}
 
  private:
   std::shared_ptr<InstanceAdminStub> child_;

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -34,11 +34,10 @@ class InstanceAdminMetadata : public InstanceAdminStub {
 
   ~InstanceAdminMetadata() override = default;
 
-  //@{
+  ///@{
   /**
    * @name Override the functions from `InstanceAdminStub`.
    */
-  ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       grpc::ClientContext&,
       google::spanner::admin::instance::v1::GetInstanceRequest const&) override;
@@ -95,7 +94,7 @@ class InstanceAdminMetadata : public InstanceAdminStub {
   future<Status> AsyncCancelOperation(
       CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::longrunning::CancelOperationRequest const&) override;
-  //@}
+  ///@}
 
  private:
   void SetMetadata(grpc::ClientContext& context,


### PR DESCRIPTION
In the `spanner::Client` documentation I added brief descriptions links to the new (recommended) overload for all the "backwards compatibility for XXX" functions.

### Before

![image](https://user-images.githubusercontent.com/6241635/211109590-977f437d-768f-4d18-bcde-82b33e84ec8f.png)

### After

![image](https://user-images.githubusercontent.com/6241635/211109753-7090971a-8b83-408c-b23d-325204711d65.png)

![image](https://user-images.githubusercontent.com/6241635/211109893-f8af70d4-ee60-4e88-91d6-4092db97ddc2.png)
