### PR TITLE
impl(spanner): start second emulator to service REST transport

### DIFF
--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -22,7 +22,7 @@ fi # include guard
 
 source module /ci/lib/io.sh
 
-# Global variable that holds the PIDs of the Spanner emulators. These will be set
+# Global variables that hold the PIDs of the Spanner emulators. These will be set
 # when the emulators are started, and will be used to kill the emulators.
 SPANNER_EMULATOR_PID=0
 SPANNER_HTTP_EMULATOR_PID=0

--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -25,6 +25,7 @@ source module /ci/lib/io.sh
 # Global variable that holds the PID of the Spanner emulator. This will be set
 # when the emulator is started, and it will be used to kill the emulator.
 SPANNER_EMULATOR_PID=0
+SPANNER_HTTP_EMULATOR_PID=0
 
 # Outputs the port number that the emulator chose to listen on.
 function spanner_emulator::internal::read_emulator_port() {
@@ -42,6 +43,24 @@ function spanner_emulator::internal::read_emulator_port() {
     sleep 1
   done
   echo "${emulator_port}"
+}
+
+# Outputs the port number that the rest emulator chose to listen on.
+function spanner_emulator::internal::read_http_emulator_port() {
+  local -r logfile="$1"
+  shift
+
+  local http_emulator_port="0"
+  local -r expected=": REST server listening at localhost:"
+  for _ in $(seq 1 8); do
+    if grep -q -s "${expected}" "${logfile}"; then
+      # The port number is whatever is after the last ':'.
+      http_emulator_port=$(grep "${expected}" "${logfile}" | awk -F: '{print $NF}')
+      break
+    fi
+    sleep 1
+  done
+  echo "${http_emulator_port}"
 }
 
 # Starts the cloud spanner emulator. On success, exports the
@@ -83,6 +102,36 @@ function spanner_emulator::start() {
 
   export SPANNER_EMULATOR_HOST="localhost:${emulator_port}"
   io::log "Spanner emulator started at ${SPANNER_EMULATOR_HOST}"
+
+  # Repeat the process to launch the emulator with HTTP support. We launch a separate process
+  # as existing tests fail if we try and use gateway_main for both gRPC and REST.
+  readonly SPANNER_HTTP_EMULATOR_CMD="${CLOUD_SDK_LOCATION}/bin/cloud_spanner_emulator/gateway_main"
+  echo "${SPANNER_HTTP_EMULATOR_CMD}"
+  if [[ ! -x "${SPANNER_HTTP_EMULATOR_CMD}" ]]; then
+    echo 1>&2 "The Cloud Spanner HTTP emulator does not seem to be installed, aborting"
+    return 1
+  fi
+
+  # The tests typically run in a Docker container, where the ports are largely
+  # free; when using in manual tests, you can set REST_EMULATOR_PORT.
+  rm -f http_emulator.log
+  # Leverage the previously determined emulator_port to avoid collision.
+  local http_port=$((emulator_port + 1))
+  local grpc_port=$((http_port + 1))
+  "${SPANNER_HTTP_EMULATOR_CMD}" --hostname "localhost" --grpc_port "${grpc_port}" --http_port "${http_port}" >http_emulator.log 2>&1 </dev/null &
+  SPANNER_HTTP_EMULATOR_PID=$!
+
+  http_emulator_port="$(spanner_emulator::internal::read_http_emulator_port http_emulator.log)"
+  if [[ "${http_emulator_port}" = "0" ]]; then
+    io::log_red "Cannot determine Cloud Spanner HTTP emulator port." >&2
+    cat http_emulator.log >&2
+    spanner_http_emulator::kill
+    return 1
+  fi
+
+  # Attempting to use https:// results in SSL errors.
+  export SPANNER_EMULATOR_REST_HOST="http://localhost:${http_emulator_port}"
+  io::log "Spanner HTTP emulator started at ${SPANNER_EMULATOR_REST_HOST}"
 }
 
 # Kills the running emulator.
@@ -94,5 +143,13 @@ function spanner_emulator::kill() {
     echo -n "."
     echo " done."
     SPANNER_EMULATOR_PID=0
+  fi
+  if (("${SPANNER_HTTP_EMULATOR_PID}" > 0)); then
+    echo -n "Killing Spanner HTTP Emulator [${SPANNER_HTTP_EMULATOR_PID}] "
+    kill "${SPANNER_HTTP_EMULATOR_PID}" || echo -n "-"
+    wait "${SPANNER_HTTP_EMULATOR_PID}" >/dev/null 2>&1 || echo -n "+"
+    echo -n "."
+    echo " done."
+    SPANNER_HTTP_EMULATOR_PID=0
   fi
 }

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -41,5 +41,6 @@ trap spanner_emulator::kill EXIT
 
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
   --test_env="SPANNER_EMULATOR_HOST=${SPANNER_EMULATOR_HOST}" \
+  --test_env="SPANNER_EMULATOR_REST_HOST=${SPANNER_EMULATOR_REST_HOST}" \
   --test_tag_filters="integration-test" -- \
   "//google/cloud/spanner/...:all"


### PR DESCRIPTION
Part of the work to test gRPC/HTTP transcoding using generated Spanner admin code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10704)
<!-- Reviewable:end -->
