### PR TITLE
impl(docfx): use and test `simplesect` support

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -330,7 +330,8 @@ bool AppendIfDocCmdGroup(std::ostream& os, MarkdownContext const& ctx,
   // Unexpected: hruler, preformatted, programlisting, verbatim, indexentry
   // Unexpected: orderedlist
   if (AppendIfItemizedList(os, ctx, node)) return true;
-  // Unexpected: simplesect, title, variablelist, table, header
+  if (AppendIfSimpleSect(os, ctx, node)) return true;
+  // Unexpected: title, variablelist, table, header
   // Unexpected: dotfile, mscfile,diafile, toclist, language, parameterlist
   // Unexpected: xrefsect, copydoc, blockquote, parblock
   return false;

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -273,7 +273,7 @@ TEST(Doxygen2Markdown, ParagraphWithUnknownOutput) {
       std::runtime_error);
 }
 
-TEST(Doxygen2Markdown, ParagraphContents) {
+TEST(Doxygen2Markdown, ParagraphSimpleContents) {
   auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
     <doxygen version="1.9.1" xml:lang="en-US">
         <para id='test-000'>The answer is 42.</para>
@@ -305,6 +305,70 @@ TEST(Doxygen2Markdown, ParagraphContents) {
     ASSERT_TRUE(AppendIfParagraph(os, {}, selected.node()));
     EXPECT_EQ(test.expected, os.str());
   }
+}
+
+TEST(Doxygen2Markdown, ParagraphSimpleSect) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <para id='test-node'>
+          <simplesect kind="remark">
+            <para>First remark paragraph.</para>
+            <para>Second remark paragraph.</para>
+          </simplesect>
+          <simplesect kind="warning">
+            <para>First warning paragraph.</para>
+            <para>Second warning paragraph.</para>
+          </simplesect>
+        </para>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"md(
+
+
+
+> Remark:
+> First remark paragraph.
+> Second remark paragraph.
+
+> **Warning:**
+> First warning paragraph.
+> Second warning paragraph.)md";
+
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfParagraph(os, {}, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
+}
+
+TEST(Doxygen2Markdown, ParagraphItemizedList) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <para id='test-node'>
+          <itemizedlist>
+            <listitem><para>First item.</para></listitem>
+            <listitem>
+              <para>Second item.</para><para>With a second paragraph.</para>
+            </listitem>
+          </itemizedlist>
+        </para>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"md(
+
+
+- First item.
+- Second item.
+
+  With a second paragraph.)md";
+
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfParagraph(os, {}, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
 }
 
 TEST(Doxygen2Markdown, ItemizedListSimple) {


### PR DESCRIPTION
I should have connected `simplesect` to `para` when I introduced it. At least we got better tests out of my mistake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10882)
<!-- Reviewable:end -->
