### PR TITLE
ci: demo builds compile all GA libraries

### DIFF
--- a/ci/cloudbuild/builds/demo-install.sh
+++ b/ci/cloudbuild/builds/demo-install.sh
@@ -39,7 +39,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ## [DONE packaging.md]

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -147,7 +147,7 @@ Install the minimal development tools, libcurl, and OpenSSL:
 ```bash
 apk update && \
     apk add bash ca-certificates ccache cmake curl git \
-        gcc g++ make patch tar unzip zip zlib-dev
+        gcc g++ make tar unzip zip zlib-dev
 ```
 
 Alpine's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -147,7 +147,7 @@ Install the minimal development tools, libcurl, and OpenSSL:
 ```bash
 apk update && \
     apk add bash ca-certificates ccache cmake curl git \
-        gcc g++ make tar unzip zip zlib-dev
+        gcc g++ make patch tar unzip zip zlib-dev
 ```
 
 Alpine's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
@@ -210,7 +210,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -408,7 +409,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -584,7 +586,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -735,7 +738,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -904,7 +908,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1070,7 +1075,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1226,7 +1232,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1393,7 +1400,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1591,7 +1599,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1795,7 +1804,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -2000,7 +2010,8 @@ cmake -H. -Bcmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE=__ga_libraries__
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -20,7 +20,8 @@ if (APPLE)
                     "on Apple platforms until #8125 is fixed.")
     return()
 endif ()
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
+                                                  VERSION_LESS 8.0)
     message(WARNING "Cannot build this google/cloud/channel "
                     "on with GCC < 8.0 until #8125 is fixed.")
     return()

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -14,10 +14,15 @@
 # limitations under the License.
 # ~~~
 
-# TODO(8125): Re-enable the macos build.
+# TODO(#8125): Re-enable the on macOS and GCC < 8.0.
 if (APPLE)
     message(WARNING "Cannot build this google/cloud/channel "
                     "on Apple platforms until #8125 is fixed.")
+    return()
+endif ()
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+    message(WARNING "Cannot build this google/cloud/channel "
+                    "on with GCC < 8.0 until #8125 is fixed.")
     return()
 endif ()
 

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -14,16 +14,16 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#8125): Re-enable the on macOS and GCC < 8.0.
+# TODO(#8125): Re-enable this on macOS and GCC < 8.0.
 if (APPLE)
-    message(WARNING "Cannot build this google/cloud/channel "
+    message(WARNING "Cannot build google/cloud/channel "
                     "on Apple platforms until #8125 is fixed.")
     return()
 endif ()
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
                                                   VERSION_LESS 8.0)
-    message(WARNING "Cannot build this google/cloud/channel "
-                    "on with GCC < 8.0 until #8125 is fixed.")
+    message(WARNING "Cannot build google/cloud/channel "
+                    "with GCC < 8.0 until #8125 is fixed.")
     return()
 endif ()
 


### PR DESCRIPTION
I want to avoid any embarrassment if the libraries fail to build for whatever reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10634)
<!-- Reviewable:end -->
