### PR TITLE
cleanup(pubsub): catch status in samples

### DIFF
--- a/google/cloud/pubsub/samples/iam_samples.cc
+++ b/google/cloud/pubsub/samples/iam_samples.cc
@@ -242,7 +242,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetTopicPolicy() sample" << std::endl;
   try {
     SetTopicPolicy({project_id, topic_id});
-  } catch (std::runtime_error const&) {
+  } catch (google::cloud::Status const&) {
     // Ignore errors in this test because SetIamPolicy is flaky without an OCC
     // loop, and we do not want to complicate the example with an OCC loop.
   }
@@ -256,7 +256,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetSubscriptionPolicy() sample" << std::endl;
   try {
     SetSubscriptionPolicy({project_id, subscription_id});
-  } catch (std::runtime_error const&) {
+  } catch (google::cloud::Status const&) {
     // Ignore errors in this test because SetIamPolicy is flaky without an OCC
     // loop, and we do not want to complicate the example with an OCC loop.
   }


### PR DESCRIPTION
Similar to #10587

We throw `Status`es now, so we should catch `Status`es as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10591)
<!-- Reviewable:end -->
