### PR TITLE
cleanup: cater to platforms with 32-bit std::streamsize

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
@@ -320,7 +320,9 @@ UploadDetail UploadOneObject(gcs::Client& client,
   while (object_bytes < upload.object_size) {
     auto n = std::min(static_cast<std::uint64_t>(buffer_size),
                       upload.object_size - object_bytes);
-    if (!stream.write(write_block.data(), n)) break;
+    if (!stream.write(write_block.data(), static_cast<std::streamsize>(n))) {
+      break;
+    }
     object_bytes += n;
   }
   stream.Close();


### PR DESCRIPTION
Explicitly cast a 64-bit value to `std::streamsize`.  This is safe because the value being cast is bounded by another value that originated as a `std::streamsize`.

Part of #10775.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10780)
<!-- Reviewable:end -->
