### PR TITLE
cleanup: more user-friendly CMake defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,10 @@ endif ()
 
 # If ccache is installed use it for the build.
 option(GOOGLE_CLOUD_CPP_ENABLE_CCACHE "Automatically use ccache if available"
-       ON)
+       OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_CCACHE)
 
-if ("${GOOGLE_CLOUD_CPP_ENABLE_CCACHE}")
+if (GOOGLE_CLOUD_CPP_ENABLE_CCACHE)
     find_program(GOOGLE_CLOUD_CPP_CCACHE_PROGRAM ccache NAMES /usr/bin/ccache)
     mark_as_advanced(GOOGLE_CLOUD_CPP_CCACHE_PROGRAM)
     if (GOOGLE_CLOUD_CPP_CCACHE_PROGRAM)

--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -52,6 +52,8 @@ function cmake::common_args() {
   local args
   args=(
     -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)"
+    -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON
   )
   args+=(-GNinja -S . -B cmake-out)
   printf "%s\n" "${args[@]}"

--- a/ci/cloudbuild/builds/lib/quickstart.sh
+++ b/ci/cloudbuild/builds/lib/quickstart.sh
@@ -55,7 +55,15 @@ function quickstart::build_one_quickstart() {
 
   io::log "[ CMake ]"
   local cmake_bin_dir="${PROJECT_ROOT}/cmake-out/quickstart/cmake-${bin_dir_suffix}"
-  cmake -H"${src_dir}" -B"${cmake_bin_dir}" "-DCMAKE_PREFIX_PATH=${prefix}"
+  local configure_args=(
+    # We still need to support CMake == 3.10 which does not have the -S option.
+    "-H${src_dir}"
+    "-B${cmake_bin_dir}"
+    -DCMAKE_PREFIX_PATH="${prefix}"
+    -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON
+  )
+  cmake "${configure_args[@]}"
   cmake --build "${cmake_bin_dir}"
 
   echo

--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -58,6 +58,7 @@ cmake_flags=(
   "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
   "-DCMAKE_INSTALL_PREFIX=${HOME}/staging"
   "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON"
+  "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
 )
 
 # The downloads can fail, therefore require a retry loop.

--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -48,6 +48,8 @@ install_vcpkg "${vcpkg_dir}"
 export NINJA_STATUS="T+%es [%f/%t] "
 cmake_flags=(
   "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
+  "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON"
+  "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
 )
 
 build_quickstart() {

--- a/ci/kokoro/windows/builds/cmake.ps1
+++ b/ci/kokoro/windows/builds/cmake.ps1
@@ -53,7 +53,8 @@ $cmake_args=@(
     "-DCMAKE_BUILD_TYPE=${env:CONFIG}",
     "-DVCPKG_TARGET_TRIPLET=${env:VCPKG_TRIPLET}",
     "-DCMAKE_C_COMPILER=cl.exe",
-    "-DCMAKE_CXX_COMPILER=cl.exe"
+    "-DCMAKE_CXX_COMPILER=cl.exe",
+    "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
 )
 
 # Configure CMake and create the build directory.

--- a/ci/kokoro/windows/builds/quickstart-cmake.ps1
+++ b/ci/kokoro/windows/builds/quickstart-cmake.ps1
@@ -80,7 +80,8 @@ ForEach($feature in $features) {
         "-DCMAKE_TOOLCHAIN_FILE=`"${vcpkg_root}/scripts/buildsystems/vcpkg.cmake`""
         "-DCMAKE_BUILD_TYPE=${env:CONFIG}",
         "-DVCPKG_TARGET_TRIPLET=${env:VCPKG_TRIPLET}",
-        "-DCMAKE_CXX_COMPILER=cl.exe"
+        "-DCMAKE_CXX_COMPILER=cl.exe",
+        "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
     )
 
     Write-Host "$(Get-Date -Format o) Configuring CMake with $cmake_args"

--- a/cmake/EnableWerror.cmake
+++ b/cmake/EnableWerror.cmake
@@ -15,7 +15,7 @@
 # ~~~
 
 option(GOOGLE_CLOUD_CPP_ENABLE_WERROR
-       "If set, compiles the library with -Werror and /WX (MSVC)." ON)
+       "If set, compiles the library with -Werror and /WX (MSVC)." OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_WERROR)
 
 # Find out what flags turn on all available warnings and turn those warnings


### PR DESCRIPTION
Change some CMake defaults to make them more suitable for our customers. For example, turning on `-Werror` can fail for our customers if they use a newer compiler. And enabling `ccache(1)` is not helpful for package maintainers.

Fixes #7387

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10819)
<!-- Reviewable:end -->
