### PR TITLE
impl(docfx): support `ulink` elements

### DIFF
--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -66,6 +66,10 @@ bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
 bool AppendIfPlainText(std::ostream& os, MarkdownContext const& ctx,
                        pugi::xml_node const& node);
 
+/// Handles nodes with URL links.
+bool AppendIfULink(std::ostream& os, MarkdownContext const& ctx,
+                   pugi::xml_node const& node);
+
 /// Handles nodes with **bold** text.
 bool AppendIfBold(std::ostream& os, MarkdownContext const& ctx,
                   pugi::xml_node const& node);

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -152,6 +152,18 @@ TEST(Doxygen2Markdown, PlainText) {
   EXPECT_EQ(os.str(), "test-only-value 42");
 }
 
+TEST(Doxygen2Markdown, ULink) {
+  pugi::xml_document doc;
+  doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <ulink id="test-node" url="https://example.com/">some text</ulink>
+    </doxygen>)xml");
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfULink(os, {}, selected.node()));
+  EXPECT_EQ(os.str(), "[some text](https://example.com/)");
+}
+
 TEST(Doxygen2Markdown, Bold) {
   pugi::xml_document doc;
   doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>
@@ -282,6 +294,7 @@ TEST(Doxygen2Markdown, ParagraphSimpleContents) {
         <para id='test-003'><emphasis>The answer is 42.</emphasis></para>
         <para id='test-004'><computeroutput>The answer is 42.</computeroutput></para>
         <para id='test-005'><ref refid="test_id">The answer is 42.</ref></para>
+        <para id='test-006'><ulink url="https://example.com/">The answer is 42.</ulink></para>
     </doxygen>)xml";
 
   struct TestCase {
@@ -294,6 +307,7 @@ TEST(Doxygen2Markdown, ParagraphSimpleContents) {
       {"test-003", "\n\n*The answer is 42.*"},
       {"test-004", "\n\n`The answer is 42.`"},
       {"test-005", "\n\n[The answer is 42.](xref:test_id)"},
+      {"test-006", "\n\n[The answer is 42.](https://example.com/)"},
   };
 
   pugi::xml_document doc;


### PR DESCRIPTION
These appear in some of the additional pages for the common library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10887)
<!-- Reviewable:end -->
