### PR TITLE
cleanup: sort generator includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,13 @@ IncludeCategories:
   Priority: 1000
 - Regex: '^\"google/cloud/'  # project includes should sort first
   Priority: 500
-- Regex: '^\"'
+- Regex: '^\"generator/'     # project includes should sort first
+  Priority: 500
+- Regex: '^\"generator/internal/' # project internals second
+  Priority: 1000
+- Regex: '^\"generator/testing/'  # testing helpers third
+  Priority: 1100
+- Regex: '^\"'         # And then includes from other projects or the system
   Priority: 1500
 - Regex: '^<grpc/'
   Priority: 2000

--- a/generator/generator.cc
+++ b/generator/generator.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "generator/generator.h"
+#include "generator/internal/codegen_utils.h"
+#include "generator/internal/descriptor_utils.h"
+#include "generator/internal/generator_interface.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/status_or.h"
 #include "absl/strings/str_split.h"
-#include "generator/internal/codegen_utils.h"
-#include "generator/internal/descriptor_utils.h"
-#include "generator/internal/generator_interface.h"
 #include <google/api/client.pb.h>
 #include <future>
 #include <string>

--- a/generator/generator_test.cc
+++ b/generator/generator_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "generator/generator.h"
-#include "google/cloud/log.h"
-#include "absl/memory/memory.h"
 #include "generator/internal/printer.h"
 #include "generator/testing/printer_mocks.h"
+#include "google/cloud/log.h"
+#include "absl/memory/memory.h"
 #include <google/protobuf/compiler/importer.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>

--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/common_options.h"
-#include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/make_status.h"
-#include "google/cloud/log.h"
-#include "google/cloud/version.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_client.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h"
@@ -24,6 +19,11 @@
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
+#include "google/cloud/common_options.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/log.h"
+#include "google/cloud/version.h"
 #include <benchmark/benchmark.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include "google/cloud/internal/async_streaming_read_rpc_impl.h"
 #include "google/cloud/internal/async_streaming_write_rpc_impl.h"
 #include "google/cloud/internal/streaming_read_rpc.h"
 #include "google/cloud/testing_util/mock_grpc_authentication_strategy.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
-#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_client_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_client_test.cc
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_client.h"
+#include "generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h"
+#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h"
-#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include <google/iam/v1/policy.pb.h>
 #include <google/protobuf/util/field_mask_util.h>
 #include <gmock/gmock.h>

--- a/generator/integration_tests/tests/golden_kitchen_sink_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_connection_test.cc
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
-#include "google/cloud/grpc_options.h"
-#include "google/cloud/polling_policy.h"
-#include "google/cloud/testing_util/scoped_log.h"
-#include "google/cloud/testing_util/status_matchers.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_options.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h"
 #include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/polling_policy.h"
+#include "google/cloud/testing_util/scoped_log.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include "google/cloud/internal/async_streaming_read_rpc_impl.h"
 #include "google/cloud/internal/async_streaming_write_rpc_impl.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
-#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/async_streaming_read_rpc_impl.h"
@@ -21,7 +22,6 @@
 #include "google/cloud/testing_util/validate_metadata.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/str_split.h"
-#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_rest_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_rest_connection_test.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/grpc_options.h"
-#include "google/cloud/polling_policy.h"
-#include "google/cloud/testing_util/scoped_log.h"
-#include "google/cloud/testing_util/status_matchers.h"
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/golden_kitchen_sink_options.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_connection_impl.h"
 #include "generator/integration_tests/tests/mock_golden_kitchen_sink_rest_stub.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/polling_policy.h"
+#include "google/cloud/testing_util/scoped_log.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_rest_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_rest_logging_decorator_test.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_logging_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_kitchen_sink_rest_stub.h"
 #include "google/cloud/internal/rest_context.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
-#include "generator/integration_tests/tests/mock_golden_kitchen_sink_rest_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_rest_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_rest_metadata_decorator_test.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_kitchen_sink_rest_stub.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
-#include "generator/integration_tests/tests/mock_golden_kitchen_sink_rest_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h"
-#include "google/cloud/testing_util/status_matchers.h"
 #include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.h"
+#include "generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h"
+#include "generator/integration_tests/test.pb.h"
 #include "google/cloud/mocks/mock_stream_range.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h"
-#include "generator/integration_tests/test.pb.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h"
+#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/internal/async_streaming_read_rpc_impl.h"
 #include "google/cloud/internal/async_streaming_write_rpc_impl.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/streaming_write_rpc_impl.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/generator/integration_tests/tests/golden_thing_admin_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_auth_decorator_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_auth_decorator.h"
