### PR TITLE
chore(deps): handle comments in urls=[] lists

### DIFF
--- a/bazel/deps-cache.sh
+++ b/bazel/deps-cache.sh
@@ -102,6 +102,7 @@ cat >"${TMPDIR}/script" <<'EOT'
       H
       b urls
     }
+    /^ *#/ b urls
     /^ *\],$/ {
       b maybe
     }


### PR DESCRIPTION
PR #10851 moved a comment into a `urls=[]` list, which the simple parser did not expect.  Hopefully things will be stable for a while now, but the sooner we move to something more general (Python based), the better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10854)
<!-- Reviewable:end -->
