### PR TITLE
impl(GCS+gRPC): synthetic self-links for ACLs

### DIFF
--- a/google/cloud/storage/internal/grpc_bucket_access_control_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_access_control_parser.cc
@@ -42,7 +42,7 @@ google::storage::v2::BucketAccessControl ToProto(
 
 storage::BucketAccessControl FromProto(
     google::storage::v2::BucketAccessControl acl,
-    std::string const& bucket_name) {
+    std::string const& bucket_name, std::string const& bucket_self_link) {
   storage::BucketAccessControl result;
   result.set_kind("storage#bucketAccessControl");
   result.set_bucket(bucket_name);
@@ -59,6 +59,7 @@ storage::BucketAccessControl FromProto(
   }
   result.set_role(std::move(*acl.mutable_role()));
   result.set_etag(std::move(*acl.mutable_etag()));
+  result.set_self_link(bucket_self_link + "/acl/" + result.entity());
 
   return result;
 }

--- a/google/cloud/storage/internal/grpc_bucket_access_control_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_access_control_parser.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/bucket_access_control.h"
 #include "google/cloud/storage/internal/patch_builder_details.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 
 namespace google {
 namespace cloud {
@@ -59,7 +60,8 @@ storage::BucketAccessControl FromProto(
   }
   result.set_role(std::move(*acl.mutable_role()));
   result.set_etag(std::move(*acl.mutable_etag()));
-  result.set_self_link(bucket_self_link + "/acl/" + result.entity());
+  result.set_self_link(
+      absl::StrCat(bucket_self_link, "/acl/", result.entity()));
 
   return result;
 }

--- a/google/cloud/storage/internal/grpc_bucket_access_control_parser.h
+++ b/google/cloud/storage/internal/grpc_bucket_access_control_parser.h
@@ -28,7 +28,7 @@ google::storage::v2::BucketAccessControl ToProto(
     storage::BucketAccessControl const& acl);
 storage::BucketAccessControl FromProto(
     google::storage::v2::BucketAccessControl acl,
-    std::string const& bucket_name);
+    std::string const& bucket_name, std::string const& bucket_self_link);
 std::string Role(storage::BucketAccessControlPatchBuilder const&);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/grpc_bucket_access_control_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_access_control_parser_test.cc
@@ -58,11 +58,12 @@ TEST(GrpcBucketAccessControlParser, FromProto) {
        "projectNumber": "test-project-number",
        "team": "test-team"
      },
-     "etag": "test-etag"
+     "etag": "test-etag",
+     "selfLink": "https://test-prefix/acl/test-entity"
   })""");
   ASSERT_STATUS_OK(expected);
 
-  auto actual = FromProto(input, "test-bucket");
+  auto actual = FromProto(input, "test-bucket", "https://test-prefix");
   EXPECT_EQ(*expected, actual);
 }
 

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.h
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.h
@@ -25,7 +25,8 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 google::storage::v2::Bucket ToProto(storage::BucketMetadata const& rhs);
-storage::BucketMetadata FromProto(google::storage::v2::Bucket const& rhs);
+storage::BucketMetadata FromProto(google::storage::v2::Bucket const& rhs,
+                                  Options const& options);
 
 google::storage::v2::Bucket::Autoclass ToProto(
     storage::BucketAutoclass const& rhs);

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
@@ -135,13 +135,15 @@ TEST(GrpcBucketMetadataParser, BucketAllFieldsRoundtrip) {
       "bucket": "test-bucket-id",
       "role": "test-role1",
       "entity": "test-entity1",
-      "etag": "test-etag1"
+      "etag": "test-etag1",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/test-bucket-id/acl/test-entity1"
     }, {
       "kind": "storage#bucketAccessControl",
       "bucket": "test-bucket-id",
       "role": "test-role2",
       "entity": "test-entity2",
-      "etag": "test-etag2"
+      "etag": "test-etag2",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/test-bucket-id/acl/test-entity2"
     }],
     "defaultObjectAcl": [{
       "kind": "storage#objectAccessControl",
@@ -229,6 +231,7 @@ TEST(GrpcBucketMetadataParser, BucketAllFieldsRoundtrip) {
       "publicAccessPrevention": "inherited"
     },
     "etag": "test-etag",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/test-bucket-id",
     "autoclass": {
       "enabled": true,
       "toggleTime": "2022-10-07T02:03:04.123456000Z"
@@ -236,7 +239,7 @@ TEST(GrpcBucketMetadataParser, BucketAllFieldsRoundtrip) {
   })""");
   ASSERT_THAT(expected, IsOk());
 
