### PR TITLE
fix(common): fewer spurious warnings in the log

### DIFF
--- a/google/cloud/internal/streaming_read_rpc.cc
+++ b/google/cloud/internal/streaming_read_rpc.cc
@@ -22,6 +22,9 @@ namespace internal {
 
 void StreamingReadRpcReportUnhandledError(Status const& status,
                                           char const* tname) {
+  // Getting a kCancelled here is expected, this is only called after cancelling
+  // the RPC.
+  if (status.ok() || status.code() == StatusCode::kCancelled) return;
   GCP_LOG(WARNING) << "unhandled error for StreamingReadRpcImpl< " << tname
                    << " > - status=" << status;
 }

--- a/google/cloud/internal/streaming_read_rpc.h
+++ b/google/cloud/internal/streaming_read_rpc.h
@@ -85,8 +85,6 @@ class StreamingReadRpcImpl : public StreamingReadRpc<ResponseType> {
     if (finished_) return;
     Cancel();
     auto status = Finish();
-    // Getting a kCancelled here is expected, as we just canceled the RPC.
-    if (status.ok() && status.code() != StatusCode::kCancelled) return;
     StreamingReadRpcReportUnhandledError(status, typeid(ResponseType).name());
   }
 

--- a/google/cloud/internal/streaming_write_rpc_impl.cc
+++ b/google/cloud/internal/streaming_write_rpc_impl.cc
@@ -22,6 +22,7 @@ namespace internal {
 
 void StreamingWriteRpcReportUnhandledError(Status const& status,
                                            char const* tname) {
+  if (status.ok() || status.code() == StatusCode::kCancelled) return;
   GCP_LOG(WARNING) << "unhandled error for StreamingWriteRpcImpl< " << tname
                    << " > - status=" << status;
 }

--- a/google/cloud/internal/streaming_write_rpc_impl.h
+++ b/google/cloud/internal/streaming_write_rpc_impl.h
@@ -56,7 +56,6 @@ class StreamingWriteRpcImpl
     if (finished_) return;
     Cancel();
     auto status = Finish();
-    if (status.ok()) return;
     StreamingWriteRpcReportUnhandledError(status, typeid(ResponseType).name());
   }
 


### PR DESCRIPTION
When a streaming RPC is cancelled we should expect the final status of the RPC to be either kOk, or kCancelled. Both are normal outcomes in this case and do not deserve a warning in the log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10811)
<!-- Reviewable:end -->
