### PR TITLE
cleanup: remove/clarify empty statements

### DIFF
--- a/google/cloud/internal/async_connection_ready_test.cc
+++ b/google/cloud/internal/async_connection_ready_test.cc
@@ -57,8 +57,7 @@ TEST(CompletionQueueTest, SuccessfulWaitingForConnection) {
   std::thread srv_thread([&] {
     bool ok;
     void* placeholder;
-    while (srv_cq->Next(&placeholder, &ok))
-      ;
+    while (srv_cq->Next(&placeholder, &ok)) continue;
   });
   auto server = builder.BuildAndStart();
 

--- a/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
@@ -353,11 +353,9 @@ TEST_F(SubscriptionConcurrencyControlTest, CleanShutdown) {
   EXPECT_CALL(*source, AckMessage).Times(AtLeast(1)).WillRepeatedly([] {
     return make_ready_future(Status{});
   });
-  ;
   EXPECT_CALL(*source, NackMessage).Times(AtLeast(1)).WillRepeatedly([] {
     return make_ready_future(Status{});
   });
-  ;
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads background(4);
 
@@ -425,7 +423,6 @@ TEST_F(SubscriptionConcurrencyControlTest, CleanShutdownEarlyAcks) {
   EXPECT_CALL(*source, AckMessage).Times(AtLeast(1)).WillRepeatedly([] {
     return make_ready_future(Status{});
   });
-  ;
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads background(4);
 

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3724,7 +3724,6 @@ void PartitionQuery(google::cloud::spanner::Client client) {
       remote_connection.ReceiveQueryPartitionFromRemoteMachine();
   if (!partition) throw std::move(partition).status();
   for (auto& row : client.ExecuteQuery(*partition)) {
-    ;
     if (!row) throw std::move(row).status();
     ProcessRow(*row);
   }

--- a/google/cloud/testing_util/validate_metadata.cc
+++ b/google/cloud/testing_util/validate_metadata.cc
@@ -238,10 +238,8 @@ ValidateMetadataFixture::~ValidateMetadataFixture() {
   // Drain completion queues.
   void* placeholder;
   bool ok;
-  while (srv_cq_->Next(&placeholder, &ok))
-    ;
-  while (cli_cq_.Next(&placeholder, &ok))
-    ;
+  while (srv_cq_->Next(&placeholder, &ok)) continue;
+  while (cli_cq_.Next(&placeholder, &ok)) continue;
 }
 
 std::multimap<std::string, std::string> ValidateMetadataFixture::GetMetadata(


### PR DESCRIPTION
For empty loop bodies I chose `continue` instead of `{}` as it is more visually distinctive, and a future edit will be more obvious.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10769)
<!-- Reviewable:end -->
