### PR TITLE
cleanup: use lambdas w move capture

### DIFF
--- a/google/cloud/internal/async_streaming_write_rpc_auth_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_auth_test.cc
@@ -119,14 +119,10 @@ TEST(AsyncStreamingWriteRpcAuth, CancelDuringAuth) {
   auto start_promise = promise<void>();
   EXPECT_CALL(*strategy, AsyncConfigureContext)
       .WillOnce([&](std::unique_ptr<grpc::ClientContext> context) {
-        struct MoveCapture {
-          std::unique_ptr<grpc::ClientContext> context;
-          StatusOr<std::unique_ptr<grpc::ClientContext>> operator()(
-              future<void>) {
-            return make_status_or(std::move(context));
-          }
-        };
-        return start_promise.get_future().then(MoveCapture{std::move(context)});
+        return start_promise.get_future().then(
+            [c = std::move(context)](auto) mutable {
+              return make_status_or(std::move(c));
+            });
       });
 
   auto uut = absl::make_unique<AuthStream>(

--- a/google/cloud/pubsub/internal/sequential_batch_sink.cc
+++ b/google/cloud/pubsub/internal/sequential_batch_sink.cc
@@ -81,19 +81,14 @@ void SequentialBatchSink::OnPublish(Status s) {
   queue_.pop_front();
   lk.unlock();
 
-  auto weak = WeakFromThis();
-  struct MoveCaptureRequest {
-    std::weak_ptr<SequentialBatchSink> weak;
-    google::cloud::promise<StatusOr<PublishResponse>> promise;
-    void operator()(future<StatusOr<PublishResponse>> f) {
-      auto response = f.get();
-      auto status = response ? Status{} : response.status();
-      promise.set_value(std::move(response));
-      if (auto self = weak.lock()) self->OnPublish(std::move(status));
-    }
-  };
+  auto w = WeakFromThis();
   sink_->AsyncPublish(std::move(pr.request))
-      .then(MoveCaptureRequest{WeakFromThis(), std::move(pr.promise)});
+      .then([w = std::move(w), p = std::move(pr.promise)](auto f) mutable {
+        auto response = f.get();
+        auto status = response ? Status{} : response.status();
+        p.set_value(std::move(response));
+        if (auto self = w.lock()) self->OnPublish(std::move(status));
+      });
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
There may be more such structs. I only looked for ones named `*MoveCapture*`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10849)
<!-- Reviewable:end -->
