### PR TITLE
ci(otel): explicitly set cmake lang version to C++14

### DIFF
--- a/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
@@ -168,6 +168,7 @@ WORKDIR /var/tmp/build/
 RUN curl -sSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
+        -DCMAKE_CXX_STANDARD=14 \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
         -DBUILD_SHARED_LIBS=ON \

--- a/ci/cloudbuild/dockerfiles/fedora-36-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-cmake.Dockerfile
@@ -147,6 +147,7 @@ WORKDIR /var/tmp/build/
 RUN curl -sSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
+        -DCMAKE_CXX_STANDARD=14 \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
         -DBUILD_SHARED_LIBS=ON \

--- a/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
@@ -178,6 +178,7 @@ WORKDIR /var/tmp/build/
 RUN curl -sSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
+        -DCMAKE_CXX_STANDARD=14 \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
         -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
Will unblock adoption of the new abseil major, which dropped C++11.

Fixes #10599

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10601)
<!-- Reviewable:end -->
