### PR TITLE
ci: deflake checks and check-api builds

### DIFF
--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -24,6 +24,7 @@ ARG ARCH=amd64
 RUN dnf makecache && \
     dnf install -y \
         cargo \
+        cmake \
         clang-tools-extra \
         diffutils \
         findutils \

--- a/ci/generate-markdown/generate-readme.sh
+++ b/ci/generate-markdown/generate-readme.sh
@@ -34,17 +34,13 @@ file="README.md"
 ) | sponge "${file}"
 
 (
-  mapfile -t libraries < <(bazelisk --batch query \
-    --noshow_progress --noshow_loading_progress \
-    'kind(cc_library, //:all) except filter("experimental|mocks|common|grpc_utils", kind(cc_library, //:all))' |
-    sed -e 's;//:;;' |
-    LC_ALL=C sort)
+  mapfile -t libraries < <(cmake -DCMAKE_MODULE_PATH="${PWD}/cmake" -P cmake/print-ga-libraries.cmake 2>&1 | LC_ALL=C sort)
   sed '/<!-- inject-GA-libraries-start -->/q' "${file}"
   for library in "${libraries[@]}"; do
     description="$(sed -n '1 s/# \(.*\) C++ Client Library/\1/p' "google/cloud/${library}/README.md")"
-    printf '* [%s](google/cloud/%s/README.md)\n' "${description}" "${library}"
-    printf '  [[quickstart]](google/cloud/%s/quickstart/README.md)\n' "${library}"
-    printf '  [[reference]](https://googleapis.dev/cpp/google-cloud-%s/latest)\n' "${library}"
+    printf -- '- [%s](google/cloud/%s/README.md)\n' "${description}" "${library}"
+    printf -- '  [[quickstart]](google/cloud/%s/quickstart/README.md)\n' "${library}"
+    printf -- '  [[reference]](https://googleapis.dev/cpp/google-cloud-%s/latest)\n' "${library}"
   done
   sed -n '/<!-- inject-GA-libraries-end -->/,$p' "${file}"
 ) | sponge "${file}"

--- a/cmake/print-ga-libraries.cmake
+++ b/cmake/print-ga-libraries.cmake
@@ -1,0 +1,24 @@
+# ~~~
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# A CMake script to print the GA features.
+
+include(GoogleCloudCppFeatures)
+
+foreach (feature IN LISTS GOOGLE_CLOUD_CPP_GA_LIBRARIES
+                          GOOGLE_CLOUD_CPP_TRANSITION_LIBRARIES)
+    message(${feature})
+endforeach ()


### PR DESCRIPTION
These builds used `bazel query` (or `bazelist query`) to discover the list of GA libraries. Starting bazel requires downloading dependencies, which can fail in the CI system. In normal Bazel builds we minimize these failures with some  `bazel fetch` before the build, but now that the list of GA libraries is in CMake there is a simpler and less flaky way to discover them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10754)
<!-- Reviewable:end -->
