### PR TITLE
cleanup: rename `docfx` feature

### DIFF
--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -219,7 +219,7 @@ endfunction ()
 # additional samples that are enabled if needed.
 function (google_cloud_cpp_enable_features)
     foreach (feature ${GOOGLE_CLOUD_CPP_ENABLE})
-        if ("${feature}" STREQUAL "docfx")
+        if ("${feature}" STREQUAL "internal-docfx")
             add_subdirectory(docfx)
         elseif ("${feature}" STREQUAL "generator")
             add_subdirectory(generator)


### PR DESCRIPTION
Use `internal-docfx` to explicitly label this as a feature intended only for internal use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10766)
<!-- Reviewable:end -->
