### PR TITLE
impl(spanner): use a read-write transaction in ExecutePartitionedDml()

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -205,7 +205,10 @@ StatusOr<spanner::ExecutionPlan> ConnectionImpl::AnalyzeSql(SqlParams params) {
 
 StatusOr<spanner::PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
     ExecutePartitionedDmlParams params) {
-  auto txn = spanner::MakeReadOnlyTransaction();  // becomes partitioned DML
+  // This becomes a partitioned DML transaction, but we choose read/write
+  // here so that ctx.route_to_leader == true during the BeginTransaction()
+  // and ExecuteStreamingSql().
+  auto txn = spanner::MakeReadWriteTransaction();
   return Visit(txn, [this, &params](
                         SessionHolder& session,
                         StatusOr<google::spanner::v1::TransactionSelector>& s,


### PR DESCRIPTION
Even though the `spanner::Transaction` created in `ExecutePartitionedDml()` is only a placeholder until it is replaced by a partitioned-dml transaction within `ExecutePartitionedDmlImpl()`, use a read-write transaction so that it is marked as "route to leader".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10908)
<!-- Reviewable:end -->