-#include "google/cloud/testing_util/mock_grpc_authentication_strategy.h"
-#include "google/cloud/testing_util/status_matchers.h"
 #include "generator/integration_tests/test.pb.h"
 #include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
+#include "google/cloud/testing_util/mock_grpc_authentication_strategy.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_thing_admin_client_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_client_test.cc
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/golden_thing_admin_client.h"
+#include "generator/integration_tests/golden/v1/golden_thing_admin_options.h"
+#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.h"
+#include "generator/integration_tests/golden/v1/mocks/mock_golden_thing_admin_connection.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/golden/v1/golden_thing_admin_options.h"
-#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.h"
-#include "generator/integration_tests/golden/v1/mocks/mock_golden_thing_admin_connection.h"
 #include <google/iam/v1/policy.pb.h>
 #include <google/protobuf/util/field_mask_util.h>
 #include <gmock/gmock.h>

--- a/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/golden_thing_admin_connection.h"
+#include "generator/integration_tests/golden/v1/golden_thing_admin_options.h"
+#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_connection_impl.h"
+#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.h"
+#include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/golden/v1/golden_thing_admin_options.h"
-#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_connection_impl.h"
-#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.h"
-#include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 #include <memory>

--- a/generator/integration_tests/tests/golden_thing_admin_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_logging_decorator_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_logging_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
-#include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_thing_admin_rest_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_connection_test.cc
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "generator/integration_tests/golden/golden_thing_admin_connection.h"
+#include "generator/integration_tests/golden/golden_thing_admin_options.h"
+#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.h"
+#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_connection_impl.h"
+#include "generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/golden/golden_thing_admin_connection.h"
-#include "generator/integration_tests/golden/golden_thing_admin_options.h"
-#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.h"
-#include "generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_connection_impl.h"
-#include "generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 #include <memory>

--- a/generator/integration_tests/tests/golden_thing_admin_rest_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_logging_decorator_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_thing_admin_rest_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_metadata_decorator_test.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.h"
+#include "generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
-#include "generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_thing_admin_round_robin_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_round_robin_decorator_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_round_robin_decorator.h"
-#include "google/cloud/testing_util/status_matchers.h"
 #include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_connection_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_connection.h"
+#include "generator/integration_tests/golden/v1/mocks/mock_golden_thing_admin_connection.h"
+#include "generator/integration_tests/test.pb.h"
 #include "google/cloud/mocks/mock_stream_range.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/golden/v1/mocks/mock_golden_thing_admin_connection.h"
-#include "generator/integration_tests/test.pb.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_stub.h"
+#include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/generator/integration_tests/tests/plumbing_test.cc
+++ b/generator/integration_tests/tests/plumbing_test.cc
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/grpc_options.h"
-#include "google/cloud/testing_util/mock_backoff_policy.h"
-#include "google/cloud/testing_util/status_matchers.h"
 #include "generator/integration_tests/golden/v1/golden_thing_admin_client.h"
 #include "generator/integration_tests/golden/v1/golden_thing_admin_options.h"
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_connection_impl.h"
 #include "generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.h"
 #include "generator/integration_tests/tests/mock_golden_thing_admin_stub.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/testing_util/mock_backoff_policy.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
 

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/internal/auth_decorator_generator.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/auth_decorator_generator.h
+++ b/generator/internal/auth_decorator_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_AUTH_DECORATOR_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_AUTH_DECORATOR_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/stub_generator_base.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "generator/internal/client_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "absl/memory/memory.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "absl/memory/memory.h"
 #include <google/api/client.pb.h>
 #include <google/protobuf/descriptor.h>
 

--- a/generator/internal/client_generator.h
+++ b/generator/internal/client_generator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CLIENT_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CLIENT_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/codegen_utils.h
+++ b/generator/internal/codegen_utils.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CODEGEN_UTILS_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CODEGEN_UTILS_H
 
+#include "generator/internal/printer.h"
 #include "google/cloud/status_or.h"
 #include "absl/strings/string_view.h"
-#include "generator/internal/printer.h"
 #include <map>
 #include <string>
 #include <vector>

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/internal/connection_generator.h"
-#include "absl/memory/memory.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/memory/memory.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/connection_generator.h
+++ b/generator/internal/connection_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CONNECTION_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CONNECTION_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "generator/internal/connection_impl_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/connection_impl_generator.h
+++ b/generator/internal/connection_impl_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CONNECTION_IMPL_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CONNECTION_IMPL_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/connection_impl_rest_generator.cc
+++ b/generator/internal/connection_impl_rest_generator.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "generator/internal/connection_impl_rest_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/connection_impl_rest_generator.h
+++ b/generator/internal/connection_impl_rest_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CONNECTION_IMPL_REST_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_CONNECTION_IMPL_REST_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -13,14 +13,6 @@
 // limitations under the License.
 
 #include "generator/internal/descriptor_utils.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "google/cloud/internal/absl_str_join_quiet.h"
