### PR TITLE
cleanup(storage): avoid `xor` in a test

### DIFF
--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -371,9 +371,11 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteLarge) {
   StatusOr<ObjectMetadata> rewritten_meta =
       writer.ResultWithProgressCallback([](StatusOr<RewriteProgress> const& p) {
         ASSERT_STATUS_OK(p);
-        EXPECT_TRUE((p->total_bytes_rewritten < p->object_size) xor p->done)
-            << "p.done=" << p->done << ", p.object_size=" << p->object_size
-            << ", p.total_bytes_rewritten=" << p->total_bytes_rewritten;
+        if (!p->done) {
+          EXPECT_LT(p->total_bytes_rewritten, p->object_size);
+        } else {
+          EXPECT_GE(p->total_bytes_rewritten, p->object_size);
+        }
       });
   ASSERT_STATUS_OK(rewritten_meta);
   ScheduleForDelete(*rewritten_meta);


### PR DESCRIPTION
Replace it with some `if()` and simpler (I think) assertions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10605)
<!-- Reviewable:end -->
