### PR TITLE
feat(generator): add some support for deprecated RPCs

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -20,15 +20,19 @@ message ServiceConfiguration {
   string service_proto_path = 1;
   string product_path = 2;
   string initial_copyright_year = 3;
+
+  // Omit the generation of the (sync) APIs for these RPCs. Include any
+  // deprecated RPCs here that we don't need for backwards compatibility.
   repeated string omitted_rpcs = 4;
+
   string service_endpoint_env_var = 5;
   string emulator_endpoint_env_var = 6;
 
-  // Generating Async APIs is typically unnecessary for RPCs that are
+  // Generating async APIs is typically unnecessary for RPCs that are
   // non-streaming, non-paginated, and not longrunning operations. If we need
-  // to generate an Async API for such an RPC, we can list it here.
+  // to generate an async API for such an RPC, we can list it here.
   //
-  // Only the Async API will be generated for RPCs listed both here and in
+  // Only the async API will be generated for RPCs listed both here and in
   // `omitted_rpcs`.
   repeated string gen_async_rpcs = 7;
 
@@ -120,6 +124,10 @@ message ServiceConfiguration {
   // For details on why we would relocate a service, see #10170, or
   // https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2022-11-11-multiple-versions-of-GCP-service-in-one-library.md
   string forwarding_product_path = 19;
+
+  // Force the generation of the (sync) APIs for these deprecated RPCs so
+  // as to maintain backwards compatibility with previous releases.
+  repeated string emitted_rpcs = 20;
 }
 
 message GeneratorConfiguration {

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -186,6 +186,7 @@ service {
   product_path: "google/cloud/bigquery"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  emitted_rpcs: ["ScheduleTransferRuns"]
 }
 
 service {
@@ -200,6 +201,7 @@ service {
   product_path: "google/cloud/bigquery"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  emitted_rpcs: ["SearchAssignments", "ScheduleTransferRuns"]
 }
 
 service {
@@ -379,6 +381,7 @@ service {
   product_path: "google/cloud/container"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  emitted_rpcs: ["SetLocations"]
 }
 
 # Container Analysis

--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -99,6 +99,11 @@ class TestStub : public GoldenKitchenSinkStub {
     return Status();
   }
 
+  Status Deprecated2(grpc::ClientContext&,
+                     google::protobuf::Empty const&) override {
+    return Status();
+  }
+
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::test::admin::database::v1::Response>>
   StreamingRead(std::unique_ptr<grpc::ClientContext>,

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_client.cc
@@ -122,6 +122,12 @@ GoldenKitchenSinkClient::DoNothing(google::protobuf::Empty const& request, Optio
   return connection_->DoNothing(request);
 }
 
+Status
+GoldenKitchenSinkClient::Deprecated2(google::protobuf::Empty const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  return connection_->Deprecated2(request);
+}
+
 StreamRange<google::test::admin::database::v1::Response>
 GoldenKitchenSinkClient::StreamingRead(std::string const& stream, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
@@ -109,10 +109,10 @@ class GoldenKitchenSinkClient {
   ///  hour.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L985}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L995}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L945}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L985}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L955}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L995}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options opts = {});
@@ -120,13 +120,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L945}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L955}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L985}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L995}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L945}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L985}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L955}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L995}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts = {});
@@ -153,10 +153,10 @@ class GoldenKitchenSinkClient {
   ///  token will contain `email` and `email_verified` claims.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1027}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1037}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L994}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1027}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1004}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1037}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options opts = {});
@@ -164,13 +164,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L994}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L1004}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1027}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1037}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L994}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1027}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1004}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1037}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options opts = {});
@@ -203,10 +203,10 @@ class GoldenKitchenSinkClient {
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1066}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1076}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1033}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1066}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1043}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1076}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options opts = {});
@@ -220,13 +220,13 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1033}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1043}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1066}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1076}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1033}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1066}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1043}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1076}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options opts = {});
@@ -244,7 +244,7 @@ class GoldenKitchenSinkClient {
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1069}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1079}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options opts = {});
@@ -253,12 +253,12 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1069}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1079}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1069}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1079}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options opts = {});
@@ -276,10 +276,10 @@ class GoldenKitchenSinkClient {
   ///  is provided, all keys are returned.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1327}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1337}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1295}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1327}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1305}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1337}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts = {});
@@ -287,13 +287,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1295}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1305}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1327}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1337}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1295}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1327}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1305}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1337}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options opts = {});
@@ -322,15 +322,27 @@ class GoldenKitchenSinkClient {
   DoNothing(google::protobuf::Empty const& request, Options opts = {});
 
   ///
+  /// A deprecated RPC for which we force API generation.
+  ///
+  /// @param request @googleapis_link{google::protobuf::Empty,google/protobuf/empty.proto#L51}
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+  ///
+  /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L51}
+  ///
+  Status
+  Deprecated2(google::protobuf::Empty const& request, Options opts = {});
+
+  ///
   /// Tests the generator for streaming read RPCs (aka server-side streaming)
   ///
   /// @param stream  A placeholder to test method signatures
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L940}
+  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L950}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L934}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L940}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L950}
   ///
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(std::string const& stream, Options opts = {});
@@ -338,13 +350,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Tests the generator for streaming read RPCs (aka server-side streaming)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L934}
+  /// @param request @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L944}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L940}
+  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L950}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L934}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L940}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L950}
   ///
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request, Options opts = {});
@@ -354,10 +366,10 @@ class GoldenKitchenSinkClient {
   ///
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return A bidirectional streaming interface with request (write) type: @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L934} and response (read) type: @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L940}
+  /// @return A bidirectional streaming interface with request (write) type: @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L944} and response (read) type: @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L950}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L934}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L940}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L950}
   ///
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,
@@ -382,11 +394,11 @@ class GoldenKitchenSinkClient {
   ///    x-goog-request-params:
   ///    table_location=instances/instance_bar&routing_id=prof_qux
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1334}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1344}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1334}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1344}
   ///
   Status
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});
@@ -395,11 +407,11 @@ class GoldenKitchenSinkClient {
   /// We use this RPC to verify the special case where a routing parameter key
   /// does not require a regex in order to match the correct value.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1334}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1344}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1334}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1344}
   ///
   Status
   ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc
@@ -71,6 +71,12 @@ GoldenKitchenSinkConnection::DoNothing(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
+Status
+GoldenKitchenSinkConnection::Deprecated2(
+    google::protobuf::Empty const&) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
 StreamRange<google::test::admin::database::v1::Response> GoldenKitchenSinkConnection::StreamingRead(
     google::test::admin::database::v1::Request const&) {
   return google::cloud::internal::MakeStreamRange<

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h
@@ -81,6 +81,9 @@ class GoldenKitchenSinkConnection {
   virtual Status
   DoNothing(google::protobuf::Empty const& request);
 
+  virtual Status
+  Deprecated2(google::protobuf::Empty const& request);
+
   virtual StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request);
 

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -58,6 +58,10 @@ Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::DoNothing(google::prot
   return Idempotency::kNonIdempotent;
 }
 
+Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::Deprecated2(google::protobuf::Empty const&) {
+  return Idempotency::kNonIdempotent;
+}
+
 Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const&) {
   return Idempotency::kNonIdempotent;
 }

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h
@@ -56,6 +56,9 @@ class GoldenKitchenSinkConnectionIdempotencyPolicy {
   DoNothing(google::protobuf::Empty const& request);
 
   virtual google::cloud::Idempotency
+  Deprecated2(google::protobuf::Empty const& request);
+
+  virtual google::cloud::Idempotency
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request);
 
   virtual google::cloud::Idempotency

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
@@ -82,6 +82,14 @@ Status GoldenKitchenSinkAuth::DoNothing(
   return child_->DoNothing(context, request);
 }
 
+Status GoldenKitchenSinkAuth::Deprecated2(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->Deprecated2(context, request);
+}
+
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
 GoldenKitchenSinkAuth::StreamingRead(
    std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
@@ -62,6 +62,10 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::protobuf::Empty const& request) override;
 
+  Status Deprecated2(
+      grpc::ClientContext& context,
+      google::protobuf::Empty const& request) override;
+
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(
       std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
@@ -129,6 +129,18 @@ GoldenKitchenSinkConnectionImpl::DoNothing(google::protobuf::Empty const& reques
       request, __func__);
 }
 
+Status
+GoldenKitchenSinkConnectionImpl::Deprecated2(google::protobuf::Empty const& request) {
+  return google::cloud::internal::RetryLoop(
+      retry_policy(), backoff_policy(),
+      idempotency_policy()->Deprecated2(request),
+      [this](grpc::ClientContext& context,
+          google::protobuf::Empty const& request) {
+        return stub_->Deprecated2(context, request);
+      },
+      request, __func__);
+}
+
 StreamRange<google::test::admin::database::v1::Response>
 GoldenKitchenSinkConnectionImpl::StreamingRead(google::test::admin::database::v1::Request const& request) {
   auto& stub = stub_;

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h
@@ -72,6 +72,9 @@ class GoldenKitchenSinkConnectionImpl
   Status
   DoNothing(google::protobuf::Empty const& request) override;
 
+  Status
+  Deprecated2(google::protobuf::Empty const& request) override;
+
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request) override;
 

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
@@ -111,6 +111,18 @@ GoldenKitchenSinkLogging::DoNothing(
       context, request, __func__, tracing_options_);
 }
 
+Status
+GoldenKitchenSinkLogging::Deprecated2(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::protobuf::Empty const& request) {
+        return child_->Deprecated2(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
 GoldenKitchenSinkLogging::StreamingRead(
     std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
@@ -62,6 +62,10 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::protobuf::Empty const& request) override;
 
+  Status Deprecated2(
+      grpc::ClientContext& context,
+      google::protobuf::Empty const& request) override;
+
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(
       std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -83,6 +83,14 @@ GoldenKitchenSinkMetadata::DoNothing(
   return child_->DoNothing(context, request);
 }
 
+Status
+GoldenKitchenSinkMetadata::Deprecated2(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  SetMetadata(context);
+  return child_->Deprecated2(context, request);
+}
+
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
 GoldenKitchenSinkMetadata::StreamingRead(
     std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -58,6 +58,10 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::protobuf::Empty const& request) override;
 
+  Status Deprecated2(
+      grpc::ClientContext& context,
+      google::protobuf::Empty const& request) override;
+
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(
       std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
@@ -63,6 +63,12 @@ Status GoldenKitchenSinkRoundRobin::DoNothing(
   return Child()->DoNothing(context, request);
 }
 
+Status GoldenKitchenSinkRoundRobin::Deprecated2(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  return Child()->Deprecated2(context, request);
+}
+
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
 GoldenKitchenSinkRoundRobin::StreamingRead(
     std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
@@ -60,6 +60,10 @@ class GoldenKitchenSinkRoundRobin : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::protobuf::Empty const& request) override;
 
+  Status Deprecated2(
+      grpc::ClientContext& context,
+      google::protobuf::Empty const& request) override;
+
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(
       std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
@@ -112,6 +112,19 @@ DefaultGoldenKitchenSinkStub::DoNothing(
     return google::cloud::Status();
 }
 
+Status
+DefaultGoldenKitchenSinkStub::Deprecated2(
+  grpc::ClientContext& client_context,
+  google::protobuf::Empty const& request) {
+    google::protobuf::Empty response;
+    auto status =
+        grpc_stub_->Deprecated2(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::MakeStatusFromRpcError(status);
+    }
+    return google::cloud::Status();
+}
+
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
 DefaultGoldenKitchenSinkStub::StreamingRead(
     std::unique_ptr<grpc::ClientContext> client_context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
@@ -65,6 +65,10 @@ class GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) = 0;
 
+  virtual Status Deprecated2(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) = 0;
+
   virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(
     std::unique_ptr<grpc::ClientContext> context,
@@ -138,6 +142,11 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
 
   Status
   DoNothing(
+    grpc::ClientContext& client_context,
+    google::protobuf::Empty const& request) override;
+
+  Status
+  Deprecated2(
     grpc::ClientContext& client_context,
     google::protobuf::Empty const& request) override;
 

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
@@ -61,6 +61,11 @@ GoldenKitchenSinkTracingConnection::DoNothing(google::protobuf::Empty const& req
   return child_->DoNothing(request);
 }
 
+Status
+GoldenKitchenSinkTracingConnection::Deprecated2(google::protobuf::Empty const& request) {
+  return child_->Deprecated2(request);
+}
+
 StreamRange<google::test::admin::database::v1::Response>
 GoldenKitchenSinkTracingConnection::StreamingRead(google::test::admin::database::v1::Request const& request) {
   return child_->StreamingRead(request);

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.h
@@ -58,6 +58,9 @@ class GoldenKitchenSinkTracingConnection
   Status
   DoNothing(google::protobuf::Empty const& request) override;
 
+  Status
+  Deprecated2(google::protobuf::Empty const& request) override;
+
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request) override;
 

--- a/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
@@ -70,6 +70,10 @@ class MockGoldenKitchenSinkConnection : public golden_v1::GoldenKitchenSinkConne
   DoNothing,
   (google::protobuf::Empty const& request), (override));
 
+  MOCK_METHOD(Status,
+  Deprecated2,
+  (google::protobuf::Empty const& request), (override));
+
   MOCK_METHOD(StreamRange<google::test::admin::database::v1::Response>,
   StreamingRead,
   (google::test::admin::database::v1::Request const& request), (override));

--- a/generator/integration_tests/golden_config.textproto
+++ b/generator/integration_tests/golden_config.textproto
@@ -19,7 +19,7 @@ service {
   additional_proto_files: "generator/integration_tests/backup.proto"
   product_path: "generator/integration_tests/golden/v1"
   initial_copyright_year: "2022"
-  omitted_rpcs: ["Omitted1", "GoldenKitchenSink.Omitted2"]
+  omitted_rpcs: ["Omitted1", "GoldenKitchenSink.Omitted2", "Deprecated1"]
   service_endpoint_env_var: "GOLDEN_KITCHEN_SINK_ENDPOINT"
   emulator_endpoint_env_var: "GOLDEN_KITCHEN_SINK_EMULATOR_HOST"
   gen_async_rpcs: ["GetDatabase", "DropDatabase", "StreamingRead", "StreamingWrite"]
@@ -27,4 +27,5 @@ service {
   generate_round_robin_decorator: true
   generate_rest_transport: true
   forwarding_product_path: "generator/integration_tests/golden"
+  emitted_rpcs: ["Deprecated2"]
 }

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -843,6 +843,16 @@ service GoldenKitchenSink {
     option (google.api.method_signature) = "";
   }
 
+  // A deprecated RPC that will omitted.
+  rpc Deprecated1(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
+
+  // A deprecated RPC for which we force API generation.
+  rpc Deprecated2(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
+
   // Tests the generator for streaming read RPCs (aka server-side streaming)
   rpc StreamingRead(Request) returns (stream Response) {
     option (google.api.method_signature) = "stream";

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -229,6 +229,42 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
        ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
 
+  MOCK_METHOD(::grpc::Status, Deprecated1,
+              (::grpc::ClientContext * context,
+               ::google::protobuf::Empty const& request,
+               ::google::protobuf::Empty* response),
+              (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      AsyncDeprecated1Raw,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      PrepareAsyncDeprecated1Raw,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+      (override));
+
+  MOCK_METHOD(::grpc::Status, Deprecated2,
+              (::grpc::ClientContext * context,
+               ::google::protobuf::Empty const& request,
+               ::google::protobuf::Empty* response),
+              (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      AsyncDeprecated2Raw,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      PrepareAsyncDeprecated2Raw,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+      (override));
+
   using StreamingReadWriteInterface =
       ::grpc::ClientReaderWriterInterface<Request, Response>;
   using StreamingReadWriteAsyncInterface =

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
@@ -119,6 +119,17 @@ TEST(GoldenKitchenSinkTracingConnectionTest, DoNothing) {
   EXPECT_THAT(result, StatusIs(StatusCode::kAborted));
 }
 
+TEST(GoldenKitchenSinkTracingConnectionTest, Deprecated2) {
+  auto mock = std::make_shared<MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*mock, Deprecated2)
+      .WillOnce(Return(internal::AbortedError("fail")));
+
+  auto under_test = GoldenKitchenSinkTracingConnection(mock);
+  google::protobuf::Empty request;
+  auto result = under_test.Deprecated2(request);
+  EXPECT_THAT(result, StatusIs(StatusCode::kAborted));
+}
+
 TEST(GoldenKitchenSinkTracingConnectionTest, StreamingRead) {
   auto mock = std::make_shared<MockGoldenKitchenSinkConnection>();
   EXPECT_CALL(*mock, StreamingRead)

--- a/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
@@ -61,6 +61,9 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
   MOCK_METHOD(Status, DoNothing,
               (grpc::ClientContext&, ::google::protobuf::Empty const&),
               (override));
+  MOCK_METHOD(Status, Deprecated2,
+              (grpc::ClientContext&, ::google::protobuf::Empty const&),
+              (override));
 
   MOCK_METHOD((std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
                    ::google::test::admin::database::v1::Request,

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -165,6 +165,11 @@ void ProcessArgForwardingProductPath(
   FormatProductPath(path->second);
 }
 
+void ProcessArgEmitRpc(
+    std::vector<std::pair<std::string, std::string>>& command_line_args) {
+  ProcessRepeated("emit_rpc", "emitted_rpcs", command_line_args);
+}
+
 }  // namespace
 
 std::string CurrentCopyrightYear() {
@@ -260,6 +265,7 @@ ProcessCommandLineArgs(std::string const& parameters) {
   ProcessArgRetryGrpcStatusCode(command_line_args);
   ProcessArgAdditionalProtoFiles(command_line_args);
   ProcessArgForwardingProductPath(command_line_args);
+  ProcessArgEmitRpc(command_line_args);
   return command_line_args;
 }
 

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -347,6 +347,17 @@ TEST(ProcessCommandLineArgs, ProcessArgForwardingProductPath) {
                                      "google/cloud/spanner/")));
 }
 
+TEST(ProcessCommandLineArgs, ProcessArgEmitRpc) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/"
+      ",emit_rpc=Emitted1"
+      ",emit_rpc=Emitted2");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result,
+              Contains(Pair("emitted_rpcs", AllOf(HasSubstr("Emitted1"),
+                                                  HasSubstr("Emitted2")))));
+}
+
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -228,6 +228,9 @@ int main(int argc, char** argv) {
     for (auto const& omit_rpc : service.omitted_rpcs()) {
       args.emplace_back("--cpp_codegen_opt=omit_rpc=" + omit_rpc);
     }
+    for (auto const& emit_rpc : service.emitted_rpcs()) {
+      args.emplace_back("--cpp_codegen_opt=emit_rpc=" + emit_rpc);
+    }
     if (service.backwards_compatibility_namespace_alias()) {
       args.emplace_back(
           "--cpp_codegen_opt=backwards_compatibility_namespace_alias=true");


### PR DESCRIPTION
Do not generate APIs for deprecated RPCs unless their names appear in
an `emitted_rpcs` list, the reverse of the existing `omitted_rpcs`.

Furthermore, require that deprecated RPCs are listed in either of
`emitted_rpcs` or `omitted_rpcs`.  Use `emitted_rpcs` when the RPC
code has previously been generated (probably from before it was
deprecated), and so is needed for backwards compatibility.  Otherwise
use `omitted_rpcs`, typically for a new-generated service with
existing deprecated RPCs (which should be rare).

This will allow us to reliably omit generating APIs for deprecated
RPCs that we have never supported.

Part of #8486.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10573)
<!-- Reviewable:end -->