-#include "google/cloud/internal/absl_str_replace_quiet.h"
-#include "google/cloud/internal/algorithm.h"
-#include "google/cloud/log.h"
-#include "absl/strings/str_split.h"
-#include "absl/strings/strip.h"
-#include "absl/types/variant.h"
 #include "generator/internal/auth_decorator_generator.h"
 #include "generator/internal/client_generator.h"
 #include "generator/internal/codegen_utils.h"
@@ -51,6 +43,14 @@
 #include "generator/internal/stub_rest_generator.h"
 #include "generator/internal/tracing_connection_generator.h"
 #include "generator/internal/tracing_stub_generator.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/internal/absl_str_replace_quiet.h"
+#include "google/cloud/internal/algorithm.h"
+#include "google/cloud/log.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/strip.h"
+#include "absl/types/variant.h"
 #include <google/api/routing.pb.h>
 #include <google/longrunning/operations.pb.h>
 #include <google/protobuf/compiler/code_generator.h>

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DESCRIPTOR_UTILS_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DESCRIPTOR_UTILS_H
 
-#include "absl/types/variant.h"
 #include "generator/internal/generator_interface.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/types/variant.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "generator/internal/descriptor_utils.h"
+#include "generator/internal/codegen_utils.h"
+#include "generator/testing/fake_source_tree.h"
+#include "generator/testing/printer_mocks.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/strings/str_split.h"
-#include "generator/internal/codegen_utils.h"
-#include "generator/testing/fake_source_tree.h"
-#include "generator/testing/printer_mocks.h"
 #include <google/protobuf/compiler/importer.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/descriptor_database.h>

--- a/generator/internal/forwarding_client_generator.h
+++ b/generator/internal/forwarding_client_generator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_CLIENT_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_CLIENT_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/forwarding_connection_generator.h
+++ b/generator/internal/forwarding_connection_generator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_CONNECTION_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_CONNECTION_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/forwarding_idempotency_policy_generator.h
+++ b/generator/internal/forwarding_idempotency_policy_generator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_IDEMPOTENCY_POLICY_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_IDEMPOTENCY_POLICY_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/forwarding_mock_connection_generator.h
+++ b/generator/internal/forwarding_mock_connection_generator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_MOCK_CONNECTION_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_MOCK_CONNECTION_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/forwarding_options_generator.h
+++ b/generator/internal/forwarding_options_generator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_OPTIONS_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_FORWARDING_OPTIONS_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/idempotency_policy_generator.cc
+++ b/generator/internal/idempotency_policy_generator.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "generator/internal/idempotency_policy_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "absl/memory/memory.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "absl/memory/memory.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/idempotency_policy_generator.h
+++ b/generator/internal/idempotency_policy_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_IDEMPOTENCY_POLICY_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_IDEMPOTENCY_POLICY_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "generator/internal/logging_decorator_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/logging_decorator_generator.h
+++ b/generator/internal/logging_decorator_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_LOGGING_DECORATOR_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_LOGGING_DECORATOR_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/stub_generator_base.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/logging_decorator_rest_generator.cc
+++ b/generator/internal/logging_decorator_rest_generator.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/internal/logging_decorator_rest_generator.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/logging_decorator_rest_generator.h
+++ b/generator/internal/logging_decorator_rest_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_LOGGING_DECORATOR_REST_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_LOGGING_DECORATOR_REST_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "generator/internal/metadata_decorator_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 #include <algorithm>
 

--- a/generator/internal/metadata_decorator_generator.h
+++ b/generator/internal/metadata_decorator_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_METADATA_DECORATOR_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_METADATA_DECORATOR_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/stub_generator_base.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "generator/internal/metadata_decorator_rest_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 #include <algorithm>
 

--- a/generator/internal/metadata_decorator_rest_generator.h
+++ b/generator/internal/metadata_decorator_rest_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_METADATA_DECORATOR_REST_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_METADATA_DECORATOR_REST_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/mock_connection_generator.cc
+++ b/generator/internal/mock_connection_generator.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/internal/mock_connection_generator.h"
-#include "absl/memory/memory.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/memory/memory.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/mock_connection_generator.h
+++ b/generator/internal/mock_connection_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_MOCK_CONNECTION_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_MOCK_CONNECTION_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/option_defaults_generator.h
+++ b/generator/internal/option_defaults_generator.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_OPTION_DEFAULTS_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_OPTION_DEFAULTS_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/options_generator.cc
+++ b/generator/internal/options_generator.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/internal/options_generator.h"
-#include "absl/memory/memory.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/memory/memory.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/options_generator.h
+++ b/generator/internal/options_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_OPTIONS_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_OPTIONS_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/predicate_utils.cc
+++ b/generator/internal/predicate_utils.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "generator/internal/predicate_utils.h"
+#include "generator/internal/descriptor_utils.h"
 #include "google/cloud/log.h"
 #include "google/cloud/optional.h"
