### PR TITLE
cleanup(storage): remove inline specifiers from XmlParser

### DIFF
--- a/google/cloud/storage/internal/xml_node.cc
+++ b/google/cloud/storage/internal/xml_node.cc
@@ -90,198 +90,21 @@ class XmlParser {
   }
 
  private:
-  inline Status SkipXmlDeclaration() {
-    // Skip the XML declaration.
-    constexpr static absl::string_view kXmlDeclStart = "<?xml";
-    constexpr static absl::string_view kXmlDeclEnd = "?>";
-    auto xml_decl_start_pos = content_.find(kXmlDeclStart);
-    if (xml_decl_start_pos == std::string::npos) {
-      // Just allow XML without declaration.
-      return Status();
-    }
-    auto xml_decl_end_pos =
-        content_.find(kXmlDeclEnd, xml_decl_start_pos + kXmlDeclStart.size());
-    if (xml_decl_end_pos == std::string::npos) {
-      return internal::InvalidArgumentError("XML declaration doesn't end",
-                                            GCP_ERROR_INFO());
-    }
-    i_ = xml_decl_end_pos + kXmlDeclEnd.size();
-    return Status();
-  }
+  Status SkipXmlDeclaration();
 
-  inline Status MainLoop() {
-    auto c = content_[i_];
-    if (c == '<') {
-      auto result = HandleLt();
-      if (!result.ok()) return result;
-    } else if (state_ == ParseState::kStartTag) {
-      auto result = HandleStartTag(c);
-      if (!result.ok()) return result;
-    } else if (state_ == ParseState::kReadingTag) {
-      auto result = HandleReadingTag(c);
-      if (!result.ok()) return result;
-    } else if (state_ == ParseState::kReadingAttr) {
-      auto result = HandleReadingAttr(c);
-      if (!result.ok()) return result;
-    } else if (state_ == ParseState::kEndTag) {
-      HandleEndTag(c);
-    } else if (state_ == ParseState::kReadingText) {
-      // Append the character until we see the next '<'.
-      text_content_ += c;
-    } else if (state_ == ParseState::kBeginClosingTag) {
-      auto result = HandleBeginClosingTag(c);
-      if (!result.ok()) return result;
-    } else if (state_ == ParseState::kReadingClosingTag) {
-      auto result = HandleReadingClosingTag(c);
-      if (!result.ok()) return result;
-    }
-    return Status();
-  }
+  Status MainLoop();
+  Status HandleLt();
+  Status HandleStartTag(char c);
+  Status HandleReadingTag(char c);
+  Status HandleReadingAttr(char c);
+  void HandleEndTag(char c);
+  Status HandleBeginClosingTag(char c);
+  Status HandleReadingClosingTag(char c);
 
-  inline Status HandleLt() {
-    if (state_ == ParseState::kReadingText) {
-      // The parser was reading text part. Add a text node to the current
-      // parent if the limits allow.
-      auto text_node = AppendTextNode(
-          UnescapeTextContent(StripTrailingSpaces(text_content_)));
-      if (!text_node) return std::move(text_node).status();
-    }
-    state_ = ParseState::kStartTag;
-    return Status();
-  }
+  Status CheckLimits();
 
