### PR TITLE
refactor: unify pkgconfig for interfaces

### DIFF
--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -291,7 +291,7 @@ install(
     DESTINATION "include/google/cloud/mocks"
     COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_add_pkgconfig_interface(
+google_cloud_cpp_add_pkgconfig(
     "mocks" "Google Cloud C++ Testing Library"
     "Helpers for testing the Google Cloud C++ Client Libraries"
     "google_cloud_cpp_common" " gmock_main")

--- a/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
@@ -90,7 +90,7 @@ google_cloud_cpp_install_headers(google_cloud_cpp_rest_protobuf_internal
                                  include/google/cloud)
 
 google_cloud_cpp_add_pkgconfig(
-    rest_protobuf
+    rest_protobuf_internal
     "REST/Protobuf Utilities for the Google Cloud C++ Client Library"
     "Provides REST and Protobuf Utilities for the Google Cloud C++ Client Library."
     "google_cloud_cpp_common")

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -453,7 +453,7 @@ install(
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
     COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_add_pkgconfig_interface(
+google_cloud_cpp_add_pkgconfig(
     pubsub_mocks "Google Cloud C++ Pub/Sub Mocks"
     "Mocks for the Google Cloud Pub/Sub C++ Client Library"
     "google_cloud_cpp_pubsub" " gmock_main")


### PR DESCRIPTION
Motivated by #10795 

Only use one invocation of `google_cloud_cpp_add_pkgconfig()` for both regular and interface libraries. (This is cleaning up a mess I made earlier).

The standardization required me to change the name of the `rest_protobuf` installed artifact. AFAICT it is never used. i.e. we do not install a `google_cloud_cpp_spanner_rest.pc` which would depend on it.