### PR TITLE
impl(generator): correct RestContext lifetime in async calls

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.cc
@@ -48,15 +48,15 @@ GoldenThingAdminRestLogging::ListDatabases(
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestLogging::AsyncCreateDatabase(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-        return child_->AsyncCreateDatabase(cq, rest_context, request);
+        return child_->AsyncCreateDatabase(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 StatusOr<google::test::admin::database::v1::Database>
@@ -74,15 +74,15 @@ GoldenThingAdminRestLogging::GetDatabase(
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestLogging::AsyncUpdateDatabaseDdl(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-        return child_->AsyncUpdateDatabaseDdl(cq, rest_context, request);
+        return child_->AsyncUpdateDatabaseDdl(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 Status
@@ -148,15 +148,15 @@ GoldenThingAdminRestLogging::TestIamPermissions(
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestLogging::AsyncCreateBackup(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateBackupRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::test::admin::database::v1::CreateBackupRequest const& request) {
-        return child_->AsyncCreateBackup(cq, rest_context, request);
+        return child_->AsyncCreateBackup(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
@@ -210,15 +210,15 @@ GoldenThingAdminRestLogging::ListBackups(
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestLogging::AsyncRestoreDatabase(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-        return child_->AsyncRestoreDatabase(cq, rest_context, request);
+        return child_->AsyncRestoreDatabase(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
@@ -248,57 +248,57 @@ GoldenThingAdminRestLogging::ListBackupOperations(
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminRestLogging::AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::test::admin::database::v1::GetDatabaseRequest const& request) {
-        return child_->AsyncGetDatabase(cq, rest_context, request);
+        return child_->AsyncGetDatabase(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 future<Status>
 GoldenThingAdminRestLogging::AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::test::admin::database::v1::DropDatabaseRequest const& request) {
-        return child_->AsyncDropDatabase(cq, rest_context, request);
+        return child_->AsyncDropDatabase(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestLogging::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::GetOperationRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::longrunning::GetOperationRequest const& request) {
-        return child_->AsyncGetOperation(cq, rest_context, request);
+        return child_->AsyncGetOperation(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 future<Status>
 GoldenThingAdminRestLogging::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::CancelOperationRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::longrunning::CancelOperationRequest const& request) {
-        return child_->AsyncCancelOperation(cq, rest_context, request);
+        return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.h
@@ -48,7 +48,7 @@ class GoldenThingAdminRestLogging : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Database> GetDatabase(
@@ -57,7 +57,7 @@ class GoldenThingAdminRestLogging : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
   Status DropDatabase(
@@ -82,7 +82,7 @@ class GoldenThingAdminRestLogging : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Backup> GetBackup(
@@ -103,7 +103,7 @@ class GoldenThingAdminRestLogging : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
@@ -116,22 +116,22 @@ class GoldenThingAdminRestLogging : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::GetOperationRequest const& request) override;
 
   future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) override;
 
  private:

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.cc
@@ -47,10 +47,10 @@ GoldenThingAdminRestMetadata::ListDatabases(
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestMetadata::AsyncCreateDatabase(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncCreateDatabase(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncCreateDatabase(cq, std::move(rest_context), request);
 }
 
 StatusOr<google::test::admin::database::v1::Database>
@@ -64,10 +64,10 @@ GoldenThingAdminRestMetadata::GetDatabase(
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestMetadata::AsyncUpdateDatabaseDdl(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncUpdateDatabaseDdl(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncUpdateDatabaseDdl(cq, std::move(rest_context), request);
 }
 
 Status
@@ -150,10 +150,10 @@ GoldenThingAdminRestMetadata::TestIamPermissions(
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestMetadata::AsyncCreateBackup(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateBackupRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncCreateBackup(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncCreateBackup(cq, std::move(rest_context), request);
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
@@ -191,10 +191,10 @@ GoldenThingAdminRestMetadata::ListBackups(
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestMetadata::AsyncRestoreDatabase(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncRestoreDatabase(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncRestoreDatabase(cq, std::move(rest_context), request);
 }
 
 StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
@@ -216,16 +216,16 @@ GoldenThingAdminRestMetadata::ListBackupOperations(
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminRestMetadata::AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
     google::test::admin::database::v1::GetDatabaseRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncGetDatabase(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncGetDatabase(cq, std::move(rest_context), request);
 }
 
 future<Status>
 GoldenThingAdminRestMetadata::AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
     google::test::admin::database::v1::DropDatabaseRequest const& request) {
   std::vector<std::string> params;
   params.reserve(3);
@@ -263,27 +263,27 @@ GoldenThingAdminRestMetadata::AsyncDropDatabase(
   }();
   database_matcher->AppendParam(request, params);
 
-  SetMetadata(rest_context, params);
+  SetMetadata(*rest_context, params);
 
-  return child_->AsyncDropDatabase(cq, rest_context, request);
+  return child_->AsyncDropDatabase(cq, std::move(rest_context), request);
 }
 
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminRestMetadata::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::GetOperationRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncGetOperation(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncGetOperation(cq, std::move(rest_context), request);
 }
 
 future<Status>
 GoldenThingAdminRestMetadata::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::CancelOperationRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncCancelOperation(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
 }
 
 void GoldenThingAdminRestMetadata::SetMetadata(

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.h
@@ -44,7 +44,7 @@ class GoldenThingAdminRestMetadata : public GoldenThingAdminRestStub {
 
   google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Database> GetDatabase(
@@ -53,7 +53,7 @@ class GoldenThingAdminRestMetadata : public GoldenThingAdminRestStub {
 
   google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
   Status DropDatabase(
@@ -78,7 +78,7 @@ class GoldenThingAdminRestMetadata : public GoldenThingAdminRestStub {
 
   google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Backup> GetBackup(
@@ -99,7 +99,7 @@ class GoldenThingAdminRestMetadata : public GoldenThingAdminRestStub {
 
   google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
@@ -112,22 +112,22 @@ class GoldenThingAdminRestMetadata : public GoldenThingAdminRestStub {
 
   google::cloud::future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   google::cloud::future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::GetOperationRequest const& request) override;
 
   google::cloud::future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) override;
 
  private:

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
@@ -59,15 +59,15 @@ DefaultGoldenThingAdminRestStub::ListDatabases(
 future<StatusOr<google::longrunning::Operation>>
 DefaultGoldenThingAdminRestStub::AsyncCreateDatabase(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateDatabaseRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           absl::StrCat("/v1/", request.parent(), "/databases")));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -88,15 +88,15 @@ DefaultGoldenThingAdminRestStub::GetDatabase(
 future<StatusOr<google::longrunning::Operation>>
 DefaultGoldenThingAdminRestStub::AsyncUpdateDatabaseDdl(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Patch<google::longrunning::Operation>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           absl::StrCat("/v1/", request.database(), "/ddl")));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -152,15 +152,15 @@ DefaultGoldenThingAdminRestStub::TestIamPermissions(
 future<StatusOr<google::longrunning::Operation>>
 DefaultGoldenThingAdminRestStub::AsyncCreateBackup(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateBackupRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           absl::StrCat("/v1/", request.parent(), "/backups")));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -210,15 +210,15 @@ DefaultGoldenThingAdminRestStub::ListBackups(
 future<StatusOr<google::longrunning::Operation>>
 DefaultGoldenThingAdminRestStub::AsyncRestoreDatabase(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           absl::StrCat("/v1/", request.parent(), "/databases:restore")));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -254,15 +254,15 @@ DefaultGoldenThingAdminRestStub::ListBackupOperations(
 future<StatusOr<google::test::admin::database::v1::Database>>
 DefaultGoldenThingAdminRestStub::AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::test::admin::database::v1::GetDatabaseRequest const& request) {
   promise<StatusOr<google::test::admin::database::v1::Database>> p;
   future<StatusOr<google::test::admin::database::v1::Database>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Get<google::test::admin::database::v1::Database>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           absl::StrCat("/v1/", request.name(), ""), {}));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -274,15 +274,15 @@ DefaultGoldenThingAdminRestStub::AsyncGetDatabase(
 future<Status>
 DefaultGoldenThingAdminRestStub::AsyncDropDatabase(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::test::admin::database::v1::DropDatabaseRequest const& request) {
   promise<StatusOr<google::protobuf::Empty>> p;
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Delete<google::protobuf::Empty>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           absl::StrCat("/v1/", request.database(), "")));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -294,15 +294,15 @@ DefaultGoldenThingAdminRestStub::AsyncDropDatabase(
 future<StatusOr<google::longrunning::Operation>>
 DefaultGoldenThingAdminRestStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::GetOperationRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto operations, auto request) {
+  std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
       p.set_value(rest_internal::Get<google::longrunning::Operation>(
-          *operations, rest_context, request,
+          *operations, *rest_context, request,
           absl::StrCat("/v1/", request.name())));
-  }, std::move(p), operations_, request};
+  }, std::move(p), operations_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -314,15 +314,15 @@ DefaultGoldenThingAdminRestStub::AsyncGetOperation(
 future<Status>
 DefaultGoldenThingAdminRestStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::CancelOperationRequest const& request) {
   promise<StatusOr<google::protobuf::Empty>> p;
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto operations, auto request) {
+  std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::protobuf::Empty>(
-          *operations, rest_context, request,
+          *operations, *rest_context, request,
           absl::StrCat("/v1/", request.name(), ":cancel")));
-  }, std::move(p), operations_, request};
+  }, std::move(p), operations_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.h
@@ -44,7 +44,7 @@ class GoldenThingAdminRestStub {
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
 
   virtual StatusOr<google::test::admin::database::v1::Database> GetDatabase(
@@ -53,7 +53,7 @@ class GoldenThingAdminRestStub {
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) = 0;
 
   virtual Status DropDatabase(
@@ -78,7 +78,7 @@ class GoldenThingAdminRestStub {
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateBackupRequest const& request) = 0;
 
   virtual StatusOr<google::test::admin::database::v1::Backup> GetBackup(
@@ -99,7 +99,7 @@ class GoldenThingAdminRestStub {
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
 
   virtual StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
@@ -112,22 +112,22 @@ class GoldenThingAdminRestStub {
 
   virtual future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
 
   virtual future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::GetOperationRequest const& request) = 0;
 
   virtual future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) = 0;
 };
 
@@ -147,7 +147,7 @@ class DefaultGoldenThingAdminRestStub : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Database> GetDatabase(
@@ -156,7 +156,7 @@ class DefaultGoldenThingAdminRestStub : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
   Status DropDatabase(
@@ -181,7 +181,7 @@ class DefaultGoldenThingAdminRestStub : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::Backup> GetBackup(
@@ -202,7 +202,7 @@ class DefaultGoldenThingAdminRestStub : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
@@ -215,22 +215,22 @@ class DefaultGoldenThingAdminRestStub : public GoldenThingAdminRestStub {
 
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::GetOperationRequest const& request) override;
 
   future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) override;
 
  private:

--- a/generator/integration_tests/tests/golden_thing_admin_rest_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_logging_decorator_test.cc
@@ -98,9 +98,10 @@ TEST(LoggingDecoratorRestTest, AsyncCreateDatabase) {
 
   GoldenThingAdminRestLogging stub(mock, TracingOptions{}, {});
   CompletionQueue cq;
-  rest_internal::RestContext context;
+  auto context = absl::make_unique<rest_internal::RestContext>();
   auto status = stub.AsyncCreateDatabase(
-      cq, context, google::test::admin::database::v1::CreateDatabaseRequest());
+      cq, std::move(context),
+      google::test::admin::database::v1::CreateDatabaseRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
   auto const log_lines = log.ExtractLines();
@@ -116,9 +117,9 @@ TEST(LoggingDecoratorRestTest, AsyncUpdateDatabaseDdl) {
 
   GoldenThingAdminRestLogging stub(mock, TracingOptions{}, {});
   CompletionQueue cq;
-  rest_internal::RestContext context;
+  auto context = absl::make_unique<rest_internal::RestContext>();
   auto status = stub.AsyncUpdateDatabaseDdl(
-      cq, context,
+      cq, std::move(context),
       google::test::admin::database::v1::UpdateDatabaseDdlRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
@@ -215,9 +216,10 @@ TEST(LoggingDecoratorRestTest, AsyncCreateBackup) {
 
   GoldenThingAdminRestLogging stub(mock, TracingOptions{}, {});
   CompletionQueue cq;
-  rest_internal::RestContext context;
+  auto context = absl::make_unique<rest_internal::RestContext>();
   auto status = stub.AsyncCreateBackup(
-      cq, context, google::test::admin::database::v1::CreateBackupRequest());
+      cq, std::move(context),
+      google::test::admin::database::v1::CreateBackupRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
   auto const log_lines = log.ExtractLines();
@@ -297,9 +299,10 @@ TEST(LoggingDecoratorRestTest, AsyncRestoreDatabase) {
 
   GoldenThingAdminRestLogging stub(mock, TracingOptions{}, {});
   CompletionQueue cq;
-  rest_internal::RestContext context;
+  auto context = absl::make_unique<rest_internal::RestContext>();
   auto status = stub.AsyncRestoreDatabase(
-      cq, context, google::test::admin::database::v1::RestoreDatabaseRequest());
+      cq, std::move(context),
+      google::test::admin::database::v1::RestoreDatabaseRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
   auto const log_lines = log.ExtractLines();

--- a/generator/integration_tests/tests/golden_thing_admin_rest_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_metadata_decorator_test.cc
@@ -150,52 +150,54 @@ TEST(ThingAdminRestMetadataDecoratorTest, AsyncCreateDatabase) {
   auto mock = std::make_shared<MockGoldenThingAdminRestStub>();
   EXPECT_CALL(*mock, AsyncCreateDatabase)
       .WillOnce(
-          [](CompletionQueue&, rest_internal::RestContext& context,
+          [](CompletionQueue&,
+             std::unique_ptr<rest_internal::RestContext> context,
              google::test::admin::database::v1::CreateDatabaseRequest const&) {
-            EXPECT_THAT(context.GetHeader("x-goog-api-client"),
+            EXPECT_THAT(context->GetHeader("x-goog-api-client"),
                         Contains(google::cloud::internal::ApiClientHeader(
                             "generator")));
-            EXPECT_THAT(context.GetHeader("x-goog-user-project"), IsEmpty());
-            EXPECT_THAT(context.GetHeader("x-goog-quota-user"),
+            EXPECT_THAT(context->GetHeader("x-goog-user-project"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-goog-quota-user"),
                         Contains("test-quota-user"));
-            EXPECT_THAT(context.GetHeader("x-server-timeout"), IsEmpty());
-            EXPECT_THAT(context.GetHeader("x-goog-request-params"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-server-timeout"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-goog-request-params"), IsEmpty());
             return LongrunningTransientError();
           });
 
   internal::OptionsSpan span(Options{}.set<QuotaUserOption>("test-quota-user"));
   GoldenThingAdminRestMetadata stub(mock);
   CompletionQueue cq;
-  rest_internal::RestContext context;
+  auto context = absl::make_unique<rest_internal::RestContext>();
   google::test::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
-  auto status = stub.AsyncCreateDatabase(cq, context, request);
+  auto status = stub.AsyncCreateDatabase(cq, std::move(context), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
 TEST(ThingAdminRestMetadataDecoratorTest, AsyncUpdateDatabaseDdl) {
   auto mock = std::make_shared<MockGoldenThingAdminRestStub>();
   EXPECT_CALL(*mock, AsyncUpdateDatabaseDdl)
-      .WillOnce([](CompletionQueue&, rest_internal::RestContext& context,
+      .WillOnce([](CompletionQueue&,
+                   std::unique_ptr<rest_internal::RestContext> context,
                    google::test::admin::database::v1::
                        UpdateDatabaseDdlRequest const&) {
         EXPECT_THAT(
-            context.GetHeader("x-goog-api-client"),
+            context->GetHeader("x-goog-api-client"),
             Contains(google::cloud::internal::ApiClientHeader("generator")));
-        EXPECT_THAT(context.GetHeader("x-goog-user-project"), IsEmpty());
-        EXPECT_THAT(context.GetHeader("x-goog-quota-user"), IsEmpty());
-        EXPECT_THAT(context.GetHeader("x-server-timeout"), IsEmpty());
-        EXPECT_THAT(context.GetHeader("x-goog-request-params"), IsEmpty());
+        EXPECT_THAT(context->GetHeader("x-goog-user-project"), IsEmpty());
+        EXPECT_THAT(context->GetHeader("x-goog-quota-user"), IsEmpty());
+        EXPECT_THAT(context->GetHeader("x-server-timeout"), IsEmpty());
+        EXPECT_THAT(context->GetHeader("x-goog-request-params"), IsEmpty());
         return LongrunningTransientError();
       });
 
   GoldenThingAdminRestMetadata stub(mock);
   CompletionQueue cq;
-  rest_internal::RestContext context;
+  auto context = absl::make_unique<rest_internal::RestContext>();
   google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   request.set_database(
       "projects/my_project/instances/my_instance/databases/my_database");
-  auto status = stub.AsyncUpdateDatabaseDdl(cq, context, request);
+  auto status = stub.AsyncUpdateDatabaseDdl(cq, std::move(context), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -356,24 +358,25 @@ TEST(ThingAdminRestMetadataDecoratorTest, AsyncCreateBackup) {
   auto mock = std::make_shared<MockGoldenThingAdminRestStub>();
   EXPECT_CALL(*mock, AsyncCreateBackup)
       .WillOnce(
-          [](CompletionQueue&, rest_internal::RestContext& context,
+          [](CompletionQueue&,
+             std::unique_ptr<rest_internal::RestContext> context,
              google::test::admin::database::v1::CreateBackupRequest const&) {
-            EXPECT_THAT(context.GetHeader("x-goog-api-client"),
+            EXPECT_THAT(context->GetHeader("x-goog-api-client"),
                         Contains(google::cloud::internal::ApiClientHeader(
                             "generator")));
-            EXPECT_THAT(context.GetHeader("x-goog-user-project"), IsEmpty());
-            EXPECT_THAT(context.GetHeader("x-goog-quota-user"), IsEmpty());
-            EXPECT_THAT(context.GetHeader("x-server-timeout"), IsEmpty());
-            EXPECT_THAT(context.GetHeader("x-goog-request-params"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-goog-user-project"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-goog-quota-user"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-server-timeout"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-goog-request-params"), IsEmpty());
             return LongrunningTransientError();
           });
 
   GoldenThingAdminRestMetadata stub(mock);
   CompletionQueue cq;
-  rest_internal::RestContext context;
+  auto context = absl::make_unique<rest_internal::RestContext>();
   google::test::admin::database::v1::CreateBackupRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
-  auto status = stub.AsyncCreateBackup(cq, context, request);
+  auto status = stub.AsyncCreateBackup(cq, std::move(context), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -479,24 +482,25 @@ TEST(ThingAdminRestMetadataDecoratorTest, AsyncRestoreDatabase) {
   auto mock = std::make_shared<MockGoldenThingAdminRestStub>();
   EXPECT_CALL(*mock, AsyncRestoreDatabase)
       .WillOnce(
-          [](CompletionQueue&, rest_internal::RestContext& context,
+          [](CompletionQueue&,
+             std::unique_ptr<rest_internal::RestContext> context,
              google::test::admin::database::v1::RestoreDatabaseRequest const&) {
-            EXPECT_THAT(context.GetHeader("x-goog-api-client"),
+            EXPECT_THAT(context->GetHeader("x-goog-api-client"),
                         Contains(google::cloud::internal::ApiClientHeader(
                             "generator")));
-            EXPECT_THAT(context.GetHeader("x-goog-user-project"), IsEmpty());
-            EXPECT_THAT(context.GetHeader("x-goog-quota-user"), IsEmpty());
-            EXPECT_THAT(context.GetHeader("x-server-timeout"), IsEmpty());
-            EXPECT_THAT(context.GetHeader("x-goog-request-params"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-goog-user-project"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-goog-quota-user"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-server-timeout"), IsEmpty());
+            EXPECT_THAT(context->GetHeader("x-goog-request-params"), IsEmpty());
             return LongrunningTransientError();
           });
 
   GoldenThingAdminRestMetadata stub(mock);
   CompletionQueue cq;
-  rest_internal::RestContext context;
+  auto context = absl::make_unique<rest_internal::RestContext>();
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
-  auto status = stub.AsyncRestoreDatabase(cq, context, request);
+  auto status = stub.AsyncRestoreDatabase(cq, std::move(context), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_rest_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_stub_test.cc
@@ -119,8 +119,6 @@ TEST(GoldenThingAdminRestStubTest, ListDatabases) {
 }
 
 TEST(GoldenThingAdminRestStubTest, AsyncCreateDatabase) {
-  // TODO(#10629): re-enable this test after fixing.
-  GTEST_SKIP();
   auto impl = std::make_shared<rest_internal::RestCompletionQueueImpl>();
   CompletionQueue cq(impl);
   std::thread t{[&] { cq.Run(); }};
@@ -130,7 +128,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncCreateDatabase) {
   auto constexpr kJsonResponsePayload =
       R"({"name":"my_operation","done":"true"})";
   std::string json_response(kJsonResponsePayload);
-  RestContext rest_context;
+  auto rest_context = absl::make_unique<RestContext>();
   google::test::admin::database::v1::CreateDatabaseRequest proto_request;
   proto_request.set_parent("projects/my_project/instances/my_instance");
 
@@ -148,7 +146,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncCreateDatabase) {
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
   StatusOr<google::longrunning::Operation> success =
-      stub.AsyncCreateDatabase(cq, rest_context, proto_request).get();
+      stub.AsyncCreateDatabase(cq, std::move(rest_context), proto_request)
+          .get();
   cq.Shutdown();
   t.join();
 
@@ -188,8 +187,6 @@ TEST(GoldenThingAdminRestStubTest, GetDatabase) {
 }
 
 TEST(GoldenThingAdminRestStubTest, AsyncUpdateDatabaseDdl) {
-  // TODO(#10629): re-enable this test after fixing.
-  GTEST_SKIP();
   auto impl = std::make_shared<rest_internal::RestCompletionQueueImpl>();
   CompletionQueue cq(impl);
   std::thread t{[&] { cq.Run(); }};
@@ -198,7 +195,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncUpdateDatabaseDdl) {
   auto constexpr kJsonResponsePayload =
       R"({"name":"my_operation","done":"true"})";
   std::string json_response(kJsonResponsePayload);
-  RestContext rest_context;
+  auto rest_context = absl::make_unique<RestContext>();
   google::test::admin::database::v1::UpdateDatabaseDdlRequest proto_request;
   proto_request.set_database(
       "projects/my_project/instances/my_instance/databases/my_database");
@@ -216,7 +213,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncUpdateDatabaseDdl) {
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
   auto success =
-      stub.AsyncUpdateDatabaseDdl(cq, rest_context, proto_request).get();
+      stub.AsyncUpdateDatabaseDdl(cq, std::move(rest_context), proto_request)
+          .get();
   cq.Shutdown();
   t.join();
 
@@ -442,8 +440,6 @@ TEST(GoldenThingAdminRestStubTest, TestIamPermissions) {
 }
 
 TEST(GoldenThingAdminRestStubTest, AsyncCreateBackup) {
-  // TODO(#10629): re-enable this test after fixing.
-  GTEST_SKIP();
   auto impl = std::make_shared<rest_internal::RestCompletionQueueImpl>();
   CompletionQueue cq(impl);
   std::thread t{[&] { cq.Run(); }};
@@ -452,7 +448,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncCreateBackup) {
   auto constexpr kJsonResponsePayload =
       R"({"name":"my_operation","done":"true"})";
   std::string json_response(kJsonResponsePayload);
-  RestContext rest_context;
+  auto rest_context = absl::make_unique<RestContext>();
   google::test::admin::database::v1::CreateBackupRequest proto_request;
   proto_request.set_parent("projects/my_project/instances/my_instance");
 
@@ -469,7 +465,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncCreateBackup) {
       });
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
-  auto success = stub.AsyncCreateBackup(cq, rest_context, proto_request).get();
+  auto success =
+      stub.AsyncCreateBackup(cq, std::move(rest_context), proto_request).get();
   cq.Shutdown();
   t.join();
 
@@ -610,8 +607,6 @@ TEST(GoldenThingAdminRestStubTest, ListBackups) {
 }
 
 TEST(GoldenThingAdminRestStubTest, AsyncRestoreDatabase) {
-  // TODO(#10629): re-enable this test after fixing.
-  GTEST_SKIP();
   auto impl = std::make_shared<rest_internal::RestCompletionQueueImpl>();
   CompletionQueue cq(impl);
   std::thread t{[&] { cq.Run(); }};
@@ -620,7 +615,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncRestoreDatabase) {
   auto constexpr kJsonResponsePayload =
       R"({"name":"my_operation","done":"true"})";
   std::string json_response(kJsonResponsePayload);
-  RestContext rest_context;
+  auto rest_context = absl::make_unique<RestContext>();
   google::test::admin::database::v1::RestoreDatabaseRequest proto_request;
   proto_request.set_parent("projects/my_project/instances/my_instance");
 
@@ -637,7 +632,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncRestoreDatabase) {
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
   auto success =
-      stub.AsyncRestoreDatabase(cq, rest_context, proto_request).get();
+      stub.AsyncRestoreDatabase(cq, std::move(rest_context), proto_request)
+          .get();
   cq.Shutdown();
   t.join();
 
@@ -726,8 +722,6 @@ TEST(GoldenThingAdminRestStubTest, ListBackupOperations) {
 }
 
 TEST(GoldenThingAdminRestStubTest, AsyncGetDatabase) {
-  // TODO(#10629): re-enable this test after fixing.
-  GTEST_SKIP();
   auto impl = std::make_shared<rest_internal::RestCompletionQueueImpl>();
   CompletionQueue cq(impl);
   std::thread t{[&] { cq.Run(); }};
@@ -736,7 +730,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetDatabase) {
   auto constexpr kJsonResponsePayload =
       R"({"name":"projects/my_project/instances/my_instance/databases/my_database","state":2})";
   std::string json_response(kJsonResponsePayload);
-  RestContext rest_context;
+  auto rest_context = absl::make_unique<RestContext>();
   google::test::admin::database::v1::GetDatabaseRequest proto_request;
   proto_request.set_name(
       "projects/my_project/instances/my_instance/databases/my_database");
@@ -751,7 +745,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetDatabase) {
       });
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
-  auto success = stub.AsyncGetDatabase(cq, rest_context, proto_request).get();
+  auto success =
+      stub.AsyncGetDatabase(cq, std::move(rest_context), proto_request).get();
   cq.Shutdown();
   t.join();
 
@@ -764,8 +759,6 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetDatabase) {
 }
 
 TEST(GoldenThingAdminRestStubTest, AsyncDropDatabase) {
-  // TODO(#10629): re-enable this test after fixing.
-  GTEST_SKIP();
   auto impl = std::make_shared<rest_internal::RestCompletionQueueImpl>();
   CompletionQueue cq(impl);
   std::thread t{[&] { cq.Run(); }};
@@ -773,7 +766,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncDropDatabase) {
   auto mock_operations_client = absl::make_unique<MockRestClient>();
   auto constexpr kJsonResponsePayload = R"({})";
   std::string json_response(kJsonResponsePayload);
-  RestContext rest_context;
+  auto rest_context = absl::make_unique<RestContext>();
   google::test::admin::database::v1::DropDatabaseRequest proto_request;
   proto_request.set_database(
       "projects/my_project/instances/my_instance/databases/my_database");
@@ -788,7 +781,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncDropDatabase) {
       });
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
-  auto success = stub.AsyncDropDatabase(cq, rest_context, proto_request).get();
+  auto success =
+      stub.AsyncDropDatabase(cq, std::move(rest_context), proto_request).get();
   cq.Shutdown();
   t.join();
 
@@ -796,8 +790,6 @@ TEST(GoldenThingAdminRestStubTest, AsyncDropDatabase) {
 }
 
 TEST(GoldenThingAdminRestStubTest, AsyncGetOperation) {
-  // TODO(#10629): re-enable this test after fixing.
-  GTEST_SKIP();
   auto impl = std::make_shared<rest_internal::RestCompletionQueueImpl>();
   CompletionQueue cq(impl);
   std::thread t{[&] { cq.Run(); }};
@@ -806,7 +798,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetOperation) {
   auto constexpr kJsonResponsePayload =
       R"({"name":"my_operation","done":true})";
   std::string json_response(kJsonResponsePayload);
-  RestContext rest_context;
+  auto rest_context = absl::make_unique<RestContext>();
   google::longrunning::GetOperationRequest proto_request;
   proto_request.set_name("my_operation");
 
@@ -819,7 +811,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetOperation) {
       });
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
-  auto success = stub.AsyncGetOperation(cq, rest_context, proto_request).get();
+  auto success =
+      stub.AsyncGetOperation(cq, std::move(rest_context), proto_request).get();
   cq.Shutdown();
   t.join();
 
@@ -829,8 +822,6 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetOperation) {
 }
 
 TEST(GoldenThingAdminRestStubTest, AsyncCancelOperation) {
-  // TODO(#10629): re-enable this test after fixing.
-  GTEST_SKIP();
   auto impl = std::make_shared<rest_internal::RestCompletionQueueImpl>();
   CompletionQueue cq(impl);
   std::thread t{[&] { cq.Run(); }};
@@ -838,7 +829,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncCancelOperation) {
   auto mock_operations_client = absl::make_unique<MockRestClient>();
   auto constexpr kJsonResponsePayload = R"({})";
   std::string json_response(kJsonResponsePayload);
-  RestContext rest_context;
+  auto rest_context = absl::make_unique<RestContext>();
   google::longrunning::CancelOperationRequest proto_request;
   proto_request.set_name("my_operation");
 
@@ -854,7 +845,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncCancelOperation) {
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
   auto success =
-      stub.AsyncCancelOperation(cq, rest_context, proto_request).get();
+      stub.AsyncCancelOperation(cq, std::move(rest_context), proto_request)
+          .get();
   cq.Shutdown();
   t.join();
 

--- a/generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h
+++ b/generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h
@@ -37,7 +37,7 @@ class MockGoldenThingAdminRestStub
   MOCK_METHOD(
       future<StatusOr<::google::longrunning::Operation>>, AsyncCreateDatabase,
       (google::cloud::CompletionQueue & cq,
-       google::cloud::rest_internal::RestContext&,
+       std::unique_ptr<google::cloud::rest_internal::RestContext>,
        ::google::test::admin::database::v1::CreateDatabaseRequest const&),
       (override));
   MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Database>,
@@ -49,7 +49,7 @@ class MockGoldenThingAdminRestStub
       future<StatusOr<::google::longrunning::Operation>>,
       AsyncUpdateDatabaseDdl,
       (google::cloud::CompletionQueue & cq,
-       google::cloud::rest_internal::RestContext&,
+       std::unique_ptr<google::cloud::rest_internal::RestContext>,
        ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&),
       (override));
   MOCK_METHOD(Status, DropDatabase,
@@ -78,7 +78,7 @@ class MockGoldenThingAdminRestStub
   MOCK_METHOD(future<StatusOr<::google::longrunning::Operation>>,
               AsyncCreateBackup,
               (google::cloud::CompletionQueue & cq,
-               google::cloud::rest_internal::RestContext&,
+               std::unique_ptr<google::cloud::rest_internal::RestContext>,
                ::google::test::admin::database::v1::CreateBackupRequest const&),
               (override));
   MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Backup>, GetBackup,
@@ -103,7 +103,7 @@ class MockGoldenThingAdminRestStub
   MOCK_METHOD(
       future<StatusOr<::google::longrunning::Operation>>, AsyncRestoreDatabase,
       (google::cloud::CompletionQueue & cq,
-       google::cloud::rest_internal::RestContext&,
+       std::unique_ptr<google::cloud::rest_internal::RestContext>,
        ::google::test::admin::database::v1::RestoreDatabaseRequest const&),
       (override));
   MOCK_METHOD(
@@ -125,27 +125,27 @@ class MockGoldenThingAdminRestStub
       future<StatusOr<google::test::admin::database::v1::Database>>,
       AsyncGetDatabase,
       (google::cloud::CompletionQueue & cq,
-       google::cloud::rest_internal::RestContext& rest_context,
+       std::unique_ptr<google::cloud::rest_internal::RestContext>,
        google::test::admin::database::v1::GetDatabaseRequest const& request),
       (override));
 
   MOCK_METHOD(
       future<Status>, AsyncDropDatabase,
       (google::cloud::CompletionQueue & cq,
-       google::cloud::rest_internal::RestContext& rest_context,
+       std::unique_ptr<google::cloud::rest_internal::RestContext>,
        google::test::admin::database::v1::DropDatabaseRequest const& request),
       (override));
 
   MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>,
               AsyncGetOperation,
               (google::cloud::CompletionQueue & cq,
-               google::cloud::rest_internal::RestContext& rest_context,
+               std::unique_ptr<google::cloud::rest_internal::RestContext>,
                google::longrunning::GetOperationRequest const& request),
               (override));
 
   MOCK_METHOD(future<Status>, AsyncCancelOperation,
               (google::cloud::CompletionQueue & cq,
-               google::cloud::rest_internal::RestContext& rest_context,
+               std::unique_ptr<google::cloud::rest_internal::RestContext>,
                google::longrunning::CancelOperationRequest const& request),
               (override));
 };

--- a/generator/internal/logging_decorator_rest_generator.cc
+++ b/generator/internal/logging_decorator_rest_generator.cc
@@ -75,7 +75,7 @@ class $logging_rest_class_name$ : public $stub_rest_class_name$ {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   future<StatusOr<google::longrunning::Operation>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
     } else {
@@ -102,14 +102,14 @@ class $logging_rest_class_name$ : public $stub_rest_class_name$ {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   future<Status> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
     } else {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   future<StatusOr<$response_type$>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
     }
@@ -121,12 +121,12 @@ class $logging_rest_class_name$ : public $stub_rest_class_name$ {
         R"""(
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::GetOperationRequest const& request) override;
 
   future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) override;
 )""");
   }
@@ -181,15 +181,15 @@ $logging_rest_class_name$::$logging_rest_class_name$(
 future<StatusOr<google::longrunning::Operation>>
 $logging_rest_class_name$::Async$method_name$(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       $request_type$ const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              $request_type$ const& request) {
-        return child_->Async$method_name$(cq, rest_context, request);
+        return child_->Async$method_name$(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 )""");
     } else {
@@ -233,15 +233,15 @@ $logging_rest_class_name$::$method_name$(
 future<Status>
 $logging_rest_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       $request_type$ const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              $request_type$ const& request) {
-        return child_->Async$method_name$(cq, rest_context, request);
+        return child_->Async$method_name$(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 )""");
     } else {
@@ -249,15 +249,15 @@ $logging_rest_class_name$::Async$method_name$(
 future<StatusOr<$response_type$>>
 $logging_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     $request_type$ const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              $request_type$ const& request) {
-        return child_->Async$method_name$(cq, rest_context, request);
+        return child_->Async$method_name$(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 )""");
     }
@@ -269,29 +269,29 @@ $logging_rest_class_name$::Async$method_name$(
 future<StatusOr<google::longrunning::Operation>>
 $logging_rest_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::GetOperationRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::longrunning::GetOperationRequest const& request) {
-        return child_->AsyncGetOperation(cq, rest_context, request);
+        return child_->AsyncGetOperation(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 
 future<Status>
 $logging_rest_class_name$::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::CancelOperationRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
-             rest_internal::RestContext& rest_context,
+             std::unique_ptr<rest_internal::RestContext> rest_context,
              google::longrunning::CancelOperationRequest const& request) {
-        return child_->AsyncCancelOperation(cq, rest_context, request);
+        return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
       },
-      cq, rest_context, request, __func__, tracing_options_);
+      cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 )""");
   }

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -136,7 +136,7 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   google::cloud::future<StatusOr<google::longrunning::Operation>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
     } else {
@@ -163,14 +163,14 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   google::cloud::future<Status> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
     } else {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   google::cloud::future<StatusOr<$response_type$>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
     }
@@ -182,12 +182,12 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
         R"""(
   google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::GetOperationRequest const& request) override;
 
   google::cloud::future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) override;
 )""");
   }
@@ -250,13 +250,13 @@ $metadata_rest_class_name$::$metadata_rest_class_name$(
 future<StatusOr<google::longrunning::Operation>>
 $metadata_rest_class_name$::Async$method_name$(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       $request_type$ const& request) {
 )""");
       CcPrintMethod(method, __FILE__, __LINE__,
-                    SetMetadataText(method, kReference));
+                    SetMetadataText(method, kPointer));
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->Async$method_name$(cq, rest_context, request);
+  return child_->Async$method_name$(cq, std::move(rest_context), request);
 }
 )""");
     } else {
@@ -298,13 +298,13 @@ $metadata_rest_class_name$::$method_name$(
 future<Status>
 $metadata_rest_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
     $request_type$ const& request) {
 )""");
       CcPrintMethod(method, __FILE__, __LINE__,
-                    SetMetadataText(method, kReference));
+                    SetMetadataText(method, kPointer));
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->Async$method_name$(cq, rest_context, request);
+  return child_->Async$method_name$(cq, std::move(rest_context), request);
 }
 )""");
     } else {
@@ -312,13 +312,13 @@ $metadata_rest_class_name$::Async$method_name$(
 future<StatusOr<$response_type$>>
 $metadata_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
     $request_type$ const& request) {
 )""");
       CcPrintMethod(method, __FILE__, __LINE__,
-                    SetMetadataText(method, kReference));
+                    SetMetadataText(method, kPointer));
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->Async$method_name$(cq, rest_context, request);
+  return child_->Async$method_name$(cq, std::move(rest_context), request);
 }
 )""");
     }
@@ -330,19 +330,19 @@ $metadata_rest_class_name$::Async$method_name$(
 future<StatusOr<google::longrunning::Operation>>
 $metadata_rest_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::GetOperationRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncGetOperation(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncGetOperation(cq, std::move(rest_context), request);
 }
 
 future<Status>
 $metadata_rest_class_name$::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::CancelOperationRequest const& request) {
-  SetMetadata(rest_context);
-  return child_->AsyncCancelOperation(cq, rest_context, request);
+  SetMetadata(*rest_context);
+  return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
 }
 )""");
   }

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -74,7 +74,7 @@ class $stub_rest_class_name$ {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   virtual future<StatusOr<google::longrunning::Operation>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) = 0;
 )""");
     } else {
@@ -101,14 +101,14 @@ class $stub_rest_class_name$ {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   virtual future<Status> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) = 0;
 )""");
     } else {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   virtual future<StatusOr<$response_type$>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) = 0;
 )""");
     }
@@ -120,12 +120,12 @@ class $stub_rest_class_name$ {
         R"""(
   virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::GetOperationRequest const& request) = 0;
 
   virtual future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) = 0;
 )""");
   }
@@ -156,7 +156,7 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
         HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   future<StatusOr<google::longrunning::Operation>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
       } else {
@@ -183,14 +183,14 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   future<Status> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
     } else {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   future<StatusOr<$response_type$>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
 )""");
     }
@@ -202,12 +202,12 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
         R"""(
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::GetOperationRequest const& request) override;
 
   future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
-      google::cloud::rest_internal::RestContext& rest_context,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) override;
 )""");
   }
@@ -294,15 +294,15 @@ Default$stub_rest_class_name$::Default$stub_rest_class_name$(
 future<StatusOr<google::longrunning::Operation>>
 Default$stub_rest_class_name$::Async$method_name$(
       CompletionQueue& cq,
-      rest_internal::RestContext& rest_context,
+      std::unique_ptr<rest_internal::RestContext> rest_context,
       $request_type$ const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::$method_http_verb$<google::longrunning::Operation>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           $method_rest_path$$method_http_query_parameters$));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -345,15 +345,15 @@ Default$stub_rest_class_name$::$method_name$(
 future<Status>
 Default$stub_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     $request_type$ const& request) {
   promise<StatusOr<google::protobuf::Empty>> p;
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::$method_http_verb$<google::protobuf::Empty>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           $method_rest_path$$method_http_query_parameters$));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -367,15 +367,15 @@ Default$stub_rest_class_name$::Async$method_name$(
 future<StatusOr<$response_type$>>
 Default$stub_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     $request_type$ const& request) {
   promise<StatusOr<$response_type$>> p;
   future<StatusOr<$response_type$>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto service, auto request) {
+  std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::$method_http_verb$<$response_type$>(
-          *service, rest_context, request,
+          *service, *rest_context, request,
           $method_rest_path$$method_http_query_parameters$));
-  }, std::move(p), service_, request};
+  }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -394,15 +394,15 @@ Default$stub_rest_class_name$::Async$method_name$(
 future<StatusOr<google::longrunning::Operation>>
 Default$stub_rest_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::GetOperationRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto operations, auto request) {
+  std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
       p.set_value(rest_internal::Get<google::longrunning::Operation>(
-          *operations, rest_context, request,
+          *operations, *rest_context, request,
           absl::StrCat("/v1/", request.name())));
-  }, std::move(p), operations_, request};
+  }, std::move(p), operations_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -414,15 +414,15 @@ Default$stub_rest_class_name$::AsyncGetOperation(
 future<Status>
 Default$stub_rest_class_name$::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
-    google::cloud::rest_internal::RestContext& rest_context,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
     google::longrunning::CancelOperationRequest const& request) {
   promise<StatusOr<google::protobuf::Empty>> p;
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
-  std::thread t{[&rest_context](auto p, auto operations, auto request) {
+  std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::protobuf::Empty>(
-          *operations, rest_context, request,
+          *operations, *rest_context, request,
           absl::StrCat("/v1/", request.name(), ":cancel")));
-  }, std::move(p), operations_, request};
+  }, std::move(p), operations_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();


### PR DESCRIPTION
For LRO and async calls, wrap the `RestContext` in a `std::unique_ptr`, in lieu of a reference, in order to guarantee the object's lifetime persists until the thread is finished.

fixes #10629 

This PR contains multiple commits to ease reviewing of generated code.