-#include "generator/internal/descriptor_utils.h"
 #include <google/longrunning/operations.pb.h>
 #include <string>
 

--- a/generator/internal/printer_test.cc
+++ b/generator/internal/printer_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "generator/internal/printer.h"
+#include "generator/testing/printer_mocks.h"
 #include "google/cloud/internal/port_platform.h"
 #include "absl/memory/memory.h"
-#include "generator/testing/printer_mocks.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/generator/internal/retry_traits_generator.h
+++ b/generator/internal/retry_traits_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_RETRY_TRAITS_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_RETRY_TRAITS_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/round_robin_decorator_generator.cc
+++ b/generator/internal/round_robin_decorator_generator.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/internal/round_robin_decorator_generator.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/round_robin_decorator_generator.h
+++ b/generator/internal/round_robin_decorator_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_ROUND_ROBIN_DECORATOR_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_ROUND_ROBIN_DECORATOR_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/stub_generator_base.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/sample_generator.h
+++ b/generator/internal/sample_generator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_SAMPLE_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_SAMPLE_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_SCAFFOLD_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_SCAFFOLD_GENERATOR_H
 
-#include "absl/types/optional.h"
 #include "generator/generator_config.pb.h"
+#include "absl/types/optional.h"
 #include <iosfwd>
 #include <map>
 #include <string>

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "generator/internal/service_code_generator.h"
+#include "generator/internal/codegen_utils.h"
+#include "generator/internal/printer.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_replace_quiet.h"
 #include "google/cloud/internal/algorithm.h"
@@ -20,8 +22,6 @@
 #include "absl/memory/memory.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
-#include "generator/internal/codegen_utils.h"
-#include "generator/internal/printer.h"
 #include <google/api/client.pb.h>
 #include <google/api/routing.pb.h>
 #include <google/protobuf/descriptor.h>

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -15,12 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_SERVICE_CODE_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_SERVICE_CODE_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/generator_config.pb.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/generator_interface.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/service_code_generator_test.cc
+++ b/generator/internal/service_code_generator_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "generator/internal/service_code_generator.h"
-#include "google/cloud/log.h"
 #include "generator/testing/printer_mocks.h"
+#include "google/cloud/log.h"
 #include <google/protobuf/compiler/importer.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>

--- a/generator/internal/stub_factory_generator.h
+++ b/generator/internal/stub_factory_generator.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_FACTORY_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_FACTORY_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/stub_factory_rest_generator.h
+++ b/generator/internal/stub_factory_rest_generator.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_FACTORY_REST_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_FACTORY_REST_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "generator/internal/stub_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/stub_generator.h
+++ b/generator/internal/stub_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/stub_generator_base.h
+++ b/generator/internal/stub_generator_base.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_GENERATOR_BASE_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_GENERATOR_BASE_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "generator/internal/stub_rest_generator.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/stub_rest_generator.h
+++ b/generator/internal/stub_rest_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_REST_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_STUB_REST_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/tracing_connection_generator.cc
+++ b/generator/internal/tracing_connection_generator.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "generator/internal/tracing_connection_generator.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {

--- a/generator/internal/tracing_connection_generator.h
+++ b/generator/internal/tracing_connection_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_TRACING_CONNECTION_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_TRACING_CONNECTION_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/service_code_generator.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/internal/tracing_stub_generator.h
+++ b/generator/internal/tracing_stub_generator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_TRACING_STUB_GENERATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_TRACING_STUB_GENERATOR_H
 
-#include "google/cloud/status.h"
 #include "generator/internal/printer.h"
 #include "generator/internal/stub_generator_base.h"
+#include "google/cloud/status.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <map>

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "generator/generator.h"
+#include "generator/generator_config.pb.h"
+#include "generator/internal/codegen_utils.h"
+#include "generator/internal/scaffold_generator.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/log.h"
@@ -19,10 +23,6 @@
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/strings/match.h"
-#include "generator/generator.h"
-#include "generator/generator_config.pb.h"
-#include "generator/internal/codegen_utils.h"
-#include "generator/internal/scaffold_generator.h"
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/text_format.h>
 #include <algorithm>


### PR DESCRIPTION
We want our own includes ahead of other projects and/or system includes to detect when we miss a `#include` in headers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10670)
<!-- Reviewable:end -->
