### PR TITLE
test(pubsub): deflake `ExactlyOnce` integration test

### DIFF
--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -492,6 +492,7 @@ TEST_F(SubscriberIntegrationTest, ExactlyOnce) {
   EXPECT_FALSE(ids.empty());
 
   promise<void> ids_empty;
+  auto ids_empty_future = ids_empty.get_future();
   auto callback = [&](pubsub::Message const& m, ExactlyOnceAckHandler h) {
     SCOPED_TRACE("Search for message " + m.message_id());
     std::unique_lock<std::mutex> lk(mu);
@@ -520,7 +521,7 @@ TEST_F(SubscriberIntegrationTest, ExactlyOnce) {
   auto result = subscriber.Subscribe(callback);
   // Wait until there are no more ids pending, then cancel the subscription and
   // get its status.
-  ids_empty.get_future().get();
+  ids_empty_future.get();
   result.cancel();
   EXPECT_STATUS_OK(result.get());
 }

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -514,7 +514,7 @@ TEST_F(SubscriberIntegrationTest, ExactlyOnce) {
       ASSERT_STATUS_OK(status) << " ack() failed for id=" << id;
     });
     if (!empty) return;
-    done.then([p = std::move(ids_empty)](auto f) mutable { p.set_value(); });
+    done.then([p = std::move(ids_empty)](auto) mutable { p.set_value(); });
   };
 
   auto result = subscriber.Subscribe(callback);

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -507,12 +507,13 @@ TEST_F(SubscriberIntegrationTest, ExactlyOnce) {
       return;
     }
     ids.erase(i);
-    if (ids.empty()) ids_empty.set_value();
+    auto const empty = ids.empty();
     lk.unlock();
     std::move(h).ack().then([id = m.message_id()](auto f) {
       auto status = f.get();
       ASSERT_STATUS_OK(status) << " ack() failed for id=" << id;
     });
+    if (empty) ids_empty.set_value();
   };
 
   auto result = subscriber.Subscribe(callback);


### PR DESCRIPTION
The test had a race condition where the subscription could be cancelled before the message was acked. The `ack()` call would fail in this case, resulting in a (flaky) test error.

Part of the work for #9619

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10715)
<!-- Reviewable:end -->
