### PR TITLE
cleanup(otel): appease clang

### DIFF
--- a/google/cloud/internal/opentelemetry_aliases.h
+++ b/google/cloud/internal/opentelemetry_aliases.h
@@ -34,7 +34,9 @@ using Span = opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>;
 using ScopedSpan = opentelemetry::trace::Scope;
 #else
 using Span = std::nullptr_t;
-using ScopedSpan = std::nullptr_t;
+struct ScopedSpan {
+  explicit ScopedSpan(Span) {}
+};
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 Span CurrentSpan();

--- a/google/cloud/internal/opentelemetry_aliases_test.cc
+++ b/google/cloud/internal/opentelemetry_aliases_test.cc
@@ -47,7 +47,6 @@ TEST(CurrentSpan, WithoutOpenTelemetry) {
   Span span = CurrentSpan();
   ScopedSpan scope(span);
   EXPECT_EQ(span, nullptr);
-  EXPECT_EQ(scope, nullptr);
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY


### PR DESCRIPTION
This was probably the right way to do the `ScopedSpan`. Otherwise clang complains about `ScopedCallContext::span_` being an unused member variable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10622)
<!-- Reviewable:end -->
