### PR TITLE
ci: switch 'target' builds to Fedora:37

### DIFF
--- a/ci/cloudbuild/triggers/bazel-oldest-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-oldest-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: bazel-oldest-ci
 substitutions:
   _BUILD_NAME: bazel-oldest
-  _DISTRO: fedora-36-bazel
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/bazel-oldest-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-oldest-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: bazel-oldest-pr
 substitutions:
   _BUILD_NAME: bazel-oldest
-  _DISTRO: fedora-36-bazel
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/bazel-targets-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: bazel-targets-ci
 substitutions:
   _BUILD_NAME: bazel-targets
-  _DISTRO: fedora-36-bazel
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/bazel-targets-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: bazel-targets-pr
 substitutions:
   _BUILD_NAME: bazel-targets
-  _DISTRO: fedora-36-bazel
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: gcs-grpc-ci
 substitutions:
   _BUILD_NAME: gcs-grpc
-  _DISTRO: fedora-36-bazel
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: gcs-grpc-pr
 substitutions:
   _BUILD_NAME: gcs-grpc
-  _DISTRO: fedora-36-bazel
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/otel-disabled-bazel-ci.yaml
+++ b/ci/cloudbuild/triggers/otel-disabled-bazel-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: otel-disabled-bazel-ci
 substitutions:
   _BUILD_NAME: otel-disabled-bazel
-  _DISTRO: fedora-36-bazel
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/otel-disabled-bazel-pr.yaml
+++ b/ci/cloudbuild/triggers/otel-disabled-bazel-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: otel-disabled-bazel-pr
 substitutions:
   _BUILD_NAME: otel-disabled-bazel
-  _DISTRO: fedora-36-bazel
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:


### PR DESCRIPTION
These builds verify that several Bazel targets and configurations work correctly.  Seemed like a good idea to ugprade them together.

Part of the work for #10254

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10738)
<!-- Reviewable:end -->
