### PR TITLE
impl(docfx): scaffolding for conversion functions

### DIFF
--- a/docfx/CMakeLists.txt
+++ b/docfx/CMakeLists.txt
@@ -23,13 +23,17 @@ if (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     return()
 endif ()
 
+find_package(pugixml CONFIG REQUIRED)
+
 include(EnableWerror)
 
-add_library(docfx # cmake-format: sort
-            parse_arguments.cc parse_arguments.h)
+add_library(
+    docfx # cmake-format: sort
+    doxygen2markdown.cc doxygen2markdown.h parse_arguments.cc parse_arguments.h)
 google_cloud_cpp_add_common_options(docfx)
 target_include_directories(docfx PUBLIC "${PROJECT_SOURCE_DIR}")
 target_compile_features(docfx PUBLIC cxx_std_17)
+target_link_libraries(docfx PUBLIC pugixml::pugixml)
 
 add_executable(doxygen2docfx doxygen2docfx.cc)
 target_link_libraries(doxygen2docfx PUBLIC docfx)
@@ -42,7 +46,7 @@ if (NOT BUILD_TESTING)
 endif ()
 
 set(unit_tests # cmake-format: sort
-               "parse_arguments_test.cc")
+               "doxygen2markdown_test.cc" "parse_arguments_test.cc")
 
 foreach (fname IN LISTS unit_tests)
     google_cloud_cpp_add_executable(target "docfx" "${fname}")

