### PR TITLE
feat(generator): more support for deprecated RPC overloads

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -259,7 +259,13 @@ service {
   service_proto_path: "google/bigtable/admin/v2/bigtable_table_admin.proto"
   product_path: "google/cloud/bigtable/admin"
   initial_copyright_year: "2021"
-  omitted_rpcs: ["CreateTableFromSnapshot", "SnapshotTable", "GetSnapshot", "ListSnapshots", "DeleteSnapshot"]
+  omitted_rpcs: [
+    "CreateTableFromSnapshot",
+    "SnapshotTable",
+    "GetSnapshot",
+    "ListSnapshots",
+    "DeleteSnapshot"
+  ]
   emulator_endpoint_env_var: "BIGTABLE_EMULATOR_HOST"
   gen_async_rpcs: ["CheckConsistency"]
   retryable_status_codes: ["kUnavailable", "kAborted"]
@@ -382,6 +388,31 @@ service {
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
   emitted_rpcs: ["SetLocations"]
+  omitted_rpcs: [
+    "CreateCluster(std::string const&, std::string const&, google::container::v1::Cluster const&)",
+    "UpdateCluster(std::string const&, std::string const&, std::string const&, google::container::v1::ClusterUpdate const&)",
+    "GetCluster(std::string const&, std::string const&, std::string const&)",
+    "ListClusters(std::string const&, std::string const&)",
+    "SetLoggingService(std::string const&, std::string const&, std::string const&, std::string const&)",
+    "SetMonitoringService(std::string const&, std::string const&, std::string const&, std::string const&)",
+    "SetAddonsConfig(std::string const&, std::string const&, std::string const&, google::container::v1::AddonsConfig const&)",
+    "SetLocations(std::string const&, std::string const&, std::string const&, std::vector<std::string> const&)",
+    "UpdateMaster(std::string const&, std::string const&, std::string const&, std::string const&)",
+    "DeleteCluster(std::string const&, std::string const&, std::string const&)",
+    "ListOperations(std::string const&, std::string const&)",
+    "GetOperation(std::string const&, std::string const&, std::string const&)",
+    "CancelOperation(std::string const&, std::string const&, std::string const&)",
+    "GetServerConfig(std::string const&, std::string const&)",
+    "ListNodePools(std::string const&, std::string const&, std::string const&)",
+    "GetNodePool(std::string const&, std::string const&, std::string const&, std::string const&)",
+    "CreateNodePool(std::string const&, std::string const&, std::string const&, google::container::v1::NodePool const&)",
+    "DeleteNodePool(std::string const&, std::string const&, std::string const&, std::string const&)",
+    "RollbackNodePoolUpgrade(std::string const&, std::string const&, std::string const&, std::string const&)",
+    "SetLegacyAbac(std::string const&, std::string const&, std::string const&, bool)",
+    "StartIPRotation(std::string const&, std::string const&, std::string const&)",
+    "CompleteIPRotation(std::string const&, std::string const&, std::string const&)",
+    "SetNetworkPolicy(std::string const&, std::string const&, std::string const&, google::container::v1::NetworkPolicy const&)"
+  ]
 }
 
 # Container Analysis
@@ -916,6 +947,10 @@ service {
   omitted_rpcs: ["SignBlob", "SignJwt", "UpdateServiceAccount"]
   backwards_compatibility_namespace_alias: true
   retryable_status_codes: ["kUnavailable"]
+  omitted_rpcs: [
+    "SignBlob(std::string const&, std::string const&)",
+    "SignJwt(std::string const&, std::string const&)"
+  ]
 }
 
 service {
@@ -1162,8 +1197,9 @@ service {
   generate_round_robin_decorator: true
   omitted_rpcs: [
     "Acknowledge",
-    "ModifyAckDeadline"
-  ],
+    "ModifyAckDeadline",
+    "Pull(std::string const&, bool, std::int32_t)"
+  ]
   gen_async_rpcs: [
     "StreamingPull",
     "Acknowledge",
@@ -1388,6 +1424,9 @@ service {
   product_path: "google/cloud/servicemanagement"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  omitted_rpcs: [
+    "ListServices(std::string const&, std::string const&)"
+  ]
 }
 
 # Service Usage

--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -99,8 +99,10 @@ class TestStub : public GoldenKitchenSinkStub {
     return Status();
   }
 
-  Status Deprecated2(grpc::ClientContext&,
-                     google::protobuf::Empty const&) override {
+  Status Deprecated2(
+      grpc::ClientContext&,
+      google::test::admin::database::v1::GenerateAccessTokenRequest const&)
+      override {
     return Status();
   }
 

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_client.cc
@@ -123,7 +123,14 @@ GoldenKitchenSinkClient::DoNothing(google::protobuf::Empty const& request, Optio
 }
 
 Status
-GoldenKitchenSinkClient::Deprecated2(google::protobuf::Empty const& request, Options opts) {
+GoldenKitchenSinkClient::Deprecated2(Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  google::test::admin::database::v1::GenerateAccessTokenRequest request;
+  return connection_->Deprecated2(request);
+}
+
+Status
+GoldenKitchenSinkClient::Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Deprecated2(request);
 }

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
@@ -109,10 +109,10 @@ class GoldenKitchenSinkClient {
   ///  hour.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L995}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L999}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L955}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L995}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L959}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L999}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options opts = {});
@@ -120,13 +120,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L955}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L959}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L995}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L999}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L955}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L995}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L959}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L999}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts = {});
@@ -153,10 +153,10 @@ class GoldenKitchenSinkClient {
   ///  token will contain `email` and `email_verified` claims.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1037}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1041}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1004}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1037}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1008}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1041}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options opts = {});
@@ -164,13 +164,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L1004}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L1008}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1037}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1041}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1004}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1037}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1008}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1041}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options opts = {});
@@ -203,10 +203,10 @@ class GoldenKitchenSinkClient {
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1076}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1080}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1043}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1076}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1047}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1080}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options opts = {});
@@ -220,13 +220,13 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1043}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1047}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1076}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1080}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1043}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1076}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1047}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1080}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options opts = {});
@@ -244,7 +244,7 @@ class GoldenKitchenSinkClient {
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1079}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1083}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options opts = {});
@@ -253,12 +253,12 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1079}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1083}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1079}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1083}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options opts = {});
@@ -276,10 +276,10 @@ class GoldenKitchenSinkClient {
   ///  is provided, all keys are returned.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1337}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1341}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1305}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1337}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1309}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1341}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts = {});
@@ -287,13 +287,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1305}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1309}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1337}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1341}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1305}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1337}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1309}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1341}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options opts = {});
@@ -324,14 +324,25 @@ class GoldenKitchenSinkClient {
   ///
   /// A deprecated RPC for which we force API generation.
   ///
-  /// @param request @googleapis_link{google::protobuf::Empty,google/protobuf/empty.proto#L51}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L51}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L959}
   ///
   Status
-  Deprecated2(google::protobuf::Empty const& request, Options opts = {});
+  Deprecated2(Options opts = {});
+
+  ///
+  /// A deprecated RPC for which we force API generation.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L959}
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+  ///
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L959}
+  ///
+  Status
+  Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts = {});
 
   ///
   /// Tests the generator for streaming read RPCs (aka server-side streaming)
