### PR TITLE
doc: install RE2 from source

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -150,6 +150,25 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz 
     ldconfig
 # ```
 
+# #### RE2
+
+# The version of RE2 included with this distro hard-codes C++11 in its
+# pkg-config file. You can skip this build and use the system's package if
+# you are not planning to use pkg-config.
+
+# ```bash
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
 # #### gRPC
 
 # Finally, we build gRPC from source:

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf makecache && \
 
 # ```bash
 RUN dnf makecache && \
-    dnf install -y c-ares-devel re2-devel libcurl-devel
+    dnf install -y c-ares-devel libcurl-devel
 # ```
 
 # Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
@@ -26,7 +26,7 @@ RUN dnf makecache && \
     dnf install -y epel-release && \
     dnf makecache && \
     dnf install -y ccache cmake curl findutils gcc-c++ git make openssl-devel \
-        patch re2-devel zlib-devel libcurl-devel c-ares-devel tar wget which
+        patch zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```
 
 # Rocky Linux's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is
@@ -101,6 +101,25 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz 
         -Dprotobuf_BUILD_TESTS=OFF \
         -Dprotobuf_ABSL_PROVIDER=package \
         -S . -B cmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
+# #### RE2
+
+# The version of RE2 included with this distro hard-codes C++11 in its
+# pkg-config file. You can skip this build and use the system's package if
+# you are not planning to use pkg-config.
+
+# ```bash
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -26,7 +26,7 @@ RUN dnf makecache && \
     dnf install -y epel-release && \
     dnf makecache && \
     dnf install -y ccache cmake findutils gcc-c++ git make openssl-devel \
-        patch re2-devel zlib-devel libcurl-devel c-ares-devel tar wget which
+        patch zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```
 
 # Rocky Linux's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is
@@ -104,6 +104,25 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz 
         -Dprotobuf_BUILD_TESTS=OFF \
         -Dprotobuf_ABSL_PROVIDER=package \
         -S . -B cmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
+# #### RE2
+
+# The version of RE2 included with this distro hard-codes C++11 in its
+# pkg-config file. You can skip this build and use the system's package if
+# you are not planning to use pkg-config.
+
+# ```bash
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig

--- a/ci/cloudbuild/dockerfiles/fedora-36-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-cmake.Dockerfile
@@ -124,8 +124,22 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz 
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 
+# The version of RE2 installed with Fedora:36 forces C++11 in its pkg-config
+# files. This is fixed in Fedora:37, but until then it is easier to just install
+# the source code.
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+
 WORKDIR /var/tmp/build/grpc
-RUN dnf makecache && dnf install -y c-ares-devel re2-devel
+RUN dnf makecache && dnf install -y c-ares-devel
 RUN curl -sSL https://github.com/grpc/grpc/archive/v1.51.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \

--- a/ci/cloudbuild/dockerfiles/fedora-36-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-cxx14.Dockerfile
@@ -140,8 +140,22 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz 
     ldconfig && \
     cd /var/tmp && rm -fr build
 
+# The version of RE2 installed with Fedora:36 forces C++11 in its pkg-config
+# files. This is fixed in Fedora:37, but until then it is easier to just install
+# the source code.
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+
 WORKDIR /var/tmp/build/grpc
-RUN dnf makecache && dnf install -y c-ares-devel re2-devel
+RUN dnf makecache && dnf install -y c-ares-devel
 RUN curl -sSL https://github.com/grpc/grpc/archive/v1.51.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \

--- a/ci/cloudbuild/dockerfiles/fedora-36-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-cxx20.Dockerfile
@@ -140,8 +140,22 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz 
     ldconfig && \
     cd /var/tmp && rm -fr build
 
+# The version of RE2 installed with Fedora:36 forces C++11 in its pkg-config
+# files. This is fixed in Fedora:37, but until then it is easier to just install
+# the source code.
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+
 WORKDIR /var/tmp/build/grpc
-RUN dnf makecache && dnf install -y c-ares-devel re2-devel
+RUN dnf makecache && dnf install -y c-ares-devel
 RUN curl -sSL https://github.com/grpc/grpc/archive/v1.51.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -354,6 +354,25 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
+#### RE2
+
+The version of RE2 included with this distro hard-codes C++11 in its
+pkg-config file. You can skip this build and use the system's package if
+you are not planning to use pkg-config.
+
+```bash
+mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
+curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
 #### gRPC
 
 Finally, we build gRPC from source:
@@ -1336,7 +1355,7 @@ sudo dnf update -y && \
 sudo dnf install -y epel-release && \
 sudo dnf makecache && \
 sudo dnf install -y ccache cmake curl findutils gcc-c++ git make openssl-devel \
-        patch re2-devel zlib-devel libcurl-devel c-ares-devel tar wget which
+        patch zlib-devel libcurl-devel c-ares-devel tar wget which
 ```
 
 Rocky Linux's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is
@@ -1411,6 +1430,25 @@ curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz | \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Dprotobuf_ABSL_PROVIDER=package \
         -S . -B cmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### RE2
+
+The version of RE2 included with this distro hard-codes C++11 in its
+pkg-config file. You can skip this build and use the system's package if
+you are not planning to use pkg-config.
+
+```bash
+mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
+curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1515,7 +1553,7 @@ sudo dnf update -y && \
 sudo dnf install -y epel-release && \
 sudo dnf makecache && \
 sudo dnf install -y ccache cmake findutils gcc-c++ git make openssl-devel \
-        patch re2-devel zlib-devel libcurl-devel c-ares-devel tar wget which
+        patch zlib-devel libcurl-devel c-ares-devel tar wget which
 ```
 
 Rocky Linux's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is
@@ -1593,6 +1631,25 @@ curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz | \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Dprotobuf_ABSL_PROVIDER=package \
         -S . -B cmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### RE2
+
+The version of RE2 included with this distro hard-codes C++11 in its
+pkg-config file. You can skip this build and use the system's package if
+you are not planning to use pkg-config.
+
+```bash
+mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
+curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_BUILD_TESTING=OFF \
+        -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -235,7 +235,7 @@ dependencies of libcurl, Protobuf, and gRPC are recent enough for our needs.
 
 ```bash
 sudo dnf makecache && \
-sudo dnf install -y c-ares-devel re2-devel libcurl-devel
+sudo dnf install -y c-ares-devel libcurl-devel
 ```
 
 Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow


### PR DESCRIPTION
The next version of gRPC fixes its pkg-config dependencies, and that exposes a latent bug in the RE2 packages for some distros.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10627)
<!-- Reviewable:end -->
