### PR TITLE
cleanup: use a CMake function for Doxygen targets

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -26,9 +26,6 @@ include(EnableWerror)
 # Helper functions to create pkg-config(1) module files.
 include(AddPkgConfig)
 
-# Generate Doxygen documentation
-include(GoogleCloudCppDoxygen)
-
 #
 # google_cloud_cpp_install_headers : install all the headers in a target
 #

--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -142,42 +142,19 @@ function (google_cloud_cpp_doxygen_targets_impl library)
 endfunction ()
 
 function (google_cloud_cpp_doxygen_targets library)
+    cmake_parse_arguments(opt "" "" "DEPENDS" ${ARGN})
+
     google_cloud_cpp_doxygen_deploy_version(VERSION)
     set(GOOGLE_CLOUD_CPP_COMMON_TAG
         "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag")
-    cmake_parse_arguments(opt "" "" "INPUTS;TAGFILES;DEPS" ${ARGN})
     google_cloud_cpp_doxygen_targets_impl(
         "${library}"
         RECURSIVE
         INPUTS
         "${CMAKE_CURRENT_SOURCE_DIR}"
         DEPENDS
-        "cloud-docs"
-        ${GOOGLE_CLOUD_CPP_DOXYGEN_DEPS}
+        ${opt_DEPENDS}
         TAGFILES
         "${GOOGLE_CLOUD_CPP_COMMON_TAG}=https://googleapis.dev/cpp/google-cloud-common/${VERSION}/"
     )
 endfunction ()
