### PR TITLE
fix(common): use atomic scheduling in RestCompletionQueue

### DIFF
--- a/google/cloud/internal/rest_completion_queue_impl.cc
+++ b/google/cloud/internal/rest_completion_queue_impl.cc
@@ -50,11 +50,8 @@ RestCompletionQueueImpl::MakeRelativeTimer(std::chrono::nanoseconds duration) {
 void RestCompletionQueueImpl::RunAsync(
     std::unique_ptr<internal::RunAsyncBase> function) {
   ++run_async_counter_;
-  // Some delay is necessary to reduce the likelihood that the timer expires
-  // before .then() is called.
-  // TODO(#10553): Refactor this mechanism to a more deterministic solution.
-  MakeRelativeTimer(std::chrono::milliseconds(500))
-      .then([f = std::move(function)](auto) { f->exec(); });
+  tq_->Schedule(std::chrono::system_clock::now(),
+                [f = std::move(function)](auto) { f->exec(); });
 }
 
 void RestCompletionQueueImpl::StartOperation(


### PR DESCRIPTION
Fixes #10553

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10571)
<!-- Reviewable:end -->
