### PR TITLE
impl(otel): add traced StreamRange

### DIFF
--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -80,6 +80,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/subject_token.h",
     "internal/throw_delegate.h",
     "internal/timer_queue.h",
+    "internal/traced_stream_range.h",
     "internal/tuple.h",
     "internal/type_list.h",
     "internal/type_traits.h",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -123,6 +123,7 @@ add_library(
     internal/throw_delegate.h
     internal/timer_queue.cc
     internal/timer_queue.h
+    internal/traced_stream_range.h
     internal/tuple.h
     internal/type_list.h
     internal/type_traits.h
@@ -355,6 +356,7 @@ if (BUILD_TESTING)
         internal/subject_token_test.cc
         internal/throw_delegate_test.cc
         internal/timer_queue_test.cc
+        internal/traced_stream_range_test.cc
         internal/tuple_test.cc
         internal/type_list_test.cc
         internal/user_agent_prefix_test.cc

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -57,6 +57,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/subject_token_test.cc",
     "internal/throw_delegate_test.cc",
     "internal/timer_queue_test.cc",
+    "internal/traced_stream_range_test.cc",
     "internal/tuple_test.cc",
     "internal/type_list_test.cc",
     "internal/user_agent_prefix_test.cc",

--- a/google/cloud/internal/traced_stream_range.h
+++ b/google/cloud/internal/traced_stream_range.h
@@ -1,0 +1,100 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACED_STREAM_RANGE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACED_STREAM_RANGE_H
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/stream_range.h"
+#include "absl/memory/memory.h"
+#include <opentelemetry/nostd/shared_ptr.h>
+#include <opentelemetry/trace/scope.h>
+#include <opentelemetry/trace/span.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+template <typename T>
+class TracedStreamRange {
+ public:
+  explicit TracedStreamRange(
+      opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span,
+      std::unique_ptr<opentelemetry::trace::Scope> scope, StreamRange<T> sr)
+      : span_(std::move(span)),
+        scope_(std::move(scope)),
+        sr_(std::move(sr)),
+        it_(sr_.begin()) {}
+
+  ~TracedStreamRange() {
+    // It is ok not to iterate the full range. We should still end our span.
+    (void)End(Status());
+  }
+
+  absl::variant<Status, T> Advance() {
+    if (it_ == sr_.end()) return End(Status());
+    auto sor = *it_;
+    ++it_;
+    if (!sor) return End(std::move(sor).status());
+    return *sor;
+  }
+
+ private:
+  Status End(Status s) {
+    if (scope_ != nullptr) {
+      s = EndSpan(*span_, std::move(s));
+      scope_.reset();
+    }
+    return s;
+  }
+
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span_;
+  // We use a unique_ptr for finer control over when the Scope is destroyed.
+  std::unique_ptr<opentelemetry::trace::Scope> scope_;
+  StreamRange<T> sr_;
+  typename StreamRange<T>::iterator it_;
+};
+
+/**
+ * Makes a traced `StreamRange<>`.
+ *
+ * The span that wraps the operation is complete when either the range is
+ * iterated over, or the returned object goes out of scope.
+ *
+ * Note that when a `StreamRange<>` is constructed, it preloads the first value.
+ * In order for any sub-operations to be tied to the parent `span`, it must be
+ * made active (by creating a `Scope` object). This API accepts a `Scope` to:
+ *   1. remind the caller to create that `Scope`
+ *   2. save a map look up
+ */
+template <typename T>
+StreamRange<T> MakeTracedStreamRange(
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span,
+    std::unique_ptr<opentelemetry::trace::Scope> scope, StreamRange<T> sr) {
+  // StreamRange is not copyable, but a shared ptr to one is.
+  auto impl = std::make_shared<TracedStreamRange<T>>(
+      std::move(span), std::move(scope), std::move(sr));
+  auto reader = [impl = std::move(impl)] { return impl->Advance(); };
+  return internal::MakeStreamRange<T>(std::move(reader));
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACED_STREAM_RANGE_H

--- a/google/cloud/internal/traced_stream_range_test.cc
+++ b/google/cloud/internal/traced_stream_range_test.cc
@@ -51,7 +51,7 @@ TEST(TracedStreamRange, Success) {
       MakeTracedStreamRange(std::move(span), std::move(scope), std::move(sr));
 
   std::vector<int> actual;
-  for (auto const& v : traced) {
+  for (auto& v : traced) {
     ASSERT_STATUS_OK(v);
     actual.push_back(*std::move(v));
   }

--- a/google/cloud/internal/traced_stream_range_test.cc
+++ b/google/cloud/internal/traced_stream_range_test.cc
@@ -1,0 +1,160 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/traced_stream_range.h"
+#include "google/cloud/mocks/mock_stream_range.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/options.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::IsActive;
+using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::SpanWithStatus;
+using ::google::cloud::testing_util::StatusIs;
+using ::google::cloud::testing_util::ThereIsAnActiveSpan;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+
+struct StringOption {
+  using Type = std::string;
+};
+
+TEST(TracedStreamRange, Success) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto sr = mocks::MakeStreamRange<int>({1, 2, 3});
+  auto traced =
+      MakeTracedStreamRange(std::move(span), std::move(scope), std::move(sr));
+
+  std::vector<int> actual;
+  for (auto const& v : traced) {
+    ASSERT_STATUS_OK(v);
+    actual.push_back(*std::move(v));
+  }
+  EXPECT_THAT(actual, ElementsAre(1, 2, 3));
+  EXPECT_FALSE(ThereIsAnActiveSpan());
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans, ElementsAre(
+                 AllOf(SpanNamed("span"),
+                       SpanWithStatus(opentelemetry::trace::StatusCode::kOk))));
+}
+
+TEST(TracedStreamRange, Error) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto sr = mocks::MakeStreamRange<int>({}, AbortedError("fail"));
+  auto traced =
+      MakeTracedStreamRange(std::move(span), std::move(scope), std::move(sr));
+  for (auto const& v : traced) {
+    EXPECT_THAT(v, StatusIs(StatusCode::kAborted));
+  }
+  EXPECT_FALSE(ThereIsAnActiveSpan());
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanNamed("span"),
+          SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"))));
+}
+
+TEST(TracedStreamRange, SpanEndsWhenRangeEnds) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto sr = mocks::MakeStreamRange<int>({1, 2, 3});
+  auto traced = MakeTracedStreamRange<int>(std::move(span), std::move(scope),
+                                           std::move(sr));
+
+  for (auto const& v : traced) {
+    EXPECT_STATUS_OK(v);
+    auto spans = span_catcher->GetSpans();
+    EXPECT_THAT(spans, IsEmpty());
+  }
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, ElementsAre(SpanNamed("span")));
+}
+
+TEST(TracedStreamRange, SpanActiveDuringSubOperations) {
+  auto span = MakeSpan("span");
+  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+
+  ::testing::MockFunction<absl::variant<Status, int>()> mock;
+  EXPECT_CALL(mock, Call)
+      .WillOnce([span] {
+        EXPECT_THAT(span, IsActive());
+        return 1;
+      })
+      .WillOnce([span] {
+        EXPECT_THAT(span, IsActive());
+        return 2;
+      })
+      .WillOnce([span] {
+        EXPECT_THAT(span, IsActive());
+        return Status();
+      });
+
+  auto sr = MakeStreamRange<int>(mock.AsStdFunction());
+  auto traced = MakeTracedStreamRange(span, std::move(scope), std::move(sr));
+  for (auto const& v : traced) {
+    EXPECT_STATUS_OK(v);
+    EXPECT_THAT(span, IsActive());
+  }
+  EXPECT_FALSE(ThereIsAnActiveSpan());
+}
+
+TEST(TracedStreamRange, SpanEndsWithSuccessOnUnfinishedRange) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  {
+    auto span = MakeSpan("span");
+    auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+    auto sr = mocks::MakeStreamRange<int>({1, 2, 3});
+    auto traced =
+        MakeTracedStreamRange(std::move(span), std::move(scope), std::move(sr));
+  }
+  EXPECT_FALSE(ThereIsAnActiveSpan());
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans, ElementsAre(
+                 AllOf(SpanNamed("span"),
+                       SpanWithStatus(opentelemetry::trace::StatusCode::kOk))));
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -54,6 +54,10 @@ std::string ToString(opentelemetry::trace::StatusCode c) {
   }
 }
 
