### PR TITLE
impl(bigquery): v2 job initial files

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -61,7 +61,6 @@ expected_dirs+=(
   ./include/google/appengine/logging/v1
   ./include/google/cloud/bigquery/logging
   ./include/google/cloud/bigquery/logging/v1
-  ./include/google/cloud/bigquery/v2
   ./include/google/cloud/bigquery/v2/minimal
   ./include/google/cloud/bigquery/v2/minimal/internal
   ./include/google/cloud/bigtable/mocks

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -61,6 +61,8 @@ expected_dirs+=(
   ./include/google/appengine/logging/v1
   ./include/google/cloud/bigquery/logging
   ./include/google/cloud/bigquery/logging/v1
+  ./include/google/cloud/bigquery/v2
+  ./include/google/cloud/bigquery/v2/minimal
   ./include/google/cloud/bigquery/v2/minimal/internal
   ./include/google/cloud/bigtable/mocks
   # no RPC services in google/cloud/certificatemanager/logging

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -61,6 +61,7 @@ expected_dirs+=(
   ./include/google/appengine/logging/v1
   ./include/google/cloud/bigquery/logging
   ./include/google/cloud/bigquery/logging/v1
+  ./include/google/cloud/bigquery/v2/minimal/internal
   ./include/google/cloud/bigtable/mocks
   # no RPC services in google/cloud/certificatemanager/logging
   ./include/google/cloud/certificatemanager/logging

--- a/google/cloud/bigquery/BUILD.bazel
+++ b/google/cloud/bigquery/BUILD.bazel
@@ -21,6 +21,7 @@ filegroup(
     srcs = glob([
         "*.cc",
         "internal/*.cc",
+        "v2/minimal/internal/*.cc",
     ]),
 )
 
@@ -29,6 +30,7 @@ filegroup(
     srcs = glob([
         "*.h",
         "internal/*.h",
+        "v2/minimal/internal/*.h",
     ]),
 )
 

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -32,8 +32,8 @@ include(GoogleCloudCppCommon)
 file(
     GLOB source_files
     RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-    "*.h" "*.cc" "internal/*.h" "internal/*.cc"
-    "v2/minimal/internal/*.h" "v2/minimal/internal/*.cc")
+    "*.h" "*.cc" "internal/*.h" "internal/*.cc" "v2/minimal/internal/*.h"
+    "v2/minimal/internal/*.cc")
 list(SORT source_files)
 add_library(google_cloud_cpp_bigquery ${source_files})
 target_include_directories(

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -21,7 +21,7 @@ set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "bigquery_internal" "bigquery_testing"
-                            "examples")
+                            "examples" "bigquery_v2_minimal_internal")
 
 include(GoogleCloudCppDoxygen)
 google_cloud_cpp_doxygen_targets("bigquery" DEPENDS cloud-docs
@@ -32,7 +32,8 @@ include(GoogleCloudCppCommon)
 file(
     GLOB source_files
     RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-    "*.h" "*.cc" "internal/*.h" "internal/*.cc")
+    "*.h" "*.cc" "internal/*.h" "internal/*.cc"
+    "v2/minimal/internal/*.h" "v2/minimal/internal/*.cc")
 list(SORT source_files)
 add_library(google_cloud_cpp_bigquery ${source_files})
 target_include_directories(

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#include "google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+    
+}  // namespace internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
@@ -19,7 +19,9 @@
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 // Implementation of internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h"
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
-    
-}  // namespace internal
-}  // namespace bigquery_v2_minimal
+namespace bigquery_v2_minimal_internal {
+
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_IDEMPOTENCY_POLICY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_IDEMPOTENCY_POLICY_H
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_IDEMPOTENCY_POLICY_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
@@ -17,10 +17,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/version.h"
+
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 // Internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_IDEMPOTENCY_POLICY_H
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 // Implementation of internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_logging.h"
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
-    
-}  // namespace internal
-}  // namespace bigquery_v2_minimal
+namespace bigquery_v2_minimal_internal {
+
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#include "google/cloud/bigquery/v2/minimal/internal/job_logging.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+    
+}  // namespace internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
@@ -19,7 +19,9 @@
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_LOGGING_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_LOGGING_H
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_LOGGING_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 // Internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_LOGGING_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_LOGGING_H
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.h
@@ -17,10 +17,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_LOGGING_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_LOGGING_H
 