-  auto const middle = FromProto(input);
+  auto const middle = FromProto(input, Options{});
   EXPECT_EQ(middle, *expected);
 
   auto const p1 = ToProto(middle);

--- a/google/cloud/storage/internal/grpc_bucket_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser.cc
@@ -401,10 +401,11 @@ storage::internal::ListBucketsResponse FromProto(
   storage::internal::ListBucketsResponse result;
   result.next_page_token = response.next_page_token();
   result.items.reserve(response.buckets_size());
+  auto const& current_options = internal::CurrentOptions();
   std::transform(response.buckets().begin(), response.buckets().end(),
                  std::back_inserter(result.items),
-                 [](google::storage::v2::Bucket const& b) {
-                   return storage_internal::FromProto(b);
+                 [&](google::storage::v2::Bucket const& b) {
+                   return storage_internal::FromProto(b, current_options);
                  });
   return result;
 }

--- a/google/cloud/storage/internal/grpc_object_access_control_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_access_control_parser.cc
@@ -20,26 +20,9 @@ namespace google {
 namespace cloud {
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
 
-google::storage::v2::ObjectAccessControl ToProto(
-    storage::ObjectAccessControl const& acl) {
-  google::storage::v2::ObjectAccessControl result;
-  result.set_role(acl.role());
-  result.set_id(acl.id());
-  result.set_entity(acl.entity());
-  result.set_entity_id(acl.entity_id());
-  result.set_email(acl.email());
-  result.set_domain(acl.domain());
-  if (acl.has_project_team()) {
-    result.mutable_project_team()->set_project_number(
-        acl.project_team().project_number);
-    result.mutable_project_team()->set_team(acl.project_team().team);
-  }
-  result.set_etag(acl.etag());
-  return result;
-}
-
-storage::ObjectAccessControl FromProto(
+storage::ObjectAccessControl FromProtoImpl(
     google::storage::v2::ObjectAccessControl acl,
     std::string const& bucket_name, std::string const& object_name,
     std::uint64_t generation) {
@@ -61,7 +44,42 @@ storage::ObjectAccessControl FromProto(
   }
   result.set_role(std::move(*acl.mutable_role()));
   result.set_etag(std::move(*acl.mutable_etag()));
+  return result;
+}
 
+}  // namespace
+
+google::storage::v2::ObjectAccessControl ToProto(
+    storage::ObjectAccessControl const& acl) {
+  google::storage::v2::ObjectAccessControl result;
+  result.set_role(acl.role());
+  result.set_id(acl.id());
+  result.set_entity(acl.entity());
+  result.set_entity_id(acl.entity_id());
+  result.set_email(acl.email());
+  result.set_domain(acl.domain());
+  if (acl.has_project_team()) {
+    result.mutable_project_team()->set_project_number(
+        acl.project_team().project_number);
+    result.mutable_project_team()->set_team(acl.project_team().team);
+  }
+  result.set_etag(acl.etag());
+  return result;
+}
+
+storage::ObjectAccessControl FromProtoDefaultObjectAccessControl(
+    google::storage::v2::ObjectAccessControl acl,
+    std::string const& bucket_name) {
+  return FromProtoImpl(std::move(acl), bucket_name, std::string{}, 0);
+}
+
+storage::ObjectAccessControl FromProto(
+    google::storage::v2::ObjectAccessControl acl,
+    std::string const& bucket_name, std::string const& object_name,
+    std::uint64_t generation, std::string const& object_self_link) {
+  auto result =
+      FromProtoImpl(std::move(acl), bucket_name, object_name, generation);
+  result.set_self_link(object_self_link + "/acl/" + result.entity());
   return result;
 }
 

--- a/google/cloud/storage/internal/grpc_object_access_control_parser.h
+++ b/google/cloud/storage/internal/grpc_object_access_control_parser.h
@@ -30,10 +30,12 @@ google::storage::v2::ObjectAccessControl ToProto(
 storage::ObjectAccessControl FromProtoDefaultObjectAccessControl(
     google::storage::v2::ObjectAccessControl acl,
     std::string const& bucket_name);
+
 storage::ObjectAccessControl FromProto(
     google::storage::v2::ObjectAccessControl acl,
     std::string const& bucket_name, std::string const& object_name,
     std::uint64_t generation, std::string const& object_self_link);
+
 std::string Role(storage::ObjectAccessControlPatchBuilder const&);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/grpc_object_access_control_parser.h
+++ b/google/cloud/storage/internal/grpc_object_access_control_parser.h
@@ -26,10 +26,14 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 google::storage::v2::ObjectAccessControl ToProto(
     storage::ObjectAccessControl const& acl);
+
+storage::ObjectAccessControl FromProtoDefaultObjectAccessControl(
+    google::storage::v2::ObjectAccessControl acl,
+    std::string const& bucket_name);
 storage::ObjectAccessControl FromProto(
     google::storage::v2::ObjectAccessControl acl,
     std::string const& bucket_name, std::string const& object_name,
-    std::uint64_t generation);
+    std::uint64_t generation, std::string const& object_self_link);
 std::string Role(storage::ObjectAccessControlPatchBuilder const&);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/grpc_object_access_control_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_access_control_parser_test.cc
@@ -61,11 +61,52 @@ TEST(GrpcObjectAccessControlParser, FromProto) {
        "projectNumber": "test-project-number",
        "team": "test-team"
      },
+     "etag": "test-etag",
+     "selfLink": "https://prefix/acl/test-entity"
+  })""");
+  ASSERT_STATUS_OK(expected);
+
+  auto actual =
+      FromProto(input, "test-bucket", "test-object", 42, "https://prefix");
+  EXPECT_EQ(*expected, actual);
+}
+
+TEST(GrpcObjectAccessControlParser, FromProtoDefaultObjectAccessControl) {
+  storage_proto::ObjectAccessControl input;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+     role: "test-role"
+     id: "test-id"
+     entity: "test-entity"
+     entity_id: "test-entity-id"
+     email: "test-email"
+     domain: "test-domain"
+     project_team: {
+       project_number: "test-project-number"
+       team: "test-team"
+     }
+     etag: "test-etag"
+     )""",
+                                                            &input));
+
+  auto const expected =
+      storage::internal::ObjectAccessControlParser::FromString(R"""({
+     "role": "test-role",
+     "id": "test-id",
+     "kind": "storage#objectAccessControl",
+     "bucket": "test-bucket",
+     "entity": "test-entity",
+     "entityId": "test-entity-id",
+     "email": "test-email",
+     "domain": "test-domain",
+     "projectTeam": {
+       "projectNumber": "test-project-number",
+       "team": "test-team"
+     },
      "etag": "test-etag"
   })""");
   ASSERT_STATUS_OK(expected);
 
