### PR TITLE
impl(generator): fix metadata includes

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.cc
@@ -20,6 +20,7 @@
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.h"
 #include "absl/strings/str_format.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/routing_matcher.h"

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.cc
@@ -20,6 +20,7 @@
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.h"
 #include "absl/strings/str_format.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/routing_matcher.h"

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -219,14 +219,13 @@ Status MetadataDecoratorRestGenerator::GenerateCc() {
   // includes
   CcPrint("\n");
   CcLocalIncludes({vars("metadata_rest_header_path"),
-                   HasExplicitRoutingMethod()
-                       ? "google/cloud/internal/absl_str_join_quiet.h"
-                       : "",
                    "google/cloud/internal/api_client_header.h",
                    HasExplicitRoutingMethod()
                        ? "google/cloud/internal/routing_matcher.h"
                        : "",
                    "google/cloud/common_options.h", "google/cloud/status_or.h",
+                   "google/cloud/internal/absl_str_cat_quiet.h",
+                   "google/cloud/internal/absl_str_join_quiet.h",
                    "absl/strings/str_format.h"});
   CcSystemIncludes({"memory"});
 


### PR DESCRIPTION
Always include headers for both `absl::StrCat` and `absl::StrJoin`  as they are used in `SetMetadata`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10660)
<!-- Reviewable:end -->
