### PR TITLE
doc: update howto guide for generated libraries

### DIFF
--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -261,7 +261,7 @@ For new GA libraries you need to create the API baseline.
 ci/cloudbuild/build.sh -t check-api-pr
 git add ci/abi-dumps/google_cloud_cpp_${library}.expected.abi.dump.gz
 git commit -m"Add API baseline" ci/abi-dumps/google_cloud_cpp_${library}.expected.abi.dump.gz
-git checkout -- ci/abi-dumps/
+git restore ci/abi-dumps/
 ```
 
 ## Verify everything compiles

--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -253,6 +253,17 @@ Announce the new library in the CHANGELOG for the next release.
 ci/cloudbuild/build.sh -t checkers-pr
 ```
 
+## Add the API baseline
+
+For new GA libraries you need to create the API baseline.
+
+```
+ci/cloudbuild/build.sh -t check-api-pr
+git add ci/abi-dumps/google_cloud_cpp_${library}.expected.abi.dump.gz
+git commit -m"Add API baseline" ci/abi-dumps/google_cloud_cpp_${library}.expected.abi.dump.gz
+git checkout -- ci/abi-dumps/
+```
+
 ## Verify everything compiles
 
 ```shell


### PR DESCRIPTION
The `check-api` build immediately starts testing new GA libraries, we need to create the API baseline as we create the new library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10516)
<!-- Reviewable:end -->
