### PR TITLE
ci: enable C++14 for more 'host' targets

### DIFF
--- a/ci/verify_current_targets/.bazelrc
+++ b/ci/verify_current_targets/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/ci/verify_deprecated_targets/.bazelrc
+++ b/ci/verify_deprecated_targets/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -1077,6 +1077,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/accessapproval/quickstart/.bazelrc
+++ b/google/cloud/accessapproval/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/accesscontextmanager/quickstart/.bazelrc
+++ b/google/cloud/accesscontextmanager/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/apigateway/quickstart/.bazelrc
+++ b/google/cloud/apigateway/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/apigeeconnect/quickstart/.bazelrc
+++ b/google/cloud/apigeeconnect/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/apikeys/quickstart/.bazelrc
+++ b/google/cloud/apikeys/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/appengine/quickstart/.bazelrc
+++ b/google/cloud/appengine/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/artifactregistry/quickstart/.bazelrc
+++ b/google/cloud/artifactregistry/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/asset/quickstart/.bazelrc
+++ b/google/cloud/asset/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/assuredworkloads/quickstart/.bazelrc
+++ b/google/cloud/assuredworkloads/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/automl/quickstart/.bazelrc
+++ b/google/cloud/automl/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/baremetalsolution/quickstart/.bazelrc
+++ b/google/cloud/baremetalsolution/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/batch/quickstart/.bazelrc
+++ b/google/cloud/batch/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/beyondcorp/quickstart/.bazelrc
+++ b/google/cloud/beyondcorp/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/bigquery/quickstart/.bazelrc
+++ b/google/cloud/bigquery/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/bigtable/quickstart/.bazelrc
+++ b/google/cloud/bigtable/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/billing/quickstart/.bazelrc
+++ b/google/cloud/billing/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/binaryauthorization/quickstart/.bazelrc
+++ b/google/cloud/binaryauthorization/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/certificatemanager/quickstart/.bazelrc
+++ b/google/cloud/certificatemanager/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/channel/quickstart/.bazelrc
+++ b/google/cloud/channel/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/cloudbuild/quickstart/.bazelrc
+++ b/google/cloud/cloudbuild/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/composer/quickstart/.bazelrc
+++ b/google/cloud/composer/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/connectors/quickstart/.bazelrc
+++ b/google/cloud/connectors/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/contactcenterinsights/quickstart/.bazelrc
+++ b/google/cloud/contactcenterinsights/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/container/quickstart/.bazelrc
+++ b/google/cloud/container/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/containeranalysis/quickstart/.bazelrc
+++ b/google/cloud/containeranalysis/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/datacatalog/quickstart/.bazelrc
+++ b/google/cloud/datacatalog/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/datamigration/quickstart/.bazelrc
+++ b/google/cloud/datamigration/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/dataplex/quickstart/.bazelrc
+++ b/google/cloud/dataplex/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/dataproc/quickstart/.bazelrc
+++ b/google/cloud/dataproc/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/datastream/quickstart/.bazelrc
+++ b/google/cloud/datastream/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/debugger/quickstart/.bazelrc
+++ b/google/cloud/debugger/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/deploy/quickstart/.bazelrc
+++ b/google/cloud/deploy/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/dialogflow_cx/quickstart/.bazelrc
+++ b/google/cloud/dialogflow_cx/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/dialogflow_es/quickstart/.bazelrc
+++ b/google/cloud/dialogflow_es/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/dlp/quickstart/.bazelrc
+++ b/google/cloud/dlp/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/documentai/quickstart/.bazelrc
+++ b/google/cloud/documentai/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/edgecontainer/quickstart/.bazelrc
+++ b/google/cloud/edgecontainer/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/eventarc/quickstart/.bazelrc
+++ b/google/cloud/eventarc/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/filestore/quickstart/.bazelrc
+++ b/google/cloud/filestore/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/functions/quickstart/.bazelrc
+++ b/google/cloud/functions/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/gameservices/quickstart/.bazelrc
+++ b/google/cloud/gameservices/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/gkehub/quickstart/.bazelrc
+++ b/google/cloud/gkehub/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/gkemulticloud/quickstart/.bazelrc
+++ b/google/cloud/gkemulticloud/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/iam/quickstart/.bazelrc
+++ b/google/cloud/iam/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/iap/quickstart/.bazelrc
+++ b/google/cloud/iap/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/ids/quickstart/.bazelrc
+++ b/google/cloud/ids/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/iot/quickstart/.bazelrc
+++ b/google/cloud/iot/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/kms/quickstart/.bazelrc
+++ b/google/cloud/kms/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/language/quickstart/.bazelrc
+++ b/google/cloud/language/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/logging/quickstart/.bazelrc
+++ b/google/cloud/logging/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/managedidentities/quickstart/.bazelrc
+++ b/google/cloud/managedidentities/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/memcache/quickstart/.bazelrc
+++ b/google/cloud/memcache/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/monitoring/quickstart/.bazelrc
+++ b/google/cloud/monitoring/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/networkconnectivity/quickstart/.bazelrc
+++ b/google/cloud/networkconnectivity/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/networkmanagement/quickstart/.bazelrc
+++ b/google/cloud/networkmanagement/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/notebooks/quickstart/.bazelrc
+++ b/google/cloud/notebooks/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/optimization/quickstart/.bazelrc
+++ b/google/cloud/optimization/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/orgpolicy/quickstart/.bazelrc
+++ b/google/cloud/orgpolicy/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/osconfig/quickstart/.bazelrc
+++ b/google/cloud/osconfig/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/oslogin/quickstart/.bazelrc
+++ b/google/cloud/oslogin/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/policytroubleshooter/quickstart/.bazelrc
+++ b/google/cloud/policytroubleshooter/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/privateca/quickstart/.bazelrc
+++ b/google/cloud/privateca/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/profiler/quickstart/.bazelrc
+++ b/google/cloud/profiler/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/pubsub/quickstart/.bazelrc
+++ b/google/cloud/pubsub/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/pubsublite/quickstart/.bazelrc
+++ b/google/cloud/pubsublite/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/recommender/quickstart/.bazelrc
+++ b/google/cloud/recommender/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/redis/quickstart/.bazelrc
+++ b/google/cloud/redis/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/resourcemanager/quickstart/.bazelrc
+++ b/google/cloud/resourcemanager/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/resourcesettings/quickstart/.bazelrc
+++ b/google/cloud/resourcesettings/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/retail/quickstart/.bazelrc
+++ b/google/cloud/retail/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/run/quickstart/.bazelrc
+++ b/google/cloud/run/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/scheduler/quickstart/.bazelrc
+++ b/google/cloud/scheduler/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/secretmanager/quickstart/.bazelrc
+++ b/google/cloud/secretmanager/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/securitycenter/quickstart/.bazelrc
+++ b/google/cloud/securitycenter/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/servicecontrol/quickstart/.bazelrc
+++ b/google/cloud/servicecontrol/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/servicedirectory/quickstart/.bazelrc
+++ b/google/cloud/servicedirectory/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/servicemanagement/quickstart/.bazelrc
+++ b/google/cloud/servicemanagement/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/serviceusage/quickstart/.bazelrc
+++ b/google/cloud/serviceusage/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/shell/quickstart/.bazelrc
+++ b/google/cloud/shell/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/spanner/quickstart/.bazelrc
+++ b/google/cloud/spanner/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/speech/quickstart/.bazelrc
+++ b/google/cloud/speech/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/storage/quickstart/.bazelrc
+++ b/google/cloud/storage/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/storagetransfer/quickstart/.bazelrc
+++ b/google/cloud/storagetransfer/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/talent/quickstart/.bazelrc
+++ b/google/cloud/talent/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/tasks/quickstart/.bazelrc
+++ b/google/cloud/tasks/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/texttospeech/quickstart/.bazelrc
+++ b/google/cloud/texttospeech/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/tpu/quickstart/.bazelrc
+++ b/google/cloud/tpu/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/trace/quickstart/.bazelrc
+++ b/google/cloud/trace/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/translate/quickstart/.bazelrc
+++ b/google/cloud/translate/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/video/quickstart/.bazelrc
+++ b/google/cloud/video/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/videointelligence/quickstart/.bazelrc
+++ b/google/cloud/videointelligence/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/vision/quickstart/.bazelrc
+++ b/google/cloud/vision/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/vmmigration/quickstart/.bazelrc
+++ b/google/cloud/vmmigration/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/vmwareengine/quickstart/.bazelrc
+++ b/google/cloud/vmwareengine/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/vpcaccess/quickstart/.bazelrc
+++ b/google/cloud/vpcaccess/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/webrisk/quickstart/.bazelrc
+++ b/google/cloud/webrisk/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/websecurityscanner/quickstart/.bazelrc
+++ b/google/cloud/websecurityscanner/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds

--- a/google/cloud/workflows/quickstart/.bazelrc
+++ b/google/cloud/workflows/quickstart/.bazelrc
@@ -24,6 +24,10 @@ build --enable_platform_specific_config=true
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds


### PR DESCRIPTION
I missed the majority of the `.bazelrc` files.

Really fixes #10600

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10606)
<!-- Reviewable:end -->
