### PR TITLE
impl(generator): limit backwards-compatibility namespace alias

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -1188,18 +1188,22 @@ std::vector<std::unique_ptr<GeneratorInterface>> MakeGenerators(
       service_vars.find("generate_rest_transport");
   if (generate_rest_transport != service_vars.end() &&
       generate_rest_transport->second == "true") {
+    // All REST interfaces postdate the change to the format of our inline
+    // namespace name, so we never need to add a backwards-compatibility alias.
+    auto rest_service_vars = service_vars;
+    rest_service_vars.erase("backwards_compatibility_namespace_alias");
     code_generators.push_back(absl::make_unique<ConnectionRestGenerator>(
-        service, service_vars, method_vars, context));
+        service, rest_service_vars, method_vars, context));
     code_generators.push_back(absl::make_unique<ConnectionImplRestGenerator>(
-        service, service_vars, method_vars, context));
+        service, rest_service_vars, method_vars, context));
     code_generators.push_back(absl::make_unique<LoggingDecoratorRestGenerator>(
-        service, service_vars, method_vars, context));
+        service, rest_service_vars, method_vars, context));
     code_generators.push_back(absl::make_unique<MetadataDecoratorRestGenerator>(
-        service, service_vars, method_vars, context));
+        service, rest_service_vars, method_vars, context));
     code_generators.push_back(absl::make_unique<StubFactoryRestGenerator>(
-        service, service_vars, method_vars, context));
+        service, rest_service_vars, method_vars, context));
     code_generators.push_back(absl::make_unique<StubRestGenerator>(
-        service, service_vars, method_vars, context));
+        service, rest_service_vars, method_vars, context));
   }
 
   return code_generators;

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -273,7 +273,7 @@ Status ServiceCodeGenerator::HeaderOpenForwardingNamespaces(
 
 void ServiceCodeGenerator::HeaderCloseNamespaces() {
   HeaderPrint("\n");
-  CloseNamespaces(header_);
+  CloseNamespaces(header_, define_backwards_compatibility_namespace_alias_);
 }
 
 Status ServiceCodeGenerator::CcOpenNamespaces(NamespaceType ns_type) {
@@ -283,7 +283,7 @@ Status ServiceCodeGenerator::CcOpenNamespaces(NamespaceType ns_type) {
 
 void ServiceCodeGenerator::CcCloseNamespaces() {
   CcPrint("\n");
-  CloseNamespaces(cc_);
+  CloseNamespaces(cc_, false);
 }
 
 void ServiceCodeGenerator::HeaderPrint(std::string const& text) {
@@ -372,12 +372,13 @@ Status ServiceCodeGenerator::OpenNamespaces(
   return {};
 }
 
-void ServiceCodeGenerator::CloseNamespaces(Printer& p) {
+void ServiceCodeGenerator::CloseNamespaces(
+    Printer& p, bool define_backwards_compatibility_namespace_alias) {
   for (auto iter = namespaces_.rbegin(); iter != namespaces_.rend(); ++iter) {
     if (*iter == "GOOGLE_CLOUD_CPP_NS") {
       p.Print("GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END\n");
       // TODO(#7463) - remove backwards compatibility namespaces
-      if (define_backwards_compatibility_namespace_alias_) {
+      if (define_backwards_compatibility_namespace_alias) {
         p.Print(
             "namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;"
             "  // NOLINT(misc-unused-alias-decls)\n");

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -198,7 +198,8 @@ class ServiceCodeGenerator : public GeneratorInterface {
 
   Status OpenNamespaces(Printer& p, NamespaceType ns_type,
                         std::string const& product_path_var);
-  void CloseNamespaces(Printer& p);
+  void CloseNamespaces(Printer& p,
+                       bool define_backwards_compatibility_namespace_alias);
 
   google::protobuf::ServiceDescriptor const* service_descriptor_;
   VarsDictionary service_vars_;

--- a/google/cloud/bigquery/bigquery_read_client.cc
+++ b/google/cloud/bigquery/bigquery_read_client.cc
@@ -80,7 +80,6 @@ BigQueryReadClient::SplitReadStream(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/bigquery_read_connection.cc
+++ b/google/cloud/bigquery/bigquery_read_connection.cc
@@ -81,7 +81,6 @@ std::shared_ptr<BigQueryReadConnection> MakeBigQueryReadConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.cc
@@ -51,7 +51,6 @@ MakeDefaultBigQueryReadConnectionIdempotencyPolicy() {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_auth_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_auth_decorator.cc
@@ -63,7 +63,6 @@ BigQueryReadAuth::SplitReadStream(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_connection_impl.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_connection_impl.cc
@@ -91,7 +91,6 @@ BigQueryReadConnectionImpl::SplitReadStream(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_logging_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_logging_decorator.cc
@@ -85,7 +85,6 @@ BigQueryReadLogging::SplitReadStream(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
@@ -79,7 +79,6 @@ void BigQueryReadMetadata::SetMetadata(grpc::ClientContext& context) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
@@ -59,7 +59,6 @@ Options BigQueryReadDefaultOptions(Options options) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_stub.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_stub.cc
@@ -70,7 +70,6 @@ DefaultBigQueryReadStub::SplitReadStream(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_stub_factory.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_stub_factory.cc
@@ -59,7 +59,6 @@ std::shared_ptr<BigQueryReadStub> CreateDefaultBigQueryReadStub(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_tracing_connection.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_tracing_connection.cc
@@ -70,7 +70,6 @@ MakeBigQueryReadTracingConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/internal/bigquery_read_tracing_stub.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_tracing_stub.cc
@@ -68,7 +68,6 @@ BigQueryReadTracingStub::SplitReadStream(
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/iam_client.cc
+++ b/google/cloud/iam/iam_client.cc
@@ -396,7 +396,6 @@ StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMClient::LintPolicy(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/iam_connection.cc
+++ b/google/cloud/iam/iam_connection.cc
@@ -209,7 +209,6 @@ std::shared_ptr<IAMConnection> MakeIAMConnection(Options options) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/iam_connection_idempotency_policy.cc
+++ b/google/cloud/iam/iam_connection_idempotency_policy.cc
@@ -181,7 +181,6 @@ MakeDefaultIAMConnectionIdempotencyPolicy() {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/iam_credentials_client.cc
+++ b/google/cloud/iam/iam_credentials_client.cc
@@ -115,7 +115,6 @@ IAMCredentialsClient::SignJwt(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/iam_credentials_connection.cc
+++ b/google/cloud/iam/iam_credentials_connection.cc
@@ -75,7 +75,6 @@ std::shared_ptr<IAMCredentialsConnection> MakeIAMCredentialsConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/iam_credentials_connection_idempotency_policy.cc
+++ b/google/cloud/iam/iam_credentials_connection_idempotency_policy.cc
@@ -61,7 +61,6 @@ MakeDefaultIAMCredentialsConnectionIdempotencyPolicy() {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_auth_decorator.cc
+++ b/google/cloud/iam/internal/iam_auth_decorator.cc
@@ -265,7 +265,6 @@ StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMAuth::LintPolicy(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_connection_impl.cc
+++ b/google/cloud/iam/internal/iam_connection_impl.cc
@@ -476,7 +476,6 @@ IAMConnectionImpl::LintPolicy(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_auth_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_auth_decorator.cc
@@ -67,7 +67,6 @@ IAMCredentialsAuth::SignJwt(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_connection_impl.cc
+++ b/google/cloud/iam/internal/iam_credentials_connection_impl.cc
@@ -90,7 +90,6 @@ IAMCredentialsConnectionImpl::SignJwt(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_logging_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_logging_decorator.cc
@@ -85,7 +85,6 @@ IAMCredentialsLogging::SignJwt(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
@@ -84,7 +84,6 @@ void IAMCredentialsMetadata::SetMetadata(grpc::ClientContext& context) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_credentials_option_defaults.cc
@@ -59,7 +59,6 @@ Options IAMCredentialsDefaultOptions(Options options) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_stub.cc
+++ b/google/cloud/iam/internal/iam_credentials_stub.cc
@@ -80,7 +80,6 @@ DefaultIAMCredentialsStub::SignJwt(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_stub_factory.cc
+++ b/google/cloud/iam/internal/iam_credentials_stub_factory.cc
@@ -60,7 +60,6 @@ std::shared_ptr<IAMCredentialsStub> CreateDefaultIAMCredentialsStub(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_tracing_connection.cc
+++ b/google/cloud/iam/internal/iam_credentials_tracing_connection.cc
@@ -79,7 +79,6 @@ MakeIAMCredentialsTracingConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_credentials_tracing_stub.cc
+++ b/google/cloud/iam/internal/iam_credentials_tracing_stub.cc
@@ -80,7 +80,6 @@ IAMCredentialsTracingStub::SignJwt(
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_logging_decorator.cc
+++ b/google/cloud/iam/internal/iam_logging_decorator.cc
@@ -372,7 +372,6 @@ StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMLogging::LintPolicy(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_metadata_decorator.cc
@@ -260,7 +260,6 @@ void IAMMetadata::SetMetadata(grpc::ClientContext& context) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_option_defaults.cc
@@ -57,7 +57,6 @@ Options IAMDefaultOptions(Options options) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_stub.cc
+++ b/google/cloud/iam/internal/iam_stub.cc
@@ -370,7 +370,6 @@ StatusOr<google::iam::admin::v1::LintPolicyResponse> DefaultIAMStub::LintPolicy(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_stub_factory.cc
+++ b/google/cloud/iam/internal/iam_stub_factory.cc
@@ -58,7 +58,6 @@ std::shared_ptr<IAMStub> CreateDefaultIAMStub(google::cloud::CompletionQueue cq,
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_tracing_connection.cc
+++ b/google/cloud/iam/internal/iam_tracing_connection.cc
@@ -266,7 +266,6 @@ std::shared_ptr<iam::IAMConnection> MakeIAMTracingConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/internal/iam_tracing_stub.cc
+++ b/google/cloud/iam/internal/iam_tracing_stub.cc
@@ -343,7 +343,6 @@ StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMTracingStub::LintPolicy(
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/database_admin_client.cc
+++ b/google/cloud/spanner/admin/database_admin_client.cc
@@ -400,7 +400,6 @@ DatabaseAdminClient::ListDatabaseRoles(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/database_admin_connection.cc
+++ b/google/cloud/spanner/admin/database_admin_connection.cc
@@ -184,7 +184,6 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.cc
+++ b/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.cc
@@ -139,7 +139,6 @@ MakeDefaultDatabaseAdminConnectionIdempotencyPolicy() {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/instance_admin_client.cc
+++ b/google/cloud/spanner/admin/instance_admin_client.cc
@@ -313,7 +313,6 @@ InstanceAdminClient::TestIamPermissions(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/instance_admin_connection.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection.cc
@@ -147,7 +147,6 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.cc
@@ -115,7 +115,6 @@ MakeDefaultInstanceAdminConnectionIdempotencyPolicy() {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_auth_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_auth_decorator.cc
@@ -289,7 +289,6 @@ future<Status> DatabaseAdminAuth::AsyncCancelOperation(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_connection_impl.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_connection_impl.cc
@@ -471,7 +471,6 @@ DatabaseAdminConnectionImpl::ListDatabaseRoles(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_logging_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_logging_decorator.cc
@@ -303,7 +303,6 @@ future<Status> DatabaseAdminLogging::AsyncCancelOperation(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
@@ -229,7 +229,6 @@ void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
@@ -72,7 +72,6 @@ Options DatabaseAdminDefaultOptions(Options options) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_stub.cc
@@ -313,7 +313,6 @@ future<Status> DefaultDatabaseAdminStub::AsyncCancelOperation(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_stub_factory.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_stub_factory.cc
@@ -62,7 +62,6 @@ std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_tracing_connection.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_tracing_connection.cc
@@ -217,7 +217,6 @@ MakeDatabaseAdminTracingConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/database_admin_tracing_stub.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_tracing_stub.cc
@@ -260,7 +260,6 @@ future<Status> DatabaseAdminTracingStub::AsyncCancelOperation(
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_auth_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_auth_decorator.cc
@@ -239,7 +239,6 @@ future<Status> InstanceAdminAuth::AsyncCancelOperation(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_connection_impl.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_connection_impl.cc
@@ -358,7 +358,6 @@ InstanceAdminConnectionImpl::TestIamPermissions(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_logging_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_logging_decorator.cc
@@ -250,7 +250,6 @@ future<Status> InstanceAdminLogging::AsyncCancelOperation(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
@@ -192,7 +192,6 @@ void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
@@ -72,7 +72,6 @@ Options InstanceAdminDefaultOptions(Options options) {
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_stub.cc
@@ -254,7 +254,6 @@ future<Status> DefaultInstanceAdminStub::AsyncCancelOperation(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_stub_factory.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_stub_factory.cc
@@ -62,7 +62,6 @@ std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_tracing_connection.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_tracing_connection.cc
@@ -172,7 +172,6 @@ MakeInstanceAdminTracingConnection(
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/admin/internal/instance_admin_tracing_stub.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_tracing_stub.cc
@@ -208,7 +208,6 @@ future<Status> InstanceAdminTracingStub::AsyncCancelOperation(
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace spanner_admin_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Do not emit backwards-compatibility namespace aliases in `cc` files,
where they're useless, or in REST APIs, where they're unnecessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10764)
<!-- Reviewable:end -->
