### PR TITLE
cleanup(storage): change part number type to std::size_t

### DIFF
--- a/google/cloud/storage/internal/xml_builders.cc
+++ b/google/cloud/storage/internal/xml_builders.cc
@@ -21,7 +21,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::shared_ptr<XmlNode> CompleteMultipartUpload(
-    std::map<unsigned int, std::string> const& parts) {
+    std::map<std::size_t, std::string> const& parts) {
   auto root = XmlNode::CreateRoot();
   auto target_node = root->AppendTagNode("CompleteMultipartUpload");
   for (auto const& p : parts) {

--- a/google/cloud/storage/internal/xml_builders.h
+++ b/google/cloud/storage/internal/xml_builders.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/xml_node.h"
 #include "google/cloud/storage/version.h"
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>
@@ -32,7 +33,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * https://cloud.google.com/storage/docs/xml-api/post-object-complete.
  */
 std::shared_ptr<XmlNode> CompleteMultipartUpload(
-    std::map<unsigned int, std::string> const& parts);
+    std::map<std::size_t, std::string> const& parts);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/xml_builders_test.cc
+++ b/google/cloud/storage/internal/xml_builders_test.cc
@@ -22,7 +22,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-constexpr auto kExpectedCompleteMultipartUploadXml =
+constexpr auto kExpectedCompleteMultipartUpload =
     R"xml(<CompleteMultipartUpload>
   <Part>
     <PartNumber>
@@ -43,13 +43,13 @@ constexpr auto kExpectedCompleteMultipartUploadXml =
 </CompleteMultipartUpload>
 )xml";
 
-TEST(BuildCompleteMultipartUploadXmlTest, Build) {
-  std::map<unsigned int, std::string> parts{
+TEST(CompleteMultipartUploadTest, Build) {
+  std::map<std::size_t, std::string> parts{
       {5U, "\"aaaa18db4cc2f85cedef654fccc4a4x8\""},
       {2U, "\"7778aef83f66abc1fa1e8477f296d394\""}};
   auto xml = CompleteMultipartUpload(parts);
   ASSERT_NE(xml, nullptr);
-  EXPECT_EQ(xml->ToString(2), kExpectedCompleteMultipartUploadXml);
+  EXPECT_EQ(xml->ToString(2), kExpectedCompleteMultipartUpload);
 }
 
 }  // namespace


### PR DESCRIPTION
Avoid `unsigned int` in the `CompleteMultipartUpload()` API.  Of the simpler alternatives, plain `int` or `std::size_t`, the latter seems more appropriate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10648)
<!-- Reviewable:end -->
