### PR TITLE
chore(deps): add GCS alternatives for remaining bazel dependencies

### DIFF
--- a/bazel/deps-cache.sh
+++ b/bazel/deps-cache.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Usage:
+#   $ deps-cache.sh [-c] [<google_cloud_cpp_deps.bzl>]
+#   $ deps-cache.sh -p [<google_cloud_cpp_deps.bzl>]
+#
+#   Args:
+#     google_cloud_cpp_deps.bzl    Path to the .bzl file that specifies the
+#                                  HTTP archives that we cache in GCS. By
+#                                  default uses "google_cloud_cpp_deps.bzl"
+#                                  in the same directory as this script.
+#
+#   Options:
+#     -c     Check that the HTTP archives are correctly cached (the default)
+#     -p     Populate the cache with current copies of the HTTP archives
+#     -h     Print help message
+#
+# Note:
+#   This does not edit the .bzl file to add cache files as URLs. It only
+#   checks/populates the cached files themselves, so they're ready for use.
+
+set -euo pipefail
+
+# Extracts all the documentation at the top of this file as the usage text.
+USAGE="$(sed -n '/^# Usage:/,/^$/s/^# \?//p' "$0")"
+readonly USAGE
+
+declare -i POPULATE_FLAG=0
+while getopts "chp" opt "$@"; do
+  case "${opt}" in
+    c)
+      POPULATE_FLAG=
+      ;;
+    p)
+      POPULATE_FLAG=1
+      ;;
+    h)
+      echo "${USAGE}"
+      exit 0
+      ;;
+    *)
+      echo "${USAGE}"
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+readonly POPULATE_FLAG
+
+BZL_FILE=
+case $# in
+  0)
+    BZL_FILE="$(dirname "$0")/google_cloud_cpp_deps.bzl"
+    ;;
+  1)
+    BZL_FILE="$1"
+    shift
+    ;;
+  *)
+    echo "${USAGE}"
+    exit 1
+    ;;
+esac
+readonly BZL_FILE
+
+PROGRAM="$(basename "$0" .sh)"
+TMPDIR=$(mktemp -d --tmpdir "${PROGRAM}.XXXXXXXXXX")
+readonly PROGRAM TMPDIR
+trap 'rm -fr "${TMPDIR}"' EXIT
+
+# Extract the http_archive information from ${BZL_FILE}.
+cat >"${TMPDIR}/script" <<'EOT'
+/^ *maybe($/ {
+  : maybe
+  n
+  /^ *repo_rule = / {
+    /^ *repo_rule = http_archive,$/ b maybe
+    Q 1
+  }
+  /^ *name = ".*",$/ {
+    s/^ *name = "\(.*\)",$/NAME="\1"/
+    H
+    b maybe
+  }
+  /^ *urls = \[$/ {
+    : urls
+    n
+    /^ *"\(.*\),$/ {
+      \@"https://storage.googleapis.com/@ b urls
+      \@"https://mirror.bazel.build/@ b urls
+      s/^ *"\(.*\)",$/ URL="\1"/
+      H
+      b urls
+    }
+    /^ *\],$/ {
+      b maybe
+    }
+    Q 2
+  }
+  /^ *sha256 = ".*",$/ {
+    s/^ *sha256 = "\(.*\)",$/ SHA256="\1"/
+    H
+    b maybe
+  }
+  /^ *#/ b maybe
+  /^ *strip_prefix = ".*",$/ b maybe
+  /^ *build_file = .*,$/ b maybe
+  /^ *patch/ b maybe
+  /^ *)$/ {
+    s/.*//
+    x
+    s/\n//g
+    p
+    b
+  }
+  Q 3
+}
+EOT
+readarray ARCHIVES < <(sed -n -f "${TMPDIR}/script" "${BZL_FILE}")
+
+# Download archives and verify checksums.
+declare -i FETCH_ERRORS=0
+for ARCHIVE in "${ARCHIVES[@]}"; do
+  eval "${ARCHIVE}" # sets ${NAME} ${URL} ${SHA256}
+  BASENAME=$(basename "${URL}")
+
+  mkdir -p "${TMPDIR}/source/${NAME}"
+  SOURCE="${TMPDIR}/source/${NAME}/${BASENAME}"
+  echo "[ Fetching ${URL} ]"
+  if ! curl -sSL -o "${SOURCE}" "${URL}"; then
+    ((++FETCH_ERRORS))
+  else
+    CHKSUM=$(sha256sum "${SOURCE}" | sed 's/ .*//')
+    if [[ "${CHKSUM}" != "${SHA256}" ]]; then
+      echo "${PROGRAM}: ${NAME}: Checksum mismatch"
+      ((++FETCH_ERRORS))
+    fi
+  fi
+  echo ''
+done
+if ((FETCH_ERRORS != 0)); then
+  echo '[ Fetch error(s) ]'
+  exit 1
+fi
+
+readonly BUCKET="cloud-cpp-community-archive"
+
+# Verify the GCS cache matches, populating if requested.
+declare -i VERIFY_ERRORS=0
+for ARCHIVE in "${ARCHIVES[@]}"; do
+  eval "${ARCHIVE}" # sets ${NAME} ${URL} ${SHA256}
+  BASENAME=$(basename "${URL}")
+  SOURCE="${TMPDIR}/source/${NAME}/${BASENAME}"
+  GCS="https://storage.googleapis.com/${BUCKET}/${NAME}/${BASENAME}"
+
+  mkdir -p "${TMPDIR}/cached/${NAME}"
+  CACHED="${TMPDIR}/cached/${NAME}/${BASENAME}"
+  echo "[ Verifying ${GCS} ]"
+  declare -i VERIFY_ERROR=0
+  if ! curl -sSL -o "${CACHED}" "${GCS}"; then
+    ((++VERIFY_ERROR))
+  elif ! cmp --silent "${SOURCE}" "${CACHED}"; then
+    ((++VERIFY_ERROR))
+  fi
+  if ((VERIFY_ERROR != 0 && POPULATE_FLAG != 0)); then
+    UPLOAD="gs://${BUCKET}/${NAME}/${BASENAME}"
+    echo "[ Uploading ${UPLOAD} ]"
+    gsutil -q cp "${SOURCE}" "${UPLOAD}"
+    echo "[ Reverifying ${GCS} ]"
+    VERIFY_ERROR=0
+    if ! curl -sSL -o "${CACHED}" "${GCS}"; then
+      ((++VERIFY_ERROR))
+    elif ! cmp --silent "${SOURCE}" "${CACHED}"; then
+      ((++VERIFY_ERROR))
+    fi
+  fi
+  if ((VERIFY_ERROR != 0)); then
+    echo "${PROGRAM}: ${NAME}: Source/GCS mismatch"
+    ((++VERIFY_ERRORS))
+  fi
+  echo ''
+done
+if ((VERIFY_ERRORS != 0)); then
+  echo '[ Verification error(s) ]'
+  exit 1
+fi
+
+echo '[ SUCCESS ]'
+exit 0

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -38,6 +38,7 @@ def google_cloud_cpp_deps(name = None):
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
             "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/platforms/platforms-0.0.6.tar.gz",
         ],
         sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
     )
