### PR TITLE
cleanup(otel): StreamRange span inactive unless reading

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
@@ -56,10 +56,10 @@ GoldenKitchenSinkTracingConnection::WriteLogEntries(google::test::admin::databas
 StreamRange<std::string>
 GoldenKitchenSinkTracingConnection::ListLogs(google::test::admin::database::v1::ListLogsRequest request) {
   auto span = internal::MakeSpan("golden_v1::GoldenKitchenSinkConnection::ListLogs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListLogs(std::move(request));
   return internal::MakeTracedStreamRange<std::string>(
-        std::move(span), std::move(scope), std::move(sr));
+        std::move(span), std::move(sr));
 }
 
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_connection.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_connection.cc
@@ -35,10 +35,10 @@ GoldenThingAdminTracingConnection::GoldenThingAdminTracingConnection(
 StreamRange<google::test::admin::database::v1::Database>
 GoldenThingAdminTracingConnection::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request) {
   auto span = internal::MakeSpan("golden_v1::GoldenThingAdminConnection::ListDatabases");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDatabases(std::move(request));
   return internal::MakeTracedStreamRange<google::test::admin::database::v1::Database>(
-        std::move(span), std::move(scope), std::move(sr));
+        std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
@@ -122,10 +122,10 @@ GoldenThingAdminTracingConnection::DeleteBackup(google::test::admin::database::v
 StreamRange<google::test::admin::database::v1::Backup>
 GoldenThingAdminTracingConnection::ListBackups(google::test::admin::database::v1::ListBackupsRequest request) {
   auto span = internal::MakeSpan("golden_v1::GoldenThingAdminConnection::ListBackups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBackups(std::move(request));
   return internal::MakeTracedStreamRange<google::test::admin::database::v1::Backup>(
-        std::move(span), std::move(scope), std::move(sr));
+        std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
@@ -136,19 +136,19 @@ GoldenThingAdminTracingConnection::RestoreDatabase(google::test::admin::database
 StreamRange<google::longrunning::Operation>
 GoldenThingAdminTracingConnection::ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request) {
   auto span = internal::MakeSpan("golden_v1::GoldenThingAdminConnection::ListDatabaseOperations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDatabaseOperations(std::move(request));
   return internal::MakeTracedStreamRange<google::longrunning::Operation>(
-        std::move(span), std::move(scope), std::move(sr));
+        std::move(span), std::move(sr));
 }
 
 StreamRange<google::longrunning::Operation>
 GoldenThingAdminTracingConnection::ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request) {
   auto span = internal::MakeSpan("golden_v1::GoldenThingAdminConnection::ListBackupOperations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBackupOperations(std::move(request));
   return internal::MakeTracedStreamRange<google::longrunning::Operation>(
-        std::move(span), std::move(scope), std::move(sr));
+        std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>

--- a/generator/internal/tracing_connection_generator.cc
+++ b/generator/internal/tracing_connection_generator.cc
@@ -264,10 +264,10 @@ $tracing_connection_class_name$::$method_name$($request_type$ const& request) {
 StreamRange<$range_output_type$>
 $tracing_connection_class_name$::$method_name$($request_type$ request) {
   auto span = internal::MakeSpan("$product_namespace$::$connection_class_name$::$method_name$");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->$method_name$(std::move(request));
   return internal::MakeTracedStreamRange<$range_output_type$>(
-        std::move(span), std::move(scope), std::move(sr));
+        std::move(span), std::move(sr));
 }
 )""";
   }

--- a/google/cloud/accessapproval/v1/internal/access_approval_tracing_connection.cc
+++ b/google/cloud/accessapproval/v1/internal/access_approval_tracing_connection.cc
@@ -37,11 +37,11 @@ AccessApprovalTracingConnection::ListApprovalRequests(
     google::cloud::accessapproval::v1::ListApprovalRequestsMessage request) {
   auto span = internal::MakeSpan(
       "accessapproval_v1::AccessApprovalConnection::ListApprovalRequests");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListApprovalRequests(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::accessapproval::v1::ApprovalRequest>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::accessapproval::v1::ApprovalRequest>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_tracing_connection.cc
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_tracing_connection.cc
@@ -39,11 +39,11 @@ AccessContextManagerTracingConnection::ListAccessPolicies(
   auto span = internal::MakeSpan(
       "accesscontextmanager::AccessContextManagerConnection::"
       "ListAccessPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAccessPolicies(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::identity::accesscontextmanager::v1::AccessPolicy>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::identity::accesscontextmanager::v1::AccessPolicy>(std::move(span),
+                                                                std::move(sr));
 }
 
 StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>
@@ -83,11 +83,11 @@ AccessContextManagerTracingConnection::ListAccessLevels(
         request) {
   auto span = internal::MakeSpan(
       "accesscontextmanager::AccessContextManagerConnection::ListAccessLevels");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAccessLevels(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::identity::accesscontextmanager::v1::AccessLevel>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::identity::accesscontextmanager::v1::AccessLevel>(std::move(span),
+                                                               std::move(sr));
 }
 
 StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>
@@ -137,11 +137,11 @@ AccessContextManagerTracingConnection::ListServicePerimeters(
   auto span = internal::MakeSpan(
       "accesscontextmanager::AccessContextManagerConnection::"
       "ListServicePerimeters");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServicePerimeters(std::move(request));
   return internal::MakeTracedStreamRange<
       google::identity::accesscontextmanager::v1::ServicePerimeter>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>
@@ -200,11 +200,11 @@ AccessContextManagerTracingConnection::ListGcpUserAccessBindings(
   auto span = internal::MakeSpan(
       "accesscontextmanager::AccessContextManagerConnection::"
       "ListGcpUserAccessBindings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGcpUserAccessBindings(std::move(request));
   return internal::MakeTracedStreamRange<
       google::identity::accesscontextmanager::v1::GcpUserAccessBinding>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>

--- a/google/cloud/apigateway/internal/api_gateway_tracing_connection.cc
+++ b/google/cloud/apigateway/internal/api_gateway_tracing_connection.cc
@@ -37,11 +37,10 @@ ApiGatewayServiceTracingConnection::ListGateways(
     google::cloud::apigateway::v1::ListGatewaysRequest request) {
   auto span = internal::MakeSpan(
       "apigateway::ApiGatewayServiceConnection::ListGateways");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGateways(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::apigateway::v1::Gateway>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::apigateway::v1::Gateway>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::apigateway::v1::Gateway>
@@ -76,10 +75,10 @@ ApiGatewayServiceTracingConnection::ListApis(
     google::cloud::apigateway::v1::ListApisRequest request) {
   auto span =
       internal::MakeSpan("apigateway::ApiGatewayServiceConnection::ListApis");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListApis(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::apigateway::v1::Api>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::apigateway::v1::Api>
@@ -114,11 +113,10 @@ ApiGatewayServiceTracingConnection::ListApiConfigs(
     google::cloud::apigateway::v1::ListApiConfigsRequest request) {
   auto span = internal::MakeSpan(
       "apigateway::ApiGatewayServiceConnection::ListApiConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListApiConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::apigateway::v1::ApiConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::apigateway::v1::ApiConfig>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::apigateway::v1::ApiConfig>

--- a/google/cloud/apigeeconnect/internal/connection_tracing_connection.cc
+++ b/google/cloud/apigeeconnect/internal/connection_tracing_connection.cc
@@ -37,11 +37,11 @@ ConnectionServiceTracingConnection::ListConnections(
     google::cloud::apigeeconnect::v1::ListConnectionsRequest request) {
   auto span = internal::MakeSpan(
       "apigeeconnect::ConnectionServiceConnection::ListConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnections(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::apigeeconnect::v1::Connection>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::apigeeconnect::v1::Connection>(std::move(span),
+                                                    std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/apikeys/internal/api_keys_tracing_connection.cc
+++ b/google/cloud/apikeys/internal/api_keys_tracing_connection.cc
@@ -41,10 +41,10 @@ ApiKeysTracingConnection::CreateKey(
 StreamRange<google::api::apikeys::v2::Key> ApiKeysTracingConnection::ListKeys(
     google::api::apikeys::v2::ListKeysRequest request) {
   auto span = internal::MakeSpan("apikeys::ApiKeysConnection::ListKeys");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListKeys(std::move(request));
   return internal::MakeTracedStreamRange<google::api::apikeys::v2::Key>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::api::apikeys::v2::Key> ApiKeysTracingConnection::GetKey(

--- a/google/cloud/appengine/internal/authorized_certificates_tracing_connection.cc
+++ b/google/cloud/appengine/internal/authorized_certificates_tracing_connection.cc
@@ -39,11 +39,11 @@ AuthorizedCertificatesTracingConnection::ListAuthorizedCertificates(
   auto span = internal::MakeSpan(
       "appengine::AuthorizedCertificatesConnection::"
       "ListAuthorizedCertificates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAuthorizedCertificates(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::appengine::v1::AuthorizedCertificate>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::appengine::v1::AuthorizedCertificate>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::appengine::v1::AuthorizedCertificate>

--- a/google/cloud/appengine/internal/authorized_domains_tracing_connection.cc
+++ b/google/cloud/appengine/internal/authorized_domains_tracing_connection.cc
@@ -37,11 +37,10 @@ AuthorizedDomainsTracingConnection::ListAuthorizedDomains(
     google::appengine::v1::ListAuthorizedDomainsRequest request) {
   auto span = internal::MakeSpan(
       "appengine::AuthorizedDomainsConnection::ListAuthorizedDomains");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAuthorizedDomains(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::appengine::v1::AuthorizedDomain>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::appengine::v1::AuthorizedDomain>(std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/appengine/internal/domain_mappings_tracing_connection.cc
+++ b/google/cloud/appengine/internal/domain_mappings_tracing_connection.cc
@@ -37,10 +37,10 @@ DomainMappingsTracingConnection::ListDomainMappings(
     google::appengine::v1::ListDomainMappingsRequest request) {
   auto span = internal::MakeSpan(
       "appengine::DomainMappingsConnection::ListDomainMappings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDomainMappings(std::move(request));
   return internal::MakeTracedStreamRange<google::appengine::v1::DomainMapping>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::appengine::v1::DomainMapping>

--- a/google/cloud/appengine/internal/firewall_tracing_connection.cc
+++ b/google/cloud/appengine/internal/firewall_tracing_connection.cc
@@ -37,10 +37,10 @@ FirewallTracingConnection::ListIngressRules(
     google::appengine::v1::ListIngressRulesRequest request) {
   auto span =
       internal::MakeSpan("appengine::FirewallConnection::ListIngressRules");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListIngressRules(std::move(request));
   return internal::MakeTracedStreamRange<google::appengine::v1::FirewallRule>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::appengine::v1::BatchUpdateIngressRulesResponse>

--- a/google/cloud/appengine/internal/instances_tracing_connection.cc
+++ b/google/cloud/appengine/internal/instances_tracing_connection.cc
@@ -37,10 +37,10 @@ InstancesTracingConnection::ListInstances(
     google::appengine::v1::ListInstancesRequest request) {
   auto span =
       internal::MakeSpan("appengine::InstancesConnection::ListInstances");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstances(std::move(request));
   return internal::MakeTracedStreamRange<google::appengine::v1::Instance>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::appengine::v1::Instance>

--- a/google/cloud/appengine/internal/services_tracing_connection.cc
+++ b/google/cloud/appengine/internal/services_tracing_connection.cc
@@ -36,10 +36,10 @@ StreamRange<google::appengine::v1::Service>
 ServicesTracingConnection::ListServices(
     google::appengine::v1::ListServicesRequest request) {
   auto span = internal::MakeSpan("appengine::ServicesConnection::ListServices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServices(std::move(request));
   return internal::MakeTracedStreamRange<google::appengine::v1::Service>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::appengine::v1::Service> ServicesTracingConnection::GetService(

--- a/google/cloud/appengine/internal/versions_tracing_connection.cc
+++ b/google/cloud/appengine/internal/versions_tracing_connection.cc
@@ -36,10 +36,10 @@ StreamRange<google::appengine::v1::Version>
 VersionsTracingConnection::ListVersions(
     google::appengine::v1::ListVersionsRequest request) {
   auto span = internal::MakeSpan("appengine::VersionsConnection::ListVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVersions(std::move(request));
   return internal::MakeTracedStreamRange<google::appengine::v1::Version>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::appengine::v1::Version> VersionsTracingConnection::GetVersion(

--- a/google/cloud/artifactregistry/internal/artifact_registry_tracing_connection.cc
+++ b/google/cloud/artifactregistry/internal/artifact_registry_tracing_connection.cc
@@ -37,11 +37,11 @@ ArtifactRegistryTracingConnection::ListDockerImages(
     google::devtools::artifactregistry::v1::ListDockerImagesRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListDockerImages");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDockerImages(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::DockerImage>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::DockerImage>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::DockerImage>
@@ -59,11 +59,11 @@ ArtifactRegistryTracingConnection::ListMavenArtifacts(
     google::devtools::artifactregistry::v1::ListMavenArtifactsRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListMavenArtifacts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMavenArtifacts(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::MavenArtifact>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::MavenArtifact>(std::move(span),
+                                                             std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::MavenArtifact>
@@ -81,11 +81,11 @@ ArtifactRegistryTracingConnection::ListNpmPackages(
     google::devtools::artifactregistry::v1::ListNpmPackagesRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListNpmPackages");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNpmPackages(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::NpmPackage>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::NpmPackage>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::NpmPackage>
@@ -103,11 +103,11 @@ ArtifactRegistryTracingConnection::ListPythonPackages(
     google::devtools::artifactregistry::v1::ListPythonPackagesRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListPythonPackages");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPythonPackages(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::PythonPackage>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::PythonPackage>(std::move(span),
+                                                             std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::PythonPackage>
@@ -141,11 +141,11 @@ ArtifactRegistryTracingConnection::ListRepositories(
     google::devtools::artifactregistry::v1::ListRepositoriesRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListRepositories");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRepositories(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::Repository>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::Repository>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::Repository>
@@ -187,11 +187,11 @@ ArtifactRegistryTracingConnection::ListPackages(
     google::devtools::artifactregistry::v1::ListPackagesRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListPackages");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPackages(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::Package>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::Package>(std::move(span),
+                                                       std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::Package>
@@ -215,11 +215,11 @@ ArtifactRegistryTracingConnection::ListVersions(
     google::devtools::artifactregistry::v1::ListVersionsRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::Version>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::Version>(std::move(span),
+                                                       std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::Version>
@@ -243,11 +243,11 @@ ArtifactRegistryTracingConnection::ListFiles(
     google::devtools::artifactregistry::v1::ListFilesRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListFiles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListFiles(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::File>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::File>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::File>
@@ -264,11 +264,11 @@ ArtifactRegistryTracingConnection::ListTags(
     google::devtools::artifactregistry::v1::ListTagsRequest request) {
   auto span = internal::MakeSpan(
       "artifactregistry::ArtifactRegistryConnection::ListTags");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTags(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::artifactregistry::v1::Tag>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::artifactregistry::v1::Tag>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::Tag>

--- a/google/cloud/asset/internal/asset_tracing_connection.cc
+++ b/google/cloud/asset/internal/asset_tracing_connection.cc
@@ -42,10 +42,10 @@ StreamRange<google::cloud::asset::v1::Asset>
 AssetServiceTracingConnection::ListAssets(
     google::cloud::asset::v1::ListAssetsRequest request) {
   auto span = internal::MakeSpan("asset::AssetServiceConnection::ListAssets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAssets(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::asset::v1::Asset>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::asset::v1::BatchGetAssetsHistoryResponse>
@@ -100,11 +100,11 @@ AssetServiceTracingConnection::SearchAllResources(
     google::cloud::asset::v1::SearchAllResourcesRequest request) {
   auto span =
       internal::MakeSpan("asset::AssetServiceConnection::SearchAllResources");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchAllResources(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::asset::v1::ResourceSearchResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::asset::v1::ResourceSearchResult>(std::move(span),
+                                                      std::move(sr));
 }
 
 StreamRange<google::cloud::asset::v1::IamPolicySearchResult>
@@ -112,11 +112,11 @@ AssetServiceTracingConnection::SearchAllIamPolicies(
     google::cloud::asset::v1::SearchAllIamPoliciesRequest request) {
   auto span =
       internal::MakeSpan("asset::AssetServiceConnection::SearchAllIamPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchAllIamPolicies(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::asset::v1::IamPolicySearchResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::asset::v1::IamPolicySearchResult>(std::move(span),
+                                                       std::move(sr));
 }
 
 StatusOr<google::cloud::asset::v1::AnalyzeIamPolicyResponse>
@@ -174,10 +174,10 @@ AssetServiceTracingConnection::ListSavedQueries(
     google::cloud::asset::v1::ListSavedQueriesRequest request) {
   auto span =
       internal::MakeSpan("asset::AssetServiceConnection::ListSavedQueries");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSavedQueries(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::asset::v1::SavedQuery>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::asset::v1::SavedQuery>
@@ -214,11 +214,11 @@ AssetServiceTracingConnection::AnalyzeOrgPolicies(
     google::cloud::asset::v1::AnalyzeOrgPoliciesRequest request) {
   auto span =
       internal::MakeSpan("asset::AssetServiceConnection::AnalyzeOrgPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->AnalyzeOrgPolicies(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::asset::v1::AnalyzeOrgPoliciesResponse::OrgPolicyResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::asset::v1::
@@ -228,11 +228,11 @@ AssetServiceTracingConnection::AnalyzeOrgPolicyGovernedContainers(
         request) {
   auto span = internal::MakeSpan(
       "asset::AssetServiceConnection::AnalyzeOrgPolicyGovernedContainers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->AnalyzeOrgPolicyGovernedContainers(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::asset::v1::AnalyzeOrgPolicyGovernedContainersResponse::
-          GovernedContainer>(std::move(span), std::move(scope), std::move(sr));
+          GovernedContainer>(std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::asset::v1::AnalyzeOrgPolicyGovernedAssetsResponse::
@@ -241,11 +241,11 @@ AssetServiceTracingConnection::AnalyzeOrgPolicyGovernedAssets(
     google::cloud::asset::v1::AnalyzeOrgPolicyGovernedAssetsRequest request) {
   auto span = internal::MakeSpan(
       "asset::AssetServiceConnection::AnalyzeOrgPolicyGovernedAssets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->AnalyzeOrgPolicyGovernedAssets(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::asset::v1::AnalyzeOrgPolicyGovernedAssetsResponse::
-          GovernedAsset>(std::move(span), std::move(scope), std::move(sr));
+          GovernedAsset>(std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/assuredworkloads/internal/assured_workloads_tracing_connection.cc
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_tracing_connection.cc
@@ -82,11 +82,11 @@ AssuredWorkloadsServiceTracingConnection::ListWorkloads(
     google::cloud::assuredworkloads::v1::ListWorkloadsRequest request) {
   auto span = internal::MakeSpan(
       "assuredworkloads::AssuredWorkloadsServiceConnection::ListWorkloads");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListWorkloads(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::assuredworkloads::v1::Workload>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::assuredworkloads::v1::Workload>(std::move(span),
+                                                     std::move(sr));
 }
 
 StreamRange<google::cloud::assuredworkloads::v1::Violation>
@@ -94,11 +94,11 @@ AssuredWorkloadsServiceTracingConnection::ListViolations(
     google::cloud::assuredworkloads::v1::ListViolationsRequest request) {
   auto span = internal::MakeSpan(
       "assuredworkloads::AssuredWorkloadsServiceConnection::ListViolations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListViolations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::assuredworkloads::v1::Violation>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::assuredworkloads::v1::Violation>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::assuredworkloads::v1::Violation>

--- a/google/cloud/automl/internal/auto_ml_tracing_connection.cc
+++ b/google/cloud/automl/internal/auto_ml_tracing_connection.cc
@@ -50,10 +50,10 @@ StreamRange<google::cloud::automl::v1::Dataset>
 AutoMlTracingConnection::ListDatasets(
     google::cloud::automl::v1::ListDatasetsRequest request) {
   auto span = internal::MakeSpan("automl::AutoMlConnection::ListDatasets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDatasets(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::automl::v1::Dataset>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::automl::v1::Dataset>
@@ -107,10 +107,10 @@ StreamRange<google::cloud::automl::v1::Model>
 AutoMlTracingConnection::ListModels(
     google::cloud::automl::v1::ListModelsRequest request) {
   auto span = internal::MakeSpan("automl::AutoMlConnection::ListModels");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListModels(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::automl::v1::Model>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
@@ -158,11 +158,11 @@ AutoMlTracingConnection::ListModelEvaluations(
     google::cloud::automl::v1::ListModelEvaluationsRequest request) {
   auto span =
       internal::MakeSpan("automl::AutoMlConnection::ListModelEvaluations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListModelEvaluations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::automl::v1::ModelEvaluation>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::automl::v1::ModelEvaluation>(std::move(span),
+                                                  std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/baremetalsolution/internal/bare_metal_solution_tracing_connection.cc
+++ b/google/cloud/baremetalsolution/internal/bare_metal_solution_tracing_connection.cc
@@ -37,11 +37,11 @@ BareMetalSolutionTracingConnection::ListInstances(
     google::cloud::baremetalsolution::v2::ListInstancesRequest request) {
   auto span = internal::MakeSpan(
       "baremetalsolution::BareMetalSolutionConnection::ListInstances");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstances(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::baremetalsolution::v2::Instance>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::baremetalsolution::v2::Instance>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::baremetalsolution::v2::Instance>
@@ -89,11 +89,11 @@ BareMetalSolutionTracingConnection::ListVolumes(
     google::cloud::baremetalsolution::v2::ListVolumesRequest request) {
   auto span = internal::MakeSpan(
       "baremetalsolution::BareMetalSolutionConnection::ListVolumes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVolumes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::baremetalsolution::v2::Volume>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::baremetalsolution::v2::Volume>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::baremetalsolution::v2::Volume>
@@ -122,11 +122,11 @@ BareMetalSolutionTracingConnection::ListNetworks(
     google::cloud::baremetalsolution::v2::ListNetworksRequest request) {
   auto span = internal::MakeSpan(
       "baremetalsolution::BareMetalSolutionConnection::ListNetworks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNetworks(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::baremetalsolution::v2::Network>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::baremetalsolution::v2::Network>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::baremetalsolution::v2::ListNetworkUsageResponse>
@@ -168,11 +168,11 @@ BareMetalSolutionTracingConnection::ListLuns(
     google::cloud::baremetalsolution::v2::ListLunsRequest request) {
   auto span = internal::MakeSpan(
       "baremetalsolution::BareMetalSolutionConnection::ListLuns");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListLuns(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::baremetalsolution::v2::Lun>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::baremetalsolution::v2::Lun>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::baremetalsolution::v2::NfsShare>
@@ -189,11 +189,11 @@ BareMetalSolutionTracingConnection::ListNfsShares(
     google::cloud::baremetalsolution::v2::ListNfsSharesRequest request) {
   auto span = internal::MakeSpan(
       "baremetalsolution::BareMetalSolutionConnection::ListNfsShares");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNfsShares(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::baremetalsolution::v2::NfsShare>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::baremetalsolution::v2::NfsShare>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::cloud::baremetalsolution::v2::NfsShare>>

--- a/google/cloud/batch/internal/batch_tracing_connection.cc
+++ b/google/cloud/batch/internal/batch_tracing_connection.cc
@@ -57,10 +57,10 @@ StreamRange<google::cloud::batch::v1::Job>
 BatchServiceTracingConnection::ListJobs(
     google::cloud::batch::v1::ListJobsRequest request) {
   auto span = internal::MakeSpan("batch::BatchServiceConnection::ListJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobs(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::batch::v1::Job>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::batch::v1::Task> BatchServiceTracingConnection::GetTask(
@@ -74,10 +74,10 @@ StreamRange<google::cloud::batch::v1::Task>
 BatchServiceTracingConnection::ListTasks(
     google::cloud::batch::v1::ListTasksRequest request) {
   auto span = internal::MakeSpan("batch::BatchServiceConnection::ListTasks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTasks(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::batch::v1::Task>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/beyondcorp/internal/app_connections_tracing_connection.cc
+++ b/google/cloud/beyondcorp/internal/app_connections_tracing_connection.cc
@@ -39,11 +39,11 @@ AppConnectionsServiceTracingConnection::ListAppConnections(
         request) {
   auto span = internal::MakeSpan(
       "beyondcorp::AppConnectionsServiceConnection::ListAppConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAppConnections(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::beyondcorp::appconnections::v1::AppConnection>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::beyondcorp::appconnections::v1::AppConnection>
@@ -85,12 +85,12 @@ AppConnectionsServiceTracingConnection::ResolveAppConnections(
         request) {
   auto span = internal::MakeSpan(
       "beyondcorp::AppConnectionsServiceConnection::ResolveAppConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ResolveAppConnections(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::beyondcorp::appconnections::v1::
-          ResolveAppConnectionsResponse::AppConnectionDetails>(
-      std::move(span), std::move(scope), std::move(sr));
+          ResolveAppConnectionsResponse::AppConnectionDetails>(std::move(span),
+                                                               std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/beyondcorp/internal/app_connectors_tracing_connection.cc
+++ b/google/cloud/beyondcorp/internal/app_connectors_tracing_connection.cc
@@ -38,11 +38,11 @@ AppConnectorsServiceTracingConnection::ListAppConnectors(
         request) {
   auto span = internal::MakeSpan(
       "beyondcorp::AppConnectorsServiceConnection::ListAppConnectors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAppConnectors(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::beyondcorp::appconnectors::v1::AppConnector>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::beyondcorp::appconnectors::v1::AppConnector>

--- a/google/cloud/beyondcorp/internal/app_gateways_tracing_connection.cc
+++ b/google/cloud/beyondcorp/internal/app_gateways_tracing_connection.cc
@@ -38,11 +38,11 @@ AppGatewaysServiceTracingConnection::ListAppGateways(
         request) {
   auto span = internal::MakeSpan(
       "beyondcorp::AppGatewaysServiceConnection::ListAppGateways");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAppGateways(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::beyondcorp::appgateways::v1::AppGateway>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::beyondcorp::appgateways::v1::AppGateway>(std::move(span),
+                                                              std::move(sr));
 }
 
 StatusOr<google::cloud::beyondcorp::appgateways::v1::AppGateway>

--- a/google/cloud/beyondcorp/internal/client_connector_services_tracing_connection.cc
+++ b/google/cloud/beyondcorp/internal/client_connector_services_tracing_connection.cc
@@ -43,12 +43,11 @@ ClientConnectorServicesServiceTracingConnection::ListClientConnectorServices(
   auto span = internal::MakeSpan(
       "beyondcorp::ClientConnectorServicesServiceConnection::"
       "ListClientConnectorServices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListClientConnectorServices(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::beyondcorp::clientconnectorservices::v1::
-          ClientConnectorService>(std::move(span), std::move(scope),
-                                  std::move(sr));
+          ClientConnectorService>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::beyondcorp::clientconnectorservices::v1::

--- a/google/cloud/beyondcorp/internal/client_gateways_tracing_connection.cc
+++ b/google/cloud/beyondcorp/internal/client_gateways_tracing_connection.cc
@@ -39,11 +39,11 @@ ClientGatewaysServiceTracingConnection::ListClientGateways(
         request) {
   auto span = internal::MakeSpan(
       "beyondcorp::ClientGatewaysServiceConnection::ListClientGateways");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListClientGateways(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::beyondcorp::clientgateways::v1::ClientGateway>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::beyondcorp::clientgateways::v1::ClientGateway>

--- a/google/cloud/bigquery/internal/analytics_hub_tracing_connection.cc
+++ b/google/cloud/bigquery/internal/analytics_hub_tracing_connection.cc
@@ -38,11 +38,11 @@ AnalyticsHubServiceTracingConnection::ListDataExchanges(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::AnalyticsHubServiceConnection::ListDataExchanges");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDataExchanges(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::analyticshub::v1::DataExchange>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::analyticshub::v1::DataExchange>(std::move(span),
+                                                               std::move(sr));
 }
 
 StreamRange<google::cloud::bigquery::analyticshub::v1::DataExchange>
@@ -51,11 +51,11 @@ AnalyticsHubServiceTracingConnection::ListOrgDataExchanges(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::AnalyticsHubServiceConnection::ListOrgDataExchanges");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListOrgDataExchanges(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::analyticshub::v1::DataExchange>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::analyticshub::v1::DataExchange>(std::move(span),
+                                                               std::move(sr));
 }
 
 StatusOr<google::cloud::bigquery::analyticshub::v1::DataExchange>
@@ -102,11 +102,11 @@ AnalyticsHubServiceTracingConnection::ListListings(
     google::cloud::bigquery::analyticshub::v1::ListListingsRequest request) {
   auto span = internal::MakeSpan(
       "bigquery::AnalyticsHubServiceConnection::ListListings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListListings(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::analyticshub::v1::Listing>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::analyticshub::v1::Listing>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::cloud::bigquery::analyticshub::v1::Listing>

--- a/google/cloud/bigquery/internal/connection_tracing_connection.cc
+++ b/google/cloud/bigquery/internal/connection_tracing_connection.cc
@@ -57,11 +57,11 @@ ConnectionServiceTracingConnection::ListConnections(
     google::cloud::bigquery::connection::v1::ListConnectionsRequest request) {
   auto span = internal::MakeSpan(
       "bigquery::ConnectionServiceConnection::ListConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnections(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::connection::v1::Connection>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::connection::v1::Connection>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::cloud::bigquery::connection::v1::Connection>

--- a/google/cloud/bigquery/internal/data_policy_tracing_connection.cc
+++ b/google/cloud/bigquery/internal/data_policy_tracing_connection.cc
@@ -87,11 +87,11 @@ DataPolicyServiceTracingConnection::ListDataPolicies(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::DataPolicyServiceConnection::ListDataPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDataPolicies(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::datapolicies::v1::DataPolicy>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::datapolicies::v1::DataPolicy>(std::move(span),
+                                                             std::move(sr));
 }
 
 StatusOr<google::iam::v1::Policy>

--- a/google/cloud/bigquery/internal/data_transfer_tracing_connection.cc
+++ b/google/cloud/bigquery/internal/data_transfer_tracing_connection.cc
@@ -47,11 +47,11 @@ DataTransferServiceTracingConnection::ListDataSources(
     google::cloud::bigquery::datatransfer::v1::ListDataSourcesRequest request) {
   auto span = internal::MakeSpan(
       "bigquery::DataTransferServiceConnection::ListDataSources");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDataSources(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::datatransfer::v1::DataSource>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::datatransfer::v1::DataSource>(std::move(span),
+                                                             std::move(sr));
 }
 
 StatusOr<google::cloud::bigquery::datatransfer::v1::TransferConfig>
@@ -99,11 +99,11 @@ DataTransferServiceTracingConnection::ListTransferConfigs(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::DataTransferServiceConnection::ListTransferConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTransferConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::bigquery::datatransfer::v1::TransferConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<
@@ -153,11 +153,11 @@ DataTransferServiceTracingConnection::ListTransferRuns(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::DataTransferServiceConnection::ListTransferRuns");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTransferRuns(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::datatransfer::v1::TransferRun>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::datatransfer::v1::TransferRun>(std::move(span),
+                                                              std::move(sr));
 }
 
 StreamRange<google::cloud::bigquery::datatransfer::v1::TransferMessage>
@@ -166,11 +166,11 @@ DataTransferServiceTracingConnection::ListTransferLogs(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::DataTransferServiceConnection::ListTransferLogs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTransferLogs(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::bigquery::datatransfer::v1::TransferMessage>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::bigquery::datatransfer::v1::CheckValidCredsResponse>

--- a/google/cloud/bigquery/internal/migration_tracing_connection.cc
+++ b/google/cloud/bigquery/internal/migration_tracing_connection.cc
@@ -58,11 +58,11 @@ MigrationServiceTracingConnection::ListMigrationWorkflows(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::MigrationServiceConnection::ListMigrationWorkflows");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMigrationWorkflows(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::bigquery::migration::v2::MigrationWorkflow>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 Status MigrationServiceTracingConnection::DeleteMigrationWorkflow(
@@ -99,11 +99,11 @@ MigrationServiceTracingConnection::ListMigrationSubtasks(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::MigrationServiceConnection::ListMigrationSubtasks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMigrationSubtasks(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::migration::v2::MigrationSubtask>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::migration::v2::MigrationSubtask>(std::move(span),
+                                                                std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/bigquery/internal/reservation_tracing_connection.cc
+++ b/google/cloud/bigquery/internal/reservation_tracing_connection.cc
@@ -47,11 +47,11 @@ ReservationServiceTracingConnection::ListReservations(
     google::cloud::bigquery::reservation::v1::ListReservationsRequest request) {
   auto span = internal::MakeSpan(
       "bigquery::ReservationServiceConnection::ListReservations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListReservations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::reservation::v1::Reservation>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::reservation::v1::Reservation>(std::move(span),
+                                                             std::move(sr));
 }
 
 StatusOr<google::cloud::bigquery::reservation::v1::Reservation>
@@ -99,11 +99,11 @@ ReservationServiceTracingConnection::ListCapacityCommitments(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::ReservationServiceConnection::ListCapacityCommitments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCapacityCommitments(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::bigquery::reservation::v1::CapacityCommitment>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>
@@ -171,11 +171,11 @@ ReservationServiceTracingConnection::ListAssignments(
     google::cloud::bigquery::reservation::v1::ListAssignmentsRequest request) {
   auto span = internal::MakeSpan(
       "bigquery::ReservationServiceConnection::ListAssignments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAssignments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::reservation::v1::Assignment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::reservation::v1::Assignment>(std::move(span),
+                                                            std::move(sr));
 }
 
 Status ReservationServiceTracingConnection::DeleteAssignment(
@@ -193,11 +193,11 @@ ReservationServiceTracingConnection::SearchAssignments(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::ReservationServiceConnection::SearchAssignments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchAssignments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::reservation::v1::Assignment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::reservation::v1::Assignment>(std::move(span),
+                                                            std::move(sr));
 }
 
 StreamRange<google::cloud::bigquery::reservation::v1::Assignment>
@@ -206,11 +206,11 @@ ReservationServiceTracingConnection::SearchAllAssignments(
         request) {
   auto span = internal::MakeSpan(
       "bigquery::ReservationServiceConnection::SearchAllAssignments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchAllAssignments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::bigquery::reservation::v1::Assignment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::bigquery::reservation::v1::Assignment>(std::move(span),
+                                                            std::move(sr));
 }
 
 StatusOr<google::cloud::bigquery::reservation::v1::Assignment>

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_tracing_connection.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_tracing_connection.cc
@@ -146,11 +146,10 @@ BigtableInstanceAdminTracingConnection::ListAppProfiles(
     google::bigtable::admin::v2::ListAppProfilesRequest request) {
   auto span = internal::MakeSpan(
       "bigtable_admin::BigtableInstanceAdminConnection::ListAppProfiles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAppProfiles(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::bigtable::admin::v2::AppProfile>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::bigtable::admin::v2::AppProfile>(std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::bigtable::admin::v2::AppProfile>>
@@ -199,11 +198,10 @@ BigtableInstanceAdminTracingConnection::ListHotTablets(
     google::bigtable::admin::v2::ListHotTabletsRequest request) {
   auto span = internal::MakeSpan(
       "bigtable_admin::BigtableInstanceAdminConnection::ListHotTablets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListHotTablets(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::bigtable::admin::v2::HotTablet>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::bigtable::admin::v2::HotTablet>(std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_tracing_connection.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_tracing_connection.cc
@@ -46,10 +46,10 @@ BigtableTableAdminTracingConnection::ListTables(
     google::bigtable::admin::v2::ListTablesRequest request) {
   auto span = internal::MakeSpan(
       "bigtable_admin::BigtableTableAdminConnection::ListTables");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTables(std::move(request));
   return internal::MakeTracedStreamRange<google::bigtable::admin::v2::Table>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::bigtable::admin::v2::Table>
@@ -154,10 +154,10 @@ BigtableTableAdminTracingConnection::ListBackups(
     google::bigtable::admin::v2::ListBackupsRequest request) {
   auto span = internal::MakeSpan(
       "bigtable_admin::BigtableTableAdminConnection::ListBackups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBackups(std::move(request));
   return internal::MakeTracedStreamRange<google::bigtable::admin::v2::Backup>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::bigtable::admin::v2::Table>>

--- a/google/cloud/billing/internal/budget_tracing_connection.cc
+++ b/google/cloud/billing/internal/budget_tracing_connection.cc
@@ -63,11 +63,11 @@ BudgetServiceTracingConnection::ListBudgets(
     google::cloud::billing::budgets::v1::ListBudgetsRequest request) {
   auto span =
       internal::MakeSpan("billing::BudgetServiceConnection::ListBudgets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBudgets(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::billing::budgets::v1::Budget>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::billing::budgets::v1::Budget>(std::move(span),
+                                                   std::move(sr));
 }
 
 Status BudgetServiceTracingConnection::DeleteBudget(

--- a/google/cloud/billing/internal/cloud_billing_tracing_connection.cc
+++ b/google/cloud/billing/internal/cloud_billing_tracing_connection.cc
@@ -46,11 +46,11 @@ CloudBillingTracingConnection::ListBillingAccounts(
     google::cloud::billing::v1::ListBillingAccountsRequest request) {
   auto span = internal::MakeSpan(
       "billing::CloudBillingConnection::ListBillingAccounts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBillingAccounts(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::billing::v1::BillingAccount>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::billing::v1::BillingAccount>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::billing::v1::BillingAccount>
@@ -76,11 +76,11 @@ CloudBillingTracingConnection::ListProjectBillingInfo(
     google::cloud::billing::v1::ListProjectBillingInfoRequest request) {
   auto span = internal::MakeSpan(
       "billing::CloudBillingConnection::ListProjectBillingInfo");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProjectBillingInfo(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::billing::v1::ProjectBillingInfo>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::billing::v1::ProjectBillingInfo>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::billing::v1::ProjectBillingInfo>

--- a/google/cloud/billing/internal/cloud_catalog_tracing_connection.cc
+++ b/google/cloud/billing/internal/cloud_catalog_tracing_connection.cc
@@ -37,20 +37,20 @@ CloudCatalogTracingConnection::ListServices(
     google::cloud::billing::v1::ListServicesRequest request) {
   auto span =
       internal::MakeSpan("billing::CloudCatalogConnection::ListServices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServices(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::billing::v1::Service>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::billing::v1::Sku>
 CloudCatalogTracingConnection::ListSkus(
     google::cloud::billing::v1::ListSkusRequest request) {
   auto span = internal::MakeSpan("billing::CloudCatalogConnection::ListSkus");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSkus(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::billing::v1::Sku>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_tracing_connection.cc
+++ b/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_tracing_connection.cc
@@ -93,11 +93,11 @@ BinauthzManagementServiceV1TracingConnection::ListAttestors(
   auto span = internal::MakeSpan(
       "binaryauthorization::BinauthzManagementServiceV1Connection::"
       "ListAttestors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAttestors(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::binaryauthorization::v1::Attestor>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::binaryauthorization::v1::Attestor>(std::move(span),
+                                                        std::move(sr));
 }
 
 Status BinauthzManagementServiceV1TracingConnection::DeleteAttestor(

--- a/google/cloud/certificatemanager/internal/certificate_manager_tracing_connection.cc
+++ b/google/cloud/certificatemanager/internal/certificate_manager_tracing_connection.cc
@@ -37,11 +37,11 @@ CertificateManagerTracingConnection::ListCertificates(
     google::cloud::certificatemanager::v1::ListCertificatesRequest request) {
   auto span = internal::MakeSpan(
       "certificatemanager::CertificateManagerConnection::ListCertificates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCertificates(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::certificatemanager::v1::Certificate>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::certificatemanager::v1::Certificate>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::cloud::certificatemanager::v1::Certificate>
@@ -80,11 +80,11 @@ CertificateManagerTracingConnection::ListCertificateMaps(
     google::cloud::certificatemanager::v1::ListCertificateMapsRequest request) {
   auto span = internal::MakeSpan(
       "certificatemanager::CertificateManagerConnection::ListCertificateMaps");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCertificateMaps(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::certificatemanager::v1::CertificateMap>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::certificatemanager::v1::CertificateMap>(std::move(span),
+                                                             std::move(sr));
 }
 
 StatusOr<google::cloud::certificatemanager::v1::CertificateMap>
@@ -125,11 +125,11 @@ CertificateManagerTracingConnection::ListCertificateMapEntries(
   auto span = internal::MakeSpan(
       "certificatemanager::CertificateManagerConnection::"
       "ListCertificateMapEntries");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCertificateMapEntries(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::certificatemanager::v1::CertificateMapEntry>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::certificatemanager::v1::CertificateMapEntry>
@@ -171,11 +171,11 @@ CertificateManagerTracingConnection::ListDnsAuthorizations(
   auto span = internal::MakeSpan(
       "certificatemanager::CertificateManagerConnection::"
       "ListDnsAuthorizations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDnsAuthorizations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::certificatemanager::v1::DnsAuthorization>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::certificatemanager::v1::DnsAuthorization>(std::move(span),
+                                                               std::move(sr));
 }
 
 StatusOr<google::cloud::certificatemanager::v1::DnsAuthorization>
@@ -216,11 +216,11 @@ CertificateManagerTracingConnection::ListCertificateIssuanceConfigs(
   auto span = internal::MakeSpan(
       "certificatemanager::CertificateManagerConnection::"
       "ListCertificateIssuanceConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCertificateIssuanceConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::certificatemanager::v1::CertificateIssuanceConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::certificatemanager::v1::CertificateIssuanceConfig>

--- a/google/cloud/channel/internal/cloud_channel_tracing_connection.cc
+++ b/google/cloud/channel/internal/cloud_channel_tracing_connection.cc
@@ -37,10 +37,10 @@ CloudChannelServiceTracingConnection::ListCustomers(
     google::cloud::channel::v1::ListCustomersRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListCustomers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCustomers(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::channel::v1::Customer>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::channel::v1::Customer>
@@ -110,11 +110,10 @@ CloudChannelServiceTracingConnection::ListEntitlements(
     google::cloud::channel::v1::ListEntitlementsRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListEntitlements");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEntitlements(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::channel::v1::Entitlement>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::channel::v1::Entitlement>(std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::channel::v1::TransferableSku>
@@ -122,11 +121,11 @@ CloudChannelServiceTracingConnection::ListTransferableSkus(
     google::cloud::channel::v1::ListTransferableSkusRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListTransferableSkus");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTransferableSkus(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::channel::v1::TransferableSku>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::channel::v1::TransferableSku>(std::move(span),
+                                                   std::move(sr));
 }
 
 StreamRange<google::cloud::channel::v1::TransferableOffer>
@@ -134,11 +133,11 @@ CloudChannelServiceTracingConnection::ListTransferableOffers(
     google::cloud::channel::v1::ListTransferableOffersRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListTransferableOffers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTransferableOffers(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::channel::v1::TransferableOffer>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::channel::v1::TransferableOffer>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::channel::v1::Entitlement>
@@ -216,11 +215,11 @@ CloudChannelServiceTracingConnection::ListChannelPartnerLinks(
     google::cloud::channel::v1::ListChannelPartnerLinksRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListChannelPartnerLinks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListChannelPartnerLinks(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::channel::v1::ChannelPartnerLink>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::channel::v1::ChannelPartnerLink>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::channel::v1::ChannelPartnerLink>
@@ -267,11 +266,11 @@ CloudChannelServiceTracingConnection::ListCustomerRepricingConfigs(
     google::cloud::channel::v1::ListCustomerRepricingConfigsRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListCustomerRepricingConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCustomerRepricingConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::channel::v1::CustomerRepricingConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::channel::v1::CustomerRepricingConfig>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::cloud::channel::v1::CustomerRepricingConfig>
@@ -325,11 +324,11 @@ CloudChannelServiceTracingConnection::ListChannelPartnerRepricingConfigs(
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::"
       "ListChannelPartnerRepricingConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListChannelPartnerRepricingConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::channel::v1::ChannelPartnerRepricingConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::channel::v1::ChannelPartnerRepricingConfig>
@@ -382,10 +381,10 @@ CloudChannelServiceTracingConnection::ListProducts(
     google::cloud::channel::v1::ListProductsRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListProducts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProducts(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::channel::v1::Product>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::channel::v1::Sku>
@@ -393,10 +392,10 @@ CloudChannelServiceTracingConnection::ListSkus(
     google::cloud::channel::v1::ListSkusRequest request) {
   auto span =
       internal::MakeSpan("channel::CloudChannelServiceConnection::ListSkus");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSkus(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::channel::v1::Sku>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::channel::v1::Offer>
@@ -404,10 +403,10 @@ CloudChannelServiceTracingConnection::ListOffers(
     google::cloud::channel::v1::ListOffersRequest request) {
   auto span =
       internal::MakeSpan("channel::CloudChannelServiceConnection::ListOffers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListOffers(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::channel::v1::Offer>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::channel::v1::PurchasableSku>
@@ -415,11 +414,11 @@ CloudChannelServiceTracingConnection::ListPurchasableSkus(
     google::cloud::channel::v1::ListPurchasableSkusRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListPurchasableSkus");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPurchasableSkus(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::channel::v1::PurchasableSku>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::channel::v1::PurchasableSku>(std::move(span),
+                                                  std::move(sr));
 }
 
 StreamRange<google::cloud::channel::v1::PurchasableOffer>
@@ -427,11 +426,11 @@ CloudChannelServiceTracingConnection::ListPurchasableOffers(
     google::cloud::channel::v1::ListPurchasableOffersRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListPurchasableOffers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPurchasableOffers(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::channel::v1::PurchasableOffer>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::channel::v1::PurchasableOffer>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::channel::v1::RegisterSubscriberResponse>
@@ -456,10 +455,10 @@ StreamRange<std::string> CloudChannelServiceTracingConnection::ListSubscribers(
     google::cloud::channel::v1::ListSubscribersRequest request) {
   auto span = internal::MakeSpan(
       "channel::CloudChannelServiceConnection::ListSubscribers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSubscribers(std::move(request));
-  return internal::MakeTracedStreamRange<std::string>(
-      std::move(span), std::move(scope), std::move(sr));
+  return internal::MakeTracedStreamRange<std::string>(std::move(span),
+                                                      std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/cloudbuild/internal/cloud_build_tracing_connection.cc
+++ b/google/cloud/cloudbuild/internal/cloud_build_tracing_connection.cc
@@ -51,11 +51,10 @@ CloudBuildTracingConnection::ListBuilds(
     google::devtools::cloudbuild::v1::ListBuildsRequest request) {
   auto span =
       internal::MakeSpan("cloudbuild::CloudBuildConnection::ListBuilds");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBuilds(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::cloudbuild::v1::Build>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::devtools::cloudbuild::v1::Build>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::devtools::cloudbuild::v1::Build>
@@ -103,11 +102,11 @@ CloudBuildTracingConnection::ListBuildTriggers(
     google::devtools::cloudbuild::v1::ListBuildTriggersRequest request) {
   auto span =
       internal::MakeSpan("cloudbuild::CloudBuildConnection::ListBuildTriggers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBuildTriggers(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::cloudbuild::v1::BuildTrigger>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::cloudbuild::v1::BuildTrigger>(std::move(span),
+                                                      std::move(sr));
 }
 
 Status CloudBuildTracingConnection::DeleteBuildTrigger(
@@ -178,11 +177,11 @@ CloudBuildTracingConnection::ListWorkerPools(
     google::devtools::cloudbuild::v1::ListWorkerPoolsRequest request) {
   auto span =
       internal::MakeSpan("cloudbuild::CloudBuildConnection::ListWorkerPools");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListWorkerPools(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::devtools::cloudbuild::v1::WorkerPool>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::devtools::cloudbuild::v1::WorkerPool>(std::move(span),
+                                                    std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/composer/internal/environments_tracing_connection.cc
+++ b/google/cloud/composer/internal/environments_tracing_connection.cc
@@ -56,11 +56,11 @@ EnvironmentsTracingConnection::ListEnvironments(
         request) {
   auto span =
       internal::MakeSpan("composer::EnvironmentsConnection::ListEnvironments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEnvironments(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::orchestration::airflow::service::v1::Environment>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<

--- a/google/cloud/composer/internal/image_versions_tracing_connection.cc
+++ b/google/cloud/composer/internal/image_versions_tracing_connection.cc
@@ -38,11 +38,11 @@ ImageVersionsTracingConnection::ListImageVersions(
         request) {
   auto span = internal::MakeSpan(
       "composer::ImageVersionsConnection::ListImageVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListImageVersions(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::orchestration::airflow::service::v1::ImageVersion>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/connectors/internal/connectors_tracing_connection.cc
+++ b/google/cloud/connectors/internal/connectors_tracing_connection.cc
@@ -37,11 +37,11 @@ ConnectorsTracingConnection::ListConnections(
     google::cloud::connectors::v1::ListConnectionsRequest request) {
   auto span =
       internal::MakeSpan("connectors::ConnectorsConnection::ListConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnections(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::connectors::v1::Connection>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::connectors::v1::Connection>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::connectors::v1::Connection>
@@ -76,11 +76,10 @@ ConnectorsTracingConnection::ListProviders(
     google::cloud::connectors::v1::ListProvidersRequest request) {
   auto span =
       internal::MakeSpan("connectors::ConnectorsConnection::ListProviders");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProviders(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::connectors::v1::Provider>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::connectors::v1::Provider>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::connectors::v1::Provider>
@@ -97,11 +96,10 @@ ConnectorsTracingConnection::ListConnectors(
     google::cloud::connectors::v1::ListConnectorsRequest request) {
   auto span =
       internal::MakeSpan("connectors::ConnectorsConnection::ListConnectors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnectors(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::connectors::v1::Connector>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::connectors::v1::Connector>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::connectors::v1::Connector>
@@ -118,11 +116,11 @@ ConnectorsTracingConnection::ListConnectorVersions(
     google::cloud::connectors::v1::ListConnectorVersionsRequest request) {
   auto span = internal::MakeSpan(
       "connectors::ConnectorsConnection::ListConnectorVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnectorVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::connectors::v1::ConnectorVersion>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::connectors::v1::ConnectorVersion>(std::move(span),
+                                                       std::move(sr));
 }
 
 StatusOr<google::cloud::connectors::v1::ConnectorVersion>
@@ -149,11 +147,11 @@ ConnectorsTracingConnection::ListRuntimeEntitySchemas(
     google::cloud::connectors::v1::ListRuntimeEntitySchemasRequest request) {
   auto span = internal::MakeSpan(
       "connectors::ConnectorsConnection::ListRuntimeEntitySchemas");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRuntimeEntitySchemas(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::connectors::v1::RuntimeEntitySchema>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::connectors::v1::RuntimeEntitySchema>(std::move(span),
+                                                          std::move(sr));
 }
 
 StreamRange<google::cloud::connectors::v1::RuntimeActionSchema>
@@ -161,11 +159,11 @@ ConnectorsTracingConnection::ListRuntimeActionSchemas(
     google::cloud::connectors::v1::ListRuntimeActionSchemasRequest request) {
   auto span = internal::MakeSpan(
       "connectors::ConnectorsConnection::ListRuntimeActionSchemas");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRuntimeActionSchemas(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::connectors::v1::RuntimeActionSchema>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::connectors::v1::RuntimeActionSchema>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::cloud::connectors::v1::RuntimeConfig>

--- a/google/cloud/contactcenterinsights/internal/contact_center_insights_tracing_connection.cc
+++ b/google/cloud/contactcenterinsights/internal/contact_center_insights_tracing_connection.cc
@@ -73,11 +73,11 @@ ContactCenterInsightsTracingConnection::ListConversations(
   auto span = internal::MakeSpan(
       "contactcenterinsights::ContactCenterInsightsConnection::"
       "ListConversations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConversations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::contactcenterinsights::v1::Conversation>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::contactcenterinsights::v1::Conversation>(std::move(span),
+                                                              std::move(sr));
 }
 
 Status ContactCenterInsightsTracingConnection::DeleteConversation(
@@ -112,11 +112,11 @@ ContactCenterInsightsTracingConnection::ListAnalyses(
     google::cloud::contactcenterinsights::v1::ListAnalysesRequest request) {
   auto span = internal::MakeSpan(
       "contactcenterinsights::ContactCenterInsightsConnection::ListAnalyses");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAnalyses(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::contactcenterinsights::v1::Analysis>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::contactcenterinsights::v1::Analysis>(std::move(span),
+                                                          std::move(sr));
 }
 
 Status ContactCenterInsightsTracingConnection::DeleteAnalysis(
@@ -294,11 +294,11 @@ ContactCenterInsightsTracingConnection::ListPhraseMatchers(
   auto span = internal::MakeSpan(
       "contactcenterinsights::ContactCenterInsightsConnection::"
       "ListPhraseMatchers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPhraseMatchers(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::contactcenterinsights::v1::PhraseMatcher>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::contactcenterinsights::v1::PhraseMatcher>(std::move(span),
+                                                               std::move(sr));
 }
 
 Status ContactCenterInsightsTracingConnection::DeletePhraseMatcher(
@@ -376,11 +376,11 @@ ContactCenterInsightsTracingConnection::ListViews(
     google::cloud::contactcenterinsights::v1::ListViewsRequest request) {
   auto span = internal::MakeSpan(
       "contactcenterinsights::ContactCenterInsightsConnection::ListViews");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListViews(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::contactcenterinsights::v1::View>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::contactcenterinsights::v1::View>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::View>

--- a/google/cloud/container/internal/cluster_manager_tracing_connection.cc
+++ b/google/cloud/container/internal/cluster_manager_tracing_connection.cc
@@ -323,11 +323,10 @@ ClusterManagerTracingConnection::ListUsableSubnetworks(
     google::container::v1::ListUsableSubnetworksRequest request) {
   auto span = internal::MakeSpan(
       "container::ClusterManagerConnection::ListUsableSubnetworks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListUsableSubnetworks(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::container::v1::UsableSubnetwork>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::container::v1::UsableSubnetwork>(std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/containeranalysis/internal/grafeas_tracing_connection.cc
+++ b/google/cloud/containeranalysis/internal/grafeas_tracing_connection.cc
@@ -44,10 +44,10 @@ StreamRange<grafeas::v1::Occurrence> GrafeasTracingConnection::ListOccurrences(
     grafeas::v1::ListOccurrencesRequest request) {
   auto span = internal::MakeSpan(
       "containeranalysis::GrafeasConnection::ListOccurrences");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListOccurrences(std::move(request));
   return internal::MakeTracedStreamRange<grafeas::v1::Occurrence>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 Status GrafeasTracingConnection::DeleteOccurrence(
@@ -103,10 +103,10 @@ StreamRange<grafeas::v1::Note> GrafeasTracingConnection::ListNotes(
     grafeas::v1::ListNotesRequest request) {
   auto span =
       internal::MakeSpan("containeranalysis::GrafeasConnection::ListNotes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNotes(std::move(request));
-  return internal::MakeTracedStreamRange<grafeas::v1::Note>(
-      std::move(span), std::move(scope), std::move(sr));
+  return internal::MakeTracedStreamRange<grafeas::v1::Note>(std::move(span),
+                                                            std::move(sr));
 }
 
 Status GrafeasTracingConnection::DeleteNote(
@@ -147,10 +147,10 @@ GrafeasTracingConnection::ListNoteOccurrences(
     grafeas::v1::ListNoteOccurrencesRequest request) {
   auto span = internal::MakeSpan(
       "containeranalysis::GrafeasConnection::ListNoteOccurrences");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNoteOccurrences(std::move(request));
   return internal::MakeTracedStreamRange<grafeas::v1::Occurrence>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/datacatalog/internal/data_catalog_tracing_connection.cc
+++ b/google/cloud/datacatalog/internal/data_catalog_tracing_connection.cc
@@ -37,11 +37,11 @@ DataCatalogTracingConnection::SearchCatalog(
     google::cloud::datacatalog::v1::SearchCatalogRequest request) {
   auto span =
       internal::MakeSpan("datacatalog::DataCatalogConnection::SearchCatalog");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchCatalog(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::datacatalog::v1::SearchCatalogResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::datacatalog::v1::SearchCatalogResult>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::cloud::datacatalog::v1::EntryGroup>
@@ -84,11 +84,11 @@ DataCatalogTracingConnection::ListEntryGroups(
     google::cloud::datacatalog::v1::ListEntryGroupsRequest request) {
   auto span =
       internal::MakeSpan("datacatalog::DataCatalogConnection::ListEntryGroups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEntryGroups(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::datacatalog::v1::EntryGroup>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::datacatalog::v1::EntryGroup>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::datacatalog::v1::Entry>
@@ -140,10 +140,10 @@ DataCatalogTracingConnection::ListEntries(
     google::cloud::datacatalog::v1::ListEntriesRequest request) {
   auto span =
       internal::MakeSpan("datacatalog::DataCatalogConnection::ListEntries");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEntries(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::datacatalog::v1::Entry>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::datacatalog::v1::EntryOverview>
@@ -280,10 +280,10 @@ DataCatalogTracingConnection::ListTags(
     google::cloud::datacatalog::v1::ListTagsRequest request) {
   auto span =
       internal::MakeSpan("datacatalog::DataCatalogConnection::ListTags");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTags(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::datacatalog::v1::Tag>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::datacatalog::v1::StarEntryResponse>

--- a/google/cloud/datacatalog/internal/policy_tag_manager_tracing_connection.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_tracing_connection.cc
@@ -63,11 +63,10 @@ PolicyTagManagerTracingConnection::ListTaxonomies(
     google::cloud::datacatalog::v1::ListTaxonomiesRequest request) {
   auto span = internal::MakeSpan(
       "datacatalog::PolicyTagManagerConnection::ListTaxonomies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTaxonomies(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::datacatalog::v1::Taxonomy>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::datacatalog::v1::Taxonomy>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
@@ -110,11 +109,11 @@ PolicyTagManagerTracingConnection::ListPolicyTags(
     google::cloud::datacatalog::v1::ListPolicyTagsRequest request) {
   auto span = internal::MakeSpan(
       "datacatalog::PolicyTagManagerConnection::ListPolicyTags");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPolicyTags(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::datacatalog::v1::PolicyTag>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::datacatalog::v1::PolicyTag>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::datacatalog::v1::PolicyTag>

--- a/google/cloud/datamigration/internal/data_migration_tracing_connection.cc
+++ b/google/cloud/datamigration/internal/data_migration_tracing_connection.cc
@@ -37,11 +37,11 @@ DataMigrationServiceTracingConnection::ListMigrationJobs(
     google::cloud::clouddms::v1::ListMigrationJobsRequest request) {
   auto span = internal::MakeSpan(
       "datamigration::DataMigrationServiceConnection::ListMigrationJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMigrationJobs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::clouddms::v1::MigrationJob>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::clouddms::v1::MigrationJob>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::clouddms::v1::MigrationJob>
@@ -121,11 +121,11 @@ DataMigrationServiceTracingConnection::ListConnectionProfiles(
     google::cloud::clouddms::v1::ListConnectionProfilesRequest request) {
   auto span = internal::MakeSpan(
       "datamigration::DataMigrationServiceConnection::ListConnectionProfiles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnectionProfiles(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::clouddms::v1::ConnectionProfile>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::clouddms::v1::ConnectionProfile>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::clouddms::v1::ConnectionProfile>

--- a/google/cloud/dataplex/internal/content_tracing_connection.cc
+++ b/google/cloud/dataplex/internal/content_tracing_connection.cc
@@ -97,10 +97,10 @@ ContentServiceTracingConnection::ListContent(
     google::cloud::dataplex::v1::ListContentRequest request) {
   auto span =
       internal::MakeSpan("dataplex::ContentServiceConnection::ListContent");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListContent(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Content>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/dataplex/internal/dataplex_tracing_connection.cc
+++ b/google/cloud/dataplex/internal/dataplex_tracing_connection.cc
@@ -55,10 +55,10 @@ DataplexServiceTracingConnection::ListLakes(
     google::cloud::dataplex::v1::ListLakesRequest request) {
   auto span =
       internal::MakeSpan("dataplex::DataplexServiceConnection::ListLakes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListLakes(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Lake>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dataplex::v1::Lake>
@@ -75,10 +75,10 @@ DataplexServiceTracingConnection::ListLakeActions(
     google::cloud::dataplex::v1::ListLakeActionsRequest request) {
   auto span = internal::MakeSpan(
       "dataplex::DataplexServiceConnection::ListLakeActions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListLakeActions(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Action>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::dataplex::v1::Zone>>
@@ -104,10 +104,10 @@ DataplexServiceTracingConnection::ListZones(
     google::cloud::dataplex::v1::ListZonesRequest request) {
   auto span =
       internal::MakeSpan("dataplex::DataplexServiceConnection::ListZones");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListZones(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Zone>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dataplex::v1::Zone>
@@ -124,10 +124,10 @@ DataplexServiceTracingConnection::ListZoneActions(
     google::cloud::dataplex::v1::ListZoneActionsRequest request) {
   auto span = internal::MakeSpan(
       "dataplex::DataplexServiceConnection::ListZoneActions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListZoneActions(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Action>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::dataplex::v1::Asset>>
@@ -153,10 +153,10 @@ DataplexServiceTracingConnection::ListAssets(
     google::cloud::dataplex::v1::ListAssetsRequest request) {
   auto span =
       internal::MakeSpan("dataplex::DataplexServiceConnection::ListAssets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAssets(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Asset>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dataplex::v1::Asset>
@@ -173,10 +173,10 @@ DataplexServiceTracingConnection::ListAssetActions(
     google::cloud::dataplex::v1::ListAssetActionsRequest request) {
   auto span = internal::MakeSpan(
       "dataplex::DataplexServiceConnection::ListAssetActions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAssetActions(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Action>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::dataplex::v1::Task>>
@@ -202,10 +202,10 @@ DataplexServiceTracingConnection::ListTasks(
     google::cloud::dataplex::v1::ListTasksRequest request) {
   auto span =
       internal::MakeSpan("dataplex::DataplexServiceConnection::ListTasks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTasks(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Task>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dataplex::v1::Task>
@@ -222,10 +222,10 @@ DataplexServiceTracingConnection::ListJobs(
     google::cloud::dataplex::v1::ListJobsRequest request) {
   auto span =
       internal::MakeSpan("dataplex::DataplexServiceConnection::ListJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobs(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Job>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dataplex::v1::Job>
@@ -267,11 +267,10 @@ DataplexServiceTracingConnection::ListEnvironments(
     google::cloud::dataplex::v1::ListEnvironmentsRequest request) {
   auto span = internal::MakeSpan(
       "dataplex::DataplexServiceConnection::ListEnvironments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEnvironments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dataplex::v1::Environment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dataplex::v1::Environment>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dataplex::v1::Environment>
@@ -288,10 +287,10 @@ DataplexServiceTracingConnection::ListSessions(
     google::cloud::dataplex::v1::ListSessionsRequest request) {
   auto span =
       internal::MakeSpan("dataplex::DataplexServiceConnection::ListSessions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSessions(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Session>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/dataplex/internal/metadata_tracing_connection.cc
+++ b/google/cloud/dataplex/internal/metadata_tracing_connection.cc
@@ -72,10 +72,10 @@ MetadataServiceTracingConnection::ListEntities(
     google::cloud::dataplex::v1::ListEntitiesRequest request) {
   auto span =
       internal::MakeSpan("dataplex::MetadataServiceConnection::ListEntities");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEntities(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataplex::v1::Entity>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dataplex::v1::Partition>
@@ -109,11 +109,10 @@ MetadataServiceTracingConnection::ListPartitions(
     google::cloud::dataplex::v1::ListPartitionsRequest request) {
   auto span =
       internal::MakeSpan("dataplex::MetadataServiceConnection::ListPartitions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPartitions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dataplex::v1::Partition>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::dataplex::v1::Partition>(std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/dataproc/internal/autoscaling_policy_tracing_connection.cc
+++ b/google/cloud/dataproc/internal/autoscaling_policy_tracing_connection.cc
@@ -67,11 +67,11 @@ AutoscalingPolicyServiceTracingConnection::ListAutoscalingPolicies(
     google::cloud::dataproc::v1::ListAutoscalingPoliciesRequest request) {
   auto span = internal::MakeSpan(
       "dataproc::AutoscalingPolicyServiceConnection::ListAutoscalingPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAutoscalingPolicies(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dataproc::v1::AutoscalingPolicy>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dataproc::v1::AutoscalingPolicy>(std::move(span),
+                                                      std::move(sr));
 }
 
 Status AutoscalingPolicyServiceTracingConnection::DeleteAutoscalingPolicy(

--- a/google/cloud/dataproc/internal/batch_controller_tracing_connection.cc
+++ b/google/cloud/dataproc/internal/batch_controller_tracing_connection.cc
@@ -52,10 +52,10 @@ BatchControllerTracingConnection::ListBatches(
     google::cloud::dataproc::v1::ListBatchesRequest request) {
   auto span =
       internal::MakeSpan("dataproc::BatchControllerConnection::ListBatches");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBatches(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataproc::v1::Batch>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 Status BatchControllerTracingConnection::DeleteBatch(

--- a/google/cloud/dataproc/internal/cluster_controller_tracing_connection.cc
+++ b/google/cloud/dataproc/internal/cluster_controller_tracing_connection.cc
@@ -76,10 +76,10 @@ ClusterControllerTracingConnection::ListClusters(
     google::cloud::dataproc::v1::ListClustersRequest request) {
   auto span =
       internal::MakeSpan("dataproc::ClusterControllerConnection::ListClusters");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListClusters(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataproc::v1::Cluster>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::dataproc::v1::DiagnoseClusterResults>>

--- a/google/cloud/dataproc/internal/job_controller_tracing_connection.cc
+++ b/google/cloud/dataproc/internal/job_controller_tracing_connection.cc
@@ -59,10 +59,10 @@ StreamRange<google::cloud::dataproc::v1::Job>
 JobControllerTracingConnection::ListJobs(
     google::cloud::dataproc::v1::ListJobsRequest request) {
   auto span = internal::MakeSpan("dataproc::JobControllerConnection::ListJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobs(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dataproc::v1::Job>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dataproc::v1::Job>

--- a/google/cloud/dataproc/internal/workflow_template_tracing_connection.cc
+++ b/google/cloud/dataproc/internal/workflow_template_tracing_connection.cc
@@ -79,11 +79,11 @@ WorkflowTemplateServiceTracingConnection::ListWorkflowTemplates(
     google::cloud::dataproc::v1::ListWorkflowTemplatesRequest request) {
   auto span = internal::MakeSpan(
       "dataproc::WorkflowTemplateServiceConnection::ListWorkflowTemplates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListWorkflowTemplates(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dataproc::v1::WorkflowTemplate>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dataproc::v1::WorkflowTemplate>(std::move(span),
+                                                     std::move(sr));
 }
 
 Status WorkflowTemplateServiceTracingConnection::DeleteWorkflowTemplate(

--- a/google/cloud/datastream/internal/datastream_tracing_connection.cc
+++ b/google/cloud/datastream/internal/datastream_tracing_connection.cc
@@ -37,11 +37,11 @@ DatastreamTracingConnection::ListConnectionProfiles(
     google::cloud::datastream::v1::ListConnectionProfilesRequest request) {
   auto span = internal::MakeSpan(
       "datastream::DatastreamConnection::ListConnectionProfiles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnectionProfiles(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::datastream::v1::ConnectionProfile>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::datastream::v1::ConnectionProfile>(std::move(span),
+                                                        std::move(sr));
 }
 
 StatusOr<google::cloud::datastream::v1::ConnectionProfile>
@@ -89,10 +89,10 @@ DatastreamTracingConnection::ListStreams(
     google::cloud::datastream::v1::ListStreamsRequest request) {
   auto span =
       internal::MakeSpan("datastream::DatastreamConnection::ListStreams");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListStreams(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::datastream::v1::Stream>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::datastream::v1::Stream>
@@ -144,11 +144,11 @@ DatastreamTracingConnection::ListStreamObjects(
     google::cloud::datastream::v1::ListStreamObjectsRequest request) {
   auto span =
       internal::MakeSpan("datastream::DatastreamConnection::ListStreamObjects");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListStreamObjects(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::datastream::v1::StreamObject>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::datastream::v1::StreamObject>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::datastream::v1::StartBackfillJobResponse>
@@ -173,10 +173,10 @@ StreamRange<std::string> DatastreamTracingConnection::FetchStaticIps(
     google::cloud::datastream::v1::FetchStaticIpsRequest request) {
   auto span =
       internal::MakeSpan("datastream::DatastreamConnection::FetchStaticIps");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->FetchStaticIps(std::move(request));
-  return internal::MakeTracedStreamRange<std::string>(
-      std::move(span), std::move(scope), std::move(sr));
+  return internal::MakeTracedStreamRange<std::string>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::cloud::datastream::v1::PrivateConnection>>
@@ -200,11 +200,11 @@ DatastreamTracingConnection::ListPrivateConnections(
     google::cloud::datastream::v1::ListPrivateConnectionsRequest request) {
   auto span = internal::MakeSpan(
       "datastream::DatastreamConnection::ListPrivateConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPrivateConnections(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::datastream::v1::PrivateConnection>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::datastream::v1::PrivateConnection>(std::move(span),
+                                                        std::move(sr));
 }
 
 future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>
@@ -233,10 +233,10 @@ DatastreamTracingConnection::ListRoutes(
     google::cloud::datastream::v1::ListRoutesRequest request) {
   auto span =
       internal::MakeSpan("datastream::DatastreamConnection::ListRoutes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRoutes(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::datastream::v1::Route>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>

--- a/google/cloud/deploy/internal/cloud_deploy_tracing_connection.cc
+++ b/google/cloud/deploy/internal/cloud_deploy_tracing_connection.cc
@@ -37,11 +37,11 @@ CloudDeployTracingConnection::ListDeliveryPipelines(
     google::cloud::deploy::v1::ListDeliveryPipelinesRequest request) {
   auto span = internal::MakeSpan(
       "deploy::CloudDeployConnection::ListDeliveryPipelines");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDeliveryPipelines(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::deploy::v1::DeliveryPipeline>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::deploy::v1::DeliveryPipeline>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::deploy::v1::DeliveryPipeline>
@@ -75,10 +75,10 @@ StreamRange<google::cloud::deploy::v1::Target>
 CloudDeployTracingConnection::ListTargets(
     google::cloud::deploy::v1::ListTargetsRequest request) {
   auto span = internal::MakeSpan("deploy::CloudDeployConnection::ListTargets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTargets(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::deploy::v1::Target>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::deploy::v1::Target>
@@ -111,10 +111,10 @@ StreamRange<google::cloud::deploy::v1::Release>
 CloudDeployTracingConnection::ListReleases(
     google::cloud::deploy::v1::ListReleasesRequest request) {
   auto span = internal::MakeSpan("deploy::CloudDeployConnection::ListReleases");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListReleases(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::deploy::v1::Release>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::deploy::v1::Release>
@@ -153,10 +153,10 @@ StreamRange<google::cloud::deploy::v1::Rollout>
 CloudDeployTracingConnection::ListRollouts(
     google::cloud::deploy::v1::ListRolloutsRequest request) {
   auto span = internal::MakeSpan("deploy::CloudDeployConnection::ListRollouts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRollouts(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::deploy::v1::Rollout>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::deploy::v1::Rollout>
@@ -185,10 +185,10 @@ StreamRange<google::cloud::deploy::v1::JobRun>
 CloudDeployTracingConnection::ListJobRuns(
     google::cloud::deploy::v1::ListJobRunsRequest request) {
   auto span = internal::MakeSpan("deploy::CloudDeployConnection::ListJobRuns");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobRuns(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::deploy::v1::JobRun>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::deploy::v1::JobRun>

--- a/google/cloud/dialogflow_cx/internal/agents_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/agents_tracing_connection.cc
@@ -36,11 +36,10 @@ StreamRange<google::cloud::dialogflow::cx::v3::Agent>
 AgentsTracingConnection::ListAgents(
     google::cloud::dialogflow::cx::v3::ListAgentsRequest request) {
   auto span = internal::MakeSpan("dialogflow_cx::AgentsConnection::ListAgents");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAgents(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Agent>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Agent>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Agent>

--- a/google/cloud/dialogflow_cx/internal/changelogs_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/changelogs_tracing_connection.cc
@@ -37,11 +37,11 @@ ChangelogsTracingConnection::ListChangelogs(
     google::cloud::dialogflow::cx::v3::ListChangelogsRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_cx::ChangelogsConnection::ListChangelogs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListChangelogs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Changelog>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Changelog>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Changelog>

--- a/google/cloud/dialogflow_cx/internal/deployments_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/deployments_tracing_connection.cc
@@ -37,11 +37,11 @@ DeploymentsTracingConnection::ListDeployments(
     google::cloud::dialogflow::cx::v3::ListDeploymentsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::DeploymentsConnection::ListDeployments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDeployments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Deployment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Deployment>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Deployment>

--- a/google/cloud/dialogflow_cx/internal/entity_types_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/entity_types_tracing_connection.cc
@@ -37,11 +37,11 @@ EntityTypesTracingConnection::ListEntityTypes(
     google::cloud::dialogflow::cx::v3::ListEntityTypesRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::EntityTypesConnection::ListEntityTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEntityTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::EntityType>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::EntityType>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::EntityType>

--- a/google/cloud/dialogflow_cx/internal/environments_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/environments_tracing_connection.cc
@@ -37,11 +37,11 @@ EnvironmentsTracingConnection::ListEnvironments(
     google::cloud::dialogflow::cx::v3::ListEnvironmentsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::EnvironmentsConnection::ListEnvironments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEnvironments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Environment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Environment>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Environment>
@@ -82,11 +82,11 @@ EnvironmentsTracingConnection::LookupEnvironmentHistory(
         request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::EnvironmentsConnection::LookupEnvironmentHistory");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->LookupEnvironmentHistory(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Environment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Environment>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::cloud::dialogflow::cx::v3::RunContinuousTestResponse>>
@@ -102,11 +102,11 @@ EnvironmentsTracingConnection::ListContinuousTestResults(
         request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::EnvironmentsConnection::ListContinuousTestResults");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListContinuousTestResults(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::ContinuousTestResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::ContinuousTestResult>(std::move(span),
+                                                               std::move(sr));
 }
 
 future<StatusOr<google::cloud::dialogflow::cx::v3::DeployFlowResponse>>

--- a/google/cloud/dialogflow_cx/internal/experiments_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/experiments_tracing_connection.cc
@@ -37,11 +37,11 @@ ExperimentsTracingConnection::ListExperiments(
     google::cloud::dialogflow::cx::v3::ListExperimentsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::ExperimentsConnection::ListExperiments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListExperiments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Experiment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Experiment>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Experiment>

--- a/google/cloud/dialogflow_cx/internal/flows_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/flows_tracing_connection.cc
@@ -51,11 +51,10 @@ StreamRange<google::cloud::dialogflow::cx::v3::Flow>
 FlowsTracingConnection::ListFlows(
     google::cloud::dialogflow::cx::v3::ListFlowsRequest request) {
   auto span = internal::MakeSpan("dialogflow_cx::FlowsConnection::ListFlows");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListFlows(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Flow>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Flow>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Flow>

--- a/google/cloud/dialogflow_cx/internal/intents_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/intents_tracing_connection.cc
@@ -37,11 +37,11 @@ IntentsTracingConnection::ListIntents(
     google::cloud::dialogflow::cx::v3::ListIntentsRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_cx::IntentsConnection::ListIntents");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListIntents(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Intent>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Intent>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Intent>

--- a/google/cloud/dialogflow_cx/internal/pages_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/pages_tracing_connection.cc
@@ -36,11 +36,10 @@ StreamRange<google::cloud::dialogflow::cx::v3::Page>
 PagesTracingConnection::ListPages(
     google::cloud::dialogflow::cx::v3::ListPagesRequest request) {
   auto span = internal::MakeSpan("dialogflow_cx::PagesConnection::ListPages");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPages(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Page>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Page>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Page>

--- a/google/cloud/dialogflow_cx/internal/security_settings_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/security_settings_tracing_connection.cc
@@ -70,11 +70,11 @@ SecuritySettingsServiceTracingConnection::ListSecuritySettings(
     google::cloud::dialogflow::cx::v3::ListSecuritySettingsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::SecuritySettingsServiceConnection::ListSecuritySettings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSecuritySettings(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::SecuritySettings>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::SecuritySettings>(std::move(span),
+                                                           std::move(sr));
 }
 
 Status SecuritySettingsServiceTracingConnection::DeleteSecuritySettings(

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_tracing_connection.cc
@@ -37,11 +37,11 @@ SessionEntityTypesTracingConnection::ListSessionEntityTypes(
     google::cloud::dialogflow::cx::v3::ListSessionEntityTypesRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::SessionEntityTypesConnection::ListSessionEntityTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSessionEntityTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::SessionEntityType>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::SessionEntityType>(std::move(span),
+                                                            std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::SessionEntityType>

--- a/google/cloud/dialogflow_cx/internal/test_cases_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/test_cases_tracing_connection.cc
@@ -37,11 +37,11 @@ TestCasesTracingConnection::ListTestCases(
     google::cloud::dialogflow::cx::v3::ListTestCasesRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_cx::TestCasesConnection::ListTestCases");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTestCases(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::TestCase>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::TestCase>(std::move(span),
+                                                   std::move(sr));
 }
 
 Status TestCasesTracingConnection::BatchDeleteTestCases(
@@ -120,11 +120,11 @@ TestCasesTracingConnection::ListTestCaseResults(
     google::cloud::dialogflow::cx::v3::ListTestCaseResultsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_cx::TestCasesConnection::ListTestCaseResults");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTestCaseResults(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::TestCaseResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::TestCaseResult>(std::move(span),
+                                                         std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::TestCaseResult>

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_tracing_connection.cc
@@ -39,11 +39,11 @@ TransitionRouteGroupsTracingConnection::ListTransitionRouteGroups(
   auto span = internal::MakeSpan(
       "dialogflow_cx::TransitionRouteGroupsConnection::"
       "ListTransitionRouteGroups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTransitionRouteGroups(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::TransitionRouteGroup>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::TransitionRouteGroup>(std::move(span),
+                                                               std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>

--- a/google/cloud/dialogflow_cx/internal/versions_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/versions_tracing_connection.cc
@@ -37,11 +37,11 @@ VersionsTracingConnection::ListVersions(
     google::cloud::dialogflow::cx::v3::ListVersionsRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_cx::VersionsConnection::ListVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Version>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Version>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Version>

--- a/google/cloud/dialogflow_cx/internal/webhooks_tracing_connection.cc
+++ b/google/cloud/dialogflow_cx/internal/webhooks_tracing_connection.cc
@@ -37,11 +37,11 @@ WebhooksTracingConnection::ListWebhooks(
     google::cloud::dialogflow::cx::v3::ListWebhooksRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_cx::WebhooksConnection::ListWebhooks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListWebhooks(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::cx::v3::Webhook>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::cx::v3::Webhook>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::cx::v3::Webhook>

--- a/google/cloud/dialogflow_es/internal/agents_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/agents_tracing_connection.cc
@@ -61,10 +61,10 @@ AgentsTracingConnection::SearchAgents(
     google::cloud::dialogflow::v2::SearchAgentsRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_es::AgentsConnection::SearchAgents");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchAgents(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dialogflow::v2::Agent>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::protobuf::Struct>> AgentsTracingConnection::TrainAgent(

--- a/google/cloud/dialogflow_es/internal/answer_records_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/answer_records_tracing_connection.cc
@@ -37,11 +37,11 @@ AnswerRecordsTracingConnection::ListAnswerRecords(
     google::cloud::dialogflow::v2::ListAnswerRecordsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::AnswerRecordsConnection::ListAnswerRecords");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAnswerRecords(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::AnswerRecord>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::AnswerRecord>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::AnswerRecord>

--- a/google/cloud/dialogflow_es/internal/contexts_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/contexts_tracing_connection.cc
@@ -37,11 +37,10 @@ ContextsTracingConnection::ListContexts(
     google::cloud::dialogflow::v2::ListContextsRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_es::ContextsConnection::ListContexts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListContexts(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::Context>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::dialogflow::v2::Context>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::Context>

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_tracing_connection.cc
@@ -55,11 +55,11 @@ ConversationDatasetsTracingConnection::ListConversationDatasets(
   auto span = internal::MakeSpan(
       "dialogflow_es::ConversationDatasetsConnection::"
       "ListConversationDatasets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConversationDatasets(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::ConversationDataset>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::ConversationDataset>(std::move(span),
+                                                          std::move(sr));
 }
 
 future<StatusOr<

--- a/google/cloud/dialogflow_es/internal/conversation_models_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_models_tracing_connection.cc
@@ -53,11 +53,11 @@ ConversationModelsTracingConnection::ListConversationModels(
     google::cloud::dialogflow::v2::ListConversationModelsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::ConversationModelsConnection::ListConversationModels");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConversationModels(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::ConversationModel>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::ConversationModel>(std::move(span),
+                                                        std::move(sr));
 }
 
 future<StatusOr<
@@ -103,11 +103,11 @@ ConversationModelsTracingConnection::ListConversationModelEvaluations(
   auto span = internal::MakeSpan(
       "dialogflow_es::ConversationModelsConnection::"
       "ListConversationModelEvaluations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConversationModelEvaluations(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::dialogflow::v2::ConversationModelEvaluation>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::dialogflow::v2::ConversationModelEvaluation>>

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_tracing_connection.cc
@@ -38,11 +38,11 @@ ConversationProfilesTracingConnection::ListConversationProfiles(
   auto span = internal::MakeSpan(
       "dialogflow_es::ConversationProfilesConnection::"
       "ListConversationProfiles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConversationProfiles(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::ConversationProfile>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::ConversationProfile>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::ConversationProfile>

--- a/google/cloud/dialogflow_es/internal/conversations_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/conversations_tracing_connection.cc
@@ -46,11 +46,11 @@ ConversationsTracingConnection::ListConversations(
     google::cloud::dialogflow::v2::ListConversationsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::ConversationsConnection::ListConversations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConversations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::Conversation>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::Conversation>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::Conversation>
@@ -76,11 +76,10 @@ ConversationsTracingConnection::ListMessages(
     google::cloud::dialogflow::v2::ListMessagesRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::ConversationsConnection::ListMessages");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMessages(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::Message>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::dialogflow::v2::Message>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::SuggestConversationSummaryResponse>

--- a/google/cloud/dialogflow_es/internal/documents_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/documents_tracing_connection.cc
@@ -37,11 +37,10 @@ DocumentsTracingConnection::ListDocuments(
     google::cloud::dialogflow::v2::ListDocumentsRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_es::DocumentsConnection::ListDocuments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDocuments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::Document>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::Document>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::Document>

--- a/google/cloud/dialogflow_es/internal/entity_types_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/entity_types_tracing_connection.cc
@@ -37,11 +37,11 @@ EntityTypesTracingConnection::ListEntityTypes(
     google::cloud::dialogflow::v2::ListEntityTypesRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::EntityTypesConnection::ListEntityTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEntityTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::EntityType>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::EntityType>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::EntityType>

--- a/google/cloud/dialogflow_es/internal/environments_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/environments_tracing_connection.cc
@@ -37,11 +37,11 @@ EnvironmentsTracingConnection::ListEnvironments(
     google::cloud::dialogflow::v2::ListEnvironmentsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::EnvironmentsConnection::ListEnvironments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEnvironments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::Environment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::Environment>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::Environment>
@@ -84,11 +84,11 @@ EnvironmentsTracingConnection::GetEnvironmentHistory(
     google::cloud::dialogflow::v2::GetEnvironmentHistoryRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::EnvironmentsConnection::GetEnvironmentHistory");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->GetEnvironmentHistory(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::EnvironmentHistory::Entry>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::EnvironmentHistory::Entry>(std::move(span),
+                                                                std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/dialogflow_es/internal/intents_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/intents_tracing_connection.cc
@@ -37,10 +37,10 @@ IntentsTracingConnection::ListIntents(
     google::cloud::dialogflow::v2::ListIntentsRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_es::IntentsConnection::ListIntents");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListIntents(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::dialogflow::v2::Intent>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::Intent>

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_tracing_connection.cc
@@ -37,11 +37,11 @@ KnowledgeBasesTracingConnection::ListKnowledgeBases(
     google::cloud::dialogflow::v2::ListKnowledgeBasesRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::KnowledgeBasesConnection::ListKnowledgeBases");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListKnowledgeBases(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::KnowledgeBase>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::KnowledgeBase>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::KnowledgeBase>

--- a/google/cloud/dialogflow_es/internal/participants_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/participants_tracing_connection.cc
@@ -55,11 +55,11 @@ ParticipantsTracingConnection::ListParticipants(
     google::cloud::dialogflow::v2::ListParticipantsRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::ParticipantsConnection::ListParticipants");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListParticipants(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::Participant>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::Participant>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::Participant>

--- a/google/cloud/dialogflow_es/internal/session_entity_types_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_tracing_connection.cc
@@ -37,11 +37,11 @@ SessionEntityTypesTracingConnection::ListSessionEntityTypes(
     google::cloud::dialogflow::v2::ListSessionEntityTypesRequest request) {
   auto span = internal::MakeSpan(
       "dialogflow_es::SessionEntityTypesConnection::ListSessionEntityTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSessionEntityTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::SessionEntityType>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::dialogflow::v2::SessionEntityType>(std::move(span),
+                                                        std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::SessionEntityType>

--- a/google/cloud/dialogflow_es/internal/versions_tracing_connection.cc
+++ b/google/cloud/dialogflow_es/internal/versions_tracing_connection.cc
@@ -37,11 +37,10 @@ VersionsTracingConnection::ListVersions(
     google::cloud::dialogflow::v2::ListVersionsRequest request) {
   auto span =
       internal::MakeSpan("dialogflow_es::VersionsConnection::ListVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::dialogflow::v2::Version>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::dialogflow::v2::Version>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::dialogflow::v2::Version>

--- a/google/cloud/dlp/internal/dlp_tracing_connection.cc
+++ b/google/cloud/dlp/internal/dlp_tracing_connection.cc
@@ -106,11 +106,11 @@ DlpServiceTracingConnection::ListInspectTemplates(
     google::privacy::dlp::v2::ListInspectTemplatesRequest request) {
   auto span =
       internal::MakeSpan("dlp::DlpServiceConnection::ListInspectTemplates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInspectTemplates(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::privacy::dlp::v2::InspectTemplate>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::privacy::dlp::v2::InspectTemplate>(std::move(span),
+                                                 std::move(sr));
 }
 
 Status DlpServiceTracingConnection::DeleteInspectTemplate(
@@ -153,11 +153,11 @@ DlpServiceTracingConnection::ListDeidentifyTemplates(
     google::privacy::dlp::v2::ListDeidentifyTemplatesRequest request) {
   auto span =
       internal::MakeSpan("dlp::DlpServiceConnection::ListDeidentifyTemplates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDeidentifyTemplates(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::privacy::dlp::v2::DeidentifyTemplate>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::privacy::dlp::v2::DeidentifyTemplate>(std::move(span),
+                                                    std::move(sr));
 }
 
 Status DlpServiceTracingConnection::DeleteDeidentifyTemplate(
@@ -205,10 +205,10 @@ StreamRange<google::privacy::dlp::v2::JobTrigger>
 DlpServiceTracingConnection::ListJobTriggers(
     google::privacy::dlp::v2::ListJobTriggersRequest request) {
   auto span = internal::MakeSpan("dlp::DlpServiceConnection::ListJobTriggers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobTriggers(std::move(request));
   return internal::MakeTracedStreamRange<google::privacy::dlp::v2::JobTrigger>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 Status DlpServiceTracingConnection::DeleteJobTrigger(
@@ -239,10 +239,10 @@ StreamRange<google::privacy::dlp::v2::DlpJob>
 DlpServiceTracingConnection::ListDlpJobs(
     google::privacy::dlp::v2::ListDlpJobsRequest request) {
   auto span = internal::MakeSpan("dlp::DlpServiceConnection::ListDlpJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDlpJobs(std::move(request));
   return internal::MakeTracedStreamRange<google::privacy::dlp::v2::DlpJob>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::privacy::dlp::v2::DlpJob>
@@ -299,11 +299,10 @@ DlpServiceTracingConnection::ListStoredInfoTypes(
     google::privacy::dlp::v2::ListStoredInfoTypesRequest request) {
   auto span =
       internal::MakeSpan("dlp::DlpServiceConnection::ListStoredInfoTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListStoredInfoTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::privacy::dlp::v2::StoredInfoType>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::privacy::dlp::v2::StoredInfoType>(std::move(span), std::move(sr));
 }
 
 Status DlpServiceTracingConnection::DeleteStoredInfoType(

--- a/google/cloud/documentai/internal/document_processor_tracing_connection.cc
+++ b/google/cloud/documentai/internal/document_processor_tracing_connection.cc
@@ -62,11 +62,11 @@ DocumentProcessorServiceTracingConnection::ListProcessorTypes(
     google::cloud::documentai::v1::ListProcessorTypesRequest request) {
   auto span = internal::MakeSpan(
       "documentai::DocumentProcessorServiceConnection::ListProcessorTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProcessorTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::documentai::v1::ProcessorType>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::documentai::v1::ProcessorType>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::documentai::v1::ProcessorType>
@@ -83,11 +83,10 @@ DocumentProcessorServiceTracingConnection::ListProcessors(
     google::cloud::documentai::v1::ListProcessorsRequest request) {
   auto span = internal::MakeSpan(
       "documentai::DocumentProcessorServiceConnection::ListProcessors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProcessors(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::documentai::v1::Processor>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::documentai::v1::Processor>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::documentai::v1::Processor>
@@ -113,11 +112,11 @@ DocumentProcessorServiceTracingConnection::ListProcessorVersions(
     google::cloud::documentai::v1::ListProcessorVersionsRequest request) {
   auto span = internal::MakeSpan(
       "documentai::DocumentProcessorServiceConnection::ListProcessorVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProcessorVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::documentai::v1::ProcessorVersion>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::documentai::v1::ProcessorVersion>(std::move(span),
+                                                       std::move(sr));
 }
 
 future<StatusOr<google::cloud::documentai::v1::DeleteProcessorVersionMetadata>>

--- a/google/cloud/edgecontainer/internal/edge_container_tracing_connection.cc
+++ b/google/cloud/edgecontainer/internal/edge_container_tracing_connection.cc
@@ -37,11 +37,11 @@ EdgeContainerTracingConnection::ListClusters(
     google::cloud::edgecontainer::v1::ListClustersRequest request) {
   auto span = internal::MakeSpan(
       "edgecontainer::EdgeContainerConnection::ListClusters");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListClusters(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::edgecontainer::v1::Cluster>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::edgecontainer::v1::Cluster>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::edgecontainer::v1::Cluster>
@@ -86,11 +86,11 @@ EdgeContainerTracingConnection::ListNodePools(
     google::cloud::edgecontainer::v1::ListNodePoolsRequest request) {
   auto span = internal::MakeSpan(
       "edgecontainer::EdgeContainerConnection::ListNodePools");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNodePools(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::edgecontainer::v1::NodePool>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::edgecontainer::v1::NodePool>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::edgecontainer::v1::NodePool>
@@ -125,11 +125,11 @@ EdgeContainerTracingConnection::ListMachines(
     google::cloud::edgecontainer::v1::ListMachinesRequest request) {
   auto span = internal::MakeSpan(
       "edgecontainer::EdgeContainerConnection::ListMachines");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMachines(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::edgecontainer::v1::Machine>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::edgecontainer::v1::Machine>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::edgecontainer::v1::Machine>
@@ -146,11 +146,11 @@ EdgeContainerTracingConnection::ListVpnConnections(
     google::cloud::edgecontainer::v1::ListVpnConnectionsRequest request) {
   auto span = internal::MakeSpan(
       "edgecontainer::EdgeContainerConnection::ListVpnConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVpnConnections(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::edgecontainer::v1::VpnConnection>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::edgecontainer::v1::VpnConnection>(std::move(span),
+                                                       std::move(sr));
 }
 
 StatusOr<google::cloud::edgecontainer::v1::VpnConnection>

--- a/google/cloud/eventarc/internal/eventarc_tracing_connection.cc
+++ b/google/cloud/eventarc/internal/eventarc_tracing_connection.cc
@@ -44,10 +44,10 @@ StreamRange<google::cloud::eventarc::v1::Trigger>
 EventarcTracingConnection::ListTriggers(
     google::cloud::eventarc::v1::ListTriggersRequest request) {
   auto span = internal::MakeSpan("eventarc::EventarcConnection::ListTriggers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTriggers(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::eventarc::v1::Trigger>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::eventarc::v1::Trigger>>
@@ -80,10 +80,10 @@ StreamRange<google::cloud::eventarc::v1::Channel>
 EventarcTracingConnection::ListChannels(
     google::cloud::eventarc::v1::ListChannelsRequest request) {
   auto span = internal::MakeSpan("eventarc::EventarcConnection::ListChannels");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListChannels(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::eventarc::v1::Channel>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::eventarc::v1::Channel>>
@@ -116,10 +116,10 @@ StreamRange<google::cloud::eventarc::v1::Provider>
 EventarcTracingConnection::ListProviders(
     google::cloud::eventarc::v1::ListProvidersRequest request) {
   auto span = internal::MakeSpan("eventarc::EventarcConnection::ListProviders");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProviders(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::eventarc::v1::Provider>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::eventarc::v1::ChannelConnection>
@@ -136,11 +136,11 @@ EventarcTracingConnection::ListChannelConnections(
     google::cloud::eventarc::v1::ListChannelConnectionsRequest request) {
   auto span = internal::MakeSpan(
       "eventarc::EventarcConnection::ListChannelConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListChannelConnections(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::eventarc::v1::ChannelConnection>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::eventarc::v1::ChannelConnection>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::cloud::eventarc::v1::ChannelConnection>>

--- a/google/cloud/filestore/internal/cloud_filestore_manager_tracing_connection.cc
+++ b/google/cloud/filestore/internal/cloud_filestore_manager_tracing_connection.cc
@@ -37,11 +37,10 @@ CloudFilestoreManagerTracingConnection::ListInstances(
     google::cloud::filestore::v1::ListInstancesRequest request) {
   auto span = internal::MakeSpan(
       "filestore::CloudFilestoreManagerConnection::ListInstances");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstances(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::filestore::v1::Instance>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::filestore::v1::Instance>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::filestore::v1::Instance>
@@ -82,10 +81,10 @@ CloudFilestoreManagerTracingConnection::ListBackups(
     google::cloud::filestore::v1::ListBackupsRequest request) {
   auto span = internal::MakeSpan(
       "filestore::CloudFilestoreManagerConnection::ListBackups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBackups(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::filestore::v1::Backup>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::filestore::v1::Backup>

--- a/google/cloud/functions/internal/cloud_functions_tracing_connection.cc
+++ b/google/cloud/functions/internal/cloud_functions_tracing_connection.cc
@@ -37,11 +37,11 @@ CloudFunctionsServiceTracingConnection::ListFunctions(
     google::cloud::functions::v1::ListFunctionsRequest request) {
   auto span = internal::MakeSpan(
       "functions::CloudFunctionsServiceConnection::ListFunctions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListFunctions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::functions::v1::CloudFunction>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::functions::v1::CloudFunction>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::functions::v1::CloudFunction>

--- a/google/cloud/gameservices/internal/game_server_clusters_tracing_connection.cc
+++ b/google/cloud/gameservices/internal/game_server_clusters_tracing_connection.cc
@@ -40,11 +40,11 @@ GameServerClustersServiceTracingConnection::ListGameServerClusters(
   auto span = internal::MakeSpan(
       "gameservices::GameServerClustersServiceConnection::"
       "ListGameServerClusters");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGameServerClusters(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gaming::v1::GameServerCluster>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gaming::v1::GameServerCluster>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::gaming::v1::GameServerCluster>

--- a/google/cloud/gameservices/internal/game_server_configs_tracing_connection.cc
+++ b/google/cloud/gameservices/internal/game_server_configs_tracing_connection.cc
@@ -39,11 +39,11 @@ GameServerConfigsServiceTracingConnection::ListGameServerConfigs(
   auto span = internal::MakeSpan(
       "gameservices::GameServerConfigsServiceConnection::"
       "ListGameServerConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGameServerConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gaming::v1::GameServerConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gaming::v1::GameServerConfig>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::gaming::v1::GameServerConfig>

--- a/google/cloud/gameservices/internal/game_server_deployments_tracing_connection.cc
+++ b/google/cloud/gameservices/internal/game_server_deployments_tracing_connection.cc
@@ -40,11 +40,11 @@ GameServerDeploymentsServiceTracingConnection::ListGameServerDeployments(
   auto span = internal::MakeSpan(
       "gameservices::GameServerDeploymentsServiceConnection::"
       "ListGameServerDeployments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGameServerDeployments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gaming::v1::GameServerDeployment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gaming::v1::GameServerDeployment>(std::move(span),
+                                                       std::move(sr));
 }
 
 StatusOr<google::cloud::gaming::v1::GameServerDeployment>

--- a/google/cloud/gameservices/internal/realms_tracing_connection.cc
+++ b/google/cloud/gameservices/internal/realms_tracing_connection.cc
@@ -37,10 +37,10 @@ RealmsServiceTracingConnection::ListRealms(
     google::cloud::gaming::v1::ListRealmsRequest request) {
   auto span =
       internal::MakeSpan("gameservices::RealmsServiceConnection::ListRealms");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRealms(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::gaming::v1::Realm>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::gaming::v1::Realm>

--- a/google/cloud/gkehub/internal/gke_hub_tracing_connection.cc
+++ b/google/cloud/gkehub/internal/gke_hub_tracing_connection.cc
@@ -36,20 +36,20 @@ StreamRange<google::cloud::gkehub::v1::Membership>
 GkeHubTracingConnection::ListMemberships(
     google::cloud::gkehub::v1::ListMembershipsRequest request) {
   auto span = internal::MakeSpan("gkehub::GkeHubConnection::ListMemberships");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMemberships(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::gkehub::v1::Membership>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::gkehub::v1::Feature>
 GkeHubTracingConnection::ListFeatures(
     google::cloud::gkehub::v1::ListFeaturesRequest request) {
   auto span = internal::MakeSpan("gkehub::GkeHubConnection::ListFeatures");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListFeatures(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::gkehub::v1::Feature>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::gkehub::v1::Membership>

--- a/google/cloud/gkemulticloud/v1/internal/attached_clusters_tracing_connection.cc
+++ b/google/cloud/gkemulticloud/v1/internal/attached_clusters_tracing_connection.cc
@@ -68,11 +68,11 @@ AttachedClustersTracingConnection::ListAttachedClusters(
     google::cloud::gkemulticloud::v1::ListAttachedClustersRequest request) {
   auto span = internal::MakeSpan(
       "gkemulticloud_v1::AttachedClustersConnection::ListAttachedClusters");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAttachedClusters(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gkemulticloud::v1::AttachedCluster>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gkemulticloud::v1::AttachedCluster>(std::move(span),
+                                                         std::move(sr));
 }
 
 future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>

--- a/google/cloud/gkemulticloud/v1/internal/aws_clusters_tracing_connection.cc
+++ b/google/cloud/gkemulticloud/v1/internal/aws_clusters_tracing_connection.cc
@@ -58,11 +58,11 @@ AwsClustersTracingConnection::ListAwsClusters(
     google::cloud::gkemulticloud::v1::ListAwsClustersRequest request) {
   auto span = internal::MakeSpan(
       "gkemulticloud_v1::AwsClustersConnection::ListAwsClusters");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAwsClusters(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gkemulticloud::v1::AwsCluster>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gkemulticloud::v1::AwsCluster>(std::move(span),
+                                                    std::move(sr));
 }
 
 future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>
@@ -107,11 +107,11 @@ AwsClustersTracingConnection::ListAwsNodePools(
     google::cloud::gkemulticloud::v1::ListAwsNodePoolsRequest request) {
   auto span = internal::MakeSpan(
       "gkemulticloud_v1::AwsClustersConnection::ListAwsNodePools");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAwsNodePools(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gkemulticloud::v1::AwsNodePool>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gkemulticloud::v1::AwsNodePool>(std::move(span),
+                                                     std::move(sr));
 }
 
 future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>

--- a/google/cloud/gkemulticloud/v1/internal/azure_clusters_tracing_connection.cc
+++ b/google/cloud/gkemulticloud/v1/internal/azure_clusters_tracing_connection.cc
@@ -52,11 +52,11 @@ AzureClustersTracingConnection::ListAzureClients(
     google::cloud::gkemulticloud::v1::ListAzureClientsRequest request) {
   auto span = internal::MakeSpan(
       "gkemulticloud_v1::AzureClustersConnection::ListAzureClients");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAzureClients(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gkemulticloud::v1::AzureClient>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gkemulticloud::v1::AzureClient>(std::move(span),
+                                                     std::move(sr));
 }
 
 future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>
@@ -93,11 +93,11 @@ AzureClustersTracingConnection::ListAzureClusters(
     google::cloud::gkemulticloud::v1::ListAzureClustersRequest request) {
   auto span = internal::MakeSpan(
       "gkemulticloud_v1::AzureClustersConnection::ListAzureClusters");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAzureClusters(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gkemulticloud::v1::AzureCluster>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gkemulticloud::v1::AzureCluster>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>
@@ -145,11 +145,11 @@ AzureClustersTracingConnection::ListAzureNodePools(
     google::cloud::gkemulticloud::v1::ListAzureNodePoolsRequest request) {
   auto span = internal::MakeSpan(
       "gkemulticloud_v1::AzureClustersConnection::ListAzureNodePools");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAzureNodePools(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::gkemulticloud::v1::AzureNodePool>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::gkemulticloud::v1::AzureNodePool>(std::move(span),
+                                                       std::move(sr));
 }
 
 future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>

--- a/google/cloud/iam/internal/iam_tracing_connection.cc
+++ b/google/cloud/iam/internal/iam_tracing_connection.cc
@@ -36,11 +36,10 @@ StreamRange<google::iam::admin::v1::ServiceAccount>
 IAMTracingConnection::ListServiceAccounts(
     google::iam::admin::v1::ListServiceAccountsRequest request) {
   auto span = internal::MakeSpan("iam::IAMConnection::ListServiceAccounts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServiceAccounts(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::iam::admin::v1::ServiceAccount>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::iam::admin::v1::ServiceAccount>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccount>
@@ -176,19 +175,19 @@ StreamRange<google::iam::admin::v1::Role>
 IAMTracingConnection::QueryGrantableRoles(
     google::iam::admin::v1::QueryGrantableRolesRequest request) {
   auto span = internal::MakeSpan("iam::IAMConnection::QueryGrantableRoles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->QueryGrantableRoles(std::move(request));
   return internal::MakeTracedStreamRange<google::iam::admin::v1::Role>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::iam::admin::v1::Role> IAMTracingConnection::ListRoles(
     google::iam::admin::v1::ListRolesRequest request) {
   auto span = internal::MakeSpan("iam::IAMConnection::ListRoles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRoles(std::move(request));
   return internal::MakeTracedStreamRange<google::iam::admin::v1::Role>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMTracingConnection::GetRole(
@@ -231,10 +230,10 @@ IAMTracingConnection::QueryTestablePermissions(
     google::iam::admin::v1::QueryTestablePermissionsRequest request) {
   auto span =
       internal::MakeSpan("iam::IAMConnection::QueryTestablePermissions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->QueryTestablePermissions(std::move(request));
   return internal::MakeTracedStreamRange<google::iam::admin::v1::Permission>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>

--- a/google/cloud/iam/v2/internal/policies_tracing_connection.cc
+++ b/google/cloud/iam/v2/internal/policies_tracing_connection.cc
@@ -35,10 +35,10 @@ PoliciesTracingConnection::PoliciesTracingConnection(
 StreamRange<google::iam::v2::Policy> PoliciesTracingConnection::ListPolicies(
     google::iam::v2::ListPoliciesRequest request) {
   auto span = internal::MakeSpan("iam_v2::PoliciesConnection::ListPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPolicies(std::move(request));
   return internal::MakeTracedStreamRange<google::iam::v2::Policy>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::iam::v2::Policy> PoliciesTracingConnection::GetPolicy(

--- a/google/cloud/iap/internal/identity_aware_proxy_admin_tracing_connection.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_admin_tracing_connection.cc
@@ -83,11 +83,10 @@ IdentityAwareProxyAdminServiceTracingConnection::ListTunnelDestGroups(
     google::cloud::iap::v1::ListTunnelDestGroupsRequest request) {
   auto span = internal::MakeSpan(
       "iap::IdentityAwareProxyAdminServiceConnection::ListTunnelDestGroups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTunnelDestGroups(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::iap::v1::TunnelDestGroup>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::iap::v1::TunnelDestGroup>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::iap::v1::TunnelDestGroup>

--- a/google/cloud/iap/internal/identity_aware_proxy_o_auth_tracing_connection.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_o_auth_tracing_connection.cc
@@ -78,11 +78,11 @@ IdentityAwareProxyOAuthServiceTracingConnection::ListIdentityAwareProxyClients(
   auto span = internal::MakeSpan(
       "iap::IdentityAwareProxyOAuthServiceConnection::"
       "ListIdentityAwareProxyClients");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListIdentityAwareProxyClients(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::iap::v1::IdentityAwareProxyClient>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::iap::v1::IdentityAwareProxyClient>(std::move(span),
+                                                        std::move(sr));
 }
 
 StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>

--- a/google/cloud/ids/internal/ids_tracing_connection.cc
+++ b/google/cloud/ids/internal/ids_tracing_connection.cc
@@ -36,10 +36,10 @@ StreamRange<google::cloud::ids::v1::Endpoint>
 IDSTracingConnection::ListEndpoints(
     google::cloud::ids::v1::ListEndpointsRequest request) {
   auto span = internal::MakeSpan("ids::IDSConnection::ListEndpoints");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEndpoints(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::ids::v1::Endpoint>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::ids::v1::Endpoint> IDSTracingConnection::GetEndpoint(

--- a/google/cloud/iot/internal/device_manager_tracing_connection.cc
+++ b/google/cloud/iot/internal/device_manager_tracing_connection.cc
@@ -72,11 +72,10 @@ DeviceManagerTracingConnection::ListDeviceRegistries(
     google::cloud::iot::v1::ListDeviceRegistriesRequest request) {
   auto span =
       internal::MakeSpan("iot::DeviceManagerConnection::ListDeviceRegistries");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDeviceRegistries(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::iot::v1::DeviceRegistry>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::iot::v1::DeviceRegistry>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::iot::v1::Device>
@@ -114,10 +113,10 @@ StreamRange<google::cloud::iot::v1::Device>
 DeviceManagerTracingConnection::ListDevices(
     google::cloud::iot::v1::ListDevicesRequest request) {
   auto span = internal::MakeSpan("iot::DeviceManagerConnection::ListDevices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDevices(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::iot::v1::Device>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::iot::v1::DeviceConfig>

--- a/google/cloud/kms/internal/ekm_tracing_connection.cc
+++ b/google/cloud/kms/internal/ekm_tracing_connection.cc
@@ -37,10 +37,10 @@ EkmServiceTracingConnection::ListEkmConnections(
     google::cloud::kms::v1::ListEkmConnectionsRequest request) {
   auto span =
       internal::MakeSpan("kms::EkmServiceConnection::ListEkmConnections");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEkmConnections(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::kms::v1::EkmConnection>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::kms::v1::EkmConnection>

--- a/google/cloud/kms/internal/key_management_tracing_connection.cc
+++ b/google/cloud/kms/internal/key_management_tracing_connection.cc
@@ -37,10 +37,10 @@ KeyManagementServiceTracingConnection::ListKeyRings(
     google::cloud::kms::v1::ListKeyRingsRequest request) {
   auto span =
       internal::MakeSpan("kms::KeyManagementServiceConnection::ListKeyRings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListKeyRings(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::kms::v1::KeyRing>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::kms::v1::CryptoKey>
@@ -48,10 +48,10 @@ KeyManagementServiceTracingConnection::ListCryptoKeys(
     google::cloud::kms::v1::ListCryptoKeysRequest request) {
   auto span =
       internal::MakeSpan("kms::KeyManagementServiceConnection::ListCryptoKeys");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCryptoKeys(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::kms::v1::CryptoKey>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::kms::v1::CryptoKeyVersion>
@@ -59,11 +59,10 @@ KeyManagementServiceTracingConnection::ListCryptoKeyVersions(
     google::cloud::kms::v1::ListCryptoKeyVersionsRequest request) {
   auto span = internal::MakeSpan(
       "kms::KeyManagementServiceConnection::ListCryptoKeyVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCryptoKeyVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::kms::v1::CryptoKeyVersion>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::kms::v1::CryptoKeyVersion>(std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::kms::v1::ImportJob>
@@ -71,10 +70,10 @@ KeyManagementServiceTracingConnection::ListImportJobs(
     google::cloud::kms::v1::ListImportJobsRequest request) {
   auto span =
       internal::MakeSpan("kms::KeyManagementServiceConnection::ListImportJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListImportJobs(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::kms::v1::ImportJob>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::kms::v1::KeyRing>

--- a/google/cloud/logging/internal/logging_service_v2_tracing_connection.cc
+++ b/google/cloud/logging/internal/logging_service_v2_tracing_connection.cc
@@ -54,10 +54,10 @@ LoggingServiceV2TracingConnection::ListLogEntries(
     google::logging::v2::ListLogEntriesRequest request) {
   auto span =
       internal::MakeSpan("logging::LoggingServiceV2Connection::ListLogEntries");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListLogEntries(std::move(request));
   return internal::MakeTracedStreamRange<google::logging::v2::LogEntry>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::api::MonitoredResourceDescriptor>
@@ -65,21 +65,20 @@ LoggingServiceV2TracingConnection::ListMonitoredResourceDescriptors(
     google::logging::v2::ListMonitoredResourceDescriptorsRequest request) {
   auto span = internal::MakeSpan(
       "logging::LoggingServiceV2Connection::ListMonitoredResourceDescriptors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMonitoredResourceDescriptors(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::api::MonitoredResourceDescriptor>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::api::MonitoredResourceDescriptor>(std::move(span), std::move(sr));
 }
 
 StreamRange<std::string> LoggingServiceV2TracingConnection::ListLogs(
     google::logging::v2::ListLogsRequest request) {
   auto span =
       internal::MakeSpan("logging::LoggingServiceV2Connection::ListLogs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListLogs(std::move(request));
-  return internal::MakeTracedStreamRange<std::string>(
-      std::move(span), std::move(scope), std::move(sr));
+  return internal::MakeTracedStreamRange<std::string>(std::move(span),
+                                                      std::move(sr));
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/google/cloud/managedidentities/internal/managed_identities_tracing_connection.cc
+++ b/google/cloud/managedidentities/internal/managed_identities_tracing_connection.cc
@@ -57,11 +57,11 @@ ManagedIdentitiesServiceTracingConnection::ListDomains(
     google::cloud::managedidentities::v1::ListDomainsRequest request) {
   auto span = internal::MakeSpan(
       "managedidentities::ManagedIdentitiesServiceConnection::ListDomains");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDomains(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::managedidentities::v1::Domain>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::managedidentities::v1::Domain>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::managedidentities::v1::Domain>

--- a/google/cloud/memcache/internal/cloud_memcache_tracing_connection.cc
+++ b/google/cloud/memcache/internal/cloud_memcache_tracing_connection.cc
@@ -37,10 +37,10 @@ CloudMemcacheTracingConnection::ListInstances(
     google::cloud::memcache::v1::ListInstancesRequest request) {
   auto span =
       internal::MakeSpan("memcache::CloudMemcacheConnection::ListInstances");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstances(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::memcache::v1::Instance>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::memcache::v1::Instance>

--- a/google/cloud/monitoring/internal/alert_policy_tracing_connection.cc
+++ b/google/cloud/monitoring/internal/alert_policy_tracing_connection.cc
@@ -37,10 +37,10 @@ AlertPolicyServiceTracingConnection::ListAlertPolicies(
     google::monitoring::v3::ListAlertPoliciesRequest request) {
   auto span = internal::MakeSpan(
       "monitoring::AlertPolicyServiceConnection::ListAlertPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAlertPolicies(std::move(request));
   return internal::MakeTracedStreamRange<google::monitoring::v3::AlertPolicy>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::monitoring::v3::AlertPolicy>

--- a/google/cloud/monitoring/internal/dashboards_tracing_connection.cc
+++ b/google/cloud/monitoring/internal/dashboards_tracing_connection.cc
@@ -46,11 +46,11 @@ DashboardsServiceTracingConnection::ListDashboards(
     google::monitoring::dashboard::v1::ListDashboardsRequest request) {
   auto span = internal::MakeSpan(
       "monitoring::DashboardsServiceConnection::ListDashboards");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDashboards(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::monitoring::dashboard::v1::Dashboard>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::monitoring::dashboard::v1::Dashboard>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::monitoring::dashboard::v1::Dashboard>

--- a/google/cloud/monitoring/internal/group_tracing_connection.cc
+++ b/google/cloud/monitoring/internal/group_tracing_connection.cc
@@ -37,10 +37,10 @@ GroupServiceTracingConnection::ListGroups(
     google::monitoring::v3::ListGroupsRequest request) {
   auto span =
       internal::MakeSpan("monitoring::GroupServiceConnection::ListGroups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGroups(std::move(request));
   return internal::MakeTracedStreamRange<google::monitoring::v3::Group>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::monitoring::v3::Group> GroupServiceTracingConnection::GetGroup(
@@ -82,10 +82,10 @@ GroupServiceTracingConnection::ListGroupMembers(
     google::monitoring::v3::ListGroupMembersRequest request) {
   auto span = internal::MakeSpan(
       "monitoring::GroupServiceConnection::ListGroupMembers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGroupMembers(std::move(request));
   return internal::MakeTracedStreamRange<google::api::MonitoredResource>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/monitoring/internal/metric_tracing_connection.cc
+++ b/google/cloud/monitoring/internal/metric_tracing_connection.cc
@@ -37,11 +37,10 @@ MetricServiceTracingConnection::ListMonitoredResourceDescriptors(
     google::monitoring::v3::ListMonitoredResourceDescriptorsRequest request) {
   auto span = internal::MakeSpan(
       "monitoring::MetricServiceConnection::ListMonitoredResourceDescriptors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMonitoredResourceDescriptors(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::api::MonitoredResourceDescriptor>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::api::MonitoredResourceDescriptor>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::api::MonitoredResourceDescriptor>
@@ -60,10 +59,10 @@ MetricServiceTracingConnection::ListMetricDescriptors(
     google::monitoring::v3::ListMetricDescriptorsRequest request) {
   auto span = internal::MakeSpan(
       "monitoring::MetricServiceConnection::ListMetricDescriptors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMetricDescriptors(std::move(request));
   return internal::MakeTracedStreamRange<google::api::MetricDescriptor>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::api::MetricDescriptor>
@@ -97,10 +96,10 @@ MetricServiceTracingConnection::ListTimeSeries(
     google::monitoring::v3::ListTimeSeriesRequest request) {
   auto span =
       internal::MakeSpan("monitoring::MetricServiceConnection::ListTimeSeries");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTimeSeries(std::move(request));
   return internal::MakeTracedStreamRange<google::monitoring::v3::TimeSeries>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 Status MetricServiceTracingConnection::CreateTimeSeries(

--- a/google/cloud/monitoring/internal/notification_channel_tracing_connection.cc
+++ b/google/cloud/monitoring/internal/notification_channel_tracing_connection.cc
@@ -39,11 +39,11 @@ NotificationChannelServiceTracingConnection::ListNotificationChannelDescriptors(
   auto span = internal::MakeSpan(
       "monitoring::NotificationChannelServiceConnection::"
       "ListNotificationChannelDescriptors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNotificationChannelDescriptors(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::monitoring::v3::NotificationChannelDescriptor>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::monitoring::v3::NotificationChannelDescriptor>(std::move(span),
+                                                             std::move(sr));
 }
 
 StatusOr<google::monitoring::v3::NotificationChannelDescriptor>
@@ -64,11 +64,11 @@ NotificationChannelServiceTracingConnection::ListNotificationChannels(
   auto span = internal::MakeSpan(
       "monitoring::NotificationChannelServiceConnection::"
       "ListNotificationChannels");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNotificationChannels(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::monitoring::v3::NotificationChannel>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::monitoring::v3::NotificationChannel>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::monitoring::v3::NotificationChannel>

--- a/google/cloud/monitoring/internal/query_tracing_connection.cc
+++ b/google/cloud/monitoring/internal/query_tracing_connection.cc
@@ -37,11 +37,10 @@ QueryServiceTracingConnection::QueryTimeSeries(
     google::monitoring::v3::QueryTimeSeriesRequest request) {
   auto span =
       internal::MakeSpan("monitoring::QueryServiceConnection::QueryTimeSeries");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->QueryTimeSeries(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::monitoring::v3::TimeSeriesData>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::monitoring::v3::TimeSeriesData>(std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/monitoring/internal/service_monitoring_tracing_connection.cc
+++ b/google/cloud/monitoring/internal/service_monitoring_tracing_connection.cc
@@ -56,10 +56,10 @@ ServiceMonitoringServiceTracingConnection::ListServices(
     google::monitoring::v3::ListServicesRequest request) {
   auto span = internal::MakeSpan(
       "monitoring::ServiceMonitoringServiceConnection::ListServices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServices(std::move(request));
   return internal::MakeTracedStreamRange<google::monitoring::v3::Service>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::monitoring::v3::Service>
@@ -105,11 +105,11 @@ ServiceMonitoringServiceTracingConnection::ListServiceLevelObjectives(
   auto span = internal::MakeSpan(
       "monitoring::ServiceMonitoringServiceConnection::"
       "ListServiceLevelObjectives");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServiceLevelObjectives(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::monitoring::v3::ServiceLevelObjective>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::monitoring::v3::ServiceLevelObjective>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::monitoring::v3::ServiceLevelObjective>

--- a/google/cloud/monitoring/internal/uptime_check_tracing_connection.cc
+++ b/google/cloud/monitoring/internal/uptime_check_tracing_connection.cc
@@ -37,11 +37,11 @@ UptimeCheckServiceTracingConnection::ListUptimeCheckConfigs(
     google::monitoring::v3::ListUptimeCheckConfigsRequest request) {
   auto span = internal::MakeSpan(
       "monitoring::UptimeCheckServiceConnection::ListUptimeCheckConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListUptimeCheckConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::monitoring::v3::UptimeCheckConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::monitoring::v3::UptimeCheckConfig>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::monitoring::v3::UptimeCheckConfig>
@@ -84,10 +84,10 @@ UptimeCheckServiceTracingConnection::ListUptimeCheckIps(
     google::monitoring::v3::ListUptimeCheckIpsRequest request) {
   auto span = internal::MakeSpan(
       "monitoring::UptimeCheckServiceConnection::ListUptimeCheckIps");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListUptimeCheckIps(std::move(request));
   return internal::MakeTracedStreamRange<google::monitoring::v3::UptimeCheckIp>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/networkconnectivity/internal/hub_tracing_connection.cc
+++ b/google/cloud/networkconnectivity/internal/hub_tracing_connection.cc
@@ -37,11 +37,11 @@ HubServiceTracingConnection::ListHubs(
     google::cloud::networkconnectivity::v1::ListHubsRequest request) {
   auto span =
       internal::MakeSpan("networkconnectivity::HubServiceConnection::ListHubs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListHubs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::networkconnectivity::v1::Hub>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::networkconnectivity::v1::Hub>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::networkconnectivity::v1::Hub>
@@ -76,11 +76,11 @@ HubServiceTracingConnection::ListSpokes(
     google::cloud::networkconnectivity::v1::ListSpokesRequest request) {
   auto span = internal::MakeSpan(
       "networkconnectivity::HubServiceConnection::ListSpokes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSpokes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::networkconnectivity::v1::Spoke>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::networkconnectivity::v1::Spoke>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::networkconnectivity::v1::Spoke>

--- a/google/cloud/networkmanagement/internal/reachability_tracing_connection.cc
+++ b/google/cloud/networkmanagement/internal/reachability_tracing_connection.cc
@@ -39,11 +39,11 @@ ReachabilityServiceTracingConnection::ListConnectivityTests(
   auto span = internal::MakeSpan(
       "networkmanagement::ReachabilityServiceConnection::"
       "ListConnectivityTests");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnectivityTests(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::networkmanagement::v1::ConnectivityTest>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::networkmanagement::v1::ConnectivityTest>(std::move(span),
+                                                              std::move(sr));
 }
 
 StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>

--- a/google/cloud/notebooks/internal/managed_notebook_tracing_connection.cc
+++ b/google/cloud/notebooks/internal/managed_notebook_tracing_connection.cc
@@ -38,10 +38,10 @@ ManagedNotebookServiceTracingConnection::ListRuntimes(
     google::cloud::notebooks::v1::ListRuntimesRequest request) {
   auto span = internal::MakeSpan(
       "notebooks::ManagedNotebookServiceConnection::ListRuntimes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRuntimes(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::notebooks::v1::Runtime>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::notebooks::v1::Runtime>

--- a/google/cloud/notebooks/internal/notebook_tracing_connection.cc
+++ b/google/cloud/notebooks/internal/notebook_tracing_connection.cc
@@ -37,11 +37,10 @@ NotebookServiceTracingConnection::ListInstances(
     google::cloud::notebooks::v1::ListInstancesRequest request) {
   auto span =
       internal::MakeSpan("notebooks::NotebookServiceConnection::ListInstances");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstances(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::notebooks::v1::Instance>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::notebooks::v1::Instance>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::notebooks::v1::Instance>
@@ -186,11 +185,11 @@ NotebookServiceTracingConnection::ListEnvironments(
     google::cloud::notebooks::v1::ListEnvironmentsRequest request) {
   auto span = internal::MakeSpan(
       "notebooks::NotebookServiceConnection::ListEnvironments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEnvironments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::notebooks::v1::Environment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::notebooks::v1::Environment>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::notebooks::v1::Environment>
@@ -219,11 +218,10 @@ NotebookServiceTracingConnection::ListSchedules(
     google::cloud::notebooks::v1::ListSchedulesRequest request) {
   auto span =
       internal::MakeSpan("notebooks::NotebookServiceConnection::ListSchedules");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSchedules(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::notebooks::v1::Schedule>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::notebooks::v1::Schedule>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::notebooks::v1::Schedule>
@@ -258,11 +256,10 @@ NotebookServiceTracingConnection::ListExecutions(
     google::cloud::notebooks::v1::ListExecutionsRequest request) {
   auto span = internal::MakeSpan(
       "notebooks::NotebookServiceConnection::ListExecutions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListExecutions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::notebooks::v1::Execution>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::notebooks::v1::Execution>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::notebooks::v1::Execution>

--- a/google/cloud/orgpolicy/internal/org_policy_tracing_connection.cc
+++ b/google/cloud/orgpolicy/internal/org_policy_tracing_connection.cc
@@ -37,11 +37,10 @@ OrgPolicyTracingConnection::ListConstraints(
     google::cloud::orgpolicy::v2::ListConstraintsRequest request) {
   auto span =
       internal::MakeSpan("orgpolicy::OrgPolicyConnection::ListConstraints");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConstraints(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::orgpolicy::v2::Constraint>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::orgpolicy::v2::Constraint>(std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::orgpolicy::v2::Policy>
@@ -49,10 +48,10 @@ OrgPolicyTracingConnection::ListPolicies(
     google::cloud::orgpolicy::v2::ListPoliciesRequest request) {
   auto span =
       internal::MakeSpan("orgpolicy::OrgPolicyConnection::ListPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPolicies(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::orgpolicy::v2::Policy>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::orgpolicy::v2::Policy>

--- a/google/cloud/osconfig/internal/os_config_tracing_connection.cc
+++ b/google/cloud/osconfig/internal/os_config_tracing_connection.cc
@@ -64,10 +64,10 @@ OsConfigServiceTracingConnection::ListPatchJobs(
     google::cloud::osconfig::v1::ListPatchJobsRequest request) {
   auto span =
       internal::MakeSpan("osconfig::OsConfigServiceConnection::ListPatchJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPatchJobs(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::osconfig::v1::PatchJob>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::osconfig::v1::PatchJobInstanceDetails>
@@ -75,11 +75,11 @@ OsConfigServiceTracingConnection::ListPatchJobInstanceDetails(
     google::cloud::osconfig::v1::ListPatchJobInstanceDetailsRequest request) {
   auto span = internal::MakeSpan(
       "osconfig::OsConfigServiceConnection::ListPatchJobInstanceDetails");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPatchJobInstanceDetails(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::osconfig::v1::PatchJobInstanceDetails>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::osconfig::v1::PatchJobInstanceDetails>(std::move(span),
+                                                            std::move(sr));
 }
 
 StatusOr<google::cloud::osconfig::v1::PatchDeployment>
@@ -105,11 +105,11 @@ OsConfigServiceTracingConnection::ListPatchDeployments(
     google::cloud::osconfig::v1::ListPatchDeploymentsRequest request) {
   auto span = internal::MakeSpan(
       "osconfig::OsConfigServiceConnection::ListPatchDeployments");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPatchDeployments(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::osconfig::v1::PatchDeployment>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::osconfig::v1::PatchDeployment>(std::move(span),
+                                                    std::move(sr));
 }
 
 Status OsConfigServiceTracingConnection::DeletePatchDeployment(

--- a/google/cloud/privateca/internal/certificate_authority_tracing_connection.cc
+++ b/google/cloud/privateca/internal/certificate_authority_tracing_connection.cc
@@ -58,11 +58,11 @@ CertificateAuthorityServiceTracingConnection::ListCertificates(
     google::cloud::security::privateca::v1::ListCertificatesRequest request) {
   auto span = internal::MakeSpan(
       "privateca::CertificateAuthorityServiceConnection::ListCertificates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCertificates(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::security::privateca::v1::Certificate>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::security::privateca::v1::Certificate>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::cloud::security::privateca::v1::Certificate>
@@ -144,11 +144,11 @@ CertificateAuthorityServiceTracingConnection::ListCertificateAuthorities(
   auto span = internal::MakeSpan(
       "privateca::CertificateAuthorityServiceConnection::"
       "ListCertificateAuthorities");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCertificateAuthorities(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::security::privateca::v1::CertificateAuthority>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
@@ -200,11 +200,11 @@ CertificateAuthorityServiceTracingConnection::ListCaPools(
     google::cloud::security::privateca::v1::ListCaPoolsRequest request) {
   auto span = internal::MakeSpan(
       "privateca::CertificateAuthorityServiceConnection::ListCaPools");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCaPools(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::security::privateca::v1::CaPool>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::security::privateca::v1::CaPool>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>
@@ -243,11 +243,11 @@ CertificateAuthorityServiceTracingConnection::ListCertificateRevocationLists(
   auto span = internal::MakeSpan(
       "privateca::CertificateAuthorityServiceConnection::"
       "ListCertificateRevocationLists");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCertificateRevocationLists(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::security::privateca::v1::CertificateRevocationList>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<
@@ -290,11 +290,11 @@ CertificateAuthorityServiceTracingConnection::ListCertificateTemplates(
   auto span = internal::MakeSpan(
       "privateca::CertificateAuthorityServiceConnection::"
       "ListCertificateTemplates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCertificateTemplates(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::security::privateca::v1::CertificateTemplate>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>>

--- a/google/cloud/pubsub/internal/schema_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/schema_tracing_connection.cc
@@ -53,10 +53,10 @@ SchemaServiceTracingConnection::ListSchemas(
     google::pubsub::v1::ListSchemasRequest request) {
   auto span =
       internal::MakeSpan("pubsub::SchemaServiceConnection::ListSchemas");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSchemas(std::move(request));
   return internal::MakeTracedStreamRange<google::pubsub::v1::Schema>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::pubsub::v1::Schema>
@@ -64,10 +64,10 @@ SchemaServiceTracingConnection::ListSchemaRevisions(
     google::pubsub::v1::ListSchemaRevisionsRequest request) {
   auto span = internal::MakeSpan(
       "pubsub::SchemaServiceConnection::ListSchemaRevisions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSchemaRevisions(std::move(request));
   return internal::MakeTracedStreamRange<google::pubsub::v1::Schema>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::pubsub::v1::Schema>

--- a/google/cloud/pubsublite/internal/admin_tracing_connection.cc
+++ b/google/cloud/pubsublite/internal/admin_tracing_connection.cc
@@ -64,10 +64,10 @@ AdminServiceTracingConnection::ListTopics(
     google::cloud::pubsublite::v1::ListTopicsRequest request) {
   auto span =
       internal::MakeSpan("pubsublite::AdminServiceConnection::ListTopics");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTopics(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::pubsublite::v1::Topic>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Topic>
@@ -91,10 +91,10 @@ StreamRange<std::string> AdminServiceTracingConnection::ListTopicSubscriptions(
     google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request) {
   auto span = internal::MakeSpan(
       "pubsublite::AdminServiceConnection::ListTopicSubscriptions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTopicSubscriptions(std::move(request));
-  return internal::MakeTracedStreamRange<std::string>(
-      std::move(span), std::move(scope), std::move(sr));
+  return internal::MakeTracedStreamRange<std::string>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
@@ -120,11 +120,11 @@ AdminServiceTracingConnection::ListSubscriptions(
     google::cloud::pubsublite::v1::ListSubscriptionsRequest request) {
   auto span = internal::MakeSpan(
       "pubsublite::AdminServiceConnection::ListSubscriptions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSubscriptions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::pubsublite::v1::Subscription>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::pubsublite::v1::Subscription>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
@@ -173,11 +173,11 @@ AdminServiceTracingConnection::ListReservations(
     google::cloud::pubsublite::v1::ListReservationsRequest request) {
   auto span = internal::MakeSpan(
       "pubsublite::AdminServiceConnection::ListReservations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListReservations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::pubsublite::v1::Reservation>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::pubsublite::v1::Reservation>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
@@ -201,10 +201,10 @@ StreamRange<std::string> AdminServiceTracingConnection::ListReservationTopics(
     google::cloud::pubsublite::v1::ListReservationTopicsRequest request) {
   auto span = internal::MakeSpan(
       "pubsublite::AdminServiceConnection::ListReservationTopics");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListReservationTopics(std::move(request));
-  return internal::MakeTracedStreamRange<std::string>(
-      std::move(span), std::move(scope), std::move(sr));
+  return internal::MakeTracedStreamRange<std::string>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>

--- a/google/cloud/recommender/internal/recommender_tracing_connection.cc
+++ b/google/cloud/recommender/internal/recommender_tracing_connection.cc
@@ -37,11 +37,10 @@ RecommenderTracingConnection::ListInsights(
     google::cloud::recommender::v1::ListInsightsRequest request) {
   auto span =
       internal::MakeSpan("recommender::RecommenderConnection::ListInsights");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInsights(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::recommender::v1::Insight>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::recommender::v1::Insight>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::recommender::v1::Insight>
@@ -67,11 +66,11 @@ RecommenderTracingConnection::ListRecommendations(
     google::cloud::recommender::v1::ListRecommendationsRequest request) {
   auto span = internal::MakeSpan(
       "recommender::RecommenderConnection::ListRecommendations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRecommendations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::recommender::v1::Recommendation>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::recommender::v1::Recommendation>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::recommender::v1::Recommendation>

--- a/google/cloud/redis/internal/cloud_redis_tracing_connection.cc
+++ b/google/cloud/redis/internal/cloud_redis_tracing_connection.cc
@@ -36,10 +36,10 @@ StreamRange<google::cloud::redis::v1::Instance>
 CloudRedisTracingConnection::ListInstances(
     google::cloud::redis::v1::ListInstancesRequest request) {
   auto span = internal::MakeSpan("redis::CloudRedisConnection::ListInstances");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstances(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::redis::v1::Instance>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::redis::v1::Instance>

--- a/google/cloud/resourcemanager/internal/folders_tracing_connection.cc
+++ b/google/cloud/resourcemanager/internal/folders_tracing_connection.cc
@@ -46,11 +46,11 @@ FoldersTracingConnection::ListFolders(
     google::cloud::resourcemanager::v3::ListFoldersRequest request) {
   auto span =
       internal::MakeSpan("resourcemanager::FoldersConnection::ListFolders");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListFolders(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::resourcemanager::v3::Folder>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::resourcemanager::v3::Folder>(std::move(span),
+                                                  std::move(sr));
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Folder>
@@ -58,11 +58,11 @@ FoldersTracingConnection::SearchFolders(
     google::cloud::resourcemanager::v3::SearchFoldersRequest request) {
   auto span =
       internal::MakeSpan("resourcemanager::FoldersConnection::SearchFolders");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchFolders(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::resourcemanager::v3::Folder>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::resourcemanager::v3::Folder>(std::move(span),
+                                                  std::move(sr));
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>

--- a/google/cloud/resourcemanager/internal/organizations_tracing_connection.cc
+++ b/google/cloud/resourcemanager/internal/organizations_tracing_connection.cc
@@ -46,11 +46,11 @@ OrganizationsTracingConnection::SearchOrganizations(
     google::cloud::resourcemanager::v3::SearchOrganizationsRequest request) {
   auto span = internal::MakeSpan(
       "resourcemanager::OrganizationsConnection::SearchOrganizations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchOrganizations(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::resourcemanager::v3::Organization>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::resourcemanager::v3::Organization>(std::move(span),
+                                                        std::move(sr));
 }
 
 StatusOr<google::iam::v1::Policy> OrganizationsTracingConnection::GetIamPolicy(

--- a/google/cloud/resourcemanager/internal/projects_tracing_connection.cc
+++ b/google/cloud/resourcemanager/internal/projects_tracing_connection.cc
@@ -46,11 +46,11 @@ ProjectsTracingConnection::ListProjects(
     google::cloud::resourcemanager::v3::ListProjectsRequest request) {
   auto span =
       internal::MakeSpan("resourcemanager::ProjectsConnection::ListProjects");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProjects(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::resourcemanager::v3::Project>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::resourcemanager::v3::Project>(std::move(span),
+                                                   std::move(sr));
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Project>
@@ -58,11 +58,11 @@ ProjectsTracingConnection::SearchProjects(
     google::cloud::resourcemanager::v3::SearchProjectsRequest request) {
   auto span =
       internal::MakeSpan("resourcemanager::ProjectsConnection::SearchProjects");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->SearchProjects(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::resourcemanager::v3::Project>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::resourcemanager::v3::Project>(std::move(span),
+                                                   std::move(sr));
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>

--- a/google/cloud/resourcesettings/internal/resource_settings_tracing_connection.cc
+++ b/google/cloud/resourcesettings/internal/resource_settings_tracing_connection.cc
@@ -39,11 +39,11 @@ ResourceSettingsServiceTracingConnection::ListSettings(
     google::cloud::resourcesettings::v1::ListSettingsRequest request) {
   auto span = internal::MakeSpan(
       "resourcesettings::ResourceSettingsServiceConnection::ListSettings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSettings(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::resourcesettings::v1::Setting>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::resourcesettings::v1::Setting>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::resourcesettings::v1::Setting>

--- a/google/cloud/retail/internal/catalog_tracing_connection.cc
+++ b/google/cloud/retail/internal/catalog_tracing_connection.cc
@@ -37,10 +37,10 @@ CatalogServiceTracingConnection::ListCatalogs(
     google::cloud::retail::v2::ListCatalogsRequest request) {
   auto span =
       internal::MakeSpan("retail::CatalogServiceConnection::ListCatalogs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCatalogs(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::retail::v2::Catalog>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::retail::v2::Catalog>

--- a/google/cloud/retail/internal/product_tracing_connection.cc
+++ b/google/cloud/retail/internal/product_tracing_connection.cc
@@ -55,10 +55,10 @@ ProductServiceTracingConnection::ListProducts(
     google::cloud::retail::v2::ListProductsRequest request) {
   auto span =
       internal::MakeSpan("retail::ProductServiceConnection::ListProducts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProducts(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::retail::v2::Product>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::retail::v2::Product>

--- a/google/cloud/retail/internal/search_tracing_connection.cc
+++ b/google/cloud/retail/internal/search_tracing_connection.cc
@@ -36,11 +36,11 @@ StreamRange<google::cloud::retail::v2::SearchResponse::SearchResult>
 SearchServiceTracingConnection::Search(
     google::cloud::retail::v2::SearchRequest request) {
   auto span = internal::MakeSpan("retail::SearchServiceConnection::Search");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->Search(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::retail::v2::SearchResponse::SearchResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::retail::v2::SearchResponse::SearchResult>(std::move(span),
+                                                               std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/run/internal/revisions_tracing_connection.cc
+++ b/google/cloud/run/internal/revisions_tracing_connection.cc
@@ -44,10 +44,10 @@ StreamRange<google::cloud::run::v2::Revision>
 RevisionsTracingConnection::ListRevisions(
     google::cloud::run::v2::ListRevisionsRequest request) {
   auto span = internal::MakeSpan("run::RevisionsConnection::ListRevisions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRevisions(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::run::v2::Revision>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::run::v2::Revision>>

--- a/google/cloud/run/internal/services_tracing_connection.cc
+++ b/google/cloud/run/internal/services_tracing_connection.cc
@@ -49,10 +49,10 @@ StreamRange<google::cloud::run::v2::Service>
 ServicesTracingConnection::ListServices(
     google::cloud::run::v2::ListServicesRequest request) {
   auto span = internal::MakeSpan("run::ServicesConnection::ListServices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServices(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::run::v2::Service>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::run::v2::Service>>

--- a/google/cloud/scheduler/internal/cloud_scheduler_tracing_connection.cc
+++ b/google/cloud/scheduler/internal/cloud_scheduler_tracing_connection.cc
@@ -37,10 +37,10 @@ CloudSchedulerTracingConnection::ListJobs(
     google::cloud::scheduler::v1::ListJobsRequest request) {
   auto span =
       internal::MakeSpan("scheduler::CloudSchedulerConnection::ListJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobs(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::scheduler::v1::Job>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::scheduler::v1::Job>

--- a/google/cloud/secretmanager/internal/secret_manager_tracing_connection.cc
+++ b/google/cloud/secretmanager/internal/secret_manager_tracing_connection.cc
@@ -37,11 +37,10 @@ SecretManagerServiceTracingConnection::ListSecrets(
     google::cloud::secretmanager::v1::ListSecretsRequest request) {
   auto span = internal::MakeSpan(
       "secretmanager::SecretManagerServiceConnection::ListSecrets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSecrets(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::secretmanager::v1::Secret>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::secretmanager::v1::Secret>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::secretmanager::v1::Secret>
@@ -93,11 +92,11 @@ SecretManagerServiceTracingConnection::ListSecretVersions(
     google::cloud::secretmanager::v1::ListSecretVersionsRequest request) {
   auto span = internal::MakeSpan(
       "secretmanager::SecretManagerServiceConnection::ListSecretVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSecretVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::secretmanager::v1::SecretVersion>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::secretmanager::v1::SecretVersion>(std::move(span),
+                                                       std::move(sr));
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>

--- a/google/cloud/securitycenter/internal/security_center_tracing_connection.cc
+++ b/google/cloud/securitycenter/internal/security_center_tracing_connection.cc
@@ -153,11 +153,11 @@ SecurityCenterTracingConnection::GroupAssets(
     google::cloud::securitycenter::v1::GroupAssetsRequest request) {
   auto span = internal::MakeSpan(
       "securitycenter::SecurityCenterConnection::GroupAssets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->GroupAssets(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::securitycenter::v1::GroupResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::securitycenter::v1::GroupResult>(std::move(span),
+                                                      std::move(sr));
 }
 
 StreamRange<google::cloud::securitycenter::v1::GroupResult>
@@ -165,11 +165,11 @@ SecurityCenterTracingConnection::GroupFindings(
     google::cloud::securitycenter::v1::GroupFindingsRequest request) {
   auto span = internal::MakeSpan(
       "securitycenter::SecurityCenterConnection::GroupFindings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->GroupFindings(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::securitycenter::v1::GroupResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::securitycenter::v1::GroupResult>(std::move(span),
+                                                      std::move(sr));
 }
 
 StreamRange<
@@ -178,11 +178,11 @@ SecurityCenterTracingConnection::ListAssets(
     google::cloud::securitycenter::v1::ListAssetsRequest request) {
   auto span = internal::MakeSpan(
       "securitycenter::SecurityCenterConnection::ListAssets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAssets(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::securitycenter::v1::ListAssetsResponse::ListAssetsResult>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<
@@ -191,11 +191,11 @@ SecurityCenterTracingConnection::ListFindings(
     google::cloud::securitycenter::v1::ListFindingsRequest request) {
   auto span = internal::MakeSpan(
       "securitycenter::SecurityCenterConnection::ListFindings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListFindings(std::move(request));
   return internal::MakeTracedStreamRange<
       google::cloud::securitycenter::v1::ListFindingsResponse::
-          ListFindingsResult>(std::move(span), std::move(scope), std::move(sr));
+          ListFindingsResult>(std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::securitycenter::v1::MuteConfig>
@@ -203,11 +203,11 @@ SecurityCenterTracingConnection::ListMuteConfigs(
     google::cloud::securitycenter::v1::ListMuteConfigsRequest request) {
   auto span = internal::MakeSpan(
       "securitycenter::SecurityCenterConnection::ListMuteConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMuteConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::securitycenter::v1::MuteConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::securitycenter::v1::MuteConfig>(std::move(span),
+                                                     std::move(sr));
 }
 
 StreamRange<google::cloud::securitycenter::v1::NotificationConfig>
@@ -215,11 +215,11 @@ SecurityCenterTracingConnection::ListNotificationConfigs(
     google::cloud::securitycenter::v1::ListNotificationConfigsRequest request) {
   auto span = internal::MakeSpan(
       "securitycenter::SecurityCenterConnection::ListNotificationConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNotificationConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::securitycenter::v1::NotificationConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::securitycenter::v1::NotificationConfig>(std::move(span),
+                                                             std::move(sr));
 }
 
 StreamRange<google::cloud::securitycenter::v1::Source>
@@ -227,11 +227,11 @@ SecurityCenterTracingConnection::ListSources(
     google::cloud::securitycenter::v1::ListSourcesRequest request) {
   auto span = internal::MakeSpan(
       "securitycenter::SecurityCenterConnection::ListSources");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSources(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::securitycenter::v1::Source>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::securitycenter::v1::Source>(std::move(span),
+                                                 std::move(sr));
 }
 
 future<StatusOr<google::cloud::securitycenter::v1::RunAssetDiscoveryResponse>>
@@ -377,11 +377,11 @@ SecurityCenterTracingConnection::ListBigQueryExports(
     google::cloud::securitycenter::v1::ListBigQueryExportsRequest request) {
   auto span = internal::MakeSpan(
       "securitycenter::SecurityCenterConnection::ListBigQueryExports");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBigQueryExports(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::securitycenter::v1::BigQueryExport>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::securitycenter::v1::BigQueryExport>(std::move(span),
+                                                         std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/servicedirectory/internal/registration_tracing_connection.cc
+++ b/google/cloud/servicedirectory/internal/registration_tracing_connection.cc
@@ -47,11 +47,11 @@ RegistrationServiceTracingConnection::ListNamespaces(
     google::cloud::servicedirectory::v1::ListNamespacesRequest request) {
   auto span = internal::MakeSpan(
       "servicedirectory::RegistrationServiceConnection::ListNamespaces");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNamespaces(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::servicedirectory::v1::Namespace>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::servicedirectory::v1::Namespace>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Namespace>
@@ -96,11 +96,11 @@ RegistrationServiceTracingConnection::ListServices(
     google::cloud::servicedirectory::v1::ListServicesRequest request) {
   auto span = internal::MakeSpan(
       "servicedirectory::RegistrationServiceConnection::ListServices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServices(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::servicedirectory::v1::Service>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::servicedirectory::v1::Service>(std::move(span),
+                                                    std::move(sr));
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Service>
@@ -143,11 +143,11 @@ RegistrationServiceTracingConnection::ListEndpoints(
     google::cloud::servicedirectory::v1::ListEndpointsRequest request) {
   auto span = internal::MakeSpan(
       "servicedirectory::RegistrationServiceConnection::ListEndpoints");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEndpoints(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::servicedirectory::v1::Endpoint>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::servicedirectory::v1::Endpoint>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Endpoint>

--- a/google/cloud/servicemanagement/internal/service_manager_tracing_connection.cc
+++ b/google/cloud/servicemanagement/internal/service_manager_tracing_connection.cc
@@ -37,11 +37,11 @@ ServiceManagerTracingConnection::ListServices(
     google::api::servicemanagement::v1::ListServicesRequest request) {
   auto span = internal::MakeSpan(
       "servicemanagement::ServiceManagerConnection::ListServices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServices(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::api::servicemanagement::v1::ManagedService>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::api::servicemanagement::v1::ManagedService>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::api::servicemanagement::v1::ManagedService>
@@ -76,10 +76,10 @@ ServiceManagerTracingConnection::ListServiceConfigs(
     google::api::servicemanagement::v1::ListServiceConfigsRequest request) {
   auto span = internal::MakeSpan(
       "servicemanagement::ServiceManagerConnection::ListServiceConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServiceConfigs(std::move(request));
-  return internal::MakeTracedStreamRange<google::api::Service>(
-      std::move(span), std::move(scope), std::move(sr));
+  return internal::MakeTracedStreamRange<google::api::Service>(std::move(span),
+                                                               std::move(sr));
 }
 
 StatusOr<google::api::Service>
@@ -114,11 +114,11 @@ ServiceManagerTracingConnection::ListServiceRollouts(
     google::api::servicemanagement::v1::ListServiceRolloutsRequest request) {
   auto span = internal::MakeSpan(
       "servicemanagement::ServiceManagerConnection::ListServiceRollouts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServiceRollouts(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::api::servicemanagement::v1::Rollout>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::api::servicemanagement::v1::Rollout>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::api::servicemanagement::v1::Rollout>

--- a/google/cloud/serviceusage/internal/service_usage_tracing_connection.cc
+++ b/google/cloud/serviceusage/internal/service_usage_tracing_connection.cc
@@ -58,11 +58,10 @@ ServiceUsageTracingConnection::ListServices(
     google::api::serviceusage::v1::ListServicesRequest request) {
   auto span =
       internal::MakeSpan("serviceusage::ServiceUsageConnection::ListServices");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListServices(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::api::serviceusage::v1::Service>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::api::serviceusage::v1::Service>(std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::api::serviceusage::v1::BatchEnableServicesResponse>>

--- a/google/cloud/spanner/admin/internal/database_admin_tracing_connection.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_tracing_connection.cc
@@ -37,11 +37,11 @@ DatabaseAdminTracingConnection::ListDatabases(
     google::spanner::admin::database::v1::ListDatabasesRequest request) {
   auto span = internal::MakeSpan(
       "spanner_admin::DatabaseAdminConnection::ListDatabases");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDatabases(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::spanner::admin::database::v1::Database>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::spanner::admin::database::v1::Database>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
@@ -154,11 +154,11 @@ DatabaseAdminTracingConnection::ListBackups(
     google::spanner::admin::database::v1::ListBackupsRequest request) {
   auto span =
       internal::MakeSpan("spanner_admin::DatabaseAdminConnection::ListBackups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBackups(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::spanner::admin::database::v1::Backup>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::spanner::admin::database::v1::Backup>(std::move(span),
+                                                    std::move(sr));
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
@@ -174,10 +174,10 @@ DatabaseAdminTracingConnection::ListDatabaseOperations(
         request) {
   auto span = internal::MakeSpan(
       "spanner_admin::DatabaseAdminConnection::ListDatabaseOperations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDatabaseOperations(std::move(request));
   return internal::MakeTracedStreamRange<google::longrunning::Operation>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::longrunning::Operation>
@@ -185,10 +185,10 @@ DatabaseAdminTracingConnection::ListBackupOperations(
     google::spanner::admin::database::v1::ListBackupOperationsRequest request) {
   auto span = internal::MakeSpan(
       "spanner_admin::DatabaseAdminConnection::ListBackupOperations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListBackupOperations(std::move(request));
   return internal::MakeTracedStreamRange<google::longrunning::Operation>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::spanner::admin::database::v1::DatabaseRole>
@@ -196,11 +196,11 @@ DatabaseAdminTracingConnection::ListDatabaseRoles(
     google::spanner::admin::database::v1::ListDatabaseRolesRequest request) {
   auto span = internal::MakeSpan(
       "spanner_admin::DatabaseAdminConnection::ListDatabaseRoles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDatabaseRoles(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::spanner::admin::database::v1::DatabaseRole>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::spanner::admin::database::v1::DatabaseRole>(std::move(span),
+                                                          std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/spanner/admin/internal/instance_admin_tracing_connection.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_tracing_connection.cc
@@ -37,11 +37,11 @@ InstanceAdminTracingConnection::ListInstanceConfigs(
     google::spanner::admin::instance::v1::ListInstanceConfigsRequest request) {
   auto span = internal::MakeSpan(
       "spanner_admin::InstanceAdminConnection::ListInstanceConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstanceConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::spanner::admin::instance::v1::InstanceConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::spanner::admin::instance::v1::InstanceConfig>(std::move(span),
+                                                            std::move(sr));
 }
 
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
@@ -83,10 +83,10 @@ InstanceAdminTracingConnection::ListInstanceConfigOperations(
         request) {
   auto span = internal::MakeSpan(
       "spanner_admin::InstanceAdminConnection::ListInstanceConfigOperations");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstanceConfigOperations(std::move(request));
   return internal::MakeTracedStreamRange<google::longrunning::Operation>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StreamRange<google::spanner::admin::instance::v1::Instance>
@@ -94,11 +94,11 @@ InstanceAdminTracingConnection::ListInstances(
     google::spanner::admin::instance::v1::ListInstancesRequest request) {
   auto span = internal::MakeSpan(
       "spanner_admin::InstanceAdminConnection::ListInstances");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInstances(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::spanner::admin::instance::v1::Instance>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::spanner::admin::instance::v1::Instance>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::spanner::admin::instance::v1::Instance>

--- a/google/cloud/speech/v2/internal/speech_tracing_connection.cc
+++ b/google/cloud/speech/v2/internal/speech_tracing_connection.cc
@@ -43,10 +43,10 @@ SpeechTracingConnection::ListRecognizers(
     google::cloud::speech::v2::ListRecognizersRequest request) {
   auto span =
       internal::MakeSpan("speech_v2::SpeechConnection::ListRecognizers");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRecognizers(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::speech::v2::Recognizer>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::speech::v2::Recognizer>
@@ -122,11 +122,10 @@ SpeechTracingConnection::ListCustomClasses(
     google::cloud::speech::v2::ListCustomClassesRequest request) {
   auto span =
       internal::MakeSpan("speech_v2::SpeechConnection::ListCustomClasses");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCustomClasses(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::speech::v2::CustomClass>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::speech::v2::CustomClass>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::speech::v2::CustomClass>
@@ -165,10 +164,10 @@ StreamRange<google::cloud::speech::v2::PhraseSet>
 SpeechTracingConnection::ListPhraseSets(
     google::cloud::speech::v2::ListPhraseSetsRequest request) {
   auto span = internal::MakeSpan("speech_v2::SpeechConnection::ListPhraseSets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPhraseSets(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::speech::v2::PhraseSet>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::speech::v2::PhraseSet>

--- a/google/cloud/storagetransfer/internal/storage_transfer_tracing_connection.cc
+++ b/google/cloud/storagetransfer/internal/storage_transfer_tracing_connection.cc
@@ -77,11 +77,10 @@ StorageTransferServiceTracingConnection::ListTransferJobs(
     google::storagetransfer::v1::ListTransferJobsRequest request) {
   auto span = internal::MakeSpan(
       "storagetransfer::StorageTransferServiceConnection::ListTransferJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTransferJobs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::storagetransfer::v1::TransferJob>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::storagetransfer::v1::TransferJob>(std::move(span), std::move(sr));
 }
 
 Status StorageTransferServiceTracingConnection::PauseTransferOperation(
@@ -149,11 +148,10 @@ StorageTransferServiceTracingConnection::ListAgentPools(
     google::storagetransfer::v1::ListAgentPoolsRequest request) {
   auto span = internal::MakeSpan(
       "storagetransfer::StorageTransferServiceConnection::ListAgentPools");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAgentPools(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::storagetransfer::v1::AgentPool>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::storagetransfer::v1::AgentPool>(std::move(span), std::move(sr));
 }
 
 Status StorageTransferServiceTracingConnection::DeleteAgentPool(

--- a/google/cloud/talent/internal/company_tracing_connection.cc
+++ b/google/cloud/talent/internal/company_tracing_connection.cc
@@ -72,10 +72,10 @@ CompanyServiceTracingConnection::ListCompanies(
     google::cloud::talent::v4::ListCompaniesRequest request) {
   auto span =
       internal::MakeSpan("talent::CompanyServiceConnection::ListCompanies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCompanies(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::talent::v4::Company>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/talent/internal/job_tracing_connection.cc
+++ b/google/cloud/talent/internal/job_tracing_connection.cc
@@ -82,10 +82,10 @@ StreamRange<google::cloud::talent::v4::Job>
 JobServiceTracingConnection::ListJobs(
     google::cloud::talent::v4::ListJobsRequest request) {
   auto span = internal::MakeSpan("talent::JobServiceConnection::ListJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobs(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::talent::v4::Job>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::talent::v4::SearchJobsResponse>

--- a/google/cloud/talent/internal/tenant_tracing_connection.cc
+++ b/google/cloud/talent/internal/tenant_tracing_connection.cc
@@ -71,10 +71,10 @@ TenantServiceTracingConnection::ListTenants(
     google::cloud::talent::v4::ListTenantsRequest request) {
   auto span =
       internal::MakeSpan("talent::TenantServiceConnection::ListTenants");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTenants(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::talent::v4::Tenant>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/tasks/internal/cloud_tasks_tracing_connection.cc
+++ b/google/cloud/tasks/internal/cloud_tasks_tracing_connection.cc
@@ -36,10 +36,10 @@ StreamRange<google::cloud::tasks::v2::Queue>
 CloudTasksTracingConnection::ListQueues(
     google::cloud::tasks::v2::ListQueuesRequest request) {
   auto span = internal::MakeSpan("tasks::CloudTasksConnection::ListQueues");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListQueues(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::tasks::v2::Queue>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksTracingConnection::GetQueue(
@@ -123,10 +123,10 @@ StreamRange<google::cloud::tasks::v2::Task>
 CloudTasksTracingConnection::ListTasks(
     google::cloud::tasks::v2::ListTasksRequest request) {
   auto span = internal::MakeSpan("tasks::CloudTasksConnection::ListTasks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTasks(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::tasks::v2::Task>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksTracingConnection::GetTask(

--- a/google/cloud/tpu/v1/internal/tpu_tracing_connection.cc
+++ b/google/cloud/tpu/v1/internal/tpu_tracing_connection.cc
@@ -35,10 +35,10 @@ TpuTracingConnection::TpuTracingConnection(
 StreamRange<google::cloud::tpu::v1::Node> TpuTracingConnection::ListNodes(
     google::cloud::tpu::v1::ListNodesRequest request) {
   auto span = internal::MakeSpan("tpu_v1::TpuConnection::ListNodes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNodes(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::tpu::v1::Node>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::tpu::v1::Node> TpuTracingConnection::GetNode(
@@ -79,11 +79,11 @@ TpuTracingConnection::ListTensorFlowVersions(
     google::cloud::tpu::v1::ListTensorFlowVersionsRequest request) {
   auto span =
       internal::MakeSpan("tpu_v1::TpuConnection::ListTensorFlowVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTensorFlowVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::tpu::v1::TensorFlowVersion>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::tpu::v1::TensorFlowVersion>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::tpu::v1::TensorFlowVersion>
@@ -98,11 +98,10 @@ StreamRange<google::cloud::tpu::v1::AcceleratorType>
 TpuTracingConnection::ListAcceleratorTypes(
     google::cloud::tpu::v1::ListAcceleratorTypesRequest request) {
   auto span = internal::MakeSpan("tpu_v1::TpuConnection::ListAcceleratorTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAcceleratorTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::tpu::v1::AcceleratorType>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::tpu::v1::AcceleratorType>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::tpu::v1::AcceleratorType>

--- a/google/cloud/tpu/v2/internal/tpu_tracing_connection.cc
+++ b/google/cloud/tpu/v2/internal/tpu_tracing_connection.cc
@@ -35,10 +35,10 @@ TpuTracingConnection::TpuTracingConnection(
 StreamRange<google::cloud::tpu::v2::Node> TpuTracingConnection::ListNodes(
     google::cloud::tpu::v2::ListNodesRequest request) {
   auto span = internal::MakeSpan("tpu_v2::TpuConnection::ListNodes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNodes(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::tpu::v2::Node>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::tpu::v2::Node> TpuTracingConnection::GetNode(
@@ -87,11 +87,10 @@ StreamRange<google::cloud::tpu::v2::AcceleratorType>
 TpuTracingConnection::ListAcceleratorTypes(
     google::cloud::tpu::v2::ListAcceleratorTypesRequest request) {
   auto span = internal::MakeSpan("tpu_v2::TpuConnection::ListAcceleratorTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListAcceleratorTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::tpu::v2::AcceleratorType>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::tpu::v2::AcceleratorType>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::tpu::v2::AcceleratorType>
@@ -106,11 +105,10 @@ StreamRange<google::cloud::tpu::v2::RuntimeVersion>
 TpuTracingConnection::ListRuntimeVersions(
     google::cloud::tpu::v2::ListRuntimeVersionsRequest request) {
   auto span = internal::MakeSpan("tpu_v2::TpuConnection::ListRuntimeVersions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListRuntimeVersions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::tpu::v2::RuntimeVersion>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::tpu::v2::RuntimeVersion>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::tpu::v2::RuntimeVersion>

--- a/google/cloud/translate/internal/translation_tracing_connection.cc
+++ b/google/cloud/translate/internal/translation_tracing_connection.cc
@@ -93,11 +93,10 @@ TranslationServiceTracingConnection::ListGlossaries(
     google::cloud::translation::v3::ListGlossariesRequest request) {
   auto span = internal::MakeSpan(
       "translate::TranslationServiceConnection::ListGlossaries");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGlossaries(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::translation::v3::Glossary>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::translation::v3::Glossary>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::translation::v3::Glossary>

--- a/google/cloud/video/internal/livestream_tracing_connection.cc
+++ b/google/cloud/video/internal/livestream_tracing_connection.cc
@@ -43,11 +43,11 @@ LivestreamServiceTracingConnection::ListChannels(
     google::cloud::video::livestream::v1::ListChannelsRequest request) {
   auto span =
       internal::MakeSpan("video::LivestreamServiceConnection::ListChannels");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListChannels(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::livestream::v1::Channel>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::livestream::v1::Channel>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::video::livestream::v1::Channel>
@@ -94,11 +94,11 @@ LivestreamServiceTracingConnection::ListInputs(
     google::cloud::video::livestream::v1::ListInputsRequest request) {
   auto span =
       internal::MakeSpan("video::LivestreamServiceConnection::ListInputs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListInputs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::livestream::v1::Input>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::livestream::v1::Input>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::video::livestream::v1::Input>
@@ -136,11 +136,11 @@ LivestreamServiceTracingConnection::ListEvents(
     google::cloud::video::livestream::v1::ListEventsRequest request) {
   auto span =
       internal::MakeSpan("video::LivestreamServiceConnection::ListEvents");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListEvents(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::livestream::v1::Event>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::livestream::v1::Event>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::video::livestream::v1::Event>

--- a/google/cloud/video/internal/transcoder_tracing_connection.cc
+++ b/google/cloud/video/internal/transcoder_tracing_connection.cc
@@ -46,11 +46,11 @@ TranscoderServiceTracingConnection::ListJobs(
     google::cloud::video::transcoder::v1::ListJobsRequest request) {
   auto span =
       internal::MakeSpan("video::TranscoderServiceConnection::ListJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::transcoder::v1::Job>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::transcoder::v1::Job>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::video::transcoder::v1::Job>
@@ -84,11 +84,11 @@ TranscoderServiceTracingConnection::ListJobTemplates(
     google::cloud::video::transcoder::v1::ListJobTemplatesRequest request) {
   auto span = internal::MakeSpan(
       "video::TranscoderServiceConnection::ListJobTemplates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListJobTemplates(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::transcoder::v1::JobTemplate>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::transcoder::v1::JobTemplate>(std::move(span),
+                                                         std::move(sr));
 }
 
 StatusOr<google::cloud::video::transcoder::v1::JobTemplate>

--- a/google/cloud/video/internal/video_stitcher_tracing_connection.cc
+++ b/google/cloud/video/internal/video_stitcher_tracing_connection.cc
@@ -46,11 +46,11 @@ VideoStitcherServiceTracingConnection::ListCdnKeys(
     google::cloud::video::stitcher::v1::ListCdnKeysRequest request) {
   auto span =
       internal::MakeSpan("video::VideoStitcherServiceConnection::ListCdnKeys");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCdnKeys(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::stitcher::v1::CdnKey>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::stitcher::v1::CdnKey>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::video::stitcher::v1::CdnKey>
@@ -103,11 +103,11 @@ VideoStitcherServiceTracingConnection::ListVodStitchDetails(
     google::cloud::video::stitcher::v1::ListVodStitchDetailsRequest request) {
   auto span = internal::MakeSpan(
       "video::VideoStitcherServiceConnection::ListVodStitchDetails");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVodStitchDetails(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::stitcher::v1::VodStitchDetail>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::stitcher::v1::VodStitchDetail>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::cloud::video::stitcher::v1::VodStitchDetail>
@@ -125,11 +125,11 @@ VideoStitcherServiceTracingConnection::ListVodAdTagDetails(
     google::cloud::video::stitcher::v1::ListVodAdTagDetailsRequest request) {
   auto span = internal::MakeSpan(
       "video::VideoStitcherServiceConnection::ListVodAdTagDetails");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVodAdTagDetails(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::stitcher::v1::VodAdTagDetail>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::stitcher::v1::VodAdTagDetail>(std::move(span),
+                                                          std::move(sr));
 }
 
 StatusOr<google::cloud::video::stitcher::v1::VodAdTagDetail>
@@ -147,11 +147,11 @@ VideoStitcherServiceTracingConnection::ListLiveAdTagDetails(
     google::cloud::video::stitcher::v1::ListLiveAdTagDetailsRequest request) {
   auto span = internal::MakeSpan(
       "video::VideoStitcherServiceConnection::ListLiveAdTagDetails");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListLiveAdTagDetails(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::stitcher::v1::LiveAdTagDetail>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::stitcher::v1::LiveAdTagDetail>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::cloud::video::stitcher::v1::LiveAdTagDetail>
@@ -178,11 +178,11 @@ VideoStitcherServiceTracingConnection::ListSlates(
     google::cloud::video::stitcher::v1::ListSlatesRequest request) {
   auto span =
       internal::MakeSpan("video::VideoStitcherServiceConnection::ListSlates");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSlates(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::video::stitcher::v1::Slate>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::video::stitcher::v1::Slate>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::video::stitcher::v1::Slate>

--- a/google/cloud/vision/internal/product_search_tracing_connection.cc
+++ b/google/cloud/vision/internal/product_search_tracing_connection.cc
@@ -46,10 +46,10 @@ ProductSearchTracingConnection::ListProductSets(
     google::cloud::vision::v1::ListProductSetsRequest request) {
   auto span =
       internal::MakeSpan("vision::ProductSearchConnection::ListProductSets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProductSets(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::vision::v1::ProductSet>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::vision::v1::ProductSet>
@@ -92,10 +92,10 @@ ProductSearchTracingConnection::ListProducts(
     google::cloud::vision::v1::ListProductsRequest request) {
   auto span =
       internal::MakeSpan("vision::ProductSearchConnection::ListProducts");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProducts(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::vision::v1::Product>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::vision::v1::Product>
@@ -145,11 +145,11 @@ ProductSearchTracingConnection::ListReferenceImages(
     google::cloud::vision::v1::ListReferenceImagesRequest request) {
   auto span = internal::MakeSpan(
       "vision::ProductSearchConnection::ListReferenceImages");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListReferenceImages(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vision::v1::ReferenceImage>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vision::v1::ReferenceImage>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::vision::v1::ReferenceImage>
@@ -183,10 +183,10 @@ ProductSearchTracingConnection::ListProductsInProductSet(
     google::cloud::vision::v1::ListProductsInProductSetRequest request) {
   auto span = internal::MakeSpan(
       "vision::ProductSearchConnection::ListProductsInProductSet");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListProductsInProductSet(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::vision::v1::Product>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::vision::v1::ImportProductSetsResponse>>

--- a/google/cloud/vmmigration/internal/vm_migration_tracing_connection.cc
+++ b/google/cloud/vmmigration/internal/vm_migration_tracing_connection.cc
@@ -37,11 +37,10 @@ VmMigrationTracingConnection::ListSources(
     google::cloud::vmmigration::v1::ListSourcesRequest request) {
   auto span =
       internal::MakeSpan("vmmigration::VmMigrationConnection::ListSources");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSources(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmmigration::v1::Source>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::vmmigration::v1::Source>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::Source>
@@ -85,11 +84,11 @@ VmMigrationTracingConnection::ListUtilizationReports(
     google::cloud::vmmigration::v1::ListUtilizationReportsRequest request) {
   auto span = internal::MakeSpan(
       "vmmigration::VmMigrationConnection::ListUtilizationReports");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListUtilizationReports(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmmigration::v1::UtilizationReport>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmmigration::v1::UtilizationReport>(std::move(span),
+                                                         std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::UtilizationReport>
@@ -121,11 +120,11 @@ VmMigrationTracingConnection::ListDatacenterConnectors(
     google::cloud::vmmigration::v1::ListDatacenterConnectorsRequest request) {
   auto span = internal::MakeSpan(
       "vmmigration::VmMigrationConnection::ListDatacenterConnectors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListDatacenterConnectors(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmmigration::v1::DatacenterConnector>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmmigration::v1::DatacenterConnector>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>
@@ -169,11 +168,11 @@ VmMigrationTracingConnection::ListMigratingVms(
     google::cloud::vmmigration::v1::ListMigratingVmsRequest request) {
   auto span = internal::MakeSpan(
       "vmmigration::VmMigrationConnection::ListMigratingVms");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListMigratingVms(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmmigration::v1::MigratingVm>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmmigration::v1::MigratingVm>(std::move(span),
+                                                   std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::MigratingVm>
@@ -238,11 +237,10 @@ VmMigrationTracingConnection::ListCloneJobs(
     google::cloud::vmmigration::v1::ListCloneJobsRequest request) {
   auto span =
       internal::MakeSpan("vmmigration::VmMigrationConnection::ListCloneJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCloneJobs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmmigration::v1::CloneJob>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmmigration::v1::CloneJob>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::CloneJob>
@@ -271,11 +269,11 @@ VmMigrationTracingConnection::ListCutoverJobs(
     google::cloud::vmmigration::v1::ListCutoverJobsRequest request) {
   auto span =
       internal::MakeSpan("vmmigration::VmMigrationConnection::ListCutoverJobs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCutoverJobs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmmigration::v1::CutoverJob>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmmigration::v1::CutoverJob>(std::move(span),
+                                                  std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::CutoverJob>
@@ -292,10 +290,10 @@ VmMigrationTracingConnection::ListGroups(
     google::cloud::vmmigration::v1::ListGroupsRequest request) {
   auto span =
       internal::MakeSpan("vmmigration::VmMigrationConnection::ListGroups");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListGroups(std::move(request));
   return internal::MakeTracedStreamRange<google::cloud::vmmigration::v1::Group>(
-      std::move(span), std::move(scope), std::move(sr));
+      std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::Group>
@@ -343,11 +341,11 @@ VmMigrationTracingConnection::ListTargetProjects(
     google::cloud::vmmigration::v1::ListTargetProjectsRequest request) {
   auto span = internal::MakeSpan(
       "vmmigration::VmMigrationConnection::ListTargetProjects");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListTargetProjects(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmmigration::v1::TargetProject>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmmigration::v1::TargetProject>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::TargetProject>
@@ -382,11 +380,11 @@ VmMigrationTracingConnection::ListReplicationCycles(
     google::cloud::vmmigration::v1::ListReplicationCyclesRequest request) {
   auto span = internal::MakeSpan(
       "vmmigration::VmMigrationConnection::ListReplicationCycles");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListReplicationCycles(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmmigration::v1::ReplicationCycle>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmmigration::v1::ReplicationCycle>(std::move(span),
+                                                        std::move(sr));
 }
 
 StatusOr<google::cloud::vmmigration::v1::ReplicationCycle>

--- a/google/cloud/vmwareengine/v1/internal/vmware_engine_tracing_connection.cc
+++ b/google/cloud/vmwareengine/v1/internal/vmware_engine_tracing_connection.cc
@@ -37,11 +37,11 @@ VmwareEngineTracingConnection::ListPrivateClouds(
     google::cloud::vmwareengine::v1::ListPrivateCloudsRequest request) {
   auto span = internal::MakeSpan(
       "vmwareengine_v1::VmwareEngineConnection::ListPrivateClouds");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListPrivateClouds(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmwareengine::v1::PrivateCloud>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmwareengine::v1::PrivateCloud>(std::move(span),
+                                                     std::move(sr));
 }
 
 StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>
@@ -83,11 +83,10 @@ VmwareEngineTracingConnection::ListClusters(
     google::cloud::vmwareengine::v1::ListClustersRequest request) {
   auto span = internal::MakeSpan(
       "vmwareengine_v1::VmwareEngineConnection::ListClusters");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListClusters(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmwareengine::v1::Cluster>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmwareengine::v1::Cluster>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::vmwareengine::v1::Cluster>
@@ -122,11 +121,10 @@ VmwareEngineTracingConnection::ListSubnets(
     google::cloud::vmwareengine::v1::ListSubnetsRequest request) {
   auto span = internal::MakeSpan(
       "vmwareengine_v1::VmwareEngineConnection::ListSubnets");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListSubnets(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmwareengine::v1::Subnet>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::vmwareengine::v1::Subnet>(std::move(span), std::move(sr));
 }
 
 StreamRange<google::cloud::vmwareengine::v1::NodeType>
@@ -134,11 +132,11 @@ VmwareEngineTracingConnection::ListNodeTypes(
     google::cloud::vmwareengine::v1::ListNodeTypesRequest request) {
   auto span = internal::MakeSpan(
       "vmwareengine_v1::VmwareEngineConnection::ListNodeTypes");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNodeTypes(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmwareengine::v1::NodeType>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmwareengine::v1::NodeType>(std::move(span),
+                                                 std::move(sr));
 }
 
 StatusOr<google::cloud::vmwareengine::v1::NodeType>
@@ -195,11 +193,11 @@ VmwareEngineTracingConnection::ListHcxActivationKeys(
     google::cloud::vmwareengine::v1::ListHcxActivationKeysRequest request) {
   auto span = internal::MakeSpan(
       "vmwareengine_v1::VmwareEngineConnection::ListHcxActivationKeys");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListHcxActivationKeys(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmwareengine::v1::HcxActivationKey>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmwareengine::v1::HcxActivationKey>(std::move(span),
+                                                         std::move(sr));
 }
 
 StatusOr<google::cloud::vmwareengine::v1::HcxActivationKey>
@@ -226,11 +224,11 @@ VmwareEngineTracingConnection::ListNetworkPolicies(
     google::cloud::vmwareengine::v1::ListNetworkPoliciesRequest request) {
   auto span = internal::MakeSpan(
       "vmwareengine_v1::VmwareEngineConnection::ListNetworkPolicies");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListNetworkPolicies(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmwareengine::v1::NetworkPolicy>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmwareengine::v1::NetworkPolicy>(std::move(span),
+                                                      std::move(sr));
 }
 
 future<StatusOr<google::cloud::vmwareengine::v1::NetworkPolicy>>
@@ -290,11 +288,11 @@ VmwareEngineTracingConnection::ListVmwareEngineNetworks(
     google::cloud::vmwareengine::v1::ListVmwareEngineNetworksRequest request) {
   auto span = internal::MakeSpan(
       "vmwareengine_v1::VmwareEngineConnection::ListVmwareEngineNetworks");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListVmwareEngineNetworks(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vmwareengine::v1::VmwareEngineNetwork>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::vmwareengine::v1::VmwareEngineNetwork>(std::move(span),
+                                                            std::move(sr));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/vpcaccess/internal/vpc_access_tracing_connection.cc
+++ b/google/cloud/vpcaccess/internal/vpc_access_tracing_connection.cc
@@ -52,11 +52,10 @@ VpcAccessServiceTracingConnection::ListConnectors(
     google::cloud::vpcaccess::v1::ListConnectorsRequest request) {
   auto span = internal::MakeSpan(
       "vpcaccess::VpcAccessServiceConnection::ListConnectors");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListConnectors(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::vpcaccess::v1::Connector>(std::move(span),
-                                               std::move(scope), std::move(sr));
+      google::cloud::vpcaccess::v1::Connector>(std::move(span), std::move(sr));
 }
 
 future<StatusOr<google::cloud::vpcaccess::v1::OperationMetadata>>

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_tracing_connection.cc
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_tracing_connection.cc
@@ -66,11 +66,11 @@ WebSecurityScannerTracingConnection::ListScanConfigs(
     google::cloud::websecurityscanner::v1::ListScanConfigsRequest request) {
   auto span = internal::MakeSpan(
       "websecurityscanner::WebSecurityScannerConnection::ListScanConfigs");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListScanConfigs(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::websecurityscanner::v1::ScanConfig>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::websecurityscanner::v1::ScanConfig>(std::move(span),
+                                                         std::move(sr));
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>
@@ -106,11 +106,11 @@ WebSecurityScannerTracingConnection::ListScanRuns(
     google::cloud::websecurityscanner::v1::ListScanRunsRequest request) {
   auto span = internal::MakeSpan(
       "websecurityscanner::WebSecurityScannerConnection::ListScanRuns");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListScanRuns(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::websecurityscanner::v1::ScanRun>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::websecurityscanner::v1::ScanRun>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanRun>
@@ -127,11 +127,11 @@ WebSecurityScannerTracingConnection::ListCrawledUrls(
     google::cloud::websecurityscanner::v1::ListCrawledUrlsRequest request) {
   auto span = internal::MakeSpan(
       "websecurityscanner::WebSecurityScannerConnection::ListCrawledUrls");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListCrawledUrls(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::websecurityscanner::v1::CrawledUrl>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::websecurityscanner::v1::CrawledUrl>(std::move(span),
+                                                         std::move(sr));
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::Finding>
@@ -148,11 +148,11 @@ WebSecurityScannerTracingConnection::ListFindings(
     google::cloud::websecurityscanner::v1::ListFindingsRequest request) {
   auto span = internal::MakeSpan(
       "websecurityscanner::WebSecurityScannerConnection::ListFindings");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListFindings(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::websecurityscanner::v1::Finding>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::websecurityscanner::v1::Finding>(std::move(span),
+                                                      std::move(sr));
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::ListFindingTypeStatsResponse>

--- a/google/cloud/workflows/internal/executions_tracing_connection.cc
+++ b/google/cloud/workflows/internal/executions_tracing_connection.cc
@@ -37,11 +37,11 @@ ExecutionsTracingConnection::ListExecutions(
     google::cloud::workflows::executions::v1::ListExecutionsRequest request) {
   auto span =
       internal::MakeSpan("workflows::ExecutionsConnection::ListExecutions");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListExecutions(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::workflows::executions::v1::Execution>(
-      std::move(span), std::move(scope), std::move(sr));
+      google::cloud::workflows::executions::v1::Execution>(std::move(span),
+                                                           std::move(sr));
 }
 
 StatusOr<google::cloud::workflows::executions::v1::Execution>

--- a/google/cloud/workflows/internal/workflows_tracing_connection.cc
+++ b/google/cloud/workflows/internal/workflows_tracing_connection.cc
@@ -37,11 +37,10 @@ WorkflowsTracingConnection::ListWorkflows(
     google::cloud::workflows::v1::ListWorkflowsRequest request) {
   auto span =
       internal::MakeSpan("workflows::WorkflowsConnection::ListWorkflows");
-  auto scope = absl::make_unique<opentelemetry::trace::Scope>(span);
+  auto scope = opentelemetry::trace::Scope(span);
   auto sr = child_->ListWorkflows(std::move(request));
   return internal::MakeTracedStreamRange<
-      google::cloud::workflows::v1::Workflow>(std::move(span), std::move(scope),
-                                              std::move(sr));
+      google::cloud::workflows::v1::Workflow>(std::move(span), std::move(sr));
 }
 
 StatusOr<google::cloud::workflows::v1::Workflow>


### PR DESCRIPTION
As discussed in our team meeting on 2023-02-01, a traced stream range parent span should only be active when making reads. It should not be active when the caller iterates over the range.

We can simplify the wrapper now that the base `StreamRange<>` does the work to re-instantiate the call span. (#10730)

<hr />

Note that the removed `SpanActiveDuringSubOperations` test is still covered. It is just not the responsibility of `MakeTracedStreamRange`.

We ensure that the underlying `StreamRange` captures the active span in this test:

https://github.com/googleapis/google-cloud-cpp/blob/13602cf4f4830c158181e37fd93b6b5fc144b4c9/google/cloud/stream_range_test.cc#L271

and we verify that the tracing connection starts an active span in these golden tests:

https://github.com/googleapis/google-cloud-cpp/blob/13602cf4f4830c158181e37fd93b6b5fc144b4c9/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc#L150

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10807)
<!-- Reviewable:end -->
