### PR TITLE
impl(storage): use std::size_t for indentation width and level

### DIFF
--- a/google/cloud/storage/internal/xml_node.cc
+++ b/google/cloud/storage/internal/xml_node.cc
@@ -400,8 +400,9 @@ std::vector<std::shared_ptr<XmlNode const>> XmlNode::GetChildren(
   return children;
 }
 
-std::string XmlNode::ToString(int indent_width,  // NOLINT(misc-no-recursion)
-                              int indent_level) const {
+// NOLINTNEXTLINE(misc-no-recursion)
+std::string XmlNode::ToString(std::size_t indent_width,
+                              std::size_t indent_level) const {
   auto const separator = std::string(indent_width == 0 ? "" : "\n");
   auto const indentation = std::string(indent_width * indent_level, ' ');
   if (!tag_name_.empty()) ++indent_level;

--- a/google/cloud/storage/internal/xml_node.h
+++ b/google/cloud/storage/internal/xml_node.h
@@ -90,7 +90,8 @@ class XmlNode : public std::enable_shared_from_this<XmlNode> {
       std::string const& tag_name) const;
 
   /// Get the XML string representation of the node.
-  std::string ToString(int indent_width = 0, int indent_level = 0) const;
+  std::string ToString(std::size_t indent_width = 0,
+                       std::size_t indent_level = 0) const;
 
   /// Append a new tag node and return the added node.
   std::shared_ptr<XmlNode> AppendTagNode(std::string tag_name) {


### PR DESCRIPTION
Quash a "multiplication result converted to larger type" alert when we produce the length of the indentation string.  Of course, we know `int` truncation (and `std::size_t` truncation, which is still possible) are not practical concerns, but this should silence the bots.

Fixes #10881.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10884)
<!-- Reviewable:end -->
