### PR TITLE
feat(spanner): introduce the RouteToLeaderOption

### DIFF
--- a/google/cloud/spanner/internal/defaults.cc
+++ b/google/cloud/spanner/internal/defaults.cc
@@ -104,6 +104,19 @@ Options DefaultOptions(Options opts) {
   min_sessions =
       (std::min)(min_sessions, max_sessions_per_channel * num_channels);
 
+  if (!opts.has<spanner::RouteToLeaderOption>()) {
+    if (auto e = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER")) {
+      for (auto const* disable : {"N", "n", "F", "f", "0", "off"}) {
+        if (*e == disable) {
+          // Change the default from "for RW/PartitionedDml transactions"
+          // to "never".
+          opts.set<spanner::RouteToLeaderOption>(false);
+          break;
+        }
+      }
+    }
+  }
+
   return opts;
 }
 

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -55,6 +55,8 @@ TEST(Options, Defaults) {
                                                absl::nullopt);
   testing_util::ScopedEnvironment user_project_env(
       "GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
+  testing_util::ScopedEnvironment route_to_leader_env(
+      "GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER", absl::nullopt);
   auto opts = spanner_internal::DefaultOptions();
 
   EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
@@ -82,6 +84,8 @@ TEST(Options, Defaults) {
   EXPECT_TRUE(opts.has<SpannerRetryPolicyOption>());
   EXPECT_TRUE(opts.has<SpannerBackoffPolicyOption>());
   EXPECT_TRUE(opts.has<spanner_internal::SessionPoolClockOption>());
+
+  EXPECT_FALSE(opts.has<spanner::RouteToLeaderOption>());
 }
 
 TEST(Options, AdminDefaults) {
@@ -148,6 +152,14 @@ TEST(Options, SpannerEmulatorHost) {
   EXPECT_EQ(opts.get<EndpointOption>(), "foo.bar.baz");
   EXPECT_EQ(opts.get<AuthorityOption>(), "spanner.googleapis.com");
   EXPECT_NE(opts.get<GrpcCredentialOption>(), nullptr);
+}
+
+TEST(Options, RouteToLeaderFromEnv) {
+  testing_util::ScopedEnvironment route_to_leader_env(
+      "GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER", "off");
+  auto opts = spanner_internal::DefaultOptions();
+  EXPECT_TRUE(opts.has<spanner::RouteToLeaderOption>());
+  EXPECT_FALSE(opts.get<spanner::RouteToLeaderOption>());
 }
 
 TEST(Options, TracingComponentsFromEnv) {

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -189,6 +189,17 @@ using SessionPoolOptionList =
                SessionPoolKeepAliveIntervalOption, SessionPoolLabelsOption>;
 
 /**
+ * Option for `google::cloud::Options` to, when present and false, suppress
+ * adding headers to distinguish requests served by the leader v/s non-leader
+ * region.
+ *
+ * @ingroup spanner-options
+ */
+struct RouteToLeaderOption {
+  using Type = bool;
+};
+
+/**
  * Option for `google::cloud::Options` to set the optimizer version used in an
  * SQL query.
  *


### PR DESCRIPTION
This will be used in upcoming code that will add a routing header to RPCs that should be served in the leader region.

The boolean option defaults to true, but the default can be changed with a suitably-negative value in `${GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER}`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10885)
<!-- Reviewable:end -->