+#include "google/cloud/version.h"
+
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 // Implementation of internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_metadata.h"
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
-    
-}  // namespace internal
-}  // namespace bigquery_v2_minimal
+namespace bigquery_v2_minimal_internal {
+
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
@@ -19,7 +19,9 @@
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#include "google/cloud/bigquery/v2/minimal/internal/job_metadata.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+    
+}  // namespace internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
@@ -17,10 +17,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_METADATA_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_METADATA_H
 
+#include "google/cloud/version.h"
+
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_METADATA_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_METADATA_H
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_METADATA_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 // Internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_METADATA_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_METADATA_H
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_options.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 // Implementation of internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_options.h"
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
-    
-}  // namespace internal
-}  // namespace bigquery_v2_minimal
+namespace bigquery_v2_minimal_internal {
+
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_options.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.cc
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#include "google/cloud/bigquery/v2/minimal/internal/job_options.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+    
+}  // namespace internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_options.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.cc
@@ -19,7 +19,9 @@
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_options.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.h
@@ -17,10 +17,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_OPTIONS_H
 
+#include "google/cloud/version.h"
+
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_options.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 // Internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_OPTIONS_H
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_options.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_OPTIONS_H
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_OPTIONS_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 // Implementation of internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h"
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
-    
-}  // namespace internal
-}  // namespace bigquery_v2_minimal
+namespace bigquery_v2_minimal_internal {
+
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.cc
@@ -19,7 +19,9 @@
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.cc
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#include "google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+    
+}  // namespace internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h
@@ -17,10 +17,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_CONNECTION_IMPL_H
 
+#include "google/cloud/version.h"
+
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_CONNECTION_IMPL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_CONNECTION_IMPL_H
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_CONNECTION_IMPL_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 // Internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_CONNECTION_IMPL_H
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -19,7 +19,9 @@
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 // Implementation of internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
-    
-}  // namespace internal
-}  // namespace bigquery_v2_minimal
+namespace bigquery_v2_minimal_internal {
+
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+    
+}  // namespace internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -17,10 +17,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
 
+#include "google/cloud/version.h"
+
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 // Internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
@@ -19,7 +19,9 @@
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 // Implementation of internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h"
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Intenal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_FACTORY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_FACTORY_H
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_FACTORY_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 // Internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_FACTORY_H
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Intenal interface for Bigquery V2 Job resource.
+// Internal interface for Bigquery V2 Job resource.
 // Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_FACTORY_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.h
@@ -17,10 +17,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_FACTORY_H
 
+#include "google/cloud/version.h"
+
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_retry_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_retry_policy.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal interface for Bigquery V2 Job resource.
+// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RETRY_POLICY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RETRY_POLICY_H
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal {
+namespace internal {
+
+}  // internal
+}  // namespace bigquery_v2_minimal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RETRY_POLICY_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_retry_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_retry_policy.h
@@ -17,10 +17,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RETRY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RETRY_POLICY_H
 
+#include "google/cloud/version.h"
+
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_retry_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_retry_policy.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 // Internal interface for Bigquery V2 Job resource.
-// Source: //depot/google3/google/cloud/bigquery/v2/job.proto
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RETRY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RETRY_POLICY_H
 
 namespace google {
 namespace cloud {
-namespace bigquery_v2_minimal {
-namespace internal {
+namespace bigquery_v2_minimal_internal {
 
-}  // internal
-}  // namespace bigquery_v2_minimal
+}  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
 


### PR DESCRIPTION
Initial mostly empty files for the Bigquery V2 job API.

For details please see design doc: go/bq-odbc-client-design

I have run checkers-pr, clang-tidy-pr for bigquery. Running it from root was taking a very long time even the second time around.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10733)
<!-- Reviewable:end -->
