### PR TITLE
impl(otel): extract attributes from status types

### DIFF
--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -41,34 +41,30 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpan(
   return GetTracer(CurrentOptions())->StartSpan(name, options);
 }
 
-void CaptureStatusDetails(
-    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
-    Status const& status) {
+void EndSpanImpl(opentelemetry::trace::Span& span, Status const& status) {
   if (status.ok()) {
-    span->SetStatus(opentelemetry::trace::StatusCode::kOk);
-    span->SetAttribute("gcloud.status_code", 0);
-    span->End();
+    span.SetStatus(opentelemetry::trace::StatusCode::kOk);
+    span.SetAttribute("gcloud.status_code", 0);
+    span.End();
     return;
   }
-  span->SetStatus(opentelemetry::trace::StatusCode::kError, status.message());
-  span->SetAttribute("gcloud.status_code", static_cast<int>(status.code()));
+  span.SetStatus(opentelemetry::trace::StatusCode::kError, status.message());
+  span.SetAttribute("gcloud.status_code", static_cast<int>(status.code()));
   auto const& ei = status.error_info();
   if (!ei.reason().empty()) {
-    span->SetAttribute("gcloud.error.reason", ei.reason());
+    span.SetAttribute("gcloud.error.reason", ei.reason());
   }
   if (!ei.domain().empty()) {
-    span->SetAttribute("gcloud.error.domain", ei.domain());
+    span.SetAttribute("gcloud.error.domain", ei.domain());
   }
   for (auto const& kv : ei.metadata()) {
-    span->SetAttribute("gcloud.error.metadata." + kv.first, kv.second);
+    span.SetAttribute("gcloud.error.metadata." + kv.first, kv.second);
   }
-  span->End();
+  span.End();
 }
 
-Status CaptureReturn(
-    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
-    Status const& status) {
-  CaptureStatusDetails(span, status);
+Status EndSpan(opentelemetry::trace::Span& span, Status const& status) {
+  EndSpanImpl(span, status);
   return status;
 }
 

--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -41,6 +41,37 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpan(
   return GetTracer(CurrentOptions())->StartSpan(name, options);
 }
 
+void CaptureStatusDetails(
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+    Status const& status) {
+  if (status.ok()) {
+    span->SetStatus(opentelemetry::trace::StatusCode::kOk);
+    span->SetAttribute("gcloud.status_code", 0);
+    span->End();
+    return;
+  }
+  span->SetStatus(opentelemetry::trace::StatusCode::kError, status.message());
+  span->SetAttribute("gcloud.status_code", static_cast<int>(status.code()));
+  auto const& ei = status.error_info();
+  if (!ei.reason().empty()) {
+    span->SetAttribute("gcloud.error.reason", ei.reason());
+  }
+  if (!ei.domain().empty()) {
+    span->SetAttribute("gcloud.error.domain", ei.domain());
+  }
+  for (auto const& kv : ei.metadata()) {
+    span->SetAttribute("gcloud.error.metadata." + kv.first, kv.second);
+  }
+  span->End();
+}
+
+Status CaptureReturn(
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+    Status const& status) {
+  CaptureStatusDetails(span, status);
+  return status;
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -62,7 +62,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpan(
     opentelemetry::nostd::string_view name);
 
 /**
- * Extracts information from a cloud status and adds it to a span.
+ * Extracts information from a `Status` and adds it to a span.
  *
  * This method will end the span, and set its [span status], accordingly. Other
  * details, such as error information, will be set as [attributes] on the span.
@@ -74,29 +74,26 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpan(
  * [span status]:
  * https://opentelemetry.io/docs/concepts/signals/traces/#span-status
  */
-void CaptureStatusDetails(
-    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
-    Status const& status);
+void EndSpanImpl(opentelemetry::trace::Span& span, Status const& status);
 
 /**
- * Extracts information from a status and adds it to a span.
+ * Extracts information from a `Status` and adds it to a span.
  *
- * The original value is returned, for the sake of composition.
+ * The span is ended. The original value is returned, for the sake of
+ * composition.
  */
-Status CaptureReturn(
-    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
-    Status const& status);
+Status EndSpan(opentelemetry::trace::Span& span, Status const& status);
 
 /**
  * Extracts information from a `StatusOr<>` and adds it to a span.
  *
- * The original value is returned, for the sake of composition.
+ * The span is ended. The original value is returned, for the sake of
+ * composition.
  */
 template <typename T>
-StatusOr<T> CaptureReturn(
-    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
-    StatusOr<T> const& value) {
-  CaptureStatusDetails(span, value.status());
+StatusOr<T> EndSpan(opentelemetry::trace::Span& span,
+                    StatusOr<T> const& value) {
+  EndSpanImpl(span, value.status());
   return value;
 }
 

--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -17,6 +17,8 @@
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include "google/cloud/options.h"
+#include "google/cloud/status.h"
+#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/nostd/string_view.h>
@@ -30,11 +32,73 @@ namespace internal {
 
 bool TracingEnabled(Options const& options);
 
+/**
+ * Returns a [tracer] to use for creating [spans].
+ *
+ * This function exists for the sake of testing. Library maintainers should call
+ * `MakeSpan(...)` directly to create a span.
+ *
+ * @see https://opentelemetry.io/docs/instrumentation/cpp/manual/#initializing-tracing
+ *
+ * [spans]:
+ * https://opentelemetry.io/docs/concepts/signals/traces/#spans-in-opentelemetry
+ * [tracer]: https://opentelemetry.io/docs/concepts/signals/traces/#tracer
+ */
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> GetTracer(
     Options const& options);
 
+/**
+ * Start a [span] using the current [tracer].
+ *
+ * The current tracer is determined by the prevailing `CurrentOptions()`.
+ *
+ * @see https://opentelemetry.io/docs/instrumentation/cpp/manual/#start-a-span
+ *
+ * [span]:
+ * https://opentelemetry.io/docs/concepts/signals/traces/#spans-in-opentelemetry
+ * [tracer]: https://opentelemetry.io/docs/concepts/signals/traces/#tracer
+ */
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpan(
     opentelemetry::nostd::string_view name);
+
+/**
+ * Extracts information from a cloud status and adds it to a span.
+ *
+ * This method will end the span, and set its [span status], accordingly. Other
+ * details, such as error information, will be set as [attributes] on the span.
+ *
+ * @see https://opentelemetry.io/docs/concepts/signals/traces/#spans-in-opentelemetry
+ *
+ * [attributes]:
+ * https://opentelemetry.io/docs/concepts/signals/traces/#attributes
+ * [span status]:
+ * https://opentelemetry.io/docs/concepts/signals/traces/#span-status
+ */
+void CaptureStatusDetails(
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+    Status const& status);
+
+/**
+ * Extracts information from a status and adds it to a span.
+ *
+ * The original value is returned, for the sake of composition.
+ */
+Status CaptureReturn(
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+    Status const& status);
+
+/**
+ * Extracts information from a `StatusOr<>` and adds it to a span.
+ *
+ * The original value is returned, for the sake of composition.
+ */
+template <typename T>
+StatusOr<T> CaptureReturn(
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+    StatusOr<T> const& value) {
+  CaptureStatusDetails(span, value.status());
+  return value;
+}
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -27,9 +27,13 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::InstallSpanCatcher;
+using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::SpanAttributesAre;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
 using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::SpanWithStatus;
+using ::testing::AllOf;
 using ::testing::Each;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
@@ -81,6 +85,130 @@ TEST(OpenTelemetry, MakeSpan) {
   EXPECT_THAT(spans, Each(SpanHasInstrumentationScope()));
   EXPECT_THAT(spans, Each(SpanKindIsClient()));
   EXPECT_THAT(spans, ElementsAre(SpanNamed("span1"), SpanNamed("span2")));
+}
+
+TEST(OpenTelemetry, CaptureStatusDetailsEndsSpan) {
+  auto span_catcher = InstallSpanCatcher();
+
+  auto s = MakeSpan("span");
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, IsEmpty());
+
+  CaptureStatusDetails(s, Status());
+  spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, ElementsAre(SpanNamed("span")));
+}
+
+TEST(OpenTelemetry, CaptureStatusDetailsSuccess) {
+  auto span_catcher = InstallSpanCatcher();
+
+  auto s = MakeSpan("success");
+  CaptureStatusDetails(s, Status());
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+          SpanAttributesAre(SpanAttribute<int>("gcloud.status_code", 0)))));
+}
+
+TEST(OpenTelemetry, CaptureStatusDetailsFail) {
+  auto span_catcher = InstallSpanCatcher();
+  auto const code = static_cast<int>(StatusCode::kAborted);
+
+  auto s = MakeSpan("fail");
+  CaptureStatusDetails(s, Status(StatusCode::kAborted, "not good"));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
+          SpanAttributesAre(SpanAttribute<int>("gcloud.status_code", code)))));
+}
+
+TEST(OpenTelemetry, CaptureStatusDetailsErrorInfo) {
+  auto span_catcher = InstallSpanCatcher();
+  auto const code = static_cast<int>(StatusCode::kAborted);
+
+  auto span = MakeSpan("reason");
+  CaptureStatusDetails(span, Status(StatusCode::kAborted, "not good",
+                                    ErrorInfo("reason", {}, {})));
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
+          SpanAttributesAre(
+              SpanAttribute<int>("gcloud.status_code", code),
+              SpanAttribute<std::string>("gcloud.error.reason", "reason")))));
+
+  span = MakeSpan("domain");
+  CaptureStatusDetails(span, Status(StatusCode::kAborted, "not good",
+                                    ErrorInfo({}, "domain", {})));
+  spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
+          SpanAttributesAre(
+              SpanAttribute<int>("gcloud.status_code", code),
+              SpanAttribute<std::string>("gcloud.error.domain", "domain")))));
+
+  span = MakeSpan("metadata");
+  CaptureStatusDetails(span,
+                       Status(StatusCode::kAborted, "not good",
+                              ErrorInfo({}, {}, {{"k1", "v1"}, {"k2", "v2"}})));
+  spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
+          SpanAttributesAre(
+              SpanAttribute<int>("gcloud.status_code", code),
+              SpanAttribute<std::string>("gcloud.error.metadata.k1", "v1"),
+              SpanAttribute<std::string>("gcloud.error.metadata.k2", "v2")))));
+}
+
+TEST(OpenTelemetry, CaptureReturnStatus) {
+  auto span_catcher = InstallSpanCatcher();
+
+  auto v1 = Status();
+  auto s1 = MakeSpan("s1");
+  auto r1 = CaptureReturn(s1, v1);
+  EXPECT_EQ(r1, v1);
+
+  auto v2 = Status(StatusCode::kAborted, "fail");
+  auto s2 = MakeSpan("s2");
+  auto r2 = CaptureReturn(s2, v2);
+  EXPECT_EQ(r2, v2);
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                  SpanWithStatus(opentelemetry::trace::StatusCode::kError)));
+}
+
+TEST(OpenTelemetry, CaptureReturnStatusOr) {
+  auto span_catcher = InstallSpanCatcher();
+
+  auto v1 = StatusOr<int>(5);
+  auto s1 = MakeSpan("s1");
+  auto r1 = CaptureReturn(s1, v1);
+  EXPECT_EQ(r1, v1);
+
+  auto v2 = StatusOr<int>(Status(StatusCode::kAborted, "fail"));
+  auto s2 = MakeSpan("s2");
+  auto r2 = CaptureReturn(s2, v2);
+  EXPECT_EQ(r2, v2);
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                  SpanWithStatus(opentelemetry::trace::StatusCode::kError)));
 }
 
 }  // namespace

--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -42,6 +42,18 @@ std::string ToString(opentelemetry::trace::SpanKind k) {
   }
 }
 
+std::string ToString(opentelemetry::trace::StatusCode c) {
+  switch (c) {
+    case opentelemetry::trace::StatusCode::kError:
+      return "ERROR";
+    case opentelemetry::trace::StatusCode::kOk:
+      return "OK";
+    case opentelemetry::trace::StatusCode::kUnset:
+    default:
+      return "UNSET";
+  }
+}
+
 std::shared_ptr<opentelemetry::exporter::memory::InMemorySpanData>
 InstallSpanCatcher() {
   auto exporter = absl::make_unique<


### PR DESCRIPTION
Part of the work for #10487 

Add helper function to extract status information (code, message, error info) and set span's status and attributes, accordingly.

Comments about the exact information we decide to capture are welcome. But I am inclined to jam this PR through, then iterate. (because much of the remaining work for the linked issue is blocked on this PR).

Also add some internal documentation for the existing functions, because one day I will forget what the code does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10557)
<!-- Reviewable:end -->