-  auto actual = FromProto(input, "test-bucket", "test-object", 42);
+  auto actual = FromProtoDefaultObjectAccessControl(input, "test-bucket");
   EXPECT_EQ(*expected, actual);
 }
 

--- a/google/cloud/storage/internal/grpc_object_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_metadata_parser.cc
@@ -112,7 +112,7 @@ storage::ObjectMetadata FromProto(google::storage::v2::Object object,
   acl.reserve(object.acl_size());
   for (auto& item : *object.mutable_acl()) {
     acl.push_back(FromProto(std::move(item), metadata.bucket(), metadata.name(),
-                            metadata.generation()));
+                            metadata.generation(), metadata.self_link()));
   }
   metadata.set_acl(std::move(acl));
   metadata.set_cache_control(std::move(*object.mutable_cache_control()));

--- a/google/cloud/storage/internal/grpc_object_metadata_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_metadata_parser_test.cc
@@ -107,7 +107,8 @@ TEST(GrpcClientFromProto, ObjectSimple) {
        "kind": "storage#objectAccessControl",
        "role": "OWNER",
        "entity": "user:test-user@gmail.com",
-       "etag": "test-etag-acl"
+       "etag": "test-etag-acl",
+       "selfLink":  "https://www.googleapis.com/storage/v1/b/test-bucket/o/test-object-name/acl/user:test-user@gmail.com"
       }
     ],
     "contentEncoding": "test-content-encoding",


### PR DESCRIPTION
This populates synthetic self-link fields for the `*AccessControl` resources. I neglected these earlier because other fields (such as ETag) were failing too and my test did not catch them.

Part of the work for #9805

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10809)
<!-- Reviewable:end -->
