### PR TITLE
cleanup(GCS+gRPC): use `retention_duration` field

### DIFF
--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -469,7 +469,8 @@ google::storage::v2::Bucket::RetentionPolicy ToProto(
   *result.mutable_effective_time() =
       google::cloud::internal::ToProtoTimestamp(rhs.effective_time);
   result.set_is_locked(rhs.is_locked);
-  result.set_retention_period(rhs.retention_period.count());
+  *result.mutable_retention_duration() =
+      google::cloud::internal::ToDurationProto(rhs.retention_period);
   return result;
 }
 
@@ -479,7 +480,9 @@ storage::BucketRetentionPolicy FromProto(
   result.effective_time =
       google::cloud::internal::ToChronoTimePoint(rhs.effective_time());
   result.is_locked = rhs.is_locked();
-  result.retention_period = std::chrono::seconds(rhs.retention_period());
+  result.retention_period = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::seconds(rhs.retention_duration().seconds()) +
+      std::chrono::nanoseconds(rhs.retention_duration().nanos()));
   return result;
 }
 

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
@@ -109,7 +109,7 @@ TEST(GrpcBucketMetadataParser, BucketAllFieldsRoundtrip) {
     retention_policy {
       effective_time { seconds: 1565194926 nanos: 123456000 }
       is_locked: true
-      retention_period: 86400
+      retention_duration { seconds: 86400 }
     }
     iam_config {
       uniform_bucket_level_access {
@@ -470,7 +470,7 @@ TEST(GrpcBucketMetadataParser, BucketLoggingRoundtrip) {
 
 TEST(GrpcBucketMetadataParser, BucketRetentionPolicyRoundtrip) {
   auto constexpr kText = R"pb(
-    retention_period: 3600
+    retention_duration { seconds: 3600 }
     effective_time { seconds: 1234 nanos: 5678000 }
     is_locked: true
   )pb";

--- a/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
@@ -434,7 +434,7 @@ TEST(GrpcBucketRequestParser, PatchBucketRequestAllOptions) {
           encryption { default_kms_key: "test-only-kms-key" }
           autoclass { enabled: true }
           billing { requester_pays: true }
-          retention_policy { retention_period: 123000 }
+          retention_policy { retention_duration { seconds: 123000 } }
           iam_config {
             uniform_bucket_level_access { enabled: true }
             public_access_prevention: "enforced"
@@ -635,7 +635,7 @@ TEST(GrpcBucketRequestParser, UpdateBucketRequestAllOptions) {
           encryption { default_kms_key: "test-only-kms-key" }
           autoclass { enabled: true }
           billing { requester_pays: true }
-          retention_policy { retention_period: 123000 }
+          retention_policy { retention_duration { seconds: 123000 } }
           iam_config {
             uniform_bucket_level_access { enabled: true }
             public_access_prevention: "enforced"

--- a/google/cloud/storage/internal/grpc_client_acl_test.cc
+++ b/google/cloud/storage/internal/grpc_client_acl_test.cc
@@ -117,7 +117,7 @@ auto constexpr kBucketProtoText = R"pb(
   retention_policy {
     effective_time { seconds: 1565194926 nanos: 123456000 }
     is_locked: true
-    retention_period: 86400
+    retention_duration { seconds: 86400 }
   }
   iam_config {
     uniform_bucket_level_access {


### PR DESCRIPTION
The `retention_period` field is deprecated and will be retired "soon".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10792)
<!-- Reviewable:end -->
