### PR TITLE
test(spanner): reset state in the DmlReturning test mutators

### DIFF
--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -611,6 +611,7 @@ TEST_F(DataTypeIntegrationTest, DmlReturning) {
         )""");
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
         EXPECT_EQ(rows.RowsModified(), 4);
+        insert_actual.clear();  // may be a re-run
         for (auto& row : StreamOf<RowType>(rows)) {
           if (row) insert_actual.push_back(*std::move(row));
         }
@@ -631,6 +632,7 @@ TEST_F(DataTypeIntegrationTest, DmlReturning) {
         )""");
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
         EXPECT_EQ(rows.RowsModified(), 4);
+        update_actual.clear();  // may be a re-run
         for (auto& row : StreamOf<RowType>(rows)) {
           if (row) update_actual.push_back(*std::move(row));
         }
@@ -651,6 +653,7 @@ TEST_F(DataTypeIntegrationTest, DmlReturning) {
         )""");
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
         EXPECT_EQ(rows.RowsModified(), 4);
+        delete_actual.clear();  // may be a re-run
         for (auto& row : StreamOf<RowType>(rows)) {
           if (row) delete_actual.push_back(*std::move(row));
         }
@@ -683,6 +686,7 @@ TEST_F(PgDataTypeIntegrationTest, DmlReturning) {
         )""");
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
         EXPECT_EQ(rows.RowsModified(), 4);
+        insert_actual.clear();  // may be a re-run
         for (auto& row : StreamOf<RowType>(rows)) {
           if (row) insert_actual.push_back(*std::move(row));
         }
@@ -703,6 +707,7 @@ TEST_F(PgDataTypeIntegrationTest, DmlReturning) {
         )""");
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
         EXPECT_EQ(rows.RowsModified(), 4);
+        update_actual.clear();  // may be a re-run
         for (auto& row : StreamOf<RowType>(rows)) {
           if (row) update_actual.push_back(*std::move(row));
         }
@@ -723,6 +728,7 @@ TEST_F(PgDataTypeIntegrationTest, DmlReturning) {
         )""");
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
         EXPECT_EQ(rows.RowsModified(), 4);
+        delete_actual.clear();  // may be a re-run
         for (auto& row : StreamOf<RowType>(rows)) {
           if (row) delete_actual.push_back(*std::move(row));
         }

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -2876,6 +2876,9 @@ void DmlWriteThenRead(google::cloud::spanner::Client client) {
             "SELECT FirstName, LastName FROM Singers where SingerId = 11");
         using RowType = std::tuple<std::string, std::string>;
         auto rows = client.ExecuteQuery(std::move(txn), std::move(select));
+        // Note: This mutator might be re-run, or its effects discarded, so
+        // changing non-transactional state (e.g., by producing output) is,
+        // in general, not something to be imitated.
         for (auto const& row : spanner::StreamOf<RowType>(rows)) {
           if (!row) return std::move(row).status();
           std::cout << "FirstName: " << std::get<0>(*row) << "\t";
@@ -2945,6 +2948,9 @@ void DmlBatchUpdate(google::cloud::spanner::Client client) {
                                   "  WHERE SingerId = 1 and AlbumId = 3")};
         auto result = client.ExecuteBatchDml(txn, statements);
         if (!result) return std::move(result).status();
+        // Note: This mutator might be re-run, or its effects discarded, so
+        // changing non-transactional state (e.g., by producing output) is,
+        // in general, not something to be imitated.
         for (std::size_t i = 0; i < result->stats.size(); ++i) {
           std::cout << result->stats[i].row_count << " rows affected"
                     << " for the statement " << (i + 1) << ".\n";
@@ -3294,6 +3300,9 @@ void UpdateUsingDmlReturning(google::cloud::spanner::Client client) {
         )""");
         using RowType = std::tuple<absl::optional<std::int64_t>>;
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
+        // Note: This mutator might be re-run, or its effects discarded, so
+        // changing non-transactional state (e.g., by producing output) is,
+        // in general, not something to be imitated.
         for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
           if (!row) return std::move(row).status();
           std::cout << "MarketingBudget: ";
@@ -3328,6 +3337,9 @@ void InsertUsingDmlReturning(google::cloud::spanner::Client client) {
         )""");
         using RowType = std::tuple<std::string>;
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
+        // Note: This mutator might be re-run, or its effects discarded, so
+        // changing non-transactional state (e.g., by producing output) is,
+        // in general, not something to be imitated.
         for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
           if (!row) return std::move(row).status();
           std::cout << "FullName: " << std::get<0>(*row) << "\n";
@@ -3354,6 +3366,9 @@ void DeleteUsingDmlReturning(google::cloud::spanner::Client client) {
         )""");
         using RowType = std::tuple<std::int64_t, std::string>;
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
+        // Note: This mutator might be re-run, or its effects discarded, so
+        // changing non-transactional state (e.g., by producing output) is,
+        // in general, not something to be imitated.
         for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
           if (!row) return std::move(row).status();
           std::cout << "SingerId: " << std::get<0>(*row) << " ";


### PR DESCRIPTION
A `Commit()` mutator might be re-run, so it should ensure its own idempotency.  Fix the `*DataTypeIntegrationTest.DmlReturning` tests accordingly.

Also raise visibility on the issue by adding a note in the samples about non-transactional state changes in mutators.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10805)
<!-- Reviewable:end -->
