### PR TITLE
impl(rest): add LogWrapper overloads using RestContext

### DIFF
--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -265,9 +265,6 @@ Result LogWrapper(Functor&& functor, google::cloud::CompletionQueue& cq,
   auto prefix = std::string(where) + "(" + RequestIdForLogging() + ")";
   GCP_LOG(DEBUG) << prefix << " << " << DebugString(request, options);
   auto response = functor(cq, context, request);
-  // Ideally we would have an ID to match the request with the asynchronous
-  // response, but for functions with this signature there is nothing that comes
-  // to mind.
   GCP_LOG(DEBUG) << prefix << " >> future_status="
                  << DebugFutureStatus(
                         response.wait_for(std::chrono::microseconds(0)));

--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -225,6 +225,65 @@ Result LogWrapper(Functor&& functor, google::cloud::CompletionQueue& cq,
   });
 }
 
+template <
+    typename Functor, typename Request, typename Context,
+    typename Result = google::cloud::internal::invoke_result_t<
+        Functor, google::cloud::CompletionQueue&, Context&, Request const&>,
+    typename std::enable_if<IsFutureStatus<Result>::value, int>::type = 0>
+Result LogWrapper(Functor&& functor, google::cloud::CompletionQueue& cq,
+                  Context& context, Request const& request, char const* where,
+                  TracingOptions const& options) {
+  // Because this is an asynchronous request we need a unique identifier so
+  // applications can match the request and response in the log.
+  auto prefix = std::string(where) + "(" + RequestIdForLogging() + ")";
+  GCP_LOG(DEBUG) << prefix << " << " << DebugString(request, options);
+  auto response = functor(cq, context, request);
+  // Ideally we would have an ID to match the request with the asynchronous
+  // response, but for functions with this signature there is nothing that comes
+  // to mind.
+  GCP_LOG(DEBUG) << prefix << " >> future_status="
+                 << DebugFutureStatus(
+                        response.wait_for(std::chrono::microseconds(0)));
+  return response.then([prefix, options](future<Status> f) {
+    auto response = f.get();
+    GCP_LOG(DEBUG) << prefix
+                   << " >> response=" << DebugString(response, options);
+    return response;
+  });
+}
+
+template <
+    typename Functor, typename Request, typename Context,
+    typename Result = google::cloud::internal::invoke_result_t<
+        Functor, google::cloud::CompletionQueue&, Context&, Request const&>,
+    typename std::enable_if<IsFutureStatusOr<Result>::value, int>::type = 0>
+Result LogWrapper(Functor&& functor, google::cloud::CompletionQueue& cq,
+                  Context& context, Request const& request, char const* where,
+                  TracingOptions const& options) {
+  // Because this is an asynchronous request we need a unique identifier so
+  // applications can match the request and response in the log.
+  auto prefix = std::string(where) + "(" + RequestIdForLogging() + ")";
+  GCP_LOG(DEBUG) << prefix << " << " << DebugString(request, options);
+  auto response = functor(cq, context, request);
+  // Ideally we would have an ID to match the request with the asynchronous
+  // response, but for functions with this signature there is nothing that comes
+  // to mind.
+  GCP_LOG(DEBUG) << prefix << " >> future_status="
+                 << DebugFutureStatus(
+                        response.wait_for(std::chrono::microseconds(0)));
+  return response.then([prefix, options](decltype(response) f) {
+    auto response = f.get();
+    if (!response) {
+      GCP_LOG(DEBUG) << prefix << " >> status="
+                     << DebugString(response.status(), options);
+    } else {
+      GCP_LOG(DEBUG) << prefix
+                     << " >> response=" << DebugString(*response, options);
+    }
+    return response;
+  });
+}
+
 template <typename Functor, typename Request, typename Response,
           typename Result = google::cloud::internal::invoke_result_t<
               Functor, grpc::ClientContext*, Request const&, Response*>,

--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -238,9 +238,6 @@ Result LogWrapper(Functor&& functor, google::cloud::CompletionQueue& cq,
   auto prefix = std::string(where) + "(" + RequestIdForLogging() + ")";
   GCP_LOG(DEBUG) << prefix << " << " << DebugString(request, options);
   auto response = functor(cq, context, request);
-  // Ideally we would have an ID to match the request with the asynchronous
-  // response, but for functions with this signature there is nothing that comes
-  // to mind.
   GCP_LOG(DEBUG) << prefix << " >> future_status="
                  << DebugFutureStatus(
                         response.wait_for(std::chrono::microseconds(0)));

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -205,6 +205,7 @@ TEST(LogWrapper, FutureStatusWithContextAndCQ) {
 }
 
 struct TestContext {};
+
 /// @test the overload for functions returning FutureStatusOr and using
 /// CompletionQueue as input
 TEST(LogWrapper, FutureStatusOrValueWithTestContextAndCQ) {


### PR DESCRIPTION
Add LogWrapper calls that can be used with REST LROs. By using a `typename Context` parameter we avoid having to include anything specifically REST.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10595)
<!-- Reviewable:end -->