@@ -48,6 +49,7 @@ def google_cloud_cpp_deps(name = None):
         name = "rules_cc",
         urls = [
             "https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/rules_cc/rules_cc-0.0.1.tar.gz",
         ],
         sha256 = "4dccbfd22c0def164c8f47458bd50e0c7148f3d92002cdb459c2a96a68498241",
     )
@@ -59,6 +61,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "abseil-cpp-20230125.0",
         urls = [
             "https://github.com/abseil/abseil-cpp/archive/20230125.0.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_absl/20230125.0.tar.gz",
         ],
         sha256 = "3ea49a7d97421b88a8c48a0de16c16048e17725c7ec0f1d3ea2683a2a75adc21",
     )
@@ -70,6 +73,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "googletest-1.13.0",
         urls = [
             "https://github.com/google/googletest/archive/v1.13.0.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googletest/v1.13.0.tar.gz",
         ],
         sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",
     )
@@ -81,6 +85,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "benchmark-1.7.0",
         urls = [
             "https://github.com/google/benchmark/archive/v1.7.0.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_benchmark/v1.7.0.tar.gz",
         ],
         sha256 = "3aff99169fa8bdee356eaa1f691e835a6e57b1efeadb8a0f9f228531158246ac",
     )
@@ -113,6 +118,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "protobuf-21.12",
         urls = [
             "https://github.com/protocolbuffers/protobuf/archive/v21.12.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_protobuf/v21.12.tar.gz",
         ],
         sha256 = "22fdaf641b31655d4b2297f9981fa5203b2866f8332d3c6333f6b0107bb320de",
     )
@@ -139,6 +145,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "grpc-1.52.1",
         urls = [
             "https://github.com/grpc/grpc/archive/v1.52.1.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_grpc_grpc/v1.52.1.tar.gz",
         ],
         sha256 = "ec125d7fdb77ecc25b01050a0d5d32616594834d3fe163b016768e2ae42a2df6",
     )
@@ -175,6 +182,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "json-3.11.2",
         urls = [
             "https://github.com/nlohmann/json/archive/v3.11.2.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_nlohmann_json/v3.11.2.tar.gz",
         ],
         sha256 = "d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273",
         build_file = Label("//bazel:nlohmann_json.BUILD"),
@@ -187,6 +195,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "crc32c-1.1.2",
         urls = [
             "https://github.com/google/crc32c/archive/1.1.2.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_google_crc32c/1.1.2.tar.gz",
         ],
         sha256 = "ac07840513072b7fcebda6e821068aa04889018f24e10e46181068fb214d7e56",
         build_file = Label("//bazel:crc32c.BUILD"),
@@ -202,6 +211,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "opentelemetry-cpp-1.8.2",
         urls = [
             "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.2.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/io_opentelemetry_cpp/v1.8.2.tar.gz",
         ],
         sha256 = "20fa97e507d067e9e2ab0c1accfc334f5a4b10d01312e55455dc3733748585f4",
     )
@@ -213,6 +223,7 @@ def google_cloud_cpp_deps(name = None):
         strip_prefix = "pugixml-1.13",
         urls = [
             "https://github.com/zeux/pugixml/archive/refs/tags/v1.13.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_zeux_pugixml/v1.13.tar.gz",
         ],
         sha256 = "5c5ad5d7caeb791420408042a7d88c2c6180781bf218feca259fd9d840a888e1",
         build_file = Label("//bazel:pugixml.BUILD"),


### PR DESCRIPTION
Add GCS alternative URLs to download archives for all the external Bazel dependencies that didn't already have one.  Hopefully this will help reduce download flakiness.

Note that Bazel says, "URLs are tried in order until one succeeds, so you should list local mirrors first."  We can do some re-ordering later, if desired, to list GCS URLs first.

Also add a script to verify and (optionally) populate the GCS cache. For now I only propose that we run it manually when dependencies are updated, but we might consider running it from, say, the `checkers` build in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10840)
<!-- Reviewable:end -->
