### PR TITLE
cleanup(doc): reset group/other permissions after mdformat

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -203,10 +203,14 @@ time {
   done
 }
 
+# mdformat does `tempfile.mkstemp(); ...; os.replace(tmp_path, path)`,
+# which results in the new .md file having mode 0600. So, run a second
+# pass to reset the group/other permissions to something more reasonable.
 printf "%-50s" "Running markdown formatter:" >&2
 time {
   # See `.mdformat.toml` for the configuration parameters.
   git_files -z -- '*.md' | xargs -r -P "$(nproc)" -n 1 -0 mdformat
+  git_files -z -- '*.md' | xargs -r -0 chmod go=u-w
 }
 
 printf "%-50s" "Running doxygen landing-page updates:" >&2


### PR DESCRIPTION
The in-place update performed by `mdformat` does not preserve the file mode, so do something simple to (probably) compensate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10635)
<!-- Reviewable:end -->
