### PR TITLE
fix: interface proto libraries work with older CMake

### DIFF
--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -315,6 +315,10 @@ include(GNUInstallDirs)
 
 # Install headers for a C++ proto library.
 function (google_cloud_cpp_install_proto_library_headers target)
+    get_target_property(type ${target} TYPE)
+    if ("${type}" STREQUAL "INTERFACE_LIBRARY")
+        return()
+    endif ()
     get_target_property(target_sources ${target} SOURCES)
     foreach (header ${target_sources})
         # Skip anything that is not a header file.
@@ -332,6 +336,10 @@ endfunction ()
 
 # Install protos for a C++ proto library.
 function (google_cloud_cpp_install_proto_library_protos target source_dir)
+    get_target_property(type ${target} TYPE)
+    if ("${type}" STREQUAL "INTERFACE_LIBRARY")
+        return()
+    endif ()
     get_target_property(target_protos ${target} PROTO_SOURCES)
     foreach (header ${target_protos})
         # Skip anything that is not a header file.

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -35,7 +35,12 @@ endif ()
 
 include(CompileProtos)
 add_library(google_cloud_cpp_dialogflow_es_protos INTERFACE)
-external_googleapis_set_version_and_alias(dialogflow_es_protos)
+set_target_properties(
+    google_cloud_cpp_dialogflow_es_protos
+    PROPERTIES EXPORT_NAME google-cloud-cpp::dialogflow_es_protos)
+add_library(google-cloud-cpp::dialogflow_es_protos ALIAS
+            google_cloud_cpp_dialogflow_es_protos)
+
 target_link_libraries(
     google_cloud_cpp_dialogflow_es_protos
     PUBLIC

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -47,11 +47,8 @@ endif ()
 add_library(google_cloud_cpp_speech_protos INTERFACE)
 target_link_libraries(google_cloud_cpp_speech_protos
                       INTERFACE google-cloud-cpp::cloud_speech_protos)
-set_target_properties(
-    google_cloud_cpp_speech_protos
-    PROPERTIES EXPORT_NAME google-cloud-cpp::speech_protos
-               VERSION "${PROJECT_VERSION}"
-               SOVERSION "${PROJECT_VERSION_MAJOR}")
+set_target_properties(google_cloud_cpp_speech_protos
+                      PROPERTIES EXPORT_NAME google-cloud-cpp::speech_protos)
 target_compile_options(google_cloud_cpp_speech_protos
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 add_library(google-cloud-cpp::speech_protos ALIAS

--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -39,9 +39,7 @@ target_link_libraries(google_cloud_cpp_texttospeech_protos
                       INTERFACE google-cloud-cpp::cloud_texttospeech_protos)
 set_target_properties(
     google_cloud_cpp_texttospeech_protos
-    PROPERTIES EXPORT_NAME google-cloud-cpp::texttospeech_protos
-               VERSION "${PROJECT_VERSION}"
-               SOVERSION "${PROJECT_VERSION_MAJOR}")
+    PROPERTIES EXPORT_NAME google-cloud-cpp::texttospeech_protos)
 target_compile_options(google_cloud_cpp_texttospeech_protos
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 add_library(google-cloud-cpp::texttospeech_protos ALIAS

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -38,11 +38,8 @@ target_link_libraries(
     google_cloud_cpp_trace_protos
     INTERFACE google-cloud-cpp::devtools_cloudtrace_v2_trace_protos
               google-cloud-cpp::devtools_cloudtrace_v2_tracing_protos)
-set_target_properties(
-    google_cloud_cpp_trace_protos
-    PROPERTIES EXPORT_NAME google-cloud-cpp::trace_protos
-               VERSION "${PROJECT_VERSION}"
-               SOVERSION "${PROJECT_VERSION_MAJOR}")
+set_target_properties(google_cloud_cpp_trace_protos
+                      PROPERTIES EXPORT_NAME google-cloud-cpp::trace_protos)
 target_compile_options(google_cloud_cpp_trace_protos
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 add_library(google-cloud-cpp::trace_protos ALIAS google_cloud_cpp_trace_protos)


### PR DESCRIPTION
Older versions of CMake are (too) strict about what properties may be attached to an interface library.  That was not working for some functions we use with proto libraries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10636)
<!-- Reviewable:end -->
