### PR TITLE
impl(spanner): add TransactionContext.route_to_leader

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -950,7 +950,8 @@ ConnectionImpl::ExecutePartitionedDmlImpl(
   s->set_id(begin->id());
 
   SqlParams sql_params(
-      {MakeTransactionFromIds(session->session_name(), begin->id(), ctx.tag),
+      {MakeTransactionFromIds(session->session_name(), begin->id(),
+                              ctx.route_to_leader, ctx.tag),
        std::move(params.statement), std::move(params.query_options),
        /*partition_token=*/{}});
   auto dml_result = CommonQueryImpl<StreamingPartitionedDmlResult>(

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -157,9 +157,9 @@ struct QueryPartitionInternals {
   static spanner::Connection::SqlParams MakeSqlParams(
       spanner::QueryPartition const& query_partition) {
     spanner::QueryOptions query_options;  // not serialized
-    return {MakeTransactionFromIds(query_partition.session_id(),
-                                   query_partition.transaction_id(),
-                                   query_partition.transaction_tag()),
+    return {MakeTransactionFromIds(
+                query_partition.session_id(), query_partition.transaction_id(),
+                /*route_to_leader=*/false, query_partition.transaction_tag()),
             query_partition.sql_statement(), query_options,
             query_partition.partition_token()};
   }

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -168,9 +168,9 @@ struct ReadPartitionInternals {
   static spanner::Connection::ReadParams MakeReadParams(
       spanner::ReadPartition const& read_partition) {
     return spanner::Connection::ReadParams{
-        MakeTransactionFromIds(read_partition.SessionId(),
-                               read_partition.TransactionId(),
-                               read_partition.TransactionTag()),
+        MakeTransactionFromIds(
+            read_partition.SessionId(), read_partition.TransactionId(),
+            /*route_to_leader=*/false, read_partition.TransactionTag()),
         read_partition.TableName(),
         FromProto(read_partition.KeySet()),
         read_partition.ColumnNames(),

--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -167,7 +167,7 @@ class Transaction {
   explicit Transaction(SingleUseOptions opts);
   // Construction of a transaction with existing IDs.
   Transaction(std::string session_id, std::string transaction_id,
-              std::string transaction_tag);
+              bool route_to_leader, std::string transaction_tag);
 
   std::shared_ptr<spanner_internal::TransactionImpl> impl_;
 };
@@ -228,7 +228,7 @@ struct TransactionInternals {
   }
 
   static spanner::Transaction MakeTransactionFromIds(
-      std::string session_id, std::string transaction_id,
+      std::string session_id, std::string transaction_id, bool route_to_leader,
       std::string transaction_tag);
 };
 
@@ -247,10 +247,10 @@ VisitInvokeResult<Functor> Visit(spanner::Transaction txn, Functor&& f) {
 }
 
 inline spanner::Transaction MakeTransactionFromIds(
-    std::string session_id, std::string transaction_id,
+    std::string session_id, std::string transaction_id, bool route_to_leader,
     std::string transaction_tag) {
   return TransactionInternals::MakeTransactionFromIds(
-      std::move(session_id), std::move(transaction_id),
+      std::move(session_id), std::move(transaction_id), route_to_leader,
       std::move(transaction_tag));
 }
 


### PR DESCRIPTION
RPCs within the transaction will then be able to inspect the context to determine if their requests should be routed to the region leader.

Mostly this is just YES for read-write transactions and NO for readonly transactions.  Partitioned-DML transactions are a slight complication, which will be dealt with presently.

Query and read partitions currently say NO, pending some updates as to how they are serialized/deserialized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10894)
<!-- Reviewable:end -->
