### PR TITLE
test(GCS+gRPC): enable production integration tests

### DIFF
--- a/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
@@ -75,14 +75,7 @@ TEST_F(GrpcHmacKeyMetadataIntegrationTest, HmacKeyCRUD) {
 
   auto get = client->GetHmacKey(metadata.access_id());
   ASSERT_STATUS_OK(get);
-  // Compare member-by-member as the ETag field is missing in the protos:
-  EXPECT_EQ(get->id(), metadata.id());
-  EXPECT_EQ(get->access_id(), metadata.access_id());
-  EXPECT_EQ(get->project_id(), metadata.project_id());
-  EXPECT_EQ(get->service_account_email(), metadata.service_account_email());
-  EXPECT_EQ(get->state(), metadata.state());
-  EXPECT_EQ(get->time_created(), metadata.time_created());
-  EXPECT_EQ(get->updated(), metadata.updated());
+  EXPECT_EQ(*get, metadata);
 
   // Before we can delete the HmacKey we need to move it to the inactive state.
   auto update = metadata;

--- a/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
@@ -41,9 +41,6 @@ class GrpcObjectMetadataIntegrationTest
 TEST_F(GrpcObjectMetadataIntegrationTest, ObjectMetadataCRUD) {
   ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                 "metadata");
-  // TODO(#9805) - restore gRPC integration tests against production
-  if (!UsingEmulator()) GTEST_SKIP();
-
   auto const bucket_name =
       GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
   ASSERT_THAT(bucket_name, Not(IsEmpty()))

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -43,9 +43,6 @@ using ObjectBasicCRUDIntegrationTest =
 
 /// @test Verify the Object CRUD (Create, Get, Update, Delete, List) operations.
 TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
-  // TODO(#9805) - restore gRPC integration tests against production
-  if (!UsingEmulator()) GTEST_SKIP();
-
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
Some tests were disabled waiting for ETag support in production.

Fixes #9805

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10813)
<!-- Reviewable:end -->
