### PR TITLE
impl(bigquery): Interface headers with request/response and stubbed out implementation and tests for GetJob api.

### DIFF
--- a/google/cloud/bigquery/bigquery_rest.cmake
+++ b/google/cloud/bigquery/bigquery_rest.cmake
@@ -18,6 +18,7 @@ add_library(
     google_cloud_cpp_bigquery_rest # cmake-format: sort
     v2/minimal/internal/bigquery_http_response.cc
     v2/minimal/internal/bigquery_http_response.h
+    v2/minimal/internal/job.h
     v2/minimal/internal/job_idempotency_policy.cc
     v2/minimal/internal/job_idempotency_policy.h
     v2/minimal/internal/job_logging.cc
@@ -26,6 +27,10 @@ add_library(
     v2/minimal/internal/job_metadata.h
     v2/minimal/internal/job_options.cc
     v2/minimal/internal/job_options.h
+    v2/minimal/internal/job_request.cc
+    v2/minimal/internal/job_request.h
+    v2/minimal/internal/job_response.cc
+    v2/minimal/internal/job_response.h
     v2/minimal/internal/job_rest_connection_impl.cc
     v2/minimal/internal/job_rest_connection_impl.h
     v2/minimal/internal/job_rest_stub.cc
@@ -68,7 +73,10 @@ function (bigquery_rest_define_tests)
 
     set(bigquery_rest_unit_tests
         # cmake-format: sort
-        v2/minimal/internal/bigquery_http_response_test.cc)
+        v2/minimal/internal/bigquery_http_response_test.cc
+        v2/minimal/internal/job_request_test.cc
+        v2/minimal/internal/job_response_test.cc
+        v2/minimal/internal/job_rest_stub_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.

--- a/google/cloud/bigquery/bigquery_rest_unit_tests.bzl
+++ b/google/cloud/bigquery/bigquery_rest_unit_tests.bzl
@@ -18,4 +18,7 @@
 
 bigquery_rest_unit_tests = [
     "v2/minimal/internal/bigquery_http_response_test.cc",
+    "v2/minimal/internal/job_request_test.cc",
+    "v2/minimal/internal/job_response_test.cc",
+    "v2/minimal/internal/job_rest_stub_test.cc",
 ]

--- a/google/cloud/bigquery/google_cloud_cpp_bigquery_rest.bzl
+++ b/google/cloud/bigquery/google_cloud_cpp_bigquery_rest.bzl
@@ -18,10 +18,13 @@
 
 google_cloud_cpp_bigquery_rest_hdrs = [
     "v2/minimal/internal/bigquery_http_response.h",
+    "v2/minimal/internal/job.h",
     "v2/minimal/internal/job_idempotency_policy.h",
     "v2/minimal/internal/job_logging.h",
     "v2/minimal/internal/job_metadata.h",
     "v2/minimal/internal/job_options.h",
+    "v2/minimal/internal/job_request.h",
+    "v2/minimal/internal/job_response.h",
     "v2/minimal/internal/job_rest_connection_impl.h",
     "v2/minimal/internal/job_rest_stub.h",
     "v2/minimal/internal/job_rest_stub_factory.h",
@@ -34,6 +37,8 @@ google_cloud_cpp_bigquery_rest_srcs = [
     "v2/minimal/internal/job_logging.cc",
     "v2/minimal/internal/job_metadata.cc",
     "v2/minimal/internal/job_options.cc",
+    "v2/minimal/internal/job_request.cc",
+    "v2/minimal/internal/job_response.cc",
     "v2/minimal/internal/job_rest_connection_impl.cc",
     "v2/minimal/internal/job_rest_stub.cc",
     "v2/minimal/internal/job_rest_stub_factory.cc",

--- a/google/cloud/bigquery/v2/minimal/internal/job.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job.h
@@ -12,36 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
-#include "google/cloud/log.h"
-#include "google/cloud/status_or.h"
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_H
+
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigQueryJobStub::~BigQueryJobStub() = default;
+// Custom class for V2 Job proto fields.
 
-StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
-    GetJobRequest const& request) {
-  GetJobResponse response;
-  if (request.project_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Project Id is empty");
-  }
-  if (request.job_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Job Id is empty");
-  }
-  // Not Implemented Yet: Call the rest client to get job details from the
-  // server.
-  return response;
-}
+struct JobConfiguration {
+  // Not Implemented Yet.
+};
+
+struct JobReference {
+  // Not Implemented Yet.
+};
+
+struct JobStatistics {
+  // Not Implemented Yet.
+};
+
+struct JobStatus {
+  // Not Implemented Yet.
+};
+
+struct Job {
+  std::string kind;
+  std::string etag;
+  std::string id;
+  std::string self_link;
+  std::string user_email;
+
+  JobStatus status;
+  JobConfiguration configuration;
+  JobStatistics stats;
+  JobReference reference;
+};
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_H

--- a/google/cloud/bigquery/v2/minimal/internal/job.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_H
 
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/v2/minimal/internal/job.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job.h
@@ -22,8 +22,6 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-// Custom class for V2 Job proto fields.
-
 struct JobConfiguration {
   // Not Implemented Yet.
 };
@@ -40,6 +38,7 @@ struct JobStatus {
   // Not Implemented Yet.
 };
 
+// Custom object for V2 Job proto fields.
 struct Job {
   std::string kind;
   std::string etag;

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -12,33 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
+#include "google/cloud/bigquery/v2/minimal/internal/job_request.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/log.h"
-#include "google/cloud/status_or.h"
+#include "google/cloud/status.h"
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigQueryJobStub::~BigQueryJobStub() = default;
+std::ostream& operator<<(std::ostream& os, GetJobRequest const& r) {
+  os << "GetJobRequest={project_id=" << r.project_id()
+     << ", job_id=" << r.job_id() << ", location=" << r.location();
+  return os << "}";
+}
 
-StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
-    GetJobRequest const& request) {
-  GetJobResponse response;
-  if (request.project_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
+StatusOr<rest_internal::RestRequest> GetJobRequest::BuildRestRequest(
+    GetJobRequest& r) {
+  rest_internal::RestRequest request;
+  if (r.project_id().empty()) {
+    GCP_LOG(DEBUG) << "Invalid request: " << r;
     return Status(StatusCode::kInvalidArgument,
                   "Invalid GetJobRequest: Project Id is empty");
   }
-  if (request.job_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
+  if (r.job_id().empty()) {
+    GCP_LOG(DEBUG) << "Invalid request: " << r;
     return Status(StatusCode::kInvalidArgument,
                   "Invalid GetJobRequest: Job Id is empty");
   }
-  // Not Implemented Yet: Call the rest client to get job details from the
-  // server.
-  return response;
+  // Set path.
+  std::string path =
+      absl::StrCat("https://bigquery.googleapis.com/bigquery/v2/projects/",
+                   r.project_id(), "/jobs/", r.job_id());
+  request.SetPath(path);
+  // Add query params.
+  if (!r.location().empty()) {
+    request.AddQueryParameter("location", r.location());
+  }
+  return request;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -18,15 +18,14 @@
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/status.h"
 #include "absl/strings/match.h"
-#include <ostream>
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest& r,
-                                                      Options opts) {
+StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r,
+                                                      Options& opts) {
   rest_internal::RestRequest request;
   if (r.project_id().empty()) {
     return internal::InvalidArgumentError(

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -25,7 +25,7 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r,
-                                                      Options& opts) {
+                                                      Options const& opts) {
   rest_internal::RestRequest request;
   if (r.project_id().empty()) {
     return internal::InvalidArgumentError(
@@ -36,8 +36,10 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r,
         "Invalid GetJobRequest: Job Id is empty", GCP_ERROR_INFO());
   }
   // Fix the endpoints prefix and suffixes.
-  auto endpoint =
-      opts.lookup<EndpointOption>("https://bigquery.googleapis.com/");
+  std::string endpoint = "https://bigquery.googleapis.com/";
+  if (opts.has<EndpointOption>()) {
+    endpoint = opts.get<EndpointOption>();
+  }
   if (!absl::StartsWith(endpoint, "https://") &&
       !absl::StartsWith(endpoint, "http://")) {
     endpoint = absl::StrCat("https://", endpoint);

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -25,33 +25,26 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<rest_internal::RestRequest> GetJobRequest::BuildRestRequest(
-    Options opts, GetJobRequest& r) {
+StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest& r,
+                                                      Options opts) {
   rest_internal::RestRequest request;
   if (r.project_id().empty()) {
     return internal::InvalidArgumentError(
-        "Invalid GetJobRequest: Project Id is empty",
-        GCP_ERROR_INFO().Build(StatusCode::kInvalidArgument));
+        "Invalid GetJobRequest: Project Id is empty", GCP_ERROR_INFO());
   }
   if (r.job_id().empty()) {
     return internal::InvalidArgumentError(
-        "Invalid GetJobRequest: Job Id is empty",
-        GCP_ERROR_INFO().Build(StatusCode::kInvalidArgument));
-  }
-  if (!opts.has<EndpointOption>()) {
-    opts.set<EndpointOption>("https://bigquery.googleapis.com/");
+        "Invalid GetJobRequest: Job Id is empty", GCP_ERROR_INFO());
   }
   // Fix the endpoints prefix and suffixes.
-  auto endpoint = opts.get<EndpointOption>();
-  if (!(absl::StartsWith(endpoint, "https://")) &&
-      !(absl::StartsWith(endpoint, "http://"))) {
+  auto endpoint =
+      opts.lookup<EndpointOption>("https://bigquery.googleapis.com/");
+  if (!absl::StartsWith(endpoint, "https://") &&
+      !absl::StartsWith(endpoint, "http://")) {
     endpoint = absl::StrCat("https://", endpoint);
   }
-  if (absl::EndsWith(endpoint, "/")) {
-    absl::StrAppend(&endpoint, "bigquery/v2/projects/");
-  } else {
-    absl::StrAppend(&endpoint, "/bigquery/v2/projects/");
-  }
+  if (!absl::EndsWith(endpoint, "/")) absl::StrAppend(&endpoint, "/");
+  absl::StrAppend(&endpoint, "bigquery/v2/projects/");
 
   std::string path =
       absl::StrCat(endpoint, r.project_id(), "/jobs/", r.job_id());

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -62,15 +62,15 @@ class GetJobRequest {
     return std::move(set_location(std::move(location)));
   }
 
-  // Builds RestRequest from GetJobRequest.
-  static StatusOr<rest_internal::RestRequest> BuildRestRequest(
-      Options opts, GetJobRequest& r);
-
  private:
   std::string project_id_;
   std::string job_id_;
   std::string location_;
 };
+
+// Builds RestRequest from GetJobRequest.
+StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest& r,
+                                                      Options opts);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -69,7 +69,7 @@ class GetJobRequest {
 
 // Builds RestRequest from GetJobRequest.
 StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r,
-                                                      Options& opts);
+                                                      Options const& opts);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -16,29 +16,28 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REQUEST_H
 
 #include "google/cloud/internal/rest_request.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <ostream>
+#include <iosfwd>
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-// Holds request parameters necessary to make the GetJob rest call.
+// Holds request parameters necessary to make the GetJob call.
 class GetJobRequest {
  public:
-  // Constructors
   GetJobRequest() = default;
   explicit GetJobRequest(std::string project_id, std::string job_id)
       : project_id_(std::move(project_id)), job_id_(std::move(job_id)) {}
 
-  // Getters
   std::string const& project_id() const { return project_id_; }
   std::string const& job_id() const { return job_id_; }
   std::string const& location() const { return location_; }
 
-  // Setters
   GetJobRequest& set_project_id(std::string project_id) & {
     project_id_ = std::move(project_id);
     return *this;
@@ -65,17 +64,13 @@ class GetJobRequest {
 
   // Builds RestRequest from GetJobRequest.
   static StatusOr<rest_internal::RestRequest> BuildRestRequest(
-      GetJobRequest& r);
+      Options opts, GetJobRequest& r);
 
-  // Members
  private:
   std::string project_id_;
   std::string job_id_;
   std::string location_;
 };
-
-// Logs GetJobRequest data.
-std::ostream& operator<<(std::ostream& os, GetJobRequest const& r);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -19,7 +19,6 @@
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <iosfwd>
 #include <string>
 
 namespace google {
@@ -69,8 +68,8 @@ class GetJobRequest {
 };
 
 // Builds RestRequest from GetJobRequest.
-StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest& r,
-                                                      Options opts);
+StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r,
+                                                      Options& opts);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -1,0 +1,85 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REQUEST_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REQUEST_H
+
+#include "google/cloud/internal/rest_request.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
+#include <ostream>
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+// Holds request parameters necessary to make the GetJob rest call.
+class GetJobRequest {
+ public:
+  // Constructors
+  GetJobRequest() = default;
+  explicit GetJobRequest(std::string project_id, std::string job_id)
+      : project_id_(std::move(project_id)), job_id_(std::move(job_id)) {}
+
+  // Getters
+  std::string const& project_id() const { return project_id_; }
+  std::string const& job_id() const { return job_id_; }
+  std::string const& location() const { return location_; }
+
+  // Setters
+  GetJobRequest& set_project_id(std::string project_id) & {
+    project_id_ = std::move(project_id);
+    return *this;
+  }
+  GetJobRequest&& set_project_id(std::string project_id) && {
+    return std::move(set_project_id(std::move(project_id)));
+  }
+
+  GetJobRequest& set_job_id(std::string job_id) & {
+    job_id_ = std::move(job_id);
+    return *this;
+  }
+  GetJobRequest&& set_job_id(std::string job_id) && {
+    return std::move(set_job_id(std::move(job_id)));
+  }
+
+  GetJobRequest& set_location(std::string location) & {
+    location_ = std::move(location);
+    return *this;
+  }
+  GetJobRequest&& set_location(std::string location) && {
+    return std::move(set_location(std::move(location)));
+  }
+
+  // Builds RestRequest from GetJobRequest.
+  static StatusOr<rest_internal::RestRequest> BuildRestRequest(
+      GetJobRequest& r);
+
+  // Members
+ private:
+  std::string project_id_;
+  std::string job_id_;
+  std::string location_;
+};
+
+// Logs GetJobRequest data.
+std::ostream& operator<<(std::ostream& os, GetJobRequest const& r);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigquery_v2_minimal_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REQUEST_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -29,26 +29,26 @@ TEST(JobRequestTest, SuccessWithLocation) {
   GetJobRequest request("1", "2");
   request.set_location("useast");
   Options opts;
-  auto actual = GetJobRequest::BuildRestRequest(opts, request);
+  auto actual = BuildRestRequest(request, opts);
   ASSERT_STATUS_OK(actual);
 
   rest_internal::RestRequest expected;
   expected.SetPath(
       "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs/2");
   expected.AddQueryParameter("location", "useast");
-  EXPECT_EQ(expected, actual.value());
+  EXPECT_EQ(expected, *actual);
 }
 
 TEST(JobRequestTest, SuccessWithoutLocation) {
   GetJobRequest request("1", "2");
   Options opts;
-  auto actual = GetJobRequest::BuildRestRequest(opts, request);
+  auto actual = BuildRestRequest(request, opts);
   ASSERT_STATUS_OK(actual);
 
   rest_internal::RestRequest expected;
   expected.SetPath(
       "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs/2");
-  EXPECT_EQ(expected, actual.value());
+  EXPECT_EQ(expected, *actual);
 }
 
 TEST(JobRequestTest, SuccessWithEndpoint) {
@@ -73,7 +73,7 @@ TEST(JobRequestTest, SuccessWithEndpoint) {
     SCOPED_TRACE("Testing for endpoint: " + test.endpoint +
                  ", expected: " + test.expected);
     opts.set<EndpointOption>(test.endpoint);
-    auto actual = GetJobRequest::BuildRestRequest(opts, request);
+    auto actual = BuildRestRequest(request, opts);
     ASSERT_STATUS_OK(actual);
     EXPECT_EQ(test.expected, actual.value().path());
   }
@@ -82,7 +82,7 @@ TEST(JobRequestTest, SuccessWithEndpoint) {
 TEST(JobRequestTest, EmptyProjectId) {
   GetJobRequest request("", "job_id");
   Options opts;
-  auto rest_request = GetJobRequest::BuildRestRequest(opts, request);
+  auto rest_request = BuildRestRequest(request, opts);
   EXPECT_THAT(rest_request, StatusIs(StatusCode::kInvalidArgument,
                                      HasSubstr("Project Id is empty")));
 }
@@ -90,7 +90,7 @@ TEST(JobRequestTest, EmptyProjectId) {
 TEST(GetJobRequest, EmptyJobId) {
   GetJobRequest request("project_id", "");
   Options opts;
-  auto rest_request = GetJobRequest::BuildRestRequest(opts, request);
+  auto rest_request = BuildRestRequest(request, opts);
   EXPECT_THAT(rest_request, StatusIs(StatusCode::kInvalidArgument,
                                      HasSubstr("Job Id is empty")));
 }

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -12,33 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
-#include "google/cloud/log.h"
-#include "google/cloud/status_or.h"
+#include "google/cloud/bigquery/v2/minimal/internal/job_request.h"
+#include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigQueryJobStub::~BigQueryJobStub() = default;
+TEST(GetJobRequestTest, BuildRestRequestSuccessWithLocation) {
+  // Not Implemented Yet.
+}
 
-StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
-    GetJobRequest const& request) {
-  GetJobResponse response;
-  if (request.project_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Project Id is empty");
-  }
-  if (request.job_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Job Id is empty");
-  }
-  // Not Implemented Yet: Call the rest client to get job details from the
-  // server.
-  return response;
+TEST(GetJobRequestTest, BuildRestRequestSuccessWithoutLocation) {
+  // Not Implemented Yet.
+}
+
+TEST(GetJobRequestTest, BuildRestRequestFailureEmptyProjectId) {
+  // Not Implemented Yet.
+}
+
+TEST(GetJobRequestTest, BuildRestRequestFailureEmptyJobId) {
+  // Not Implemented Yet.
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -53,7 +53,6 @@ TEST(JobRequestTest, SuccessWithoutLocation) {
 
 TEST(JobRequestTest, SuccessWithEndpoint) {
   GetJobRequest request("1", "2");
-  Options opts;
 
   struct EndpointTest {
     std::string endpoint;
@@ -72,10 +71,11 @@ TEST(JobRequestTest, SuccessWithEndpoint) {
   for (auto const& test : cases) {
     SCOPED_TRACE("Testing for endpoint: " + test.endpoint +
                  ", expected: " + test.expected);
+    Options opts;
     opts.set<EndpointOption>(test.endpoint);
     auto actual = BuildRestRequest(request, opts);
     ASSERT_STATUS_OK(actual);
-    EXPECT_EQ(test.expected, actual.value().path());
+    EXPECT_EQ(test.expected, actual->path());
   }
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -24,9 +24,8 @@ StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
     BigQueryHttpResponse const& http_response) {
   GetJobResponse response;
   if (http_response.payload.empty()) {
-    return internal::InvalidArgumentError(
-        "Empty payload in HTTP response.",
-        GCP_ERROR_INFO().Build(StatusCode::kInternal));
+    return internal::InternalError("Empty payload in HTTP response.",
+                                   GCP_ERROR_INFO());
   }
   // Not Implemented Yet: Parse HttpResponse and build GetJobResponse object.
   return response;

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -12,32 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
-#include "google/cloud/log.h"
-#include "google/cloud/status_or.h"
+#include "google/cloud/bigquery/v2/minimal/internal/job_response.h"
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigQueryJobStub::~BigQueryJobStub() = default;
-
-StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
-    GetJobRequest const& request) {
+StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
+    BigQueryHttpResponse const& http_response) {
   GetJobResponse response;
-  if (request.project_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Project Id is empty");
+  if (http_response.payload.empty()) {
+    return Status(StatusCode::kUnknown, "Empty payload in HTTP response.");
   }
-  if (request.job_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Job Id is empty");
-  }
-  // Not Implemented Yet: Call the rest client to get job details from the
-  // server.
+  // Not Implemented Yet: Parse HttpResponse and build GetJobResponse object.
   return response;
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_response.h"
+#include "google/cloud/internal/make_status.h"
 
 namespace google {
 namespace cloud {
@@ -23,7 +24,9 @@ StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
     BigQueryHttpResponse const& http_response) {
   GetJobResponse response;
   if (http_response.payload.empty()) {
-    return Status(StatusCode::kUnknown, "Empty payload in HTTP response.");
+    return internal::InvalidArgumentError(
+        "Empty payload in HTTP response.",
+        GCP_ERROR_INFO().Build(StatusCode::kInternal));
   }
   // Not Implemented Yet: Parse HttpResponse and build GetJobResponse object.
   return response;

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Internal interface for Bigquery V2 Job resource.
-
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RESPONSE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RESPONSE_H
 
 #include "google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h"
 #include "google/cloud/bigquery/v2/minimal/internal/job.h"
+#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -12,36 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
-#include "google/cloud/log.h"
-#include "google/cloud/status_or.h"
+// Internal interface for Bigquery V2 Job resource.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RESPONSE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RESPONSE_H
+
+#include "google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h"
+#include "google/cloud/bigquery/v2/minimal/internal/job.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigQueryJobStub::~BigQueryJobStub() = default;
+// Parses the BigQueryHttpResponse and builds a GetJobResponse.
+struct GetJobResponse {
+  // Builds GetJobResponse from HttpResponse.
+  static StatusOr<GetJobResponse> BuildFromHttpResponse(
+      BigQueryHttpResponse const& http_response);
 
-StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
-    GetJobRequest const& request) {
-  GetJobResponse response;
-  if (request.project_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Project Id is empty");
-  }
-  if (request.job_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Job Id is empty");
-  }
-  // Not Implemented Yet: Call the rest client to get job details from the
-  // server.
-  return response;
-}
+  Job job;
+  BigQueryHttpResponse http_response;
+};
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud
 }  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_RESPONSE_H

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -26,7 +26,9 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 // Parses the BigQueryHttpResponse and builds a GetJobResponse.
-struct GetJobResponse {
+class GetJobResponse {
+ public:
+  GetJobResponse() = default;
   // Builds GetJobResponse from HttpResponse.
   static StatusOr<GetJobResponse> BuildFromHttpResponse(
       BigQueryHttpResponse const& http_response);

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_response.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -20,12 +21,19 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-TEST(GetJobResponseTest, BuildFromHttpResponseSuccess) {
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::HasSubstr;
+
+TEST(JobResponseTest, Success) {
   // Not Implemented Yet.
 }
 
-TEST(GetJobResponseTest, BuildFromHttpResponseFailure) {
-  // Not Implemented Yet.
+TEST(JobResponseTest, EmptyPayload) {
+  BigQueryHttpResponse http_response;
+  auto job_response = GetJobResponse::BuildFromHttpResponse(http_response);
+  EXPECT_THAT(job_response,
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("Empty payload in HTTP response")));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -12,33 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
-#include "google/cloud/log.h"
-#include "google/cloud/status_or.h"
+#include "google/cloud/bigquery/v2/minimal/internal/job_response.h"
+#include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigQueryJobStub::~BigQueryJobStub() = default;
+TEST(GetJobResponseTest, BuildFromHttpResponseSuccess) {
+  // Not Implemented Yet.
+}
 
-StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
-    GetJobRequest const& request) {
-  GetJobResponse response;
-  if (request.project_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Project Id is empty");
-  }
-  if (request.job_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Job Id is empty");
-  }
-  // Not Implemented Yet: Call the rest client to get job details from the
-  // server.
-  return response;
+TEST(GetJobResponseTest, BuildFromHttpResponseFailure) {
+  // Not Implemented Yet.
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -32,7 +32,7 @@ TEST(JobResponseTest, EmptyPayload) {
   BigQueryHttpResponse http_response;
   auto job_response = GetJobResponse::BuildFromHttpResponse(http_response);
   EXPECT_THAT(job_response,
-              StatusIs(StatusCode::kInvalidArgument,
+              StatusIs(StatusCode::kInternal,
                        HasSubstr("Empty payload in HTTP response")));
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
-#include "google/cloud/log.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/status_or.h"
 
 namespace google {
@@ -27,14 +27,14 @@ StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
     GetJobRequest const& request) {
   GetJobResponse response;
   if (request.project_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Project Id is empty");
+    return internal::InvalidArgumentError(
+        "Invalid GetJobRequest: Project Id is empty",
+        GCP_ERROR_INFO().Build(StatusCode::kInvalidArgument));
   }
   if (request.job_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Job Id is empty");
+    return internal::InvalidArgumentError(
+        "Invalid GetJobRequest: Job Id is empty",
+        GCP_ERROR_INFO().Build(StatusCode::kInvalidArgument));
   }
   // Not Implemented Yet: Call the rest client to get job details from the
   // server.

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -21,20 +21,18 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigQueryJobStub::~BigQueryJobStub() = default;
+BigQueryJobRestStub::~BigQueryJobRestStub() = default;
 
-StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
+StatusOr<GetJobResponse> DefaultBigQueryJobRestStub::GetJob(
     GetJobRequest const& request) {
   GetJobResponse response;
   if (request.project_id().empty()) {
     return internal::InvalidArgumentError(
-        "Invalid GetJobRequest: Project Id is empty",
-        GCP_ERROR_INFO().Build(StatusCode::kInvalidArgument));
+        "Invalid GetJobRequest: Project Id is empty", GCP_ERROR_INFO());
   }
   if (request.job_id().empty()) {
     return internal::InvalidArgumentError(
-        "Invalid GetJobRequest: Job Id is empty",
-        GCP_ERROR_INFO().Build(StatusCode::kInvalidArgument));
+        "Invalid GetJobRequest: Job Id is empty", GCP_ERROR_INFO());
   }
   // Not Implemented Yet: Call the rest client to get job details from the
   // server.

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -12,17 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Internal interface for Bigquery V2 Job resource.
+// Internal Stub interface for Bigquery V2 Job apis.
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
 
+#include "google/cloud/bigquery/v2/minimal/internal/job_request.h"
+#include "google/cloud/bigquery/v2/minimal/internal/job_response.h"
+#include "google/cloud/internal/rest_client.h"
+#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <memory>
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+class BigQueryJobStub {
+ public:
+  virtual ~BigQueryJobStub() = 0;
+
+  virtual StatusOr<GetJobResponse> GetJob(GetJobRequest const& request) = 0;
+};
+
+class DefaultBigQueryJobStub : public BigQueryJobStub {
+ public:
+  explicit DefaultBigQueryJobStub(
+      std::unique_ptr<rest_internal::RestClient> rest_stub)
+      : rest_stub_(std::move(rest_stub)) {}
+
+  StatusOr<GetJobResponse> GetJob(GetJobRequest const& request) override;
+
+ private:
+  std::unique_ptr<rest_internal::RestClient> rest_stub_;
+};
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Internal Stub interface for Bigquery V2 Job apis.
-
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REST_STUB_H
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -27,16 +27,16 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-class BigQueryJobStub {
+class BigQueryJobRestStub {
  public:
-  virtual ~BigQueryJobStub() = 0;
+  virtual ~BigQueryJobRestStub() = 0;
 
   virtual StatusOr<GetJobResponse> GetJob(GetJobRequest const& request) = 0;
 };
 
-class DefaultBigQueryJobStub : public BigQueryJobStub {
+class DefaultBigQueryJobRestStub : public BigQueryJobRestStub {
  public:
-  explicit DefaultBigQueryJobStub(
+  explicit DefaultBigQueryJobRestStub(
       std::unique_ptr<rest_internal::RestClient> rest_stub)
       : rest_stub_(std::move(rest_stub)) {}
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_test.cc
@@ -13,32 +13,19 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
-#include "google/cloud/log.h"
-#include "google/cloud/status_or.h"
+#include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigQueryJobStub::~BigQueryJobStub() = default;
+TEST(BigQueryJobStubTest, GetJobSuccess) {
+  // Not Implemented Yet.
+}
 
-StatusOr<GetJobResponse> DefaultBigQueryJobStub::GetJob(
-    GetJobRequest const& request) {
-  GetJobResponse response;
-  if (request.project_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Project Id is empty");
-  }
-  if (request.job_id().empty()) {
-    GCP_LOG(DEBUG) << "Invalid request: " << request;
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid GetJobRequest: Job Id is empty");
-  }
-  // Not Implemented Yet: Call the rest client to get job details from the
-  // server.
-  return response;
+TEST(BigQueryJobStubTest, GetJobFailure) {
+  // Not Implemented Yet.
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Most of the implementation and tests are stubbed out.

I was trying to be mindful of the PR size as requested and also the request for the implmentation and testing files to be submitted in a single PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10837)
<!-- Reviewable:end -->
