### PR TITLE
doc(grafeas): prepare for Fedora:37

### DIFF
--- a/google/cloud/grafeas/CMakeLists.txt
+++ b/google/cloud/grafeas/CMakeLists.txt
@@ -15,17 +15,6 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Grafeas API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Grafeas API")
-set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
-set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "grafeas_internal" "grafeas_testing"
-                            "examples")
-# set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
-# ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
-
-include(GoogleCloudCppDoxygen)
-google_cloud_cpp_doxygen_targets("grafeas" DEPENDS cloud-docs
-                                 google-cloud-cpp::grafeas_protos)
 
 include(GoogleCloudCppCommon)
 


### PR DESCRIPTION
The `grafeas` library has nothing but protos, and therefore no input for Doxygen.  Newer versions of Doxygen reject empty input lists, and we do not even upload the output anywhere.  Seems better to save time by not generating a documentation set that is empty and unused.

Part of the work for #10254

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10746)
<!-- Reviewable:end -->
