### PR TITLE
impl(otel): traced retry backoff (sync)

### DIFF
--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -15,20 +15,25 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OPENTELEMETRY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OPENTELEMETRY_H
 
-#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/nostd/string_view.h>
 #include <opentelemetry/trace/span.h>
 #include <opentelemetry/trace/tracer.h>
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include <chrono>
+#include <functional>
 
 namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 bool TracingEnabled(Options const& options);
 
@@ -97,10 +102,15 @@ StatusOr<T> EndSpan(opentelemetry::trace::Span& span,
   return value;
 }
 
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+/// Wraps the sleeper in a span, if tracing is enabled.
+std::function<void(std::chrono::milliseconds)> MakeTracedSleeper(
+    std::function<void(std::chrono::milliseconds)> const& sleeper);
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google
-#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OPENTELEMETRY_H

--- a/google/cloud/internal/rest_retry_loop_test.cc
+++ b/google/cloud/internal/rest_retry_loop_test.cc
@@ -47,7 +47,9 @@ struct TestRetryablePolicy {
 auto constexpr kNumRetries = 3;
 
 std::unique_ptr<internal::RetryPolicy> TestRetryPolicy() {
-  return internal::LimitedErrorCountRetryPolicy<TestRetryablePolicy>(3).clone();
+  return internal::LimitedErrorCountRetryPolicy<TestRetryablePolicy>(
+             kNumRetries)
+      .clone();
 }
 
 std::unique_ptr<BackoffPolicy> TestBackoffPolicy() {

--- a/google/cloud/internal/rest_retry_loop_test.cc
+++ b/google/cloud/internal/rest_retry_loop_test.cc
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/internal/rest_retry_loop.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/opentelemetry_options.h"
 #include "google/cloud/options.h"
 #include "google/cloud/testing_util/mock_backoff_policy.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
@@ -41,8 +44,10 @@ struct TestRetryablePolicy {
   }
 };
 
+auto constexpr kNumRetries = 3;
+
 std::unique_ptr<internal::RetryPolicy> TestRetryPolicy() {
-  return internal::LimitedErrorCountRetryPolicy<TestRetryablePolicy>(5).clone();
+  return internal::LimitedErrorCountRetryPolicy<TestRetryablePolicy>(3).clone();
 }
 
 std::unique_ptr<BackoffPolicy> TestBackoffPolicy() {
@@ -191,6 +196,44 @@ TEST(RestRetryLoopTest, TooManyTransientFailuresIdempotent) {
   EXPECT_THAT(actual.status().message(), HasSubstr("the answer to everything"));
   EXPECT_THAT(actual.status().message(), HasSubstr("Retry policy exhausted"));
 }
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+TEST(RestRetryLoopTest, TracingEnabled) {
+  using ::google::cloud::testing_util::SpanNamed;
+  using ::testing::AllOf;
+  using ::testing::Each;
+  using ::testing::SizeIs;
+  auto span_catcher = testing_util::InstallSpanCatcher();
+  internal::OptionsSpan span(
+      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+
+  StatusOr<int> actual = RestRetryLoop(
+      TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
+      [](RestContext&, int) {
+        return StatusOr<int>(internal::UnavailableError("try again"));
+      },
+      0, "error message");
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, AllOf(SizeIs(kNumRetries), Each(SpanNamed("Backoff"))));
+}
+
+TEST(RestRetryLoopTest, TracingDisabled) {
+  using ::testing::IsEmpty;
+  auto span_catcher = testing_util::InstallSpanCatcher();
+  internal::OptionsSpan span(
+      Options{}.set<internal::OpenTelemetryTracingOption>(false));
+
+  StatusOr<int> actual = RestRetryLoop(
+      TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
+      [](RestContext&, int) { return StatusOr<int>(0); }, 0, "error message");
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, IsEmpty());
+}
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/retry_loop_test.cc
+++ b/google/cloud/internal/retry_loop_test.cc
@@ -46,7 +46,7 @@ struct TestRetryablePolicy {
 auto constexpr kNumRetries = 3;
 
 std::unique_ptr<RetryPolicy> TestRetryPolicy() {
-  return LimitedErrorCountRetryPolicy<TestRetryablePolicy>(3).clone();
+  return LimitedErrorCountRetryPolicy<TestRetryablePolicy>(kNumRetries).clone();
 }
 
 std::unique_ptr<BackoffPolicy> TestBackoffPolicy() {


### PR DESCRIPTION
Part of the work for #10489 

Adds ability to trace a synchronous backoff. Implemented in the gRPC / REST retry loops.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10589)
<!-- Reviewable:end -->
