### PR TITLE
test(spanner): avoid timeouts in 32-bit builds

### DIFF
--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -48,7 +48,7 @@ struct Config {
   std::chrono::seconds duration = std::chrono::seconds(5);
 
   int threads = 0;  // 0 means use the threads_per_core setting.
-  int threads_per_core = 4;
+  int threads_per_core = 3;
 
   bool show_help = false;
 };


### PR DESCRIPTION
Reduce the number of threads-per-core in `client_stress_test` from 4 to 3.  On a machine with a large number of processing units, this apparently reduces the number of threads enough to not exhaust the 32-bit address space.

Part of #10775.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10787)
<!-- Reviewable:end -->
