### PR TITLE
test(GCS+gRPC): more integration tests in production

### DIFF
--- a/google/cloud/storage/tests/grpc_object_media_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_media_integration_test.cc
@@ -39,9 +39,6 @@ class GrpcObjectMediaIntegrationTest
 TEST_F(GrpcObjectMediaIntegrationTest, CancelResumableUpload) {
   ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                 "metadata");
-  // TODO(#9804) - restore gRPC integration tests against production
-  if (!UsingEmulator()) GTEST_SKIP();
-
   auto const bucket_name =
       GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
   ASSERT_THAT(bucket_name, Not(IsEmpty()))

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -737,8 +737,6 @@ TEST_F(ObjectIntegrationTest, DeleteAccessControlFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, DeleteResumableUpload) {
-  // TODO(#9804) - enable in production.
-  if (!UsingEmulator()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient(
       absl::make_unique<LimitedErrorCountRetryPolicy>(1));
   ASSERT_STATUS_OK(client);


### PR DESCRIPTION
Enable the tests blocked by lacking a functional
`CancelResumableUpload()` in production.

Fixes #9804

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10810)
<!-- Reviewable:end -->
