### PR TITLE
cleanup(otel): suppress warning if disabled

### DIFF
--- a/google/cloud/internal/opentelemetry_aliases_test.cc
+++ b/google/cloud/internal/opentelemetry_aliases_test.cc
@@ -44,8 +44,8 @@ TEST(CurrentSpan, WithOpenTelemetry) {
 #else
 
 TEST(CurrentSpan, WithoutOpenTelemetry) {
-  auto span = CurrentSpan();
-  auto scope = ScopedSpan(span);
+  Span span = CurrentSpan();
+  ScopedSpan scope(span);
   EXPECT_EQ(span, nullptr);
   EXPECT_EQ(scope, nullptr);
 }


### PR DESCRIPTION
`ScopedSpan` is a `std::nullptr_t`. `clang-tidy` emitted a `google-readability-casting` warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10609)
<!-- Reviewable:end -->
