### PR TITLE
cleanup: less noise when failing to find Doxygen

### DIFF
--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ~~~
 
-find_package(Doxygen)
+find_package(Doxygen QUIET)
 
 function (google_cloud_cpp_doxygen_deploy_version VAR)
     set(VERSION "${PROJECT_VERSION}")


### PR DESCRIPTION
Most of our builds do not need Doxygen, and when they fail to find it they merrily continue. With this change we do not get 100 lines saying the same thing (that Doxygen was not found).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10637)
<!-- Reviewable:end -->
