### PR TITLE
ci: add a trailing newline to files that don't already have one

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -130,6 +130,8 @@ time {
   expressions=("-e" "'s/[[:blank:]]\+$//'")
   # Removes trailing blank lines (see http://sed.sourceforge.net/sed1line.txt)
   expressions+=("-e" "':x;/^\n*$/{\$d;N;bx;}'")
+  # Adds a trailing newline if one doesn't already exist
+  expressions+=("-e" "'\$a\'")
   git_files -z | grep -zv '\.gz$' | grep -zv 'googleapis.patch$' |
     (xargs -r -P "$(nproc)" -n 50 -0 grep -ZPL "\b[D]O NOT EDIT\b" || true) |
     xargs -r -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""


### PR DESCRIPTION
As part of applying whitespace fixes to text files during the `checkers` build, ensure that there is a newline at end-of-file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10841)
<!-- Reviewable:end -->