--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -22,20 +22,15 @@ namespace {
 [[noreturn]] void UnknownChildType(std::string_view where,
                                    pugi::xml_node const& child) {
   std::ostringstream os;
-  os << "Unknown child in " << where << "(): name=" << child.name();
-  os << ", attributes=[";
-  for (auto const& a : child.attributes()) {
-    os << ", " << a.name() << "=" << a.as_string();
-  }
-  os << "]";
-  child.print(os);
+  os << "Unknown child in " << where << "(): node=";
+  child.print(os, /*indent=*/"", /*flags=*/pugi::format_raw);
   throw std::runtime_error(std::move(os).str());
 }
 
 }  // namespace
 
 bool AppendIfPlainText(std::ostream& os, pugi::xml_node const& node) {
-  if (node.name() != std::string_view{} || !node.attributes().empty()) {
+  if (!std::string_view{node.name()}.empty() || !node.attributes().empty()) {
     return false;
   }
   os << node.value();
@@ -43,13 +38,13 @@ bool AppendIfPlainText(std::ostream& os, pugi::xml_node const& node) {
 }
 
 bool AppendIfComputerOutput(std::ostream& os, pugi::xml_node const& node) {
-  if (node.name() != std::string_view{"computeroutput"}) return false;
+  if (std::string_view{node.name()} != "computeroutput") return false;
   os << '`' << node.child_value() << '`';
   return true;
 }
 
 bool AppendIfParagraph(std::ostream& os, pugi::xml_node const& node) {
-  if (node.name() != std::string_view{"para"}) return false;
+  if (std::string_view{node.name()} != "para") return false;
   for (auto const& child : node) {
     if (AppendIfPlainText(os, child)) continue;
     if (AppendIfComputerOutput(os, child)) continue;

--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -1,0 +1,60 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "docfx/doxygen2markdown.h"
+#include <iostream>
+#include <sstream>
+#include <string_view>
+
+namespace {
+
+[[noreturn]] void UnknownChildType(std::string_view where,
+                                   pugi::xml_node const& child) {
+  std::ostringstream os;
+  os << "Unknown child in " << where << "(): name=" << child.name();
+  os << ", attributes=[";
+  for (auto const& a : child.attributes()) {
+    os << ", " << a.name() << "=" << a.as_string();
+  }
+  os << "]";
+  child.print(os);
+  throw std::runtime_error(std::move(os).str());
+}
+
+}  // namespace
+
+bool AppendIfPlainText(std::ostream& os, pugi::xml_node const& node) {
+  if (node.name() != std::string_view{} || !node.attributes().empty()) {
+    return false;
+  }
+  os << node.value();
+  return true;
+}
+
+bool AppendIfComputerOutput(std::ostream& os, pugi::xml_node const& node) {
+  if (node.name() != std::string_view{"computeroutput"}) return false;
+  os << '`' << node.child_value() << '`';
+  return true;
+}
+
+bool AppendIfParagraph(std::ostream& os, pugi::xml_node const& node) {
+  if (node.name() != std::string_view{"para"}) return false;
+  for (auto const& child : node) {
+    if (AppendIfPlainText(os, child)) continue;
+    if (AppendIfComputerOutput(os, child)) continue;
+    UnknownChildType(__func__, child);
+  }
+  os << "\n";
+  return true;
+}

--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -1,0 +1,25 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2MARKDOWN_H
+#define GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2MARKDOWN_H
+
+#include <iosfwd>
+#include <pugixml.hpp>
+
+bool AppendIfPlainText(std::ostream& os, pugi::xml_node const& node);
+bool AppendIfComputerOutput(std::ostream& os, pugi::xml_node const& node);
+bool AppendIfParagraph(std::ostream& os, pugi::xml_node const& node);
+
+#endif  // GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2MARKDOWN_H

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -1,0 +1,72 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "docfx/doxygen2markdown.h"
+#include <gmock/gmock.h>
+#include <sstream>
+
+namespace {
+
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+TEST(Doxygen2Markdown, PlainText) {
+  pugi::xml_document doc;
+  doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <para id="plain-text">test-only-value 42</para>
+    </doxygen>)xml");
+  auto selected = doc.select_node("//*[@id='plain-text']");
+  ASSERT_TRUE(selected);
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfPlainText(os, *selected.node().children().begin()));
+  EXPECT_EQ(os.str(), "test-only-value 42");
+}
+
+TEST(Doxygen2Markdown, ComputerOutput) {
+  pugi::xml_document doc;
+  doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <computeroutput id="test-node">int f() { return 42; }</computeroutput>
+    </doxygen>)xml");
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfComputerOutput(os, selected.node()));
+  EXPECT_EQ(os.str(), "`int f() { return 42; }`");
+}
+
+TEST(Doxygen2Markdown, Paragraph) {
+  pugi::xml_document doc;
+  doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <para id='test-node'>Try using <computeroutput id="test-node">int f() { return 42; }</computeroutput> in your code.</para>
+    </doxygen>)xml");
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfParagraph(os, selected.node()));
+  EXPECT_EQ(os.str(), "Try using `int f() { return 42; }` in your code.\n");
+}
+
+TEST(Doxygen2Markdown, ParagraphWithUnknown) {
+  pugi::xml_document doc;
+  doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <para id='test-node'>Uh oh: <itemizedlist></itemizedlist></para>
+    </doxygen>)xml");
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  EXPECT_THROW(AppendIfParagraph(os, selected.node()), std::runtime_error);
+}
+
+}  // namespace

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -87,7 +87,8 @@ TEST(Doxygen2Markdown, ParagraphWithUnknownOutput) {
         AppendIfParagraph(os, selected.node());
       } catch (std::runtime_error const& ex) {
         EXPECT_THAT(ex.what(), Not(HasSubstr("\n")));
-        EXPECT_THAT(ex.what(), HasSubstr("<itemizedlist a1=\"attr1\" a2=\"attr2\">"));
+        EXPECT_THAT(ex.what(),
+                    HasSubstr("<itemizedlist a1=\"attr1\" a2=\"attr2\">"));
         EXPECT_THAT(ex.what(), HasSubstr("<listitem>1</listitem>"));
         EXPECT_THAT(ex.what(), HasSubstr("<listitem>2</listitem>"));
         EXPECT_THAT(ex.what(), HasSubstr("</itemizedlist>"));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,6 +27,10 @@
     "protobuf",
     "nlohmann-json",
     "benchmark",
-    "gtest"
+    "gtest",
+    {
+      "name": "pugixml",
+      "$description": "Only used for the docfx feature"
+    }
   ]
 }


### PR DESCRIPTION
This PR introduces the first function to convert simple paragraphs in Doxygen XML to MarkDown strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10763)
<!-- Reviewable:end -->