-  inline Status HandleStartTag(char const& c) {
-    if (c == '/') {
-      state_ = ParseState::kBeginClosingTag;
-    } else if (!IsSpace(c)) {
-      state_ = ParseState::kReadingTag;
-      tag_name_ = c;
-    }
-    return Status();
-  }
-
-  inline Status HandleReadingTag(char const& c) {
-    if (IsSpace(c)) {
-      state_ = ParseState::kReadingAttr;
-    } else if (c == '>') {
-      // The tag ends. We create a new tag node and set it as the current
-      // parent. It will increase both the node_count_ and the depth.
-      auto tag_node = AppendTagNode(UnescapeTagName(tag_name_));
-      if (!tag_node) return std::move(tag_node).status();
-      parent_history_.push(std::move(current_parent_));
-      current_parent_ = std::move(*tag_node);
-      state_ = ParseState::kEndTag;
-    } else if (c == '/') {
-      // This is a tag with this form <TAG/>. Read ahead to the next '>'.
-      auto close_tag_pos = content_.find('>', i_ + 1);
-      if (close_tag_pos == std::string::npos) {
-        return internal::InvalidArgumentError("The tag never closes.",
-                                              GCP_ERROR_INFO());
-      }
-      i_ = close_tag_pos + 1;
-      auto tag_node = AppendTagNode(UnescapeTagName(tag_name_));
-      if (!tag_node) return std::move(tag_node).status();
-      state_ = ParseState::kEndTag;
-    } else {
-      tag_name_ += c;
-    }
-    return Status();
-  }
-
-  inline Status HandleReadingAttr(char const& c) {
-    // We don't need the attributes at all. We ignore them.
-    if (c == '>') {
-      auto tag_node = AppendTagNode(UnescapeTagName(tag_name_));
-      if (!tag_node) return std::move(tag_node).status();
-      parent_history_.push(std::move(current_parent_));
-      current_parent_ = std::move(*tag_node);
-      state_ = ParseState::kEndTag;
-    }
-    return Status();
-  }
-
-  inline void HandleEndTag(char const& c) {
-    if (IsSpace(c)) {
-      // Left trim text content.
-      return;
-    }
-    // A text part starts.
-    text_content_ = c;
-    state_ = ParseState::kReadingText;
-  }
-
-  inline Status HandleBeginClosingTag(char const& c) {
-    if (IsSpace(c)) {
-      // Left trim tag names.
-      return Status();
-    }
-    close_tag_ = c;
-    state_ = ParseState::kReadingClosingTag;
-    if (c == '>') {
-      // "</>" is invalid.
-      return internal::InvalidArgumentError("Invalid tag '</>' found",
-                                            GCP_ERROR_INFO());
-    }
-    return Status();
-  }
-
-  inline Status HandleReadingClosingTag(char const& c) {
-    if (IsSpace(c)) {
-      return Status();
-    }
-    if (c == '>') {
-      auto close_tag = UnescapeTagName(StripTrailingSpaces(close_tag_));
-      if (current_parent_->GetTagName() != close_tag) {
-        // Mismatched close tag.
-        return internal::InvalidArgumentError(
-            absl::StrCat("Mismatched close tag found, starttag: '",
-                         current_parent_->GetTagName(), "' and the endtag: '",
-                         close_tag, "'."),
-            GCP_ERROR_INFO());
-      }
-      // The current tag ends. Set the current marker to the previous parent.
-      current_parent_ = std::move(parent_history_.top());
-      parent_history_.pop();
-      state_ = ParseState::kEndTag;
-    } else {
-      close_tag_ += c;
-    }
-    return Status();
-  }
-
-  inline Status CheckLimits() {
-    if (node_count_ == options_.get<XmlParserMaxNodeCount>()) {
-      return internal::InvalidArgumentError(
-          absl::StrCat("Exceeding max node count of ",
-                       options_.get<XmlParserMaxNodeCount>()),
-          GCP_ERROR_INFO());
-    }
-    if (parent_history_.size() == options_.get<XmlParserMaxNodeDepth>()) {
-      return internal::InvalidArgumentError(
-          absl::StrCat("Exceeding max node depth of ",
-                       options_.get<XmlParserMaxNodeDepth>()),
-          GCP_ERROR_INFO());
-    }
-    return Status();
-  }
-
-  inline StatusOr<std::shared_ptr<XmlNode>> AppendTagNode(
-      std::string tag_name) {
-    auto res = CheckLimits();
-    if (!res.ok()) return res;
-    auto ret = current_parent_->AppendTagNode(std::move(tag_name));
-    ++node_count_;
-    return ret;
-  }
-
-  inline StatusOr<std::shared_ptr<XmlNode>> AppendTextNode(
-      std::string text_content) {
-    auto res = CheckLimits();
-    if (!res.ok()) return res;
-    auto ret = current_parent_->AppendTextNode(std::move(text_content));
-    ++node_count_;
-    return ret;
-  }
+  StatusOr<std::shared_ptr<XmlNode>> AppendTagNode(std::string tag_name);
+  StatusOr<std::shared_ptr<XmlNode>> AppendTextNode(std::string text_content);
 
   absl::string_view content_;
   Options const& options_;
