### PR TITLE
ci: add `docfx` to clang-tidy build

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -25,7 +25,13 @@ export CC=clang
 export CXX=clang++
 export CTCACHE_DIR=~/.cache/ctcache
 read -r ENABLED_FEATURES < <(features::always_build_cmake)
-ENABLED_FEATURES="${ENABLED_FEATURES},experimental-storage-grpc,generator"
+# Add some features that we don't always build, but we want to run clang-tidy
+# over them.
+ENABLED_FEATURES="${ENABLED_FEATURES},experimental-storage-grpc"
+ENABLED_FEATURES="${ENABLED_FEATURES},generator"
+ENABLED_FEATURES="${ENABLED_FEATURES},internal-docfx"
+readonly ENABLED_FEATURES
+
 mapfile -t cmake_args < <(cmake::common_args)
 
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache

--- a/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
@@ -39,6 +39,9 @@ RUN dnf makecache && dnf install -y java-latest-openjdk
 RUN dnf makecache && dnf install -y "dnf-command(debuginfo-install)"
 RUN dnf makecache && dnf debuginfo-install -y libstdc++
 
+# This is used by the docfx tool.
+RUN dnf makecache && dnf install -y pugixml-devel
+
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -19,7 +19,6 @@
 namespace {
 
 using ::testing::HasSubstr;
-using ::testing::IsEmpty;
 using ::testing::Not;
 
 TEST(Doxygen2Markdown, PlainText) {


### PR DESCRIPTION
This needs installing a package in the Docker image, and enabling the feature in the build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10771)
<!-- Reviewable:end -->
