### PR TITLE
fix(pubsub): fewer default threads for 32-bit builds

### DIFF
--- a/google/cloud/pubsub/internal/defaults.cc
+++ b/google/cloud/pubsub/internal/defaults.cc
@@ -36,6 +36,10 @@ using ms = std::chrono::milliseconds;
 
 std::size_t DefaultThreadCount() {
   auto constexpr kDefaultThreadCount = 4;
+  // On 32-bit machines the address space is quickly consumed by background
+  // threads. Create just a few threads by default on such platforms. If the
+  // application needs more threads, it can override this default.
+  if (std::numeric_limits<std::size_t>::digits < 64) return kDefaultThreadCount;
   auto const n = std::thread::hardware_concurrency();
   return n == 0 ? kDefaultThreadCount : n;
 }


### PR DESCRIPTION
When the code is compiled for 32-bit platforms using 4 * thread-count background threads can quickly exhaust the address space. Reduce the default number of background threads to just 4.

Part of the work for #10775

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10793)
<!-- Reviewable:end -->