@@ -295,6 +118,199 @@ class XmlParser {
   std::stack<std::shared_ptr<XmlNode>> parent_history_;
   ParseState state_ = ParseState::kInit;
 };
+
+Status XmlParser::SkipXmlDeclaration() {
+  // Skip the XML declaration.
+  constexpr static absl::string_view kXmlDeclStart = "<?xml";
+  constexpr static absl::string_view kXmlDeclEnd = "?>";
+  auto xml_decl_start_pos = content_.find(kXmlDeclStart);
+  if (xml_decl_start_pos == std::string::npos) {
+    // Just allow XML without declaration.
+    return Status();
+  }
+  auto xml_decl_end_pos =
+      content_.find(kXmlDeclEnd, xml_decl_start_pos + kXmlDeclStart.size());
+  if (xml_decl_end_pos == std::string::npos) {
+    return internal::InvalidArgumentError("XML declaration doesn't end",
+                                          GCP_ERROR_INFO());
+  }
+  i_ = xml_decl_end_pos + kXmlDeclEnd.size();
+  return Status();
+}
+
+Status XmlParser::MainLoop() {
+  auto c = content_[i_];
+  if (c == '<') {
+    auto result = HandleLt();
+    if (!result.ok()) return result;
+  } else if (state_ == ParseState::kStartTag) {
+    auto result = HandleStartTag(c);
+    if (!result.ok()) return result;
+  } else if (state_ == ParseState::kReadingTag) {
+    auto result = HandleReadingTag(c);
+    if (!result.ok()) return result;
+  } else if (state_ == ParseState::kReadingAttr) {
+    auto result = HandleReadingAttr(c);
+    if (!result.ok()) return result;
+  } else if (state_ == ParseState::kEndTag) {
+    HandleEndTag(c);
+  } else if (state_ == ParseState::kReadingText) {
+    // Append the character until we see the next '<'.
+    text_content_ += c;
+  } else if (state_ == ParseState::kBeginClosingTag) {
+    auto result = HandleBeginClosingTag(c);
+    if (!result.ok()) return result;
+  } else if (state_ == ParseState::kReadingClosingTag) {
+    auto result = HandleReadingClosingTag(c);
+    if (!result.ok()) return result;
+  }
+  return Status();
+}
+
+Status XmlParser::HandleLt() {
+  if (state_ == ParseState::kReadingText) {
+    // The parser was reading text part. Add a text node to the current
+    // parent if the limits allow.
+    auto text_node =
+        AppendTextNode(UnescapeTextContent(StripTrailingSpaces(text_content_)));
+    if (!text_node) return std::move(text_node).status();
+  }
+  state_ = ParseState::kStartTag;
+  return Status();
+}
+
+Status XmlParser::HandleStartTag(char c) {
+  if (c == '/') {
+    state_ = ParseState::kBeginClosingTag;
+  } else if (!IsSpace(c)) {
+    state_ = ParseState::kReadingTag;
+    tag_name_ = c;
+  }
+  return Status();
+}
+
+Status XmlParser::HandleReadingTag(char c) {
+  if (IsSpace(c)) {
+    state_ = ParseState::kReadingAttr;
+  } else if (c == '>') {
+    // The tag ends. We create a new tag node and set it as the current
+    // parent. It will increase both the node_count_ and the depth.
+    auto tag_node = AppendTagNode(UnescapeTagName(tag_name_));
+    if (!tag_node) return std::move(tag_node).status();
+    parent_history_.push(std::move(current_parent_));
+    current_parent_ = std::move(*tag_node);
+    state_ = ParseState::kEndTag;
+  } else if (c == '/') {
+    // This is a tag with this form <TAG/>. Read ahead to the next '>'.
+    auto close_tag_pos = content_.find('>', i_ + 1);
+    if (close_tag_pos == std::string::npos) {
+      return internal::InvalidArgumentError("The tag never closes.",
+                                            GCP_ERROR_INFO());
+    }
+    i_ = close_tag_pos + 1;
+    auto tag_node = AppendTagNode(UnescapeTagName(tag_name_));
+    if (!tag_node) return std::move(tag_node).status();
+    state_ = ParseState::kEndTag;
+  } else {
+    tag_name_ += c;
+  }
+  return Status();
+}
+
+Status XmlParser::HandleReadingAttr(char c) {
+  // We don't need the attributes at all. We ignore them.
+  if (c == '>') {
+    auto tag_node = AppendTagNode(UnescapeTagName(tag_name_));
+    if (!tag_node) return std::move(tag_node).status();
+    parent_history_.push(std::move(current_parent_));
+    current_parent_ = std::move(*tag_node);
+    state_ = ParseState::kEndTag;
+  }
+  return Status();
+}
+
+void XmlParser::HandleEndTag(char c) {
+  if (IsSpace(c)) {
+    // Left trim text content.
+    return;
+  }
+  // A text part starts.
+  text_content_ = c;
+  state_ = ParseState::kReadingText;
+}
+
+Status XmlParser::HandleBeginClosingTag(char c) {
+  if (IsSpace(c)) {
+    // Left trim tag names.
+    return Status();
+  }
+  close_tag_ = c;
+  state_ = ParseState::kReadingClosingTag;
+  if (c == '>') {
+    // "</>" is invalid.
+    return internal::InvalidArgumentError("Invalid tag '</>' found",
+                                          GCP_ERROR_INFO());
+  }
+  return Status();
+}
+
+Status XmlParser::HandleReadingClosingTag(char c) {
+  if (IsSpace(c)) {
+    return Status();
+  }
+  if (c == '>') {
+    auto close_tag = UnescapeTagName(StripTrailingSpaces(close_tag_));
+    if (current_parent_->GetTagName() != close_tag) {
+      // Mismatched close tag.
+      return internal::InvalidArgumentError(
+          absl::StrCat("Mismatched close tag found, starttag: '",
+                       current_parent_->GetTagName(), "' and the endtag: '",
+                       close_tag, "'."),
+          GCP_ERROR_INFO());
+    }
+    // The current tag ends. Set the current marker to the previous parent.
+    current_parent_ = std::move(parent_history_.top());
+    parent_history_.pop();
+    state_ = ParseState::kEndTag;
+  } else {
+    close_tag_ += c;
+  }
+  return Status();
+}
+
+Status XmlParser::CheckLimits() {
+  if (node_count_ == options_.get<XmlParserMaxNodeCount>()) {
+    return internal::InvalidArgumentError(
+        absl::StrCat("Exceeding max node count of ",
+                     options_.get<XmlParserMaxNodeCount>()),
+        GCP_ERROR_INFO());
+  }
+  if (parent_history_.size() == options_.get<XmlParserMaxNodeDepth>()) {
+    return internal::InvalidArgumentError(
+        absl::StrCat("Exceeding max node depth of ",
+                     options_.get<XmlParserMaxNodeDepth>()),
+        GCP_ERROR_INFO());
+  }
+  return Status();
+}
+
+StatusOr<std::shared_ptr<XmlNode>> XmlParser::AppendTagNode(
+    std::string tag_name) {
+  auto res = CheckLimits();
+  if (!res.ok()) return res;
+  auto ret = current_parent_->AppendTagNode(std::move(tag_name));
+  ++node_count_;
+  return ret;
+}
+
+StatusOr<std::shared_ptr<XmlNode>> XmlParser::AppendTextNode(
+    std::string text_content) {
+  auto res = CheckLimits();
+  if (!res.ok()) return res;
+  auto ret = current_parent_->AppendTextNode(std::move(text_content));
+  ++node_count_;
+  return ret;
+}
 
 }  // namespace
 


### PR DESCRIPTION
Don't do micro optimizations until we have a micro benchmark to evaluate the effects.

Also stop using in-class definitions, which makes the API clearer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10669)
<!-- Reviewable:end -->
