### PR TITLE
test(pubsub): avoid crashes in 32-bit builds

### DIFF
--- a/google/cloud/pubsub/internal/subscription_message_queue_test.cc
+++ b/google/cloud/pubsub/internal/subscription_message_queue_test.cc
@@ -506,8 +506,8 @@ TEST_P(SubscriptionMessageQueueOrderingTest, RespectOrderingKeysTorture) {
 
 INSTANTIATE_TEST_SUITE_P(
     SubscriptionMessageQueueOrderingTest, SubscriptionMessageQueueOrderingTest,
-    ::testing::Values(TestParams{1, 4, 1000}, TestParams{1, 1000, 1000},
-                      TestParams{8, 4, 1000}, TestParams{8, 1000, 1000}),
+    ::testing::Values(TestParams{1, 4, 1000}, TestParams{1, 64, 1000},
+                      TestParams{8, 4, 1000}, TestParams{8, 64, 1000}),
     ::testing::PrintToStringParamName());
 
 }  // namespace


### PR DESCRIPTION
This reduces the number of threads created by the test. AFAICT, each thread consumes 8MiB of virtual address space (not all of that committed), and the test was creating 1,000 threads. That is too large for a 32-bit address space.

Part of the work for #10775

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10785)
<!-- Reviewable:end -->
