### PR TITLE
refactor(generator): split `FakeSourceTree`

### DIFF
--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -42,13 +42,14 @@ load(":google_cloud_cpp_generator_testing.bzl", "google_cloud_cpp_generator_test
 cc_library(
     name = "google_cloud_cpp_generator_testing",
     testonly = True,
-    srcs = google_cloud_cpp_generator_testing_hdrs,
-    hdrs = google_cloud_cpp_generator_testing_srcs,
+    srcs = google_cloud_cpp_generator_testing_srcs,
+    hdrs = google_cloud_cpp_generator_testing_hdrs,
     deps = [
         ":google_cloud_cpp_generator",
         "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protoc_lib",
     ],
 )
 

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -146,22 +146,21 @@ function (google_cloud_cpp_generator_define_tests)
     # the GTest::gmock target, and the target names are also weird.
     find_package(GTest CONFIG REQUIRED)
 
-    add_library(google_cloud_cpp_generator_testing INTERFACE)
-    target_sources(
-        google_cloud_cpp_generator_testing
-        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/testing/printer_mocks.h)
+    add_library(
+        google_cloud_cpp_generator_testing # cmake-format: sort
+        testing/fake_source_tree.cc testing/fake_source_tree.h
+        testing/printer_mocks.h)
+    google_cloud_cpp_add_common_options(google_cloud_cpp_generator_testing)
     target_link_libraries(
         google_cloud_cpp_generator_testing
-        INTERFACE google_cloud_cpp_testing GTest::gmock_main GTest::gmock
-                  GTest::gtest)
+        PUBLIC google_cloud_cpp_testing GTest::gmock_main GTest::gmock
+               GTest::gtest protobuf::libprotoc)
     create_bazel_config(google_cloud_cpp_generator_testing YEAR "2020")
     target_include_directories(
-        google_cloud_cpp_generator_testing
-        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-                  $<INSTALL_INTERFACE:include>)
+        google_cloud_cpp_generator_testing PUBLIC ${PROJECT_SOURCE_DIR}
+                                                  ${PROJECT_BINARY_DIR})
     target_compile_options(google_cloud_cpp_generator_testing
-                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+                           PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
     set(google_cloud_cpp_generator_unit_tests
         # cmake-format: sort

--- a/generator/google_cloud_cpp_generator_testing.bzl
+++ b/generator/google_cloud_cpp_generator_testing.bzl
@@ -17,8 +17,10 @@
 """Automatically generated source lists for google_cloud_cpp_generator_testing - DO NOT EDIT."""
 
 google_cloud_cpp_generator_testing_hdrs = [
+    "testing/fake_source_tree.h",
     "testing/printer_mocks.h",
 ]
 
 google_cloud_cpp_generator_testing_srcs = [
+    "testing/fake_source_tree.cc",
 ]

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
+#include "generator/testing/fake_source_tree.h"
 #include "generator/testing/printer_mocks.h"
 #include <google/protobuf/compiler/importer.h>
 #include <google/protobuf/descriptor.pb.h>
@@ -31,6 +32,7 @@ namespace cloud {
 namespace generator_internal {
 namespace {
 
+using ::google::cloud::generator_testing::FakeSourceTree;
 using ::google::cloud::generator_testing::MockGeneratorContext;
 using ::google::cloud::generator_testing::MockZeroCopyOutputStream;
 using ::google::cloud::testing_util::IsOk;
@@ -51,24 +53,6 @@ using ::testing::Not;
 using ::testing::Pair;
 using ::testing::Return;
 using ::testing::UnorderedElementsAre;
-
-class StringSourceTree : public google::protobuf::compiler::SourceTree {
- public:
-  explicit StringSourceTree(std::map<std::string, std::string> files)
-      : files_(std::move(files)) {}
-
-  google::protobuf::io::ZeroCopyInputStream* Open(
-      std::string const& filename) override {
-    auto iter = files_.find(filename);
-    return iter == files_.end() ? nullptr
-                                : new google::protobuf::io::ArrayInputStream(
-                                      iter->second.data(),
-                                      static_cast<int>(iter->second.size()));
-  }
-
- private:
-  std::map<std::string, std::string> files_;
-};
 
 class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
  public:
@@ -165,7 +149,7 @@ class CreateServiceVarsTest
  private:
   FileDescriptorProto file_proto_;
   AbortingErrorCollector collector_;
-  StringSourceTree source_tree_;
+  FakeSourceTree source_tree_;
   google::protobuf::SimpleDescriptorDatabase simple_db_;
   google::protobuf::compiler::SourceTreeDescriptorDatabase source_tree_db_;
   google::protobuf::MergedDescriptorDatabase merged_db_;
@@ -592,7 +576,7 @@ class CreateMethodVarsTest
  private:
   FileDescriptorProto file_proto_;
   AbortingErrorCollector collector_;
-  StringSourceTree source_tree_;
+  FakeSourceTree source_tree_;
   google::protobuf::SimpleDescriptorDatabase simple_db_;
   google::protobuf::compiler::SourceTreeDescriptorDatabase source_tree_db_;
   google::protobuf::MergedDescriptorDatabase merged_db_;
@@ -1116,7 +1100,7 @@ message RoutingParameter {
 }
 )""";
 
-  StringSourceTree source_tree(std::map<std::string, std::string>{
+  FakeSourceTree source_tree(std::map<std::string, std::string>{
       {"google/api/routing.proto", kRoutingProto},
       {"google/cloud/foo/service.proto", kServiceBoilerPlate + service_proto}});
   google::protobuf::compiler::SourceTreeDescriptorDatabase source_tree_db(

--- a/generator/testing/fake_source_tree.cc
+++ b/generator/testing/fake_source_tree.cc
@@ -1,0 +1,35 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "generator/testing/fake_source_tree.h"
+
+namespace google {
+namespace cloud {
+namespace generator_testing {
+
+FakeSourceTree::FakeSourceTree(std::map<std::string, std::string> files)
+    : files_(std::move(files)) {}
+
+google::protobuf::io::ZeroCopyInputStream* FakeSourceTree::Open(
+    std::string const& filename) {
+  auto iter = files_.find(filename);
+  return iter == files_.end()
+             ? nullptr
+             : new google::protobuf::io::ArrayInputStream(
+                   iter->second.data(), static_cast<int>(iter->second.size()));
+}
+
+}  // namespace generator_testing
+}  // namespace cloud
+}  // namespace google

--- a/generator/testing/fake_source_tree.h
+++ b/generator/testing/fake_source_tree.h
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GENERATOR_TESTING_FAKE_SOURCE_TREE_H
+#define GOOGLE_CLOUD_CPP_GENERATOR_TESTING_FAKE_SOURCE_TREE_H
+
+#include <google/protobuf/compiler/importer.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#include <map>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace generator_testing {
+
+class FakeSourceTree : public google::protobuf::compiler::SourceTree {
+ public:
+  explicit FakeSourceTree(std::map<std::string, std::string> files);
+
+  google::protobuf::io::ZeroCopyInputStream* Open(
+      std::string const& filename) override;
+
+ private:
+  std::map<std::string, std::string> files_;
+};
+
+}  // namespace generator_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GENERATOR_TESTING_FAKE_SOURCE_TREE_H


### PR DESCRIPTION
I am about to create another test that will need a fake source tree.

Part of the work for #7664

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10667)
<!-- Reviewable:end -->
