### PR TITLE
cleanup(otel): neater span matchers

### DIFF
--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -25,6 +25,23 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace testing_util {
 
+std::string ToString(opentelemetry::trace::SpanKind k) {
+  switch (k) {
+    case opentelemetry::trace::SpanKind::kInternal:
+      return "INTERNAL";
+    case opentelemetry::trace::SpanKind::kServer:
+      return "SERVER";
+    case opentelemetry::trace::SpanKind::kClient:
+      return "CLIENT";
+    case opentelemetry::trace::SpanKind::kProducer:
+      return "PRODUCER";
+    case opentelemetry::trace::SpanKind::kConsumer:
+      return "CONSUMER";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 std::shared_ptr<opentelemetry::exporter::memory::InMemorySpanData>
 InstallSpanCatcher() {
   auto exporter = absl::make_unique<

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -32,55 +32,30 @@ namespace testing_util {
 
 using SpanDataPtr = std::unique_ptr<opentelemetry::sdk::trace::SpanData>;
 
-MATCHER(SpanHasInstrumentationScope, "") {
+std::string ToString(opentelemetry::trace::SpanKind k);
+
+MATCHER(SpanHasInstrumentationScope,
+        "has instrumentation scope (name: gcloud-cpp | version: " +
+            version_string() + ")") {
   auto const& scope = arg->GetInstrumentationScope();
   auto const& name = scope.GetName();
   auto const& version = scope.GetVersion();
-
-  bool match = true;
-  if (name != "gcloud-cpp") {
-    *result_listener << "instrumentation scope name: " << name << ")\n";
-    match = false;
-  }
-  if (version != version_string()) {
-    *result_listener << "instrumentation scope version: " << version << ")\n";
-    match = false;
-  }
-  return match;
+  *result_listener << "has instrumentation scope (name: " << name
+                   << " | version: " << version << ")";
+  return name == "gcloud-cpp" && version == version_string();
 }
 
-MATCHER(SpanKindIsClient, "") {
-  auto to_str = [](opentelemetry::trace::SpanKind k) {
-    switch (k) {
-      case opentelemetry::trace::SpanKind::kInternal:
-        return "INTERNAL";
-      case opentelemetry::trace::SpanKind::kServer:
-        return "SERVER";
-      case opentelemetry::trace::SpanKind::kClient:
-        return "CLIENT";
-      case opentelemetry::trace::SpanKind::kProducer:
-        return "PRODUCER";
-      case opentelemetry::trace::SpanKind::kConsumer:
-      default:
-        return "UNKNOWN";
-    }
-  };
-
+MATCHER(SpanKindIsClient,
+        "has span kind: " + ToString(opentelemetry::trace::SpanKind::kClient)) {
   auto const& kind = arg->GetSpanKind();
-  if (kind != opentelemetry::trace::SpanKind::kClient) {
-    *result_listener << "span kind: " << to_str(kind) << ")\n";
-    return false;
-  }
-  return true;
+  *result_listener << "has span kind: " << ToString(kind);
+  return kind == opentelemetry::trace::SpanKind::kClient;
 }
 
-MATCHER_P(SpanNamed, name, "") {
+MATCHER_P(SpanNamed, name, "has name: " + std::string{name}) {
   auto const& actual = arg->GetName();
-  if (actual != name) {
-    *result_listener << "span name: " << actual << ")\n";
-    return false;
-  }
-  return true;
+  *result_listener << "has name: " << actual;
+  return actual == name;
 }
 
 /**

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -46,9 +46,9 @@ MATCHER(SpanHasInstrumentationScope,
 }
 
 MATCHER(SpanKindIsClient,
-        "has span kind: " + ToString(opentelemetry::trace::SpanKind::kClient)) {
+        "has kind: " + ToString(opentelemetry::trace::SpanKind::kClient)) {
   auto const& kind = arg->GetSpanKind();
-  *result_listener << "has span kind: " << ToString(kind);
+  *result_listener << "has kind: " << ToString(kind);
   return kind == opentelemetry::trace::SpanKind::kClient;
 }
 


### PR DESCRIPTION
In response to @devbww's comments: https://github.com/googleapis/google-cloud-cpp/pull/10501#pullrequestreview-1244622069

Fix up the error output for span matchers. For example, this test:

```
TEST(OpenTelemetry, Fail) {
  auto span_catcher = InstallSpanCatcher();
  auto provider = opentelemetry::trace::Provider::GetTracerProvider();
  auto tracer = provider->GetTracer("bad-scope-name", "bad-scope-version");

  auto s = tracer->StartSpan("bad-span-name");
  s->End();

  auto spans = span_catcher->GetSpans();
  auto& span = spans[0];
  EXPECT_THAT(span, SpanHasInstrumentationScope());
  EXPECT_THAT(span, SpanKindIsClient());
  EXPECT_THAT(span, SpanNamed("expected-span-name"));
}
```

... produces the following error output:

```
[ RUN      ] OpenTelemetry.Fail
/workspace/google/cloud/internal/opentelemetry_test.cc:98: Failure
Value of: span
Expected: has instrumentation scope (name: gcloud-cpp | version: v2.7.0-rc)
  Actual: (ptr = 0x1964b40, value = 304-byte object <18-A3 45-00 00-00 00-00 C4-2D 1B-29 E4-D8 DC-9B 10-35 DF-F3 E9-EA B8-80 00-6D CB-E3 30-C5 71-32 01-00 00-00 00-00 00-00 C0-79 45-00 00-00 00-00 40-3D 96-01 00-00 00-00 30-38 96-01 00-00 00-00 ... 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 70-51 96-01 00-00 00-00 F0-40 96-01 00-00 00-00>), has instrumentation scope (name: bad-scope-name | version: bad-scope-version)
/workspace/google/cloud/internal/opentelemetry_test.cc:99: Failure
Value of: span
Expected: has span kind: CLIENT
  Actual: (ptr = 0x1964b40, value = 304-byte object <18-A3 45-00 00-00 00-00 C4-2D 1B-29 E4-D8 DC-9B 10-35 DF-F3 E9-EA B8-80 00-6D CB-E3 30-C5 71-32 01-00 00-00 00-00 00-00 C0-79 45-00 00-00 00-00 40-3D 96-01 00-00 00-00 30-38 96-01 00-00 00-00 ... 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 70-51 96-01 00-00 00-00 F0-40 96-01 00-00 00-00>), has span kind: INTERNAL
/workspace/google/cloud/internal/opentelemetry_test.cc:100: Failure
Value of: span
Expected: has name: expected-span-name
  Actual: (ptr = 0x1964b40, value = 304-byte object <18-A3 45-00 00-00 00-00 C4-2D 1B-29 E4-D8 DC-9B 10-35 DF-F3 E9-EA B8-80 00-6D CB-E3 30-C5 71-32 01-00 00-00 00-00 00-00 C0-79 45-00 00-00 00-00 40-3D 96-01 00-00 00-00 30-38 96-01 00-00 00-00 ... 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 70-51 96-01 00-00 00-00 F0-40 96-01 00-00 00-00>), has name: bad-span-name
[  FAILED  ] OpenTelemetry.Fail (0 ms)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10554)
<!-- Reviewable:end -->