+bool ThereIsAnActiveSpan() {
+  return opentelemetry::trace::Tracer::GetCurrentSpan()->GetContext().IsValid();
+}
+
 std::shared_ptr<opentelemetry::exporter::memory::InMemorySpanData>
 InstallSpanCatcher() {
   auto exporter = absl::make_unique<

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -23,6 +23,7 @@
 #include <opentelemetry/sdk/trace/span_data.h>
 #include <opentelemetry/trace/span.h>
 #include <opentelemetry/trace/span_metadata.h>
+#include <opentelemetry/trace/tracer.h>
 #include <memory>
 #include <string>
 
@@ -48,6 +49,12 @@ using SpanDataPtr = std::unique_ptr<opentelemetry::sdk::trace::SpanData>;
 std::string ToString(opentelemetry::trace::SpanKind k);
 
 std::string ToString(opentelemetry::trace::StatusCode c);
+
+bool ThereIsAnActiveSpan();
+
+MATCHER(IsActive, "") {
+  return opentelemetry::trace::Tracer::GetCurrentSpan() == arg;
+}
 
 MATCHER(SpanHasInstrumentationScope,
         "has instrumentation scope (name: gcloud-cpp | version: " +


### PR DESCRIPTION
Fixes #10487 

Adds a function to make a traced `StreamRange<>`.

The new test matcher and helper function could be used to improve readability in existing tests. My plan is to send a `cleanup` PR after this one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10641)
<!-- Reviewable:end -->
