### PR TITLE
ci: enable C++14 for Bazel 'host' targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds


### PR DESCRIPTION
Fixes #10600 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10604)
<!-- Reviewable:end -->
