### PR TITLE
refactor(ci): consolidate bazel tag filters

### DIFF
--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -48,7 +48,9 @@ args+=("--instrument_test_targets")
 # Based on the recommendations from:
 #     https://github.com/bazelbuild/bazel/issues/3236
 args+=("--sandbox_tmpfs_path=/tmp")
+io::log_h2 "Running coverage on non-integration tests."
 bazel coverage "${args[@]}" --test_tag_filters=-integration-test ...
+
 GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance"
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators coverage "${args[@]}" "${integration_args[@]}"
@@ -56,7 +58,8 @@ integration::bazel_with_emulators coverage "${args[@]}" "${integration_args[@]}"
 io::log_h2 "Running Storage integration tests (with emulator and Legacy http)"
 "google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh" \
   bazel coverage "${args[@]}" "${integration_args[@]}" \
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP=yes"
+  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP=yes" \
+  "--test_tag_filters=integration-test"
 
 # Where does this token come from? For triggered ci/pr builds GCB will securely
 # inject this into the environment. See the "secretEnv" setting in the

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -162,34 +162,36 @@ function integration::bazel_with_emulators() {
     "google/cloud:internal_unified_rest_credentials_integration_test"
   )
 
-  tag_filters="integration-test"
+  production_tests_tag_filters="integration-test"
   if echo "${args[@]}" | grep -w -q -- "--config=msan"; then
-    tag_filters="integration-test,-no-msan"
+    production_tests_tag_filters="integration-test,-no-msan"
   fi
 
   io::log_h2 "Running integration tests that require production access"
-  bazel "${verb}" "${args[@]}" --test_tag_filters="${tag_filters}" \
+  bazel "${verb}" "${args[@]}" \
+    --test_tag_filters="${production_tests_tag_filters}" \
     "${production_integration_tests[@]}"
 
   io::log_h2 "Running Pub/Sub integration tests (with emulator)"
   "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}"
+    bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test"
 
   io::log_h2 "Running Storage integration tests (with emulator)"
   "google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}"
+    bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test"
 
   io::log_h2 "Running Spanner integration tests (with emulator)"
   "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}" --test_tag_filters=integration-test,-http-transcoding-test
+    bazel "${verb}" "${args[@]}" \
+    --test_tag_filters="integration-test,-http-transcoding-test"
 
   io::log_h2 "Running Bigtable integration tests (with emulator)"
   "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}"
+    bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test"
 
   io::log_h2 "Running REST integration tests (with emulator)"
   "google/cloud/internal/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}"
+    bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test"
 
   # This test is run separately because the access token changes every time and
   # that would mess up bazel's test cache for all the other tests.

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -45,8 +45,7 @@ production_only_targets=(
   "//google/cloud/bigtable/tests:admin_iam_policy_integration_test"
 )
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
-  --test_tag_filters="integration-test" -- \
-  "${production_only_targets[@]}"
+  -- "${production_only_targets[@]}"
 
 # `start_emulators` creates unsightly *.log files in the current directory
 # (which is ${PROJECT_ROOT}) and we cannot use a subshell because we want the
@@ -67,9 +66,7 @@ done
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
   --test_env="BIGTABLE_EMULATOR_HOST=${BIGTABLE_EMULATOR_HOST}" \
   --test_env="BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}" \
-  --test_tag_filters="integration-test" -- \
-  "//google/cloud/bigtable/..." \
-  "${excluded_targets[@]}"
+  -- "//google/cloud/bigtable/..." "${excluded_targets[@]}"
 exit_status=$?
 
 kill_emulators

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
@@ -35,8 +35,7 @@ production_only_targets=(
   "//google/cloud/pubsub/samples:iam_samples"
 )
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
-  --test_tag_filters="integration-test" -- \
-  "${production_only_targets[@]}"
+  -- "${production_only_targets[@]}"
 
 # Start the emulator and arranges to kill it, run in $HOME because
 # pubsub_emulator::start creates unsightly *.log files in the workspace
@@ -53,6 +52,4 @@ done
 
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
   --test_env="PUBSUB_EMULATOR_HOST=${PUBSUB_EMULATOR_HOST}" \
-  --test_tag_filters="integration-test" -- \
-  "//google/cloud/pubsub/...:all" \
-  "${excluded_targets[@]}"
+  -- "//google/cloud/pubsub/...:all" "${excluded_targets[@]}"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -55,8 +55,7 @@ production_only_targets=(
   "//google/cloud/storage/tests:unified_credentials_integration_test"
 )
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
-  --test_tag_filters="integration-test" -- \
-  "${production_only_targets[@]}" "${excluded_targets[@]}"
+  -- "${production_only_targets[@]}" "${excluded_targets[@]}"
 
 # `start_emulator` creates unsightly *.log files in the current directory
 # (which is ${PROJECT_ROOT}) and we cannot use a subshell because we want the
@@ -109,9 +108,7 @@ emulator_args=(
 # the emulator. Note that the HMAC service account is completely invalid and
 # it is not unique to each test, neither is a problem when using the emulator.
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" "${emulator_args[@]}" \
-  --test_tag_filters="integration-test" -- \
-  "//google/cloud/storage/...:all" \
-  "${excluded_targets[@]}"
+  -- "//google/cloud/storage/...:all" "${excluded_targets[@]}"
 exit_status=$?
 
 if [[ "$exit_status" -ne 0 ]]; then


### PR DESCRIPTION
Specify integration test tags in one place, `integration.sh`, instead of in each script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10812)
<!-- Reviewable:end -->
