### PR TITLE
feat(generator): another comment workaround

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -628,6 +628,8 @@ std::string FormatApiMethodSignatureParameters(
              " `<parent>/instanceConfigs/us-east1`,"},
             {" <parent>/instanceConfigs/nam3.",
              " `<parent>/instanceConfigs/nam3`."},
+            // Runaway escaping and just duplication is gkemulticloud proto file
+            {" formatted as `resource name formatted as", " formatted as"},
         });
     absl::StrAppendFormat(&parameter_comments, "  /// @param %s %s\n",
                           FieldName(parameter_descriptor), std::move(comment));

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -628,7 +628,8 @@ std::string FormatApiMethodSignatureParameters(
              " `<parent>/instanceConfigs/us-east1`,"},
             {" <parent>/instanceConfigs/nam3.",
              " `<parent>/instanceConfigs/nam3`."},
-            // Runaway escaping and just duplication in gkemulticloud proto file.
+            // Runaway escaping and just duplication in gkemulticloud proto
+            // file.
             {" formatted as `resource name formatted as", " formatted as"},
         });
     absl::StrAppendFormat(&parameter_comments, "  /// @param %s %s\n",

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -628,7 +628,7 @@ std::string FormatApiMethodSignatureParameters(
              " `<parent>/instanceConfigs/us-east1`,"},
             {" <parent>/instanceConfigs/nam3.",
              " `<parent>/instanceConfigs/nam3`."},
-            // Runaway escaping and just duplication is gkemulticloud proto file
+            // Runaway escaping and just duplication in gkemulticloud proto file.
             {" formatted as `resource name formatted as", " formatted as"},
         });
     absl::StrAppendFormat(&parameter_comments, "  /// @param %s %s\n",


### PR DESCRIPTION
One of the comments in the `gkemultcloud` protos is incorrectly formatted. I have sent a fix upstream, but while that works its way through the pipelines, this workaround will keep the code generation happy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10515)
<!-- Reviewable:end -->
