### PR TITLE
impl(otel): process gRPC Client Context

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/options.h"
 #include <grpcpp/grpcpp.h>
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -65,8 +65,7 @@ void InjectTraceContext(grpc::ClientContext& context, Options const& options);
  * The span is ended. The original value is returned, for the sake of
  * composition.
  *
- * Note that this function should be called after the server has filled in the
- * relevant information, such as the peer.
+ * Note that this function should be called after the RPC has finished.
  */
 template <typename T>
 T EndSpan(grpc::ClientContext& context, opentelemetry::trace::Span& span,

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -38,6 +38,7 @@ using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
 using ::google::cloud::testing_util::SpanNamed;
 using ::google::cloud::testing_util::SpanWithStatus;
+using ::testing::_;
 using ::testing::AllOf;
 using ::testing::ElementsAre;
 using ::testing::Pair;
@@ -92,10 +93,11 @@ TEST(OpenTelemetry, EndSpan) {
   auto spans = span_catcher->GetSpans();
   // It is too hard to mock a `grpc::ClientContext`. We will just check that the
   // expected attribute key is set.
-  EXPECT_THAT(spans,
-              ElementsAre(AllOf(
-                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(SpanAttribute<std::string>("grpc.peer")))));
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)))));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
@@ -36,6 +37,7 @@ using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
 using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::SpanWithStatus;
 using ::testing::AllOf;
 using ::testing::ElementsAre;
 using ::testing::Pair;
@@ -77,6 +79,23 @@ TEST(OpenTelemetry, InjectTraceContextGrpc) {
   testing_util::ValidateMetadataFixture fixture;
   auto md = fixture.GetMetadata(context);
   EXPECT_THAT(md, ElementsAre(Pair("x-test-key", "test-value")));
+}
+
+TEST(OpenTelemetry, EndSpan) {
+  auto span_catcher = InstallSpanCatcher();
+
+  grpc::ClientContext context;
+  auto span = MakeSpanGrpc("google.cloud.foo.v1.Foo", "GetBar");
+  auto status = EndSpan(context, *span, Status());
+  EXPECT_STATUS_OK(status);
+
+  auto spans = span_catcher->GetSpans();
+  // It is too hard to mock a `grpc::ClientContext`. We will just check that the
+  // expected attribute key is set.
+  EXPECT_THAT(spans,
+              ElementsAre(AllOf(
+                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                  SpanHasAttributes(SpanAttribute<std::string>("grpc.peer")))));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -111,15 +111,8 @@ template <typename... Args>
 template <typename T>
 ::testing::Matcher<
     std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>>
-SpanAttribute(std::string const& key) {
-  return ::testing::Pair(key, ::testing::VariantWith<T>(::testing::_));
-}
-
-template <typename T>
-::testing::Matcher<
-    std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>>
-SpanAttribute(std::string const& key, T value) {
-  return ::testing::Pair(key, ::testing::VariantWith<T>(value));
+SpanAttribute(std::string const& key, ::testing::Matcher<T const&> matcher) {
+  return ::testing::Pair(key, ::testing::VariantWith<T>(matcher));
 }
 
 /**

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -111,6 +111,13 @@ template <typename... Args>
 template <typename T>
 ::testing::Matcher<
     std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>>
+SpanAttribute(std::string const& key) {
+  return ::testing::Pair(key, ::testing::VariantWith<T>(::testing::_));
+}
+
+template <typename T>
+::testing::Matcher<
+    std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>>
 SpanAttribute(std::string const& key, T value) {
   return ::testing::Pair(key, ::testing::VariantWith<T>(value));
 }


### PR DESCRIPTION
Part of the work for #10489 

Introduce a method to extract relevant tracing info from a `grpc::ClientContext`.

The RPC Semantic Conventions would have us split up the peer URI into a port, IP address, IP version. Take on some technical debt by not initially doing this work.

gRPC has helpers to parse the URI, but they are an internal implementation. So leave a note for ourselves on where we can find a way to parse the URI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10735)
<!-- Reviewable:end -->
