### PR TITLE
ci: make Dockerfiles slightly more cache-friendly

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-36-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-cxx14.Dockerfile
@@ -28,16 +28,20 @@ RUN dnf makecache && \
         openssl-devel patch python python3.8 \
         python-pip tar unzip w3m wget which zip zlib-devel
 
+# Install the Python modules needed to run the storage emulator
+RUN dnf makecache && dnf install -y python3-devel
+RUN pip3 install --upgrade pip
+RUN pip3 install setuptools wheel
+
+# The Cloud Pub/Sub emulator needs Java, and so does `bazel coverage` :shrug:
+# Bazel needs the '-devel' version with javac.
+RUN dnf makecache && dnf install -y java-latest-openjdk-devel
+
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
 RUN echo 'root:' | chpasswd
-
-# Install the Python modules needed to run the storage emulator
-RUN dnf makecache && dnf install -y python3-devel
-RUN pip3 install --upgrade pip
-RUN pip3 install setuptools wheel
 
 # Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 # when handling `.pc` files with lots of `Requires:` deps, which happens with
@@ -198,9 +202,6 @@ ENV CLOUDSDK_PYTHON=python3.8
 RUN /var/tmp/ci/install-cloud-sdk.sh
 ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
-# The Cloud Pub/Sub emulator needs Java, and so does `bazel coverage` :shrug:
-# Bazel needs the '-devel' version with javac.
-RUN dnf makecache && dnf install -y java-latest-openjdk-devel
 
 # Some of the above libraries may have installed in /usr/local, so make sure
 # those library directories will be found.

--- a/ci/cloudbuild/dockerfiles/fedora-36-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-36-cxx20.Dockerfile
@@ -28,16 +28,19 @@ RUN dnf makecache && \
         openssl-devel patch python python3 \
         python-pip tar unzip wget which zip zlib-devel
 
+# Install the Python modules needed to run the storage emulator
+RUN dnf makecache && dnf install -y python3-devel
+RUN pip3 install --upgrade pip
+RUN pip3 install setuptools wheel
+
+# This is needed to install gRPC
+RUN dnf makecache && dnf install -y c-ares-devel
+
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
 RUN echo 'root:' | chpasswd
-
-# Install the Python modules needed to run the storage emulator
-RUN dnf makecache && dnf install -y python3-devel
-RUN pip3 install --upgrade pip
-RUN pip3 install setuptools wheel
 
 # Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 # when handling `.pc` files with lots of `Requires:` deps, which happens with
@@ -155,7 +158,6 @@ RUN curl -sSL https://github.com/google/re2/archive/2022-12-01.tar.gz | \
     ldconfig
 
 WORKDIR /var/tmp/build/grpc
-RUN dnf makecache && dnf install -y c-ares-devel
 RUN curl -sSL https://github.com/grpc/grpc/archive/v1.51.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \

--- a/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
@@ -54,6 +54,7 @@ RUN cmake -GNinja -S llvm -B build \
 # build the libraries
 RUN cmake --build build -- cxx cxxabi
 RUN cmake --build build -- install-cxx install-cxxabi
+RUN ldconfig
 
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.

--- a/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
@@ -23,15 +23,19 @@ RUN dnf makecache && \
         git llvm llvm-devel make ninja-build openssl-devel patch python \
         python3 python3-devel python3-lit python-pip tar unzip which wget xz
 
+# Install the Python modules needed to run the storage emulator
+RUN dnf makecache && dnf install -y python3-devel
+RUN pip3 install --upgrade pip
+RUN pip3 install setuptools wheel
+
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN dnf makecache && dnf install -y java-latest-openjdk
+
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
 RUN echo 'root:' | chpasswd
-
-# Install the Python modules needed to run the storage emulator
-RUN pip3 install --upgrade pip
-RUN pip3 install setuptools wheel
 
 WORKDIR /var/tmp/build
 
@@ -59,8 +63,6 @@ ENV CLOUDSDK_PYTHON=python3.10
 RUN /var/tmp/ci/install-cloud-sdk.sh
 ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
-# The Cloud Pub/Sub emulator needs Java :shrug:
-RUN dnf makecache && dnf install -y java-latest-openjdk
 
 RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-${ARCH}" && \
     chmod +x /usr/bin/bazelisk && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
@@ -50,6 +50,11 @@ RUN apt-get update && \
         apt-utils \
         ca-certificates \
         apt-transport-https
+# Install Python packages used in the integration tests.
+RUN update-alternatives --install /usr/bin/python python $(which python3) 10
+RUN pip3 install setuptools wheel
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)
 
 # Install all the direct (and indirect) dependencies for google-cloud-cpp.
 # Use a different directory for each build, and remove the downloaded
@@ -189,10 +194,6 @@ RUN curl -sSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.1
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 
-# Install Python packages used in the integration tests.
-RUN update-alternatives --install /usr/bin/python python $(which python3) 10
-RUN pip3 install setuptools wheel
-
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.
 COPY . /var/tmp/ci
@@ -200,5 +201,3 @@ WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
 ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
-# The Cloud Pub/Sub emulator needs Java :shrug:
-RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)

--- a/ci/cloudbuild/dockerfiles/ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-focal.Dockerfile
@@ -57,6 +57,9 @@ RUN apt-get update && \
 RUN update-alternatives --install /usr/bin/python python $(which python3) 10
 RUN pip3 install setuptools wheel
 
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)
+
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.
 COPY . /var/tmp/ci
@@ -64,8 +67,6 @@ WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
 ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
-# The Cloud Pub/Sub emulator needs Java :shrug:
-RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)
 
 RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-${ARCH}" && \
     chmod +x /usr/bin/bazelisk && \


### PR DESCRIPTION
In general, the system packages (stuff installed with `apt-get` or its analog) tend to change less often than packages we compile from source. It makes sense to install them early in the Dockerfile, so that step is preserved when a new package is installed from source.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10639)
<!-- Reviewable:end -->
