### PR TITLE
cleanup: cater to platforms with 32-bit std::size_t

### DIFF
--- a/google/cloud/storage/tests/object_read_large_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_large_integration_test.cc
@@ -40,7 +40,7 @@ std::size_t CurrentRss() {
   std::vector<std::string> fields = absl::StrSplit(
       std::string{std::istreambuf_iterator<char>{is.rdbuf()}, {}}, ' ');
   // The fields are documented in proc(5).
-  return std::stoull(fields[1]) * 4096;
+  return static_cast<std::size_t>(std::stoull(fields[1])) * 4096;
 }
 
 std::string DebugRss() {


### PR DESCRIPTION
Explicitly cast the result of `std::stoull()` to `std::size_t`. This is safe because the value being cast is a count of memory pages in the 32-bit address space.

Addresses #10772.  Part of #10775.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10779)
<!-- Reviewable:end -->
