### PR TITLE
impl(docfx): handle `simplesect` elements

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -235,7 +235,7 @@ bool AppendIfListItem(std::ostream& os, MarkdownContext const& ctx,
 //
 // These are small sections, such as the `@see` notes, or a `@warning`
 // callout.  How we want to render them depends on their type. For most we will
-// use a simple H6 header, put things like 'warning' or 'note' deserve a block
+// use a simple H6 header, but things like 'warning' or 'note' deserve a block
 // quote.
 //
 // clang-format off
@@ -260,7 +260,6 @@ bool AppendIfListItem(std::ostream& os, MarkdownContext const& ctx,
 //       <xsd:enumeration value="rcs" />
 //     </xsd:restriction>
 //   </xsd:simpleType>
-//
 //
 //   <xsd:complexType name="docSimpleSectType">
 //     <xsd:sequence>

--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -86,4 +86,12 @@ bool AppendIfItemizedList(std::ostream& os, MarkdownContext const& ctx,
 bool AppendIfListItem(std::ostream& os, MarkdownContext const& ctx,
                       pugi::xml_node const& node);
 
+/// Handle a `simplesect` element (a section without sub-sections).
+bool AppendIfSimpleSect(std::ostream& os, MarkdownContext const& ctx,
+                        pugi::xml_node const& node);
+
+/// Handle the title for a section-like element.
+void AppendTitle(std::ostream& os, MarkdownContext const& ctx,
+                 pugi::xml_node const& node);
+
 #endif  // GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2MARKDOWN_H


### PR DESCRIPTION
These appear in most pages, they are generated by many Doxygen commands, including `@note`, `@warning`, and `@par`. All of these are used routinely in our documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10860)
<!-- Reviewable:end -->
