### PR TITLE
impl(otel): inject trace context for gRPC

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -15,7 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_OPENTELEMETRY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_OPENTELEMETRY_H
 
+#include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <grpcpp/grpcpp.h>
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/trace/span.h>
@@ -38,6 +40,23 @@ namespace internal {
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanGrpc(
     opentelemetry::nostd::string_view service,
     opentelemetry::nostd::string_view method);
+
+/**
+ * Propagate trace context for an outbound gRPC call.
+ *
+ * The trace context is added as metadata in the `grpc::ClientContext`. By
+ * injecting the trace context, we can potentially pick up a client side span
+ * from within Google's servers.
+ *
+ * The format of the metadata is determined by the `TextMapPropagator` used for
+ * the given call. Circa 2023-01, Google expects an `X-Cloud-Trace-Context`
+ * [header].
+ *
+ * @see https://opentelemetry.io/docs/concepts/instrumenting-library/#injecting-context
+ *
+ * [header]: https://cloud.google.com/trace/docs/setup#force-trace
+ */
+void InjectTraceContext(grpc::ClientContext& context, Options const& options);
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 

--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/opentelemetry_options.h"
 #include "google/cloud/options.h"
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include <opentelemetry/context/propagation/global_propagator.h>
 #include <opentelemetry/trace/provider.h>
 #include <opentelemetry/trace/span_startoptions.h>
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
@@ -35,6 +36,13 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> GetTracer(
     Options const&) {
   auto provider = opentelemetry::trace::Provider::GetTracerProvider();
   return provider->GetTracer("gcloud-cpp", version_string());
+}
+
+opentelemetry::nostd::shared_ptr<
+    opentelemetry::context::propagation::TextMapPropagator>
+GetTextMapPropagator(Options const&) {
+  return opentelemetry::context::propagation::GlobalTextMapPropagator::
+      GetGlobalPropagator();
 }
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpan(

--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -20,6 +20,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include <opentelemetry/context/propagation/text_map_propagator.h>
 #include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/nostd/string_view.h>
 #include <opentelemetry/trace/span.h>
@@ -51,6 +52,19 @@ bool TracingEnabled(Options const& options);
  */
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> GetTracer(
     Options const& options);
+
+/**
+ * Returns a [propagator] to use for propagating context across process
+ * boundaries.
+ *
+ * @see https://opentelemetry.io/docs/instrumentation/cpp/manual/#context-propagation
+ *
+ * [propagator]:
+ * https://opentelemetry.io/docs/reference/specification/context/api-propagators/#textmap-propagator
+ */
+opentelemetry::nostd::shared_ptr<
+    opentelemetry::context::propagation::TextMapPropagator>
+GetTextMapPropagator(Options const& options);
 
 /**
  * Start a [span] using the current [tracer].

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include <gmock/gmock.h>
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/context/propagation/noop_propagator.h>
 #include <opentelemetry/trace/default_span.h>
 #include <opentelemetry/version.h>
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
@@ -74,6 +76,20 @@ TEST(OpenTelemetry, GetTracer) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(SpanHasInstrumentationScope()));
+}
+
+TEST(OpenTelemetry, GetTextMapPropagator) {
+  // Set the global propagator
+  namespace propagation = ::opentelemetry::context::propagation;
+  opentelemetry::nostd::shared_ptr<propagation::TextMapPropagator> expected =
+      std::shared_ptr<propagation::TextMapPropagator>(
+          std::make_shared<propagation::NoOpPropagator>());
+  propagation::GlobalTextMapPropagator::SetGlobalPropagator(expected);
+
+  auto options = Options{};
+  auto actual = GetTextMapPropagator(options);
+
+  EXPECT_EQ(actual, expected);
 }
 
 TEST(OpenTelemetry, MakeSpan) {


### PR DESCRIPTION
Part of the work for #10489 

Add `InjectTraceContext(...)`, which is used for context propagation. For now we only use the global propagator (exactly how we only use the global tracer provider). In the future it may become `Option` dependent.

If you are wondering when I will settle on the customer-facing options for tracing, tomorrow I will pick a date by which I must have made the decision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10646)
<!-- Reviewable:end -->
