### PR TITLE
cleanup(bigtable): consistent Bazel target names

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -105,7 +105,7 @@ cc_library(
 cc_library(
     name = "bigtable",
     deps = [
-        "//google/cloud/bigtable:bigtable_client_internal",
+        "//google/cloud/bigtable:google_cloud_cpp_bigtable",
     ],
 )
 

--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -19,7 +19,7 @@ licenses(["notice"])  # Apache 2.0
 load(":google_cloud_cpp_bigtable.bzl", "google_cloud_cpp_bigtable_hdrs", "google_cloud_cpp_bigtable_srcs")
 
 cc_library(
-    name = "bigtable_client_internal",
+    name = "google_cloud_cpp_bigtable",
     srcs = google_cloud_cpp_bigtable_srcs,
     hdrs = google_cloud_cpp_bigtable_hdrs,
     visibility = [
@@ -52,7 +52,7 @@ cc_library(
         "//:__pkg__",
     ],
     deps = [
-        ":bigtable_client_internal",
+        ":google_cloud_cpp_bigtable",
         "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googletest//:gtest_main",
@@ -68,7 +68,7 @@ cc_library(
     hdrs = bigtable_client_testing_hdrs,
     visibility = ["//visibility:public"],
     deps = [
-        ":bigtable_client_internal",
+        ":google_cloud_cpp_bigtable",
         ":google_cloud_cpp_bigtable_mocks",
         "//:common",
         "//:grpc_utils",
@@ -84,8 +84,8 @@ load(":bigtable_client_unit_tests.bzl", "bigtable_client_unit_tests")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     deps = [
-        ":bigtable_client_internal",
         ":bigtable_client_testing",
+        ":google_cloud_cpp_bigtable",
         "//:common",
         "//:grpc_utils",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
@@ -102,8 +102,8 @@ cc_test(
         "internal/readrowsparser_test.cc",
     ],
     deps = [
-        ":bigtable_client_internal",
         ":bigtable_client_testing",
+        ":google_cloud_cpp_bigtable",
         "//:common",
         "//:grpc_utils",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",


### PR DESCRIPTION
Renamed an internal target to be more consistent with other libraries. This will enable other small cleanups.