### PR TITLE
doc: de-dup endpoint environment-variable documentation

### DIFF
--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -43,13 +43,13 @@ which should give you a taste of the Cloud AutoML API C++ client library API.
 
 <!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_AUTO_ML_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "automl.googleapis.com")
-  used by `MakeAutoMlConnection()`.
-
 - `GOOGLE_CLOUD_CPP_AUTOML_PREDICTION_SERVICE_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "automl.googleapis.com")
   used by `MakePredictionServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_AUTO_ML_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "automl.googleapis.com")
+  used by `MakeAutoMlConnection()`.
 
 <!-- inject-endpoint-env-vars-end -->
 

--- a/google/cloud/bigquery/doc/main.dox
+++ b/google/cloud/bigquery/doc/main.dox
@@ -61,6 +61,10 @@ behaviors in the library.
   `EndpointOption` (which defaults to "analyticshub.googleapis.com")
   used by `MakeAnalyticsHubServiceConnection()`.
 
+- `GOOGLE_CLOUD_CPP_BIGQUERY_CONNECTION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "bigqueryconnection.googleapis.com")
+  used by `MakeConnection()`.
+
 - `GOOGLE_CLOUD_CPP_BIGQUERY_READ_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "bigquerystorage.googleapis.com")
   used by `MakeBigQueryReadConnection()`.
@@ -68,10 +72,6 @@ behaviors in the library.
 - `GOOGLE_CLOUD_CPP_BIGQUERY_WRITE_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "bigquerystorage.googleapis.com")
   used by `MakeBigQueryWriteConnection()`.
-
-- `GOOGLE_CLOUD_CPP_BIGQUERY_CONNECTION_SERVICE_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "bigqueryconnection.googleapis.com")
-  used by `MakeConnection()`.
 
 - `GOOGLE_CLOUD_CPP_DATA_POLICY_SERVICE_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "bigquerydatapolicy.googleapis.com")

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -57,13 +57,17 @@ which should give you a taste of the Dialogflow API C++ client library API.
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeDeploymentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
-  used by `MakeEntityTypesConnection()`.
-
 - `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeEnvironmentsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
+  used by `MakeVersionsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
+  used by `MakeEntityTypesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_EXPERIMENTS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
@@ -85,13 +89,13 @@ which should give you a taste of the Dialogflow API C++ client library API.
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeSecuritySettingsServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
-  used by `MakeSessionEntityTypesConnection()`.
-
 - `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeSessionsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
+  used by `MakeSessionEntityTypesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_TEST_CASES_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
@@ -100,10 +104,6 @@ which should give you a taste of the Dialogflow API C++ client library API.
 - `GOOGLE_CLOUD_CPP_TRANSITION_ROUTE_GROUPS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeTransitionRouteGroupsConnection()`.
-
-- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
-  used by `MakeVersionsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_WEBHOOKS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -57,6 +57,10 @@ which should give you a taste of the Dialogflow API C++ client library API.
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeContextsConnection()`.
 
+- `GOOGLE_CLOUD_CPP_CONVERSATIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
+  used by `MakeConversationsConnection()`.
+
 - `GOOGLE_CLOUD_CPP_CONVERSATION_DATASETS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeConversationDatasetsConnection()`.
@@ -69,9 +73,13 @@ which should give you a taste of the Dialogflow API C++ client library API.
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeConversationProfilesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_CONVERSATIONS_ENDPOINT=...` overrides the
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
-  used by `MakeConversationsConnection()`.
+  used by `MakeEnvironmentsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
+  used by `MakeVersionsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_DOCUMENTS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
@@ -80,10 +88,6 @@ which should give you a taste of the Dialogflow API C++ client library API.
 - `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeEntityTypesConnection()`.
-
-- `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
-  used by `MakeEnvironmentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_FULFILLMENTS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
@@ -101,17 +105,13 @@ which should give you a taste of the Dialogflow API C++ client library API.
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeParticipantsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
-  used by `MakeSessionEntityTypesConnection()`.
-
 - `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeSessionsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` overrides the
+- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
-  used by `MakeVersionsConnection()`.
+  used by `MakeSessionEntityTypesConnection()`.
 
 <!-- inject-endpoint-env-vars-end -->
 

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -57,13 +57,13 @@ which should give you a taste of the Cloud Monitoring API C++ client library API
   `EndpointOption` (which defaults to "monitoring.googleapis.com")
   used by `MakeGroupServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "monitoring.googleapis.com")
-  used by `MakeMetricServiceConnection()`.
-
 - `GOOGLE_CLOUD_CPP_METRICS_SCOPES_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "monitoring.googleapis.com")
   used by `MakeMetricsScopesConnection()`.
+
+- `GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeMetricServiceConnection()`.
 
 - `GOOGLE_CLOUD_CPP_NOTIFICATION_CHANNEL_SERVICE_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "monitoring.googleapis.com")

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -52,13 +52,13 @@ which should give you a taste of the Retail API C++ client library API.
   `EndpointOption` (which defaults to "retail.googleapis.com")
   used by `MakeCompletionServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_RETAIL_PREDICTION_SERVICE_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "retail.googleapis.com")
-  used by `MakePredictionServiceConnection()`.
-
 - `GOOGLE_CLOUD_CPP_PRODUCT_SERVICE_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "retail.googleapis.com")
   used by `MakeProductServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_RETAIL_PREDICTION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "retail.googleapis.com")
+  used by `MakePredictionServiceConnection()`.
 
 - `GOOGLE_CLOUD_CPP_SEARCH_SERVICE_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "retail.googleapis.com")

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -46,10 +46,6 @@ which should give you a taste of the Cloud Speech-to-Text API C++ client library
   `EndpointOption` (which defaults to "speech.googleapis.com")
   used by `MakeSpeechConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "speech.googleapis.com")
-  used by `MakeSpeechConnection()`.
-
 <!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -47,10 +47,6 @@ which should give you a taste of the Cloud TPU API C++ client library API.
   `EndpointOption` (which defaults to "tpu.googleapis.com")
   used by `MakeTpuConnection()`.
 
-- `GOOGLE_CLOUD_CPP_TPU_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "tpu.googleapis.com")
-  used by `MakeTpuConnection()`.
-
 <!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC


### PR DESCRIPTION
De-duplicate entries for endpoint-overriding environment variables, which can arise when we support multiple versions of the same service. This was true for speech and tpu.

An artifact of the de-duplication is that entries are now sorted, which isn't a bad thing, but causes some initial churn.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10788)
<!-- Reviewable:end -->
