### PR TITLE
ci: switch multiple builds to Fedora:37

### DIFF
--- a/ci/cloudbuild/triggers/cmake-gcs-rest-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcs-rest-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-gcs-rest-ci
 substitutions:
   _BUILD_NAME: cmake-gcs-rest
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/cmake-gcs-rest-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcs-rest-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-gcs-rest-pr
 substitutions:
   _BUILD_NAME: cmake-gcs-rest
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/cmake-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-install-ci
 substitutions:
   _BUILD_NAME: cmake-install
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/cmake-install-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-install-pr
 substitutions:
   _BUILD_NAME: cmake-install
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/cmake-single-feature-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-single-feature-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-single-feature-ci
 substitutions:
   _BUILD_NAME: cmake-single-feature
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/cmake-single-feature-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-single-feature-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-single-feature-pr
 substitutions:
   _BUILD_NAME: cmake-single-feature
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/integration-production-ci.yaml
+++ b/ci/cloudbuild/triggers/integration-production-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: integration-production-ci
 substitutions:
   _BUILD_NAME: integration-production
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/integration-production-pr.yaml
+++ b/ci/cloudbuild/triggers/integration-production-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: integration-production-pr
 substitutions:
   _BUILD_NAME: integration-production
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/noex-ci.yaml
+++ b/ci/cloudbuild/triggers/noex-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: noex-ci
 substitutions:
   _BUILD_NAME: noex
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/noex-pr.yaml
+++ b/ci/cloudbuild/triggers/noex-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: noex-pr
 substitutions:
   _BUILD_NAME: noex
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/quickstart-production-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: quickstart-production-ci
 substitutions:
   _BUILD_NAME: quickstart-production
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/quickstart-production-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: quickstart-production-pr
 substitutions:
   _BUILD_NAME: quickstart-production
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/shared-ci.yaml
+++ b/ci/cloudbuild/triggers/shared-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: shared-ci
 substitutions:
   _BUILD_NAME: shared
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/shared-pr.yaml
+++ b/ci/cloudbuild/triggers/shared-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: shared-pr
 substitutions:
   _BUILD_NAME: shared
-  _DISTRO: fedora-36-cmake
+  _DISTRO: fedora-37-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:


### PR DESCRIPTION
These are builds that do not require specialized tools:

- `cmake-gcs-rest`
- `cmake-install`
- `cmake-single-feature`
- `integration-production`
- `noex`
- `quickstart-production`
- `shared`

Part of the work for #10254

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10722)
<!-- Reviewable:end -->