@@ -339,10 +350,10 @@ class GoldenKitchenSinkClient {
   /// @param stream  A placeholder to test method signatures
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L950}
+  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L954}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L950}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L948}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L954}
   ///
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(std::string const& stream, Options opts = {});
@@ -350,13 +361,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Tests the generator for streaming read RPCs (aka server-side streaming)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L944}
+  /// @param request @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L948}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L950}
+  /// @return @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L954}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L950}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L948}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L954}
   ///
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request, Options opts = {});
@@ -366,10 +377,10 @@ class GoldenKitchenSinkClient {
   ///
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return A bidirectional streaming interface with request (write) type: @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L944} and response (read) type: @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L950}
+  /// @return A bidirectional streaming interface with request (write) type: @googleapis_link{google::test::admin::database::v1::Request,generator/integration_tests/test.proto#L948} and response (read) type: @googleapis_link{google::test::admin::database::v1::Response,generator/integration_tests/test.proto#L954}
   ///
-  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L944}
-  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L950}
+  /// [google.test.admin.database.v1.Request]: @googleapis_reference_link{generator/integration_tests/test.proto#L948}
+  /// [google.test.admin.database.v1.Response]: @googleapis_reference_link{generator/integration_tests/test.proto#L954}
   ///
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,
@@ -394,11 +405,11 @@ class GoldenKitchenSinkClient {
   ///    x-goog-request-params:
   ///    table_location=instances/instance_bar&routing_id=prof_qux
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1344}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1348}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1344}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1348}
   ///
   Status
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});
@@ -407,11 +418,11 @@ class GoldenKitchenSinkClient {
   /// We use this RPC to verify the special case where a routing parameter key
   /// does not require a regex in order to match the correct value.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1344}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1348}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1344}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1348}
   ///
   Status
   ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc
@@ -73,7 +73,7 @@ GoldenKitchenSinkConnection::DoNothing(
 
 Status
 GoldenKitchenSinkConnection::Deprecated2(
-    google::protobuf::Empty const&) {
+    google::test::admin::database::v1::GenerateAccessTokenRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h
@@ -82,7 +82,7 @@ class GoldenKitchenSinkConnection {
   DoNothing(google::protobuf::Empty const& request);
 
   virtual Status
-  Deprecated2(google::protobuf::Empty const& request);
+  Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
 
   virtual StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request);

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -58,7 +58,7 @@ Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::DoNothing(google::prot
   return Idempotency::kNonIdempotent;
 }
 
-Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::Deprecated2(google::protobuf::Empty const&) {
+Idempotency GoldenKitchenSinkConnectionIdempotencyPolicy::Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const&) {
   return Idempotency::kNonIdempotent;
 }
 

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h
@@ -56,7 +56,7 @@ class GoldenKitchenSinkConnectionIdempotencyPolicy {
   DoNothing(google::protobuf::Empty const& request);
 
   virtual google::cloud::Idempotency
-  Deprecated2(google::protobuf::Empty const& request);
+  Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
 
   virtual google::cloud::Idempotency
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request);

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
@@ -84,7 +84,7 @@ Status GoldenKitchenSinkAuth::DoNothing(
 
 Status GoldenKitchenSinkAuth::Deprecated2(
     grpc::ClientContext& context,
-    google::protobuf::Empty const& request) {
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
   return child_->Deprecated2(context, request);

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
@@ -64,7 +64,7 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
 
   Status Deprecated2(
       grpc::ClientContext& context,
-      google::protobuf::Empty const& request) override;
+      google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
@@ -130,12 +130,12 @@ GoldenKitchenSinkConnectionImpl::DoNothing(google::protobuf::Empty const& reques
 }
 
 Status
-GoldenKitchenSinkConnectionImpl::Deprecated2(google::protobuf::Empty const& request) {
+GoldenKitchenSinkConnectionImpl::Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return google::cloud::internal::RetryLoop(
       retry_policy(), backoff_policy(),
       idempotency_policy()->Deprecated2(request),
       [this](grpc::ClientContext& context,
-          google::protobuf::Empty const& request) {
+          google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
         return stub_->Deprecated2(context, request);
       },
       request, __func__);

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h
@@ -73,7 +73,7 @@ class GoldenKitchenSinkConnectionImpl
   DoNothing(google::protobuf::Empty const& request) override;
 
   Status
-  Deprecated2(google::protobuf::Empty const& request) override;
+  Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request) override;

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
@@ -114,10 +114,10 @@ GoldenKitchenSinkLogging::DoNothing(
 Status
 GoldenKitchenSinkLogging::Deprecated2(
     grpc::ClientContext& context,
-    google::protobuf::Empty const& request) {
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             google::protobuf::Empty const& request) {
+             google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
         return child_->Deprecated2(context, request);
       },
       context, request, __func__, tracing_options_);

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
@@ -64,7 +64,7 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
 
   Status Deprecated2(
       grpc::ClientContext& context,
-      google::protobuf::Empty const& request) override;
+      google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -86,7 +86,7 @@ GoldenKitchenSinkMetadata::DoNothing(
 Status
 GoldenKitchenSinkMetadata::Deprecated2(
     grpc::ClientContext& context,
-    google::protobuf::Empty const& request) {
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   SetMetadata(context);
   return child_->Deprecated2(context, request);
 }

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -60,7 +60,7 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
 
   Status Deprecated2(
       grpc::ClientContext& context,
-      google::protobuf::Empty const& request) override;
+      google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
@@ -65,7 +65,7 @@ Status GoldenKitchenSinkRoundRobin::DoNothing(
 
 Status GoldenKitchenSinkRoundRobin::Deprecated2(
     grpc::ClientContext& context,
-    google::protobuf::Empty const& request) {
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return Child()->Deprecated2(context, request);
 }
 

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
@@ -62,7 +62,7 @@ class GoldenKitchenSinkRoundRobin : public GoldenKitchenSinkStub {
 
   Status Deprecated2(
       grpc::ClientContext& context,
-      google::protobuf::Empty const& request) override;
+      google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
@@ -115,7 +115,7 @@ DefaultGoldenKitchenSinkStub::DoNothing(
 Status
 DefaultGoldenKitchenSinkStub::Deprecated2(
   grpc::ClientContext& client_context,
-  google::protobuf::Empty const& request) {
+  google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
     google::protobuf::Empty response;
     auto status =
         grpc_stub_->Deprecated2(&client_context, request, &response);

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
@@ -67,7 +67,7 @@ class GoldenKitchenSinkStub {
 
   virtual Status Deprecated2(
     grpc::ClientContext& context,
-    google::protobuf::Empty const& request) = 0;
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) = 0;
 
   virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(
@@ -148,7 +148,7 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
   Status
   Deprecated2(
     grpc::ClientContext& client_context,
-    google::protobuf::Empty const& request) override;
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::Response>>
   StreamingRead(

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
@@ -62,7 +62,7 @@ GoldenKitchenSinkTracingConnection::DoNothing(google::protobuf::Empty const& req
 }
 
 Status
-GoldenKitchenSinkTracingConnection::Deprecated2(google::protobuf::Empty const& request) {
+GoldenKitchenSinkTracingConnection::Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return child_->Deprecated2(request);
 }
 

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.h
@@ -59,7 +59,7 @@ class GoldenKitchenSinkTracingConnection
   DoNothing(google::protobuf::Empty const& request) override;
 
   Status
-  Deprecated2(google::protobuf::Empty const& request) override;
+  Deprecated2(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
   StreamRange<google::test::admin::database::v1::Response>
   StreamingRead(google::test::admin::database::v1::Request const& request) override;

--- a/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
@@ -72,7 +72,7 @@ class MockGoldenKitchenSinkConnection : public golden_v1::GoldenKitchenSinkConne
 
   MOCK_METHOD(Status,
   Deprecated2,
-  (google::protobuf::Empty const& request), (override));
+  (google::test::admin::database::v1::GenerateAccessTokenRequest const& request), (override));
 
   MOCK_METHOD(StreamRange<google::test::admin::database::v1::Response>,
   StreamingRead,

--- a/generator/integration_tests/golden_config.textproto
+++ b/generator/integration_tests/golden_config.textproto
@@ -19,13 +19,30 @@ service {
   additional_proto_files: "generator/integration_tests/backup.proto"
   product_path: "generator/integration_tests/golden/v1"
   initial_copyright_year: "2022"
-  omitted_rpcs: ["Omitted1", "GoldenKitchenSink.Omitted2", "Deprecated1"]
+  omitted_rpcs: [
+    "Omitted1",
+    "GoldenKitchenSink.Omitted2",
+    "Deprecated1",
+    "Deprecated2(std::string const&)",
+    "GenerateAccessToken(std::string const&, std::string const&)"
+  ]
   service_endpoint_env_var: "GOLDEN_KITCHEN_SINK_ENDPOINT"
   emulator_endpoint_env_var: "GOLDEN_KITCHEN_SINK_EMULATOR_HOST"
-  gen_async_rpcs: ["GetDatabase", "DropDatabase", "StreamingRead", "StreamingWrite"]
-  retryable_status_codes: ["GoldenKitchenSink.kInternal", "kUnavailable", "GoldenThingAdmin.kDeadlineExceeded"]
+  gen_async_rpcs: [
+    "GetDatabase",
+    "DropDatabase",
+    "StreamingRead",
+    "StreamingWrite"
+  ]
+  retryable_status_codes: [
+    "GoldenKitchenSink.kInternal",
+    "kUnavailable",
+    "GoldenThingAdmin.kDeadlineExceeded"
+  ]
   generate_round_robin_decorator: true
   generate_rest_transport: true
   forwarding_product_path: "generator/integration_tests/golden"
-  emitted_rpcs: ["Deprecated2"]
+  emitted_rpcs: [
+    "Deprecated2"
+  ]
 }

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -844,13 +844,17 @@ service GoldenKitchenSink {
   }
 
   // A deprecated RPC that will omitted.
-  rpc Deprecated1(google.protobuf.Empty) returns (google.protobuf.Empty) {
+  rpc Deprecated1(GenerateAccessTokenRequest) returns (google.protobuf.Empty) {
     option deprecated = true;
+    option (google.api.method_signature) = "";
+    option (google.api.method_signature) = "not_used_anymore";
   }
 
   // A deprecated RPC for which we force API generation.
-  rpc Deprecated2(google.protobuf.Empty) returns (google.protobuf.Empty) {
+  rpc Deprecated2(GenerateAccessTokenRequest) returns (google.protobuf.Empty) {
     option deprecated = true;
+    option (google.api.method_signature) = "";
+    option (google.api.method_signature) = "not_used_anymore";
   }
 
   // Tests the generator for streaming read RPCs (aka server-side streaming)

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -229,40 +229,52 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
        ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
 
-  MOCK_METHOD(::grpc::Status, Deprecated1,
-              (::grpc::ClientContext * context,
-               ::google::protobuf::Empty const& request,
-               ::google::protobuf::Empty* response),
-              (override));
+  MOCK_METHOD(
+      ::grpc::Status, Deprecated1,
+      (::grpc::ClientContext * context,
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
+           request,
+       ::google::protobuf::Empty* response),
+      (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       AsyncDeprecated1Raw,
       (::grpc::ClientContext * context,
-       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
+           request,
+       ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       PrepareAsyncDeprecated1Raw,
       (::grpc::ClientContext * context,
-       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
+           request,
+       ::grpc::CompletionQueue* cq),
       (override));
 
-  MOCK_METHOD(::grpc::Status, Deprecated2,
-              (::grpc::ClientContext * context,
-               ::google::protobuf::Empty const& request,
-               ::google::protobuf::Empty* response),
-              (override));
+  MOCK_METHOD(
+      ::grpc::Status, Deprecated2,
+      (::grpc::ClientContext * context,
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
+           request,
+       ::google::protobuf::Empty* response),
+      (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       AsyncDeprecated2Raw,
       (::grpc::ClientContext * context,
-       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
+           request,
+       ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       PrepareAsyncDeprecated2Raw,
       (::grpc::ClientContext * context,
-       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
+           request,
+       ::grpc::CompletionQueue* cq),
       (override));
 
   using StreamingReadWriteInterface =

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
@@ -125,7 +125,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, Deprecated2) {
       .WillOnce(Return(internal::AbortedError("fail")));
 
   auto under_test = GoldenKitchenSinkTracingConnection(mock);
-  google::protobuf::Empty request;
+  google::test::admin::database::v1::GenerateAccessTokenRequest request;
   auto result = under_test.Deprecated2(request);
   EXPECT_THAT(result, StatusIs(StatusCode::kAborted));
 }

--- a/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
@@ -61,9 +61,11 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
   MOCK_METHOD(Status, DoNothing,
               (grpc::ClientContext&, ::google::protobuf::Empty const&),
               (override));
-  MOCK_METHOD(Status, Deprecated2,
-              (grpc::ClientContext&, ::google::protobuf::Empty const&),
-              (override));
+  MOCK_METHOD(
+      Status, Deprecated2,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&),
+      (override));
 
   MOCK_METHOD((std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
                    ::google::test::admin::database::v1::Request,

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/absl_str_replace_quiet.h"
+#include "google/cloud/log.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
@@ -267,6 +269,15 @@ ProcessCommandLineArgs(std::string const& parameters) {
   ProcessArgForwardingProductPath(command_line_args);
   ProcessArgEmitRpc(command_line_args);
   return command_line_args;
+}
+
+std::string SafeReplaceAll(absl::string_view s, absl::string_view from,
+                           absl::string_view to) {
+  if (absl::StrContains(s, to)) {
+    GCP_LOG(FATAL) << "SafeReplaceAll() found \"" << to << "\" in \"" << s
+                   << "\"";
+  }
+  return absl::StrReplaceAll(s, {{from, to}});
 }
 
 std::string CopyrightLicenseFileHeader() {

--- a/generator/internal/codegen_utils.h
+++ b/generator/internal/codegen_utils.h
@@ -100,6 +100,18 @@ StatusOr<std::vector<std::pair<std::string, std::string>>>
 ProcessCommandLineArgs(std::string const& parameters);
 
 /**
+ * Change all occurrences of @p from to @p to within @p s.
+ *
+ * The "safe" part means it is a fatal error for @p s to already contain
+ * @p to. This makes it possible to reliably reverse the mapping.
+ *
+ * The primary use case is to replace/restore commas in the values used by
+ * ProcessCommandLineArgs(), where comma is a metacharacter (see above).
+ */
+std::string SafeReplaceAll(absl::string_view s, absl::string_view from,
+                           absl::string_view to);
+
+/**
  * Standard legal boilerplate file header.
  */
 std::string CopyrightLicenseFileHeader();

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -27,6 +27,7 @@ using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AllOf;
 using ::testing::Contains;
+using ::testing::ContainsRegex;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Pair;
@@ -356,6 +357,15 @@ TEST(ProcessCommandLineArgs, ProcessArgEmitRpc) {
   EXPECT_THAT(*result,
               Contains(Pair("emitted_rpcs", AllOf(HasSubstr("Emitted1"),
                                                   HasSubstr("Emitted2")))));
+}
+
+TEST(SafeReplaceAll, Success) {
+  EXPECT_EQ("one@two", SafeReplaceAll("one,two", ",", "@"));
+}
+
+TEST(SafeReplaceAll, Death) {
+  EXPECT_DEATH_IF_SUPPORTED(SafeReplaceAll("one@two", ",", "@"),
+                            ContainsRegex(R"(found "@" in "one@two")"));
 }
 
 }  // namespace

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/log.h"
 #include "google/cloud/status_or.h"
@@ -20,6 +21,7 @@
 #include "absl/strings/match.h"
 #include "generator/generator.h"
 #include "generator/generator_config.pb.h"
+#include "generator/internal/codegen_utils.h"
 #include "generator/internal/scaffold_generator.h"
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/text_format.h>
@@ -51,6 +53,7 @@ namespace {
 using google::cloud::generator_internal::GenerateScaffold;
 using google::cloud::generator_internal::LibraryName;
 using google::cloud::generator_internal::LibraryPath;
+using google::cloud::generator_internal::SafeReplaceAll;
 
 google::cloud::StatusOr<google::cloud::cpp::generator::GeneratorConfiguration>
 GetConfig(std::string const& filepath) {
@@ -226,10 +229,12 @@ int main(int argc, char** argv) {
       args.emplace_back("--cpp_codegen_opt=omit_service=" + omit_service);
     }
     for (auto const& omit_rpc : service.omitted_rpcs()) {
-      args.emplace_back("--cpp_codegen_opt=omit_rpc=" + omit_rpc);
+      args.emplace_back(absl::StrCat("--cpp_codegen_opt=omit_rpc=",
+                                     SafeReplaceAll(omit_rpc, ",", "@")));
     }
     for (auto const& emit_rpc : service.emitted_rpcs()) {
-      args.emplace_back("--cpp_codegen_opt=emit_rpc=" + emit_rpc);
+      args.emplace_back(absl::StrCat("--cpp_codegen_opt=emit_rpc=",
+                                     SafeReplaceAll(emit_rpc, ",", "@")));
     }
     if (service.backwards_compatibility_namespace_alias()) {
       args.emplace_back(


### PR DESCRIPTION
Require that all "method_signature" overloads that use deprecated
fields appear in either the `emitted_rpcs` or `omitted_rpcs` lists.
This allows us to distinguish between RPC overloads using a newly-
deprecated field, which we want to keep generating for backwards
compatibility, and RPC overloads using deprecated fields in newly-
generated services, which we want to ignore.

Add `omitted_rpcs` entries for RPC overloads we currently ignore.

A subtle change is that we now compute the full "signature uid" for
all overloads, not just the un-deprecated ones.  This is a feature.
Without it, we ran the risk of choosing a new "first match" from a
clashing set should a field be newly deprecated, and therefore
silently changing the meaning of existing programs.

Add some simple support for allowing commas in the elements of
`emitted_rpcs` and `omitted_rpcs`.

Part of https://github.com/googleapis/google-cloud-cpp/issues/8486.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10583)
<!-- Reviewable:end -->
