### PR TITLE
impl(spanner): call ConfigureContext() for streaming RPCs

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -449,6 +449,7 @@ spanner::RowStream ConnectionImpl::ReadImpl(
                   tracing_options](std::string const& resume_token) mutable {
     if (!resume_token.empty()) request->set_resume_token(resume_token);
     auto context = absl::make_unique<grpc::ClientContext>();
+    internal::ConfigureContext(*context, internal::CurrentOptions());
     auto grpc_reader = stub->StreamingRead(*context, *request);
     std::unique_ptr<PartialResultSetReader> reader =
         absl::make_unique<DefaultPartialResultSetReader>(
@@ -669,6 +670,7 @@ ResultType ConnectionImpl::CommonQueryImpl(
                     tracing_options](std::string const& resume_token) mutable {
       if (!resume_token.empty()) request.set_resume_token(resume_token);
       auto context = absl::make_unique<grpc::ClientContext>();
+      internal::ConfigureContext(*context, internal::CurrentOptions());
       auto grpc_reader = stub->ExecuteStreamingSql(*context, request);
       std::unique_ptr<PartialResultSetReader> reader =
           absl::make_unique<DefaultPartialResultSetReader>(


### PR DESCRIPTION
Call `ConfigureContext()` in the two cases (`StreamingRead()` and `ExecuteStreamingSql()`) where the Spanner connection allocates its own `grpc::ClientContext` objects.

Part of #9454.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10879)
<!-- Reviewable:end -->
