### PR TITLE
impl: pkg-config respects compile defs

### DIFF
--- a/cmake/AddPkgConfig.cmake
+++ b/cmake/AddPkgConfig.cmake
@@ -55,6 +55,12 @@ function (google_cloud_cpp_add_pkgconfig library name description)
     else ()
         set(GOOGLE_CLOUD_CPP_PC_LIBS "-l${target}")
     endif ()
+    get_target_property(target_defs ${target} INTERFACE_COMPILE_DEFINITIONS)
+    if (target_defs)
+        foreach (def ${target_defs})
+            string(APPEND GOOGLE_CLOUD_CPP_PC_CFLAGS " -D${def}")
+        endforeach ()
+    endif ()
 
     # Create and install the pkg-config files.
     configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"

--- a/cmake/templates/config.pc.in
+++ b/cmake/templates/config.pc.in
@@ -23,4 +23,4 @@ Requires: @GOOGLE_CLOUD_CPP_PC_REQUIRES@
 Version: @DOXYGEN_PROJECT_NUMBER@
 
 Libs: -L${libdir} @GOOGLE_CLOUD_CPP_PC_LIBS@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @GOOGLE_CLOUD_CPP_PC_CFLAGS@

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -170,7 +170,9 @@ if (experimental-opentelemetry IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
         target_compile_definitions(
             google_cloud_cpp_common
             PUBLIC # Enable OpenTelemetry features in google-cloud-cpp
-                   GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY)
+                   GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+                   # TODO(#10975) - install separate opentelemetry .pc file
+                   HAVE_ABSEIL)
         set(GOOGLE_CLOUD_CPP_FIND_OPTIONAL_DEPENDENCIES
             "find_dependency(opentelemetry-cpp)")
     endif ()


### PR DESCRIPTION
Part of the work for #10795 

Capture the `-D` flags that were present when the library was compiled (the [INTERFACE_COMPILE_DEFINITIONS](https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_COMPILE_DEFINITIONS.html)).

Note that we could also extract other Cflags, such as `-I` flags by looking at [INCLUDE_DIRECTORIES](https://cmake.org/cmake/help/latest/prop_tgt/INCLUDE_DIRECTORIES.html). But there is no need to do so now, so I'd rather not touch it. I looked into capturing the target's linked libraries, but could not find them.

Also, add `HAVE_ABSEIL` to the compile definitions to unblock other work. It relies on us transitively picking up opentelemetry's deps (`absl_strings absl_bad_variant_access absl_any absl_base absl_bits absl_city`). And we assume `opentelemetry` is installed in a standard place to look for includes. I am okay with this, for now.

This produces `google_cloud_cpp_common.pc`:
```
prefix=${pcfiledir}/../..
exec_prefix=${prefix}
libdir=${exec_prefix}/lib64
includedir=${prefix}/include

Name: Google Cloud C++ Client Library Common Components
Description: Common Components used by the Google Cloud C++ Client Libraries.
Requires: absl_memory absl_optional absl_span absl_strings absl_time absl_time_zone absl_variant openssl
Version: 2.8.0-rc

Libs: -L${libdir} -lgoogle_cloud_cpp_common
Cflags: -I${includedir}  -DGOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY -DHAVE_ABSEIL
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10797)
<!-- Reviewable:end -->