-
-# TODO(#10519) - have each subproject call this directly.
-# ~~~
-# Find out the name of the subproject.
-# ~~~
-get_filename_component(GOOGLE_CLOUD_CPP_SUBPROJECT
-                       "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
-
-if ("cloud" STREQUAL "${GOOGLE_CLOUD_CPP_SUBPROJECT}")
-    # We cannot recurse from the google/cloud directory, because it will
-    # traverse all of the libraries. So we turn off recursion and manually
-    # provide the subdirectories to be traversed.
-    google_cloud_cpp_doxygen_targets_impl(
-        "cloud"
-        INPUTS
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/mocks"
-        "${CMAKE_CURRENT_SOURCE_DIR}/doc"
-        DEPENDS
-        ${GOOGLE_CLOUD_CPP_DOXYGEN_DEPS})
-else ()
-    google_cloud_cpp_doxygen_targets("${GOOGLE_CLOUD_CPP_SUBPROJECT}")
-endif ()

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -371,8 +371,9 @@ foreach (dir IN LISTS service_dirs)
     list(APPEND DOXYGEN_EXCLUDE_SYMBOLS "$library$_$${ns}internal")
 endforeach ()
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::$library$_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("$library$"
+                                 DEPENDS google-cloud-cpp::$library$_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -20,9 +20,19 @@ set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/samples")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "testing_util" "examples")
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::rpc_status_protos
-                                  google-cloud-cpp::bigtable_protos)
+# We cannot recurse from the google/cloud directory, because it will traverse
+# all of the libraries. So we turn off recursion and manually provide the
+# subdirectories to be traversed.
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets_impl(
+    "cloud"
+    INPUTS
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mocks"
+    "${CMAKE_CURRENT_SOURCE_DIR}/doc"
+    DEPENDS
+    google-cloud-cpp::rpc_status_protos
+    google-cloud-cpp::bigtable_protos)
 
 include(GoogleCloudCppCommon)
 include(CreateBazelConfig)

--- a/google/cloud/accessapproval/CMakeLists.txt
+++ b/google/cloud/accessapproval/CMakeLists.txt
@@ -35,8 +35,9 @@ foreach (dir IN LISTS service_dirs)
     endif ()
 endforeach ()
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::accessapproval_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("accessapproval" DEPENDS cloud-docs
+                                 google-cloud-cpp::accessapproval_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "accesscontextmanager_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::accesscontextmanager_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("accesscontextmanager" DEPENDS cloud-docs
+                                 google-cloud-cpp::accesscontextmanager_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "apigateway_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::apigateway_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("apigateway" DEPENDS cloud-docs
+                                 google-cloud-cpp::apigateway_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "apigeeconnect_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::apigeeconnect_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("apigeeconnect" DEPENDS cloud-docs
+                                 google-cloud-cpp::apigeeconnect_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/apikeys/CMakeLists.txt
+++ b/google/cloud/apikeys/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "apikeys_internal" "apikeys_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::apikeys_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("apikeys" DEPENDS cloud-docs
+                                 google-cloud-cpp::apikeys_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "appengine_internal" "appengine_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::appengine_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("appengine" DEPENDS cloud-docs
+                                 google-cloud-cpp::appengine_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/artifactregistry/CMakeLists.txt
+++ b/google/cloud/artifactregistry/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "artifactregistry_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::artifactregistry_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("artifactregistry" DEPENDS cloud-docs
+                                 google-cloud-cpp::artifactregistry_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -23,11 +23,12 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "asset_internal" "asset_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::asset_protos)
+include(GoogleCloudCppDoxygen)
 set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES
     "${PROJECT_BINARY_DIR}/google/cloud/accesscontextmanager"
     "${PROJECT_BINARY_DIR}/google/cloud/osconfig")
+google_cloud_cpp_doxygen_targets("asset" DEPENDS cloud-docs
+                                 google-cloud-cpp::asset_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "assuredworkloads_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::assuredworkloads_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("assuredworkloads" DEPENDS cloud-docs
+                                 google-cloud-cpp::assuredworkloads_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/automl/CMakeLists.txt
+++ b/google/cloud/automl/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "automl_internal" "automl_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::automl_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("automl" DEPENDS cloud-docs
+                                 google-cloud-cpp::automl_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/baremetalsolution/CMakeLists.txt
+++ b/google/cloud/baremetalsolution/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "baremetalsolution_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::baremetalsolution_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("baremetalsolution" DEPENDS cloud-docs
+                                 google-cloud-cpp::baremetalsolution_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/batch/CMakeLists.txt
+++ b/google/cloud/batch/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "batch_internal" "batch_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::batch_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("batch" DEPENDS cloud-docs
+                                 google-cloud-cpp::batch_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/beyondcorp/CMakeLists.txt
+++ b/google/cloud/beyondcorp/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "beyondcorp_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::beyondcorp_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("beyondcorp" DEPENDS cloud-docs
+                                 google-cloud-cpp::beyondcorp_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "bigquery_internal" "bigquery_testing"
                             "examples")
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::cloud_bigquery_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("bigquery" DEPENDS cloud-docs
+                                 google-cloud-cpp::cloud_bigquery_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -25,6 +25,10 @@ set(DOXYGEN_EXAMPLE_PATH
 set(DOXYGEN_EXCLUDE_SYMBOLS "benchmarks" "bigtable_admin_internal"
                             "bigtable_internal" "internal" "testing" "examples")
 
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("bigtable" DEPENDS cloud-docs
+                                 google-cloud-cpp::bigtable_protos)
+
 include(GoogleCloudCppCommon)
 
 # Configure the location of proto files, particularly the googleapis protos.

--- a/google/cloud/billing/CMakeLists.txt
+++ b/google/cloud/billing/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "billing_internal" "billing_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::billing_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("billing" DEPENDS cloud-docs
+                                 google-cloud-cpp::billing_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -25,10 +25,13 @@ set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
 # Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::binaryauthorization_protos
-                                  google-cloud-cpp::grafeas_protos)
 set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES
     "${PROJECT_BINARY_DIR}/google/cloud/grafeas")
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets(
+    "binaryauthorization" DEPENDS cloud-docs
+    google-cloud-cpp::binaryauthorization_protos
+    google-cloud-cpp::grafeas_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/certificatemanager/CMakeLists.txt
+++ b/google/cloud/certificatemanager/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "certificatemanager_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::certificatemanager_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("certificatemanager" DEPENDS cloud-docs
+                                 google-cloud-cpp::certificatemanager_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -30,8 +30,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "channel_internal" "channel_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::channel_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("channel" DEPENDS cloud-docs
+                                 google-cloud-cpp::channel_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/cloudbuild/CMakeLists.txt
+++ b/google/cloud/cloudbuild/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "cloudbuild_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::cloudbuild_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("cloudbuild" DEPENDS cloud-docs
+                                 google-cloud-cpp::cloudbuild_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "composer_internal" "composer_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::composer_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("composer" DEPENDS cloud-docs
+                                 google-cloud-cpp::composer_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/connectors/CMakeLists.txt
+++ b/google/cloud/connectors/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "connectors_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::connectors_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("connectors" DEPENDS cloud-docs
+                                 google-cloud-cpp::connectors_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/container/CMakeLists.txt
+++ b/google/cloud/container/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "container_internal" "container_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::container_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("container" DEPENDS cloud-docs
+                                 google-cloud-cpp::container_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/containeranalysis/CMakeLists.txt
+++ b/google/cloud/containeranalysis/CMakeLists.txt
@@ -23,10 +23,11 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "containeranalysis_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::containeranalysis_protos)
 set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES
     "${PROJECT_BINARY_DIR}/google/cloud/grafeas")
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("containeranalysis" DEPENDS cloud-docs
+                                 google-cloud-cpp::containeranalysis_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/datacatalog/CMakeLists.txt
+++ b/google/cloud/datacatalog/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "datacatalog_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::datacatalog_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("datacatalog" DEPENDS cloud-docs
+                                 google-cloud-cpp::datacatalog_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/datamigration/CMakeLists.txt
+++ b/google/cloud/datamigration/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "datamigration_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::datamigration_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("datamigration" DEPENDS cloud-docs
+                                 google-cloud-cpp::datamigration_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/dataplex/CMakeLists.txt
+++ b/google/cloud/dataplex/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "dataplex_internal" "dataplex_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::dataplex_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("dataplex" DEPENDS cloud-docs
+                                 google-cloud-cpp::dataplex_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "dataproc_internal" "dataproc_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::dataproc_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("dataproc" DEPENDS cloud-docs
+                                 google-cloud-cpp::dataproc_protos)
 
 find_package(gRPC REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/google/cloud/datastream/CMakeLists.txt
+++ b/google/cloud/datastream/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "datastream_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::datastream_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("datastream" DEPENDS cloud-docs
+                                 google-cloud-cpp::datastream_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/debugger/CMakeLists.txt
+++ b/google/cloud/debugger/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "debugger_internal" "debugger_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::debugger_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("debugger" DEPENDS cloud-docs
+                                 google-cloud-cpp::debugger_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/deploy/CMakeLists.txt
+++ b/google/cloud/deploy/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "deploy_internal" "deploy_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::deploy_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("deploy" DEPENDS cloud-docs
+                                 google-cloud-cpp::deploy_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/dialogflow_cx/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "dialogflow_cx_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::dialogflow_cx_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("dialogflow_cx" DEPENDS cloud-docs
+                                 google-cloud-cpp::dialogflow_cx_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "dialogflow_es_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::dialogflow_es_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("dialogflow_es" DEPENDS cloud-docs
+                                 google-cloud-cpp::dialogflow_es_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/dlp/CMakeLists.txt
+++ b/google/cloud/dlp/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "dlp_internal" "dlp_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::dlp_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("dlp" DEPENDS cloud-docs
+                                 google-cloud-cpp::dlp_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/documentai/CMakeLists.txt
+++ b/google/cloud/documentai/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "documentai_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::documentai_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("documentai" DEPENDS cloud-docs
+                                 google-cloud-cpp::documentai_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/edgecontainer/CMakeLists.txt
+++ b/google/cloud/edgecontainer/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "edgecontainer_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::edgecontainer_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("edgecontainer" DEPENDS cloud-docs
+                                 google-cloud-cpp::edgecontainer_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "eventarc_internal" "eventarc_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::eventarc_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("eventarc" DEPENDS cloud-docs
+                                 google-cloud-cpp::eventarc_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "filestore_internal" "filestore_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::filestore_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("filestore" DEPENDS cloud-docs
+                                 google-cloud-cpp::filestore_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "functions_internal" "functions_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::functions_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("functions" DEPENDS cloud-docs
+                                 google-cloud-cpp::functions_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/gameservices/CMakeLists.txt
+++ b/google/cloud/gameservices/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "gameservices_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::gameservices_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("gameservices" DEPENDS cloud-docs
+                                 google-cloud-cpp::gameservices_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "gkehub_internal" "gkehub_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::gkehub_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("gkehub" DEPENDS cloud-docs
+                                 google-cloud-cpp::gkehub_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/gkemulticloud/CMakeLists.txt
+++ b/google/cloud/gkemulticloud/CMakeLists.txt
@@ -33,8 +33,9 @@ foreach (dir IN LISTS service_dirs)
     list(APPEND DOXYGEN_EXCLUDE_SYMBOLS "gkemulticloud_${ns}internal")
 endforeach ()
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::gkemulticloud_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("gkemulticloud" DEPENDS cloud-docs
+                                 google-cloud-cpp::gkemulticloud_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/grafeas/CMakeLists.txt
+++ b/google/cloud/grafeas/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "grafeas_internal" "grafeas_testing"
 # set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
 # ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::grafeas_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("grafeas" DEPENDS cloud-docs
+                                 google-cloud-cpp::grafeas_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -33,8 +33,9 @@ foreach (dir IN LISTS service_dirs)
     list(APPEND DOXYGEN_EXCLUDE_SYMBOLS "iam_${ns}internal")
 endforeach ()
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::iam_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("iam" DEPENDS cloud-docs
+                                 google-cloud-cpp::iam_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/iap/CMakeLists.txt
+++ b/google/cloud/iap/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "iap_internal" "iap_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::iap_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("iap" DEPENDS cloud-docs
+                                 google-cloud-cpp::iap_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -22,8 +22,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "ids_internal" "ids_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::ids_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("ids" DEPENDS cloud-docs
+                                 google-cloud-cpp::ids_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/iot/CMakeLists.txt
+++ b/google/cloud/iot/CMakeLists.txt
@@ -22,8 +22,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "iot_internal" "iot_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::iot_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("iot" DEPENDS cloud-docs
+                                 google-cloud-cpp::iot_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "kms_internal" "kms_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::kms_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("kms" DEPENDS cloud-docs
+                                 google-cloud-cpp::kms_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/language/CMakeLists.txt
+++ b/google/cloud/language/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "language_internal" "language_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::language_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("language" DEPENDS cloud-docs
+                                 google-cloud-cpp::language_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "logging_internal" "logging_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::logging_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("logging" DEPENDS cloud-docs
+                                 google-cloud-cpp::logging_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/managedidentities/CMakeLists.txt
+++ b/google/cloud/managedidentities/CMakeLists.txt
@@ -26,8 +26,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "managedidentities_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::managedidentities_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("managedidentities" DEPENDS cloud-docs
+                                 google-cloud-cpp::managedidentities_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "memcache_internal" "memcache_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::memcache_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("memcache" DEPENDS cloud-docs
+                                 google-cloud-cpp::memcache_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/monitoring/CMakeLists.txt
+++ b/google/cloud/monitoring/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "monitoring_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::monitoring_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("monitoring" DEPENDS cloud-docs
+                                 google-cloud-cpp::monitoring_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/networkconnectivity/CMakeLists.txt
+++ b/google/cloud/networkconnectivity/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "networkconnectivity_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::networkconnectivity_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("networkconnectivity" DEPENDS cloud-docs
+                                 google-cloud-cpp::networkconnectivity_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/networkmanagement/CMakeLists.txt
+++ b/google/cloud/networkmanagement/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "networkmanagement_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::networkmanagement_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("networkmanagement" DEPENDS cloud-docs
+                                 google-cloud-cpp::networkmanagement_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/notebooks/CMakeLists.txt
+++ b/google/cloud/notebooks/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "notebooks_internal" "notebooks_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::notebooks_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("notebooks" DEPENDS cloud-docs
+                                 google-cloud-cpp::notebooks_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/optimization/CMakeLists.txt
+++ b/google/cloud/optimization/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "optimization_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::optimization_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("optimization" DEPENDS cloud-docs
+                                 google-cloud-cpp::optimization_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/orgpolicy/CMakeLists.txt
+++ b/google/cloud/orgpolicy/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "orgpolicy_internal" "orgpolicy_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::orgpolicy_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("orgpolicy" DEPENDS cloud-docs
+                                 google-cloud-cpp::orgpolicy_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "osconfig_internal" "osconfig_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::osconfig_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("osconfig" DEPENDS cloud-docs
+                                 google-cloud-cpp::osconfig_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "oslogin_internal" "oslogin_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::oslogin_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("oslogin" DEPENDS cloud-docs
+                                 google-cloud-cpp::oslogin_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/policytroubleshooter/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "policytroubleshooter_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::policytroubleshooter_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("policytroubleshooter" DEPENDS cloud-docs
+                                 google-cloud-cpp::policytroubleshooter_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/privateca/CMakeLists.txt
+++ b/google/cloud/privateca/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "privateca_internal" "privateca_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::privateca_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("privateca" DEPENDS cloud-docs
+                                 google-cloud-cpp::privateca_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/profiler/CMakeLists.txt
+++ b/google/cloud/profiler/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "profiler_internal" "profiler_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::profiler_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("profiler" DEPENDS cloud-docs
+                                 google-cloud-cpp::profiler_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -21,15 +21,13 @@ set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsub_internal" "pubsub_testing"
-                            "examples")
+                            "examples" "samples")
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::pubsub_protos)
-if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-    set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS ${GOOGLE_CLOUD_CPP_DOXYGEN_DEPS}
-                                      pubsub_samples_protos)
-else ()
-    set(DOXYGEN_EXCLUDE_SYMBOLS ${DOXYGEN_EXCLUDE_SYMBOLS} "samples")
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("pubsub" DEPENDS cloud-docs
+                                 google-cloud-cpp::pubsub_protos)
+if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES AND TARGET pubsub-docs)
+    add_dependencies(pubsub-docs pubsub_samples_protos)
 endif ()
 
 include(GoogleCloudCppCommon)

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsublite_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::pubsublite_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("pubsublite" DEPENDS cloud-docs
+                                 google-cloud-cpp::pubsublite_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "recommender_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::recommender_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("recommender" DEPENDS cloud-docs
+                                 google-cloud-cpp::recommender_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "redis_internal" "redis_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::redis_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("redis" DEPENDS cloud-docs
+                                 google-cloud-cpp::redis_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/resourcemanager/CMakeLists.txt
+++ b/google/cloud/resourcemanager/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "resourcemanager_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::resourcemanager_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("resourcemanager" DEPENDS cloud-docs
+                                 google-cloud-cpp::resourcemanager_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/resourcesettings/CMakeLists.txt
+++ b/google/cloud/resourcesettings/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "resourcesettings_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::resourcesettings_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("resourcesettings" DEPENDS cloud-docs
+                                 google-cloud-cpp::resourcesettings_protos)
 
 find_package(gRPC REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/google/cloud/retail/CMakeLists.txt
+++ b/google/cloud/retail/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "retail_internal" "retail_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::retail_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("retail" DEPENDS cloud-docs
+                                 google-cloud-cpp::retail_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/run/CMakeLists.txt
+++ b/google/cloud/run/CMakeLists.txt
@@ -22,8 +22,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "run_internal" "run_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::run_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("run" DEPENDS cloud-docs
+                                 google-cloud-cpp::run_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "scheduler_internal" "scheduler_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::scheduler_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("scheduler" DEPENDS cloud-docs
+                                 google-cloud-cpp::scheduler_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "secretmanager_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::secretmanager_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("secretmanager" DEPENDS cloud-docs
+                                 google-cloud-cpp::secretmanager_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "securitycenter_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::securitycenter_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("securitycenter" DEPENDS cloud-docs
+                                 google-cloud-cpp::securitycenter_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "servicecontrol_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::servicecontrol_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("servicecontrol" DEPENDS cloud-docs
+                                 google-cloud-cpp::servicecontrol_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/servicedirectory/CMakeLists.txt
+++ b/google/cloud/servicedirectory/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "servicedirectory_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::servicedirectory_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("servicedirectory" DEPENDS cloud-docs
+                                 google-cloud-cpp::servicedirectory_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/servicemanagement/CMakeLists.txt
+++ b/google/cloud/servicemanagement/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "servicemanagement_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::servicemanagement_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("servicemanagement" DEPENDS cloud-docs
+                                 google-cloud-cpp::servicemanagement_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/serviceusage/CMakeLists.txt
+++ b/google/cloud/serviceusage/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "serviceusage_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::serviceusage_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("serviceusage" DEPENDS cloud-docs
+                                 google-cloud-cpp::serviceusage_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "shell_internal" "shell_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::shell_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("shell" DEPENDS cloud-docs
+                                 google-cloud-cpp::shell_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -25,8 +25,9 @@ set(DOXYGEN_EXAMPLE_PATH
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "spanner_admin_internal"
                             "spanner_internal" "spanner_testing" "examples")
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::spanner_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("spanner" DEPENDS cloud-docs
+                                 google-cloud-cpp::spanner_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -34,8 +34,9 @@ foreach (dir IN LISTS service_dirs)
     list(APPEND DOXYGEN_EXCLUDE_SYMBOLS "speech_${ns}internal")
 endforeach ()
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::speech_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("speech" DEPENDS cloud-docs
+                                 google-cloud-cpp::speech_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "storage_benchmarks" "storage_internal"
                             "examples")
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::storage_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("storage" DEPENDS cloud-docs
+                                 google-cloud-cpp::storage_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -33,8 +33,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "storagetransfer_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::storagetransfer_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("storagetransfer" DEPENDS cloud-docs
+                                 google-cloud-cpp::storagetransfer_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/talent/CMakeLists.txt
+++ b/google/cloud/talent/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "talent_internal" "talent_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::talent_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("talent" DEPENDS cloud-docs
+                                 google-cloud-cpp::talent_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "tasks_internal" "tasks_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::tasks_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("tasks" DEPENDS cloud-docs
+                                 google-cloud-cpp::tasks_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "texttospeech_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::texttospeech_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("texttospeech" DEPENDS cloud-docs
+                                 google-cloud-cpp::texttospeech_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -22,8 +22,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "tpu_internal" "tpu_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::tpu_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("tpu" DEPENDS cloud-docs
+                                 google-cloud-cpp::tpu_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "trace_internal" "trace_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::trace_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("trace" DEPENDS cloud-docs
+                                 google-cloud-cpp::trace_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/translate/CMakeLists.txt
+++ b/google/cloud/translate/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "translate_internal" "translate_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::translate_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("translate" DEPENDS cloud-docs
+                                 google-cloud-cpp::translate_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/video/CMakeLists.txt
+++ b/google/cloud/video/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "video_internal" "video_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::video_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("video" DEPENDS cloud-docs
+                                 google-cloud-cpp::video_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/videointelligence/CMakeLists.txt
+++ b/google/cloud/videointelligence/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "videointelligence_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::videointelligence_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("videointelligence" DEPENDS cloud-docs
+                                 google-cloud-cpp::videointelligence_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/vision/CMakeLists.txt
+++ b/google/cloud/vision/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "vision_internal" "vision_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::vision_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("vision" DEPENDS cloud-docs
+                                 google-cloud-cpp::vision_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "vmmigration_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::vmmigration_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("vmmigration" DEPENDS cloud-docs
+                                 google-cloud-cpp::vmmigration_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/vmwareengine/CMakeLists.txt
+++ b/google/cloud/vmwareengine/CMakeLists.txt
@@ -33,8 +33,9 @@ foreach (dir IN LISTS service_dirs)
     list(APPEND DOXYGEN_EXCLUDE_SYMBOLS "vmwareengine_${ns}internal")
 endforeach ()
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::vmwareengine_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("vmwareengine" DEPENDS cloud-docs
+                                 google-cloud-cpp::vmwareengine_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/vpcaccess/CMakeLists.txt
+++ b/google/cloud/vpcaccess/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "vpcaccess_internal" "vpcaccess_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::vpcaccess_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("vpcaccess" DEPENDS cloud-docs
+                                 google-cloud-cpp::vpcaccess_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/webrisk/CMakeLists.txt
+++ b/google/cloud/webrisk/CMakeLists.txt
@@ -23,8 +23,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "webrisk_internal" "webrisk_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::webrisk_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("webrisk" DEPENDS cloud-docs
+                                 google-cloud-cpp::webrisk_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "websecurityscanner_internal"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::websecurityscanner_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("websecurityscanner" DEPENDS cloud-docs
+                                 google-cloud-cpp::websecurityscanner_protos)
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -24,8 +24,9 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "workflows_internal" "workflows_testing"
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
-# Creates the proto headers needed by doxygen.
-set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::workflows_protos)
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("workflows" DEPENDS cloud-docs
+                                 google-cloud-cpp::workflows_protos)
 
 include(GoogleCloudCppCommon)
 


### PR DESCRIPTION
I want to reduce the number of global variables used to control the Doxygen output.  Getting things into a function is a good start, but not the end of these cleanups.

Part of the work for #10519

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10640)
<!-- Reviewable:end -->
