### PR TITLE
impl(rest): add RestCompletionQueueImpl

### DIFF
--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -350,6 +350,7 @@ load(":google_cloud_cpp_rest_protobuf_internal_unit_tests.bzl", "google_cloud_cp
     srcs = [test],
     deps = [
         ":google_cloud_cpp_rest_protobuf_internal",
+        "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_rest_private",
         "@com_google_googleapis//google/iam/admin/v1:admin_cc_grpc",

--- a/google/cloud/google_cloud_cpp_rest_protobuf_internal.bzl
+++ b/google/cloud/google_cloud_cpp_rest_protobuf_internal.bzl
@@ -17,9 +17,11 @@
 """Automatically generated source lists for google_cloud_cpp_rest_protobuf_internal - DO NOT EDIT."""
 
 google_cloud_cpp_rest_protobuf_internal_hdrs = [
+    "internal/rest_completion_queue_impl.h",
     "internal/rest_stub_helpers.h",
 ]
 
 google_cloud_cpp_rest_protobuf_internal_srcs = [
+    "internal/rest_completion_queue_impl.cc",
     "internal/rest_stub_helpers.cc",
 ]

--- a/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
@@ -15,8 +15,11 @@
 # ~~~
 
 # the library
-add_library(google_cloud_cpp_rest_protobuf_internal # cmake-format: sort
-            internal/rest_stub_helpers.cc internal/rest_stub_helpers.h)
+add_library(
+    google_cloud_cpp_rest_protobuf_internal # cmake-format: sort
+    internal/rest_completion_queue_impl.cc
+    internal/rest_completion_queue_impl.h internal/rest_stub_helpers.cc
+    internal/rest_stub_helpers.h)
 target_link_libraries(
     google_cloud_cpp_rest_protobuf_internal
     PUBLIC google-cloud-cpp::common google-cloud-cpp::rest_internal
@@ -105,6 +108,7 @@ function (google_cloud_cpp_rest_protobuf_internal_add_test fname labels)
     target_link_libraries(
         ${target}
         PRIVATE google-cloud-cpp::rest_protobuf_internal
+                google_cloud_cpp_testing_grpc
                 google_cloud_cpp_testing
                 google-cloud-cpp::common
                 google-cloud-cpp::iam_protos
@@ -124,6 +128,7 @@ if (BUILD_TESTING)
     # List the unit tests, then setup the targets and dependencies.
     set(google_cloud_cpp_rest_protobuf_internal_unit_tests
         # cmake-format: sort
+        internal/rest_completion_queue_impl_test.cc
         internal/rest_log_wrapper_test.cc internal/rest_stub_helpers_test.cc)
 
     # Export the list of unit tests so the Bazel BUILD file can pick them up.

--- a/google/cloud/google_cloud_cpp_rest_protobuf_internal_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_rest_protobuf_internal_unit_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 google_cloud_cpp_rest_protobuf_internal_unit_tests = [
+    "internal/rest_completion_queue_impl_test.cc",
     "internal/rest_log_wrapper_test.cc",
     "internal/rest_stub_helpers_test.cc",
 ]

--- a/google/cloud/internal/rest_completion_queue_impl.cc
+++ b/google/cloud/internal/rest_completion_queue_impl.cc
@@ -51,7 +51,7 @@ void RestCompletionQueueImpl::RunAsync(
   ++run_async_counter_;
   // Some delay is necessary to reduce the likelihood that the timer expires
   // before .then() is called.
-  // TODO(#xxxxx): Refactor this mechanism to a more deterministic solution.
+  // TODO(#10553): Refactor this mechanism to a more deterministic solution.
   MakeRelativeTimer(std::chrono::milliseconds(500))
       .then([f = std::move(function)](auto) { f->exec(); });
 }

--- a/google/cloud/internal/rest_completion_queue_impl.cc
+++ b/google/cloud/internal/rest_completion_queue_impl.cc
@@ -1,0 +1,71 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/rest_completion_queue_impl.h"
+#include "google/cloud/internal/timer_queue.h"
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+RestCompletionQueueImpl::RestCompletionQueueImpl()
+    : shutdown_guard_(
+          // Capturing `this` here is safe because the lifetime of copies of
+          // this member do not outlive `StartOperation`.
+          std::shared_ptr<void>(reinterpret_cast<void*>(this),
+                                [this](void*) { tq_.Shutdown(); })) {}
+
+void RestCompletionQueueImpl::Run() { tq_.Service(); }
+
+void RestCompletionQueueImpl::Shutdown() {
+  std::lock_guard<std::mutex> lk(mu_);
+  tq_.Shutdown();
+  shutdown_ = true;
+  shutdown_guard_.reset();
+}
+
+void RestCompletionQueueImpl::CancelAll() { tq_.CancelAll(); }
+
+future<StatusOr<std::chrono::system_clock::time_point>>
+RestCompletionQueueImpl::MakeDeadlineTimer(
+    std::chrono::system_clock::time_point deadline) {
+  return tq_.Schedule(deadline);
+}
+
+future<StatusOr<std::chrono::system_clock::time_point>>
+RestCompletionQueueImpl::MakeRelativeTimer(std::chrono::nanoseconds duration) {
+  using std::chrono::system_clock;
+  auto const d = std::chrono::duration_cast<system_clock::duration>(duration);
+  return MakeDeadlineTimer(system_clock::now() + d);
+}
+
+// Use an "immediately" expiring timer in order to get the thread(s) servicing
+// the TimerQueue to execute the function. However, if the timer
+// expires before .then() is invoked, the lambda will be immediately called and
+// the passing of execution to the queue servicing thread will not occur.
+void RestCompletionQueueImpl::RunAsync(
+    std::unique_ptr<internal::RunAsyncBase> function) {
+  ++run_async_counter_;
+  // Some delay is necessary to reduce the likelihood that the timer expires
+  // before .then() is called.
+  // TODO(#xxxxx): Refactor this mechanism to a more deterministic solution.
+  MakeRelativeTimer(std::chrono::milliseconds(500))
+      .then([f = std::move(function)](auto) { f->exec(); });
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/rest_completion_queue_impl.h
+++ b/google/cloud/internal/rest_completion_queue_impl.h
@@ -1,0 +1,96 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_COMPLETION_QUEUE_IMPL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_COMPLETION_QUEUE_IMPL_H
+
+#include "google/cloud/future.h"
+#include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/internal/timer_queue.h"
+#include "google/cloud/log.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
+#include "absl/functional/function_ref.h"
+#include <atomic>
+#include <chrono>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Implementation for CompletionQueue that does NOT use a grpc::CompletionQueue.
+ * Due to the lack of a completion queue that can manage multiple, simultaneous
+ * REST requests, asynchronous calls should be launched on a thread of their own
+ * and RunAsync should only be called with a function to join that thread after
+ * it completes its work.
+ */
+class RestCompletionQueueImpl final
+    : public internal::CompletionQueueImpl,
+      public std::enable_shared_from_this<RestCompletionQueueImpl> {
+ public:
+  ~RestCompletionQueueImpl() override = default;
+  RestCompletionQueueImpl();
+
+  /// Run the event loop until Shutdown() is called.
+  void Run() override;
+
+  /// Terminate the event loop.
+  void Shutdown() override;
+
+  /// Cancel all existing operations.
+  void CancelAll() override;
+
+  /// Create a new timer.
+  future<StatusOr<std::chrono::system_clock::time_point>> MakeDeadlineTimer(
+      std::chrono::system_clock::time_point deadline) override;
+
+  /// Create a new timer.
+  future<StatusOr<std::chrono::system_clock::time_point>> MakeRelativeTimer(
+      std::chrono::nanoseconds duration) override;
+
+  /// Enqueue a new asynchronous function.
+  void RunAsync(std::unique_ptr<internal::RunAsyncBase> function) override;
+
+  /// This function is not supported by RestCompletionQueueImpl, but as the
+  /// function is pure virtual, it must be overridden.
+  void StartOperation(std::shared_ptr<internal::AsyncGrpcOperation>,
+                      absl::FunctionRef<void(void*)>) override {
+    GCP_LOG(FATAL) << " function not supported.\n";
+  }
+
+  /// The underlying gRPC completion queue, which does not exist.
+  grpc::CompletionQueue* cq() override { return nullptr; }
+
+  /// Some counters for testing and debugging.
+  std::int64_t run_async_counter() const { return run_async_counter_.load(); }
+
+ private:
+  std::mutex mu_;
+  internal::TimerQueue tq_;
+  bool shutdown_{false};  // GUARDED_BY(mu_)
+  std::shared_ptr<void> shutdown_guard_;
+
+  // These are metrics used in testing.
+  std::atomic<std::int64_t> run_async_counter_{0};
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_COMPLETION_QUEUE_IMPL_H

--- a/google/cloud/internal/rest_completion_queue_impl.h
+++ b/google/cloud/internal/rest_completion_queue_impl.h
@@ -33,6 +33,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * Implementation for CompletionQueue that does NOT use a grpc::CompletionQueue.
+ *
  * Due to the lack of a completion queue that can manage multiple, simultaneous
  * REST requests, asynchronous calls should be launched on a thread of their own
  * and RunAsync should only be called with a function to join that thread after

--- a/google/cloud/internal/rest_completion_queue_impl.h
+++ b/google/cloud/internal/rest_completion_queue_impl.h
@@ -68,9 +68,7 @@ class RestCompletionQueueImpl final
   /// This function is not supported by RestCompletionQueueImpl, but as the
   /// function is pure virtual, it must be overridden.
   void StartOperation(std::shared_ptr<internal::AsyncGrpcOperation>,
-                      absl::FunctionRef<void(void*)>) override {
-    GCP_LOG(FATAL) << " function not supported.\n";
-  }
+                      absl::FunctionRef<void(void*)>) override;
 
   /// The underlying gRPC completion queue, which does not exist.
   grpc::CompletionQueue* cq() override { return nullptr; }
@@ -79,10 +77,7 @@ class RestCompletionQueueImpl final
   std::int64_t run_async_counter() const { return run_async_counter_.load(); }
 
  private:
-  std::mutex mu_;
-  internal::TimerQueue tq_;
-  bool shutdown_{false};  // GUARDED_BY(mu_)
-  std::shared_ptr<void> shutdown_guard_;
+  std::shared_ptr<internal::TimerQueue> tq_;
 
   // These are metrics used in testing.
   std::atomic<std::int64_t> run_async_counter_{0};

--- a/google/cloud/internal/rest_completion_queue_impl_test.cc
+++ b/google/cloud/internal/rest_completion_queue_impl_test.cc
@@ -1,0 +1,279 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/rest_completion_queue_impl.h"
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/future.h"
+#include "google/cloud/testing_util/fake_completion_queue_impl.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <chrono>
+#include <deque>
+#include <memory>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::testing_util::FakeCompletionQueueImpl;
+using ::testing::Contains;
+using ::testing::Eq;
+
+/// @test A regression test for #5141
+TEST(RestCompletionQueueImplTest, TimerCancel) {
+  // There are a lot of magical numbers in this test, there were tuned to #5141
+  // 99 out of 100 times on my workstation.
+  auto impl = absl::make_unique<RestCompletionQueueImpl>();
+  CompletionQueue cq(std::move(impl));
+  std::vector<std::thread> runners;
+  std::generate_n(std::back_inserter(runners), 4, [&cq] {
+    return std::thread([](CompletionQueue c) { c.Run(); }, cq);
+  });
+
+  using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
+  auto worker = [&](CompletionQueue cq) {
+    for (int i = 0; i != 10000; ++i) {
+      std::vector<TimerFuture> timers;
+      for (int j = 0; j != 10; ++j) {
+        timers.push_back(cq.MakeRelativeTimer(std::chrono::microseconds(10)));
+      }
+      cq.CancelAll();
+      for (auto& t : timers) t.cancel();
+    }
+  };
+  std::vector<std::thread> workers;
+  std::generate_n(std::back_inserter(runners), 8,
+                  [&] { return std::thread(worker, cq); });
+
+  for (auto& t : workers) t.join();
+  cq.Shutdown();
+  for (auto& t : runners) t.join();
+}
+
+TEST(RestCompletionQueueImplTest, TimerSmokeTest) {
+  auto impl = absl::make_unique<RestCompletionQueueImpl>();
+  CompletionQueue cq(std::move(impl));
+  std::thread t([&cq] { cq.Run(); });
+
+  using ms = std::chrono::milliseconds;
+  promise<void> wait_for_sleep;
+  cq.MakeRelativeTimer(ms(2))
+      .then([&wait_for_sleep](
+                future<StatusOr<std::chrono::system_clock::time_point>>) {
+        wait_for_sleep.set_value();
+      })
+      .get();
+
+  auto f = wait_for_sleep.get_future();
+  EXPECT_EQ(std::future_status::ready, f.wait_for(ms(0)));
+  cq.Shutdown();
+  t.join();
+}
+
+TEST(RestCompletionQueueImplTest, MockSmokeTest) {
+  auto mock = std::make_shared<FakeCompletionQueueImpl>();
+  CompletionQueue cq(mock);
+  using ms = std::chrono::milliseconds;
+  promise<void> wait_for_sleep;
+  cq.MakeRelativeTimer(ms(20000)).then(
+      [&wait_for_sleep](
+          future<StatusOr<std::chrono::system_clock::time_point>>) {
+        wait_for_sleep.set_value();
+      });
+  mock->SimulateCompletion(/*ok=*/true);
+
+  auto f = wait_for_sleep.get_future();
+  EXPECT_EQ(std::future_status::ready, f.wait_for(ms(0)));
+  cq.Shutdown();
+}
+
+TEST(RestCompletionQueueImplTest, RunAsync) {
+  auto impl = absl::make_unique<RestCompletionQueueImpl>();
+  CompletionQueue cq(std::move(impl));
+
+  std::thread runner([&cq] { cq.Run(); });
+
+  std::promise<void> done_promise;
+  cq.RunAsync([&done_promise](CompletionQueue&) { done_promise.set_value(); });
+
+  auto done = done_promise.get_future();
+  done.get();
+
+  cq.Shutdown();
+  runner.join();
+}
+
+TEST(RestCompletionQueueImplTest, RunAsyncVoid) {
+  auto impl = absl::make_unique<RestCompletionQueueImpl>();
+  CompletionQueue cq(std::move(impl));
+
+  std::thread runner([&cq] { cq.Run(); });
+
+  std::promise<void> done_promise;
+  cq.RunAsync([&done_promise] { done_promise.set_value(); });
+
+  auto done = done_promise.get_future();
+  done.get();
+
+  cq.Shutdown();
+  runner.join();
+}
+
+TEST(RestCompletionQueueImplTest, RunAsyncCompletionQueueDestroyed) {
+  auto cq_impl = std::make_shared<FakeCompletionQueueImpl>();
+
+  std::promise<void> done_promise;
+  {
+    CompletionQueue cq(cq_impl);
+    cq.RunAsync([&done_promise](CompletionQueue& cq) {
+      done_promise.set_value();
+      cq.Shutdown();
+    });
+  }
+  cq_impl->SimulateCompletion(true);
+
+  done_promise.get_future().get();
+}
+
+TEST(RestCompletionQueueImplTest, RunAsyncMoveOnly) {
+  struct MoveOnly {
+    promise<void> p;
+    void operator()(CompletionQueue&) { p.set_value(); }
+  };
+  static_assert(!std::is_copy_assignable<MoveOnly>::value,
+                "MoveOnly test type should not copy-assignable");
+
+  promise<void> p;
+  auto done = p.get_future();
+  auto impl = absl::make_unique<RestCompletionQueueImpl>();
+  CompletionQueue cq(std::move(impl));
+  std::thread t{[&cq] { cq.Run(); }};
+  cq.RunAsync(MoveOnly{std::move(p)});
+  done.get();
+  cq.Shutdown();
+  t.join();
+}
+
+TEST(RestCompletionQueueImplTest, RunAsyncMoveOnlyVoid) {
+  struct MoveOnly {
+    promise<void> p;
+    void operator()() { p.set_value(); }
+  };
+  static_assert(!std::is_copy_assignable<MoveOnly>::value,
+                "MoveOnly test type should not copy-assignable");
+
+  promise<void> p;
+  auto done = p.get_future();
+  auto impl = absl::make_unique<RestCompletionQueueImpl>();
+  CompletionQueue cq(std::move(impl));
+  std::thread t{[&cq] { cq.Run(); }};
+  cq.RunAsync(MoveOnly{std::move(p)});
+  done.get();
+  cq.Shutdown();
+  t.join();
+}
+
+TEST(RestCompletionQueueImplTest, RunAsyncThread) {
+  auto impl = absl::make_unique<RestCompletionQueueImpl>();
+  CompletionQueue cq(std::move(impl));
+
+  std::set<std::thread::id> runner_ids;
+  auto constexpr kRunners = 8;
+  std::vector<std::thread> runners(kRunners);
+  for (auto& t : runners) {
+    promise<std::thread::id> started;
+    auto f = started.get_future();
+    t = std::thread(
+        [&cq](promise<std::thread::id> p) {
+          p.set_value(std::this_thread::get_id());
+          cq.Run();
+        },
+        std::move(started));
+    runner_ids.insert(f.get());
+  }
+
+  auto constexpr kIterations = 10000;
+  std::vector<promise<std::thread::id>> pending(kIterations);
+  std::vector<future<std::thread::id>> actual;
+  for (int i = 0; i != kIterations; ++i) {
+    auto& p = pending[i];
+    actual.push_back(p.get_future());
+    cq.RunAsync(
+        [&p](CompletionQueue&) { p.set_value(std::this_thread::get_id()); });
+  }
+
+  for (auto& done : actual) {
+    auto id = done.get();
+    EXPECT_THAT(runner_ids, Contains(id));
+  }
+
+  cq.Shutdown();
+  for (auto& t : runners) t.join();
+}
+
+// The purpose of this test is to model the "LRO per thread" paradigm which
+// uses a new thread per LRO operation and only uses the CompletionQueue to
+// join the thread after the work has been done.
+TEST(RestCompletionQueueImplTest, RunAsyncSingleRunner) {
+  auto impl = std::make_shared<RestCompletionQueueImpl>();
+  CompletionQueue cq(impl);
+  std::thread t{[&] { cq.Run(); }};
+
+  auto constexpr kIterations = 100;
+  std::atomic<int> threads_joined{0};
+  std::vector<std::pair<future<void>, std::thread>> workers;
+  std::vector<promise<void>> work;
+  for (int i = 0; i != kIterations; ++i) {
+    promise<void> p;
+    work.push_back(std::move(p));
+  }
+
+  for (int i = 0; i != kIterations; ++i) {
+    auto& p = work[i];
+    auto f = p.get_future();
+    workers.emplace_back(std::move(f), [&work, i]() { work[i].set_value(); });
+  }
+
+  std::vector<future<void>> results;
+  for (auto& w : workers) {
+    auto f = std::move(w.first);
+    results.push_back(f.then(
+        [t1 = std::move(w.second), cq, &threads_joined](auto f2) mutable {
+          cq.RunAsync([t2 = std::move(t1), &threads_joined]() mutable {
+            ASSERT_FALSE(std::this_thread::get_id() == t2.get_id());
+            t2.join();
+            ++threads_joined;
+          });
+          f2.get();
+        }));
+  }
+
+  for (auto& r : results) {
+    r.get();
+  }
+
+  cq.Shutdown();
+  t.join();
+  EXPECT_THAT(impl->run_async_counter(), Eq(kIterations));
+  EXPECT_THAT(threads_joined, Eq(kIterations));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This PR provides an implementation for use with `CompletionQueue` that does not rely on `grpc::CompletionQueue`. This implementation of `CompletionQueue` will be used to make LRO and Async calls for services that use REST transport.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10539)
<!-- Reviewable:end -->
