### PR TITLE
cleanup(bigtable): remove unused CMake option

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -433,16 +433,6 @@ if (BUILD_TESTING)
     endforeach ()
 endif ()
 
-option(GOOGLE_CLOUD_CPP_FORCE_STATIC_ANALYZER_ERRORS
-       "If set, enable tests that force errors detected by the static analyzer."
-       "")
-mark_as_advanced(GOOGLE_CLOUD_CPP_FORCE_STATIC_ANALYZER_ERRORS)
-if (GOOGLE_CLOUD_CPP_FORCE_STATIC_ANALYZER_ERRORS)
-    target_compile_definitions(
-        bigtable_client_force_sanitizer_failures_test
-        PRIVATE -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
-endif ()
-
 # Only compile integration tests and benchmarks if testing is enabled.
 if (BUILD_TESTING)
     add_subdirectory(admin/integration_tests)

--- a/google/cloud/bigtable/force_sanitizer_failures_test.cc
+++ b/google/cloud/bigtable/force_sanitizer_failures_test.cc
@@ -17,19 +17,6 @@
 /// @test a trivial test to keep the compiler happy when all tests are disabled.
 TEST(ForceSanitizerFailuresTest, Trivial) {}
 
-#ifdef BIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS
-TEST(ForceScanBuildDiagnostic, Test) {
-  int r = std::rand();
-  if (r != 0) {
-    int x = std::numeric_limits<int>::max() / r;
-    EXPECT_LE(0, x);
-  } else {
-    int x = std::numeric_limits<int>::min() / r;
-    EXPECT_GE(0, x);
-  }
-}
-#endif  // BIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS
-
 // These tests are only used when testing the CI scripts, we want to keep them
 // as documentation and a quick way to exercise the tests.  It might be
 // interesting to figure out a way to always enable these tests.


### PR DESCRIPTION
Remove some code and CMake option used to force a static analysis error. We no longer have any builds with this static analysis, and when we did, the flag was used to troubleshoot problems with the build not failing when it should. The latter is better done with a local change rather than polluting the options namespace.

Motivated by #8572 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10818)
<!-- Reviewable:end -->
