### PR TITLE
chore: (temporarily) pause otel bazel updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,11 +57,6 @@
       "versioning": "loose"
     },
     {
-      "matchPackageNames": ["io_opentelemetry_cpp", "open-telemetry/opentelemetry-cpp"],
-      "groupName": "OpenTelemetry",
-      "versioning": "loose"
-    },
-    {
       "matchPackageNames": ["com_google_benchmark", "google/benchmark"],
       "groupName": "Benchmark",
       "versioning": "loose"
@@ -78,6 +73,7 @@
   ],
   "ignoreDeps": [
     "boringssl",
-    "com_google_googleapis"
+    "com_google_googleapis",
+    "io_opentelemetry_cpp"
   ]
 }


### PR DESCRIPTION
`opentelemetry-cpp` is pinned to a commit for bazel builds, while we wait for a fix to be included in their next release.

This PR tells `renovate-bot` not to send PRs for each new commit (or whatever the bot's PR cadence is). It is a temporary measure. See #10543 

We should still get notified of a new `opentelemetry-cpp` release, because of our cmake builds. I signed up for release email alerts, anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10542)
<!-- Reviewable:end -->
