### PR TITLE
impl(common): cleaner RestCQ's `RunAsync()`

### DIFF
--- a/google/cloud/internal/rest_completion_queue_impl.cc
+++ b/google/cloud/internal/rest_completion_queue_impl.cc
@@ -50,8 +50,7 @@ RestCompletionQueueImpl::MakeRelativeTimer(std::chrono::nanoseconds duration) {
 void RestCompletionQueueImpl::RunAsync(
     std::unique_ptr<internal::RunAsyncBase> function) {
   ++run_async_counter_;
-  tq_->Schedule(std::chrono::system_clock::now(),
-                [f = std::move(function)](auto) { f->exec(); });
+  tq_->Schedule([f = std::move(function)](auto) { f->exec(); });
 }
 
 void RestCompletionQueueImpl::StartOperation(

--- a/google/cloud/internal/timer_queue.h
+++ b/google/cloud/internal/timer_queue.h
@@ -149,6 +149,21 @@ class TimerQueue : public std::enable_shared_from_this<TimerQueue> {
   }
 
   /**
+   * Schedule an immediately expired timer and atomically run @p functor on it.
+   *
+   * See the `Schedule(std::chrono::system_clock::time_point,Functor)` for
+   * details.
+   */
+  template <typename Functor>
+  auto Schedule(Functor&& functor)
+      -> decltype(std::declval<TimerQueue>().Schedule(
+          std::chrono::system_clock::time_point{},
+          std::forward<Functor>(functor))) {
+    return Schedule(std::chrono::system_clock::time_point::min(),
+                    std::forward<Functor>(functor));
+  }
+
+  /**
    * Signals all threads that have called Service() to return.
    *
    * Once this function returns no more timers can be scheduled successfully.

--- a/google/cloud/internal/timer_queue.h
+++ b/google/cloud/internal/timer_queue.h
@@ -149,10 +149,9 @@ class TimerQueue : public std::enable_shared_from_this<TimerQueue> {
   }
 
   /**
-   * Schedule an immediately expired timer and atomically run @p functor on it.
+   * Schedule an immediately expiring timer and atomically run @p functor on it.
    *
-   * See the `Schedule(std::chrono::system_clock::time_point,Functor)` for
-   * details.
+   * See `Schedule(std::chrono::system_clock::time_point,Functor)` for details.
    */
   template <typename Functor>
   auto Schedule(Functor&& functor)


### PR DESCRIPTION
This adds an overload for `TimerQueue::Schedule()` that offers a cleaner implementation for `RestCompletionQueueImpl::RunAsync()`.  Certainly faster too, but that might be a very small difference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10579)
<!-- Reviewable:end -->
