### PR TITLE
test(GCS+gRPC): enable Bucket patch integration tests

### DIFF
--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -286,9 +286,6 @@ TEST_F(BucketIntegrationTest, PatchLifecycleConditions) {
 }
 
 TEST_F(BucketIntegrationTest, FullPatch) {
-  // TODO(#9801) - enable in production.
-  if (UsingGrpc() && !UsingEmulator()) GTEST_SKIP();
-
   std::string bucket_name = MakeRandomBucketName();
   StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -365,10 +362,10 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   desired_state.set_storage_class(storage_class::Coldline());
 
   // versioning()
-  if (!desired_state.has_versioning()) {
-    desired_state.enable_versioning();
-  } else {
+  if (desired_state.has_versioning() && desired_state.versioning()->enabled) {
     desired_state.reset_versioning();
+  } else {
+    desired_state.enable_versioning();
   }
 
   // website()
@@ -496,9 +493,6 @@ TEST_F(BucketIntegrationTest, PublicAccessPreventionPatch) {
 
 /// @test Verify that we can set the RPO in a Bucket.
 TEST_F(BucketIntegrationTest, RpoPatch) {
-  // TODO(#9802) - enable in production.
-  if (UsingGrpc() && !UsingEmulator()) GTEST_SKIP();
-
   std::string bucket_name = MakeRandomBucketName();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);


### PR DESCRIPTION
Restore or enable the Bucket metadata integration tests against production. These used to fail due to multiple little bugs in the client, tests, and/or production.

Fixes #9801 and fixes #9802

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10802)
<!-- Reviewable:end -->
