### PR TITLE
impl(rest): improve error messaging from failed json to proto

### DIFF
--- a/google/cloud/internal/rest_stub_helpers.cc
+++ b/google/cloud/internal/rest_stub_helpers.cc
@@ -31,12 +31,14 @@ Status RestResponseToProto(google::protobuf::Message& destination,
   auto json_to_proto_status =
       google::protobuf::util::JsonStringToMessage(*json_response, &destination);
   if (!json_to_proto_status.ok()) {
-    return internal::InternalError(
+    return Status(
+        static_cast<StatusCode>(json_to_proto_status.code()),
         std::string(json_to_proto_status.message()),
         GCP_ERROR_INFO()
             .WithReason("Failure creating proto Message from Json")
             .WithMetadata("message_type", destination.GetTypeName())
-            .WithMetadata("json_string", *json_response));
+            .WithMetadata("json_string", *json_response)
+            .Build(static_cast<StatusCode>(json_to_proto_status.code())));
   }
   return {};
 }

--- a/google/cloud/internal/rest_stub_helpers.cc
+++ b/google/cloud/internal/rest_stub_helpers.cc
@@ -30,8 +30,13 @@ Status RestResponseToProto(google::protobuf::Message& destination,
   auto json_to_proto_status =
       google::protobuf::util::JsonStringToMessage(*json_response, &destination);
   if (!json_to_proto_status.ok()) {
-    return Status{
-        StatusCode::kInternal, std::string{json_to_proto_status.message()}, {}};
+    ErrorInfo err_info("Failure creating proto Message from Json",
+                       "google-cloud-cpp",
+                       {{"message_type", destination.GetTypeName()},
+                        {"json_string", *json_response}});
+    return Status{StatusCode::kInternal,
+                  std::string{json_to_proto_status.message()},
+                  std::move(err_info)};
   }
   return {};
 }

--- a/google/cloud/internal/rest_stub_helpers.cc
+++ b/google/cloud/internal/rest_stub_helpers.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/rest_stub_helpers.h"
+#include "google/cloud/internal/make_status.h"
 
 namespace google {
 namespace cloud {
@@ -30,13 +31,12 @@ Status RestResponseToProto(google::protobuf::Message& destination,
   auto json_to_proto_status =
       google::protobuf::util::JsonStringToMessage(*json_response, &destination);
   if (!json_to_proto_status.ok()) {
-    ErrorInfo err_info("Failure creating proto Message from Json",
-                       "google-cloud-cpp",
-                       {{"message_type", destination.GetTypeName()},
-                        {"json_string", *json_response}});
-    return Status{StatusCode::kInternal,
-                  std::string{json_to_proto_status.message()},
-                  std::move(err_info)};
+    return internal::InternalError(
+        std::string(json_to_proto_status.message()),
+        GCP_ERROR_INFO()
+            .WithReason("Failure creating proto Message from Json")
+            .WithMetadata("message_type", destination.GetTypeName())
+            .WithMetadata("json_string", *json_response));
   }
   return {};
 }

--- a/google/cloud/internal/rest_stub_helpers_test.cc
+++ b/google/cloud/internal/rest_stub_helpers_test.cc
@@ -57,7 +57,7 @@ TEST(RestStubHelpers, RestResponseToProtoErrorInfo) {
 
   google::iam::admin::v1::Role role;
   auto status = RestResponseToProto(role, std::move(*mock_200_response));
-  EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(status, Not(IsOk()));
   EXPECT_THAT(status.error_info().reason(),
               Eq("Failure creating proto Message from Json"));
   EXPECT_THAT(

--- a/google/cloud/internal/rest_stub_helpers_test.cc
+++ b/google/cloud/internal/rest_stub_helpers_test.cc
@@ -57,7 +57,7 @@ TEST(RestStubHelpers, RestResponseToProtoErrorInfo) {
 
   google::iam::admin::v1::Role role;
   auto status = RestResponseToProto(role, std::move(*mock_200_response));
-  EXPECT_THAT(status, StatusIs(StatusCode::kInternal));
+  EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
   EXPECT_THAT(status.error_info().reason(),
               Eq("Failure creating proto Message from Json"));
   EXPECT_THAT(

--- a/google/cloud/internal/rest_stub_helpers_test.cc
+++ b/google/cloud/internal/rest_stub_helpers_test.cc
@@ -60,7 +60,6 @@ TEST(RestStubHelpers, RestResponseToProtoErrorInfo) {
   EXPECT_THAT(status, StatusIs(StatusCode::kInternal));
   EXPECT_THAT(status.error_info().reason(),
               Eq("Failure creating proto Message from Json"));
-  EXPECT_THAT(status.error_info().domain(), Eq("google-cloud-cpp"));
   EXPECT_THAT(
       status.error_info().metadata(),
       Contains(std::make_pair(std::string("message_type"),


### PR DESCRIPTION
Provide more detailed diagnostic when a json response from a REST call fails parsing into its intended protobuf Message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10602)
<!-- Reviewable:end -->
