### PR TITLE
cleanup: fast checkers ignores deleted files

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -65,7 +65,7 @@ git_files() {
   if [ -z "${GOOGLE_CLOUD_CPP_FAST_CHECKERS-}" ]; then
     git ls-files "${@}"
   else
-    git diff main --name-only "${@}"
+    git diff main --name-only --diff-filter=d "${@}"
   fi
 }
 


### PR DESCRIPTION
ignore deleted files in "fast checkers".

`git diff --diff-filter=...` documentation: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10625)
<!-- Reviewable:end -->
