### PR TITLE
cleanup(otel): fix string_view usage in gRPC carrier

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -58,7 +58,8 @@ class GrpcClientCarrier
 
   void Set(opentelemetry::nostd::string_view key,
            opentelemetry::nostd::string_view value) noexcept override {
-    context_.AddMetadata(key.data(), value.data());
+    context_.AddMetadata({key.data(), key.size()},
+                         {value.data(), value.size()});
   }
 
  private:


### PR DESCRIPTION
@devbww pointed out that the use of `string_view` was problematic: https://github.com/googleapis/google-cloud-cpp/pull/10646#discussion_r1086216072

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10664)
<!-- Reviewable:end -->
