### PR TITLE
cleanup(otel): `TracingEnabled()` always exists

### DIFF
--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -28,10 +28,6 @@ namespace internal {
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
-bool TracingEnabled(Options const& options) {
-  return options.get<OpenTelemetryTracingOption>();
-}
-
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> GetTracer(
     Options const&) {
   auto provider = opentelemetry::trace::Provider::GetTracerProvider();
@@ -79,6 +75,14 @@ Status EndSpan(opentelemetry::trace::Span& span, Status const& status) {
   return status;
 }
 
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+bool TracingEnabled(Options const& options) {
+  return options.get<OpenTelemetryTracingOption>();
+}
+#else
+bool TracingEnabled(Options const&) { return false; }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 std::function<void(std::chrono::milliseconds)> MakeTracedSleeper(

--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -36,8 +36,6 @@ namespace internal {
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
-bool TracingEnabled(Options const& options);
-
 /**
  * Returns a [tracer] to use for creating [spans].
  *
@@ -117,6 +115,8 @@ StatusOr<T> EndSpan(opentelemetry::trace::Span& span,
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+bool TracingEnabled(Options const& options);
 
 /// Wraps the sleeper in a span, if tracing is enabled.
 std::function<void(std::chrono::milliseconds)> MakeTracedSleeper(

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -54,17 +54,6 @@ TEST(OpenTelemetry, IsUsable) {
   EXPECT_EQ(span.ToString(), "DefaultSpan");
 }
 
-TEST(OpenTelemetry, TracingEnabled) {
-  auto options = Options{};
-  EXPECT_FALSE(TracingEnabled(options));
-
-  options.set<OpenTelemetryTracingOption>(false);
-  EXPECT_FALSE(TracingEnabled(options));
-
-  options.set<OpenTelemetryTracingOption>(true);
-  EXPECT_TRUE(TracingEnabled(options));
-}
-
 TEST(OpenTelemetry, GetTracer) {
   auto span_catcher = InstallSpanCatcher();
 
@@ -232,6 +221,17 @@ TEST(OpenTelemetry, EndSpanStatusOr) {
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError)));
 }
 
+TEST(OpenTelemetry, TracingEnabled) {
+  auto options = Options{};
+  EXPECT_FALSE(TracingEnabled(options));
+
+  options.set<OpenTelemetryTracingOption>(false);
+  EXPECT_FALSE(TracingEnabled(options));
+
+  options.set<OpenTelemetryTracingOption>(true);
+  EXPECT_TRUE(TracingEnabled(options));
+}
+
 TEST(OpenTelemetry, MakeTracedSleeperEnabled) {
   auto span_catcher = InstallSpanCatcher();
 
@@ -265,6 +265,10 @@ TEST(OpenTelemetry, MakeTracedSleeperDisabled) {
 }
 
 #else
+
+TEST(NoOpenTelemetry, TracingEnabled) {
+  EXPECT_FALSE(TracingEnabled(Options{}));
+}
 
 TEST(NoOpenTelemetry, MakeTracedSleeper) {
   MockFunction<void(ms)> mock_sleeper;


### PR DESCRIPTION
Motivated by #10491 

I cannot avoid a clang diagnostic warning from an unused parameter. `NOLINT`s do not solve the problem. It seems nicer to do the `#ifdefs` in one place, than in N `MakeFooTracingStub(..., Options const& options)`.

If anyone wishes to say "I told you so", now is the time. https://github.com/googleapis/google-cloud-cpp/pull/10496#discussion_r1062730261

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10804)
<!-- Reviewable:end -->
