### PR TITLE
cleanup: update some reference links

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -234,7 +234,7 @@ which sadly forces our users to reach into the `internal` namespace to mock
 things.  Furthermore, some of the `RawClient` decorators should be called
 `*Stub`.
 
-[check-expected-example-link]: https://github.com/googleapis/google-cloud-cpp/blob/6bd0fae69af98939a1ba4fedea7bb20366ad15d9/google/cloud/spanner/client.cc#L358-L360
+[check-expected-example-link]: https://github.com/googleapis/google-cloud-cpp/blob/0288f8c00dd21de2fb012c517155b300667edc5c/google/cloud/spanner/client.cc#L335-L338
 [client-options-link]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/storage/client_options.h
 [common-options-link]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/common_options.h
 [grpc-options-link]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/grpc_options.h

--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -267,4 +267,4 @@ git commit -m"Manually update READMEs, quickstart, and top-level stuff" \
 ```
 
 [#10237]: https://github.com/googleapis/google-cloud-cpp/issues/10237
-[retryable-status-codes]: https://github.com/googleapis/googleapis/blob/0fea253787a4f2769b97b0ed3a8f5b28ef17ffa7/google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json#L77-L80
+[retryable-status-codes]: https://github.com/googleapis/googleapis/blob/70147caca58ebf4c8cd7b96f5d569a72723e11c1/google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json#L77-L80

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
@@ -409,7 +409,7 @@ class GoldenKitchenSinkClient {
   /// An RPC to test that explicit routing headers are supported.
   ///
   /// We copy the most testing example given in the `google.api.routing` proto:
-  /// https://github.com/googleapis/googleapis/blob/f46dc249e1987a6bef1a70a371e8288ea4c17481/google/api/routing.proto#L353-L385
+  /// https://github.com/googleapis/googleapis/blob/70147caca58ebf4c8cd7b96f5d569a72723e11c1/google/api/routing.proto#L353-L385
   ///
   /// Our integration test should verify that, given the message:
   ///

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -873,7 +873,7 @@ service GoldenKitchenSink {
   // An RPC to test that explicit routing headers are supported.
   //
   // We copy the most testing example given in the `google.api.routing` proto:
-  // https://github.com/googleapis/googleapis/blob/f46dc249e1987a6bef1a70a371e8288ea4c17481/google/api/routing.proto#L353-L385
+  // https://github.com/googleapis/googleapis/blob/70147caca58ebf4c8cd7b96f5d569a72723e11c1/google/api/routing.proto#L353-L385
   //
   // Our integration test should verify that, given the message:
   //
@@ -1344,7 +1344,7 @@ message ListServiceAccountKeysResponse {
 }
 
 // We use the following message for our integration test, as defined here:
-// https://github.com/googleapis/googleapis/blob/f46dc249e1987a6bef1a70a371e8288ea4c17481/google/api/routing.proto#L40-L53
+// https://github.com/googleapis/googleapis/blob/70147caca58ebf4c8cd7b96f5d569a72723e11c1/google/api/routing.proto#L40-L53
 message ExplicitRoutingRequest {
   // The name of the Table
   // Values can be of the following formats:

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -318,7 +318,7 @@ TEST_F(MetadataDecoratorTest, ExplicitRouting) {
   // In this test, we will use the request message provided in the
   // `google.api.routing` examples:
   //
-  // https://github.com/googleapis/googleapis/blob/f46dc249e1987a6bef1a70a371e8288ea4c17481/google/api/routing.proto#L57-L60
+  // https://github.com/googleapis/googleapis/blob/70147caca58ebf4c8cd7b96f5d569a72723e11c1/google/api/routing.proto#L57-L60
   google::test::admin::database::v1::ExplicitRoutingRequest request;
   request.set_table_name(
       "projects/proj_foo/instances/instance_bar/tables/table_baz");
@@ -327,7 +327,7 @@ TEST_F(MetadataDecoratorTest, ExplicitRouting) {
   // We verify the routing metadata against the expectations provided in
   // `google.api.routing` for Example 9:
   //
-  // https://github.com/googleapis/googleapis/blob/f46dc249e1987a6bef1a70a371e8288ea4c17481/google/api/routing.proto#L387-L390
+  // https://github.com/googleapis/googleapis/blob/70147caca58ebf4c8cd7b96f5d569a72723e11c1/google/api/routing.proto#L387-L390
   std::string expected1 = "table_location=instances/instance_bar";
   std::string expected2 = "routing_id=prof_qux";
 

--- a/google/cloud/bigtable/doc/bigtable-main.dox
+++ b/google/cloud/bigtable/doc/bigtable-main.dox
@@ -67,7 +67,7 @@ library.
 [google-cloud-cpp]: https://github.com/googleapis/google-cloud-cpp
 [project-readme]:   https://github.com/googleapis/google-cloud-cpp#readme
 [project-build]:    https://github.com/googleapis/google-cloud-cpp#building-and-installing
-[howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/tree/main/doc/contributor/howto-guide-setup-development-workstation.md
+[howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/contributor/howto-guide-setup-development-workstation.md
 [github-readme]:    https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/bigtable#readme
 [quickstart guide]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/bigtable/quickstart#readme
 [packaging guide]:  https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd

--- a/google/cloud/bigtable/tools/convert_acceptance_tests.py
+++ b/google/cloud/bigtable/tools/convert_acceptance_tests.py
@@ -25,7 +25,7 @@ parser.
 
 Usage:
   curl -L \
-   https://raw.githubusercontent.com/googleapis/conformance-tests/master/bigtable/v2/readrows.json |
+   https://raw.githubusercontent.com/googleapis/conformance-tests/main/bigtable/v2/readrows.json |
   python3 ../tools/convert_acceptance_tests.py |
   clang-format >readrowsparser_acceptance_tests.inc
 

--- a/google/cloud/capture_build_info.bzl
+++ b/google/cloud/capture_build_info.bzl
@@ -29,7 +29,7 @@ https://github.com/bazelbuild/rules_cc/blob/main/examples/my_c_compile/my_c_comp
 
 I found this fragment particularly useful:
 
-https://github.com/bazelbuild/rules_cc/blob/58f8e026c00a8a20767e3dc669f46ba23bc93bdb/examples/my_c_compile/my_c_compile.bzl#L40-L51
+https://github.com/bazelbuild/rules_cc/blob/0d68932a68bcd6f332b14ccc561990586de2318d/examples/my_c_compile/my_c_compile.bzl#L40-L51
 """
 
 load("@rules_cc//cc:action_names.bzl", "CPP_COMPILE_ACTION_NAME")

--- a/google/cloud/iam/quickstart/README.md
+++ b/google/cloud/iam/quickstart/README.md
@@ -156,7 +156,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 
 [authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started "Authentication Getting Started"
 [bazel-grpc-macos-bug]: https://github.com/bazelbuild/bazel/issues/4341
-[bazel-install]: https://docs.bazel.build/versions/master/install.html
+[bazel-install]: https://docs.bazel.build/versions/main/install.html
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -38,7 +38,7 @@ namespace {
  *
  * This code originates from the following example:
  *
- * https://github.com/open-telemetry/opentelemetry-cpp/blob/a343da043e1351c3cc3003bfce94724345ee22f1/examples/grpc/tracer_common.h#L26-L45
+ * https://github.com/open-telemetry/opentelemetry-cpp/blob/d56a5c702fc2154ef82400df4801cd511ffb63ea/examples/grpc/tracer_common.h#L26-L45
  *
  * [carrier]:
  * https://opentelemetry.io/docs/reference/specification/context/api-propagators/#carrier

--- a/google/cloud/internal/time_utils.h
+++ b/google/cloud/internal/time_utils.h
@@ -29,7 +29,7 @@ namespace internal {
 // These functions convert between an `absl::Time` and a
 // `google::protobuf::Timestamp` proto. The required format for the Timestamp
 // proto is documented in this file:
-// https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
+// https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/timestamp.proto
 //
 // In particular, the Timestamp proto must:
 // * be in the range ["0001-01-01T00:00:00Z", "9999-12-31T23:59:59.999999999Z"]

--- a/google/cloud/pubsub/doc/pubsub-main.dox
+++ b/google/cloud/pubsub/doc/pubsub-main.dox
@@ -54,7 +54,7 @@ library.
 
 [project-readme]:  https://github.com/googleapis/google-cloud-cpp#readme
 [project-build]:   https://github.com/googleapis/google-cloud-cpp#building-and-installing
-[howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/tree/main/doc/contributor/howto-guide-setup-development-workstation.md
+[howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/contributor/howto-guide-setup-development-workstation.md
 [github-readme]:    https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/pubsub#readme
 [quickstart guide]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/pubsub/quickstart#readme
 [packaging guide]:  https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -36,7 +36,7 @@ into your project.
 [google-cloud-cpp]: https://github.com/googleapis/google-cloud-cpp
 [project-readme]:   https://github.com/googleapis/google-cloud-cpp#readme
 [project-build]:    https://github.com/googleapis/google-cloud-cpp#building-and-installing
-[howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/tree/main/doc/contributor/howto-guide-setup-development-workstation.md
+[howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/contributor/howto-guide-setup-development-workstation.md
 [github-readme]:    https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/bigtable#readme
 [quickstart guide]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/bigtable/quickstart#readme
 [packaging guide]:  https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd

--- a/google/cloud/spanner/partition_options.h
+++ b/google/cloud/spanner/partition_options.h
@@ -33,7 +33,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * See documentation in [spanner.proto][spanner-proto].
  *
  * [spanner-proto]:
- * https://github.com/googleapis/googleapis/blob/0ed34e9fdf601dfc37eb24c40e17495b86771ff4/google/spanner/v1/spanner.proto#L651
+ * https://github.com/googleapis/googleapis/blob/70147caca58ebf4c8cd7b96f5d569a72723e11c1/google/spanner/v1/spanner.proto#L758
  */
 struct PartitionOptions {
   /**

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -70,7 +70,7 @@ project.
 [github-link]:     https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 [project-readme]:  https://github.com/googleapis/google-cloud-cpp#readme
 [project-build]:   https://github.com/googleapis/google-cloud-cpp#building-and-installing
-[howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/tree/main/doc/contributor/howto-guide-setup-development-workstation.md
+[howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/contributor/howto-guide-setup-development-workstation.md
 [github-readme]:    https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage#readme
 [quickstart guide]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage/quickstart#readme
 [packaging guide]:  https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd

--- a/google/cloud/testing_util/mock_async_response_reader.h
+++ b/google/cloud/testing_util/mock_async_response_reader.h
@@ -35,8 +35,7 @@ namespace testing_util {
  * Destroy method below preserves that behavior even after
  * https://github.com/grpc/proposal/pull/238):
  *
- *
- *     https://github.com/grpc/grpc/blob/608188c680961b8506847c135b5170b41a9081e8/include/grpcpp/impl/codegen/async_unary_call.h#L305
+ *     https://github.com/grpc/grpc/blob/a3f10052090539cd3e19aa8e04f3bf8eceae2964/include/grpcpp/support/async_unary_call.h#L407
  *
  * No delete, no destructor, nothing. The gRPC library expects all
  * `grpc::ClientAsyncResponseReader<R>` objects to be allocated from a


### PR DESCRIPTION
Use more recent branch names, blobs, and paths.  Also, use "blob" instead of "tree" for file links (to avoid a forwarding step).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10774)
<!-- Reviewable:end -->
