### PR TITLE
impl(spanner): support route_to_leader in query/read partitions

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -555,9 +555,9 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
     std::vector<spanner::ReadPartition> read_partitions;
     for (auto const& partition : response->partitions()) {
       read_partitions.push_back(MakeReadPartition(
-          response->transaction().id(), ctx.tag, session->session_name(),
-          partition.partition_token(), params.table, params.keys,
-          params.columns, params.read_options));
+          response->transaction().id(), ctx.route_to_leader, ctx.tag,
+          session->session_name(), partition.partition_token(), params.table,
+          params.keys, params.columns, params.read_options));
     }
 
     return read_partitions;
@@ -850,9 +850,10 @@ ConnectionImpl::PartitionQueryImpl(
 
     std::vector<spanner::QueryPartition> query_partitions;
     for (auto const& partition : response->partitions()) {
-      query_partitions.push_back(MakeQueryPartition(
-          response->transaction().id(), ctx.tag, session->session_name(),
-          partition.partition_token(), params.statement));
+      query_partitions.push_back(
+          MakeQueryPartition(response->transaction().id(), ctx.route_to_leader,
+                             ctx.tag, session->session_name(),
+                             partition.partition_token(), params.statement));
     }
     return query_partitions;
   }

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -2584,10 +2584,10 @@ TEST(ConnectionImplTest, PartitionReadSuccess) {
 
   std::vector<spanner::ReadPartition> expected_read_partitions = {
       spanner_internal::MakeReadPartition(
-          "CAFEDEAD", "", "test-session-name", "BADDECAF", "table",
+          "CAFEDEAD", false, "", "test-session-name", "BADDECAF", "table",
           spanner::KeySet::All(), {"UserId", "UserName"}, read_options),
       spanner_internal::MakeReadPartition(
-          "CAFEDEAD", "", "test-session-name", "DEADBEEF", "table",
+          "CAFEDEAD", false, "", "test-session-name", "DEADBEEF", "table",
           spanner::KeySet::All(), {"UserId", "UserName"}, read_options)};
 
   EXPECT_THAT(*result, UnorderedPointwise(Eq(), expected_read_partitions));
@@ -2689,10 +2689,12 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
   ASSERT_STATUS_OK(result);
 
   std::vector<spanner::QueryPartition> expected_query_partitions = {
-      spanner_internal::MakeQueryPartition("CAFEDEAD", "", "test-session-name",
-                                           "BADDECAF", sql_statement),
-      spanner_internal::MakeQueryPartition("CAFEDEAD", "", "test-session-name",
-                                           "DEADBEEF", sql_statement)};
+      spanner_internal::MakeQueryPartition("CAFEDEAD", false, "",
+                                           "test-session-name", "BADDECAF",
+                                           sql_statement),
+      spanner_internal::MakeQueryPartition("CAFEDEAD", false, "",
+                                           "test-session-name", "DEADBEEF",
+                                           sql_statement)};
 
   EXPECT_THAT(*result, UnorderedPointwise(Eq(), expected_query_partitions));
 }

--- a/google/cloud/spanner/query_partition.cc
+++ b/google/cloud/spanner/query_partition.cc
@@ -20,12 +20,16 @@ namespace cloud {
 namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-QueryPartition::QueryPartition(std::string transaction_id,
+// Local extension to google::spanner::v1::ExecuteSqlRequest.
+constexpr int kRouteToLeaderFieldNumber = 511037314;
+
+QueryPartition::QueryPartition(std::string transaction_id, bool route_to_leader,
                                std::string transaction_tag,
                                std::string session_id,
                                std::string partition_token,
                                SqlStatement sql_statement)
     : transaction_id_(std::move(transaction_id)),
+      route_to_leader_(route_to_leader),
       transaction_tag_(std::move(transaction_tag)),
       session_id_(std::move(session_id)),
       partition_token_(std::move(partition_token)),
@@ -33,6 +37,7 @@ QueryPartition::QueryPartition(std::string transaction_id,
 
 bool operator==(QueryPartition const& a, QueryPartition const& b) {
   return a.transaction_id_ == b.transaction_id_ &&
+         a.route_to_leader_ == b.route_to_leader_ &&
          a.transaction_tag_ == b.transaction_tag_ &&
          a.session_id_ == b.session_id_ &&
          a.partition_token_ == b.partition_token_ &&
@@ -59,6 +64,14 @@ StatusOr<std::string> SerializeQueryPartition(
   // However, we do encode any transaction tag in proto.request_options.
   proto.mutable_request_options()->set_transaction_tag(
       query_partition.transaction_tag());
+
+  // Add route_to_leader to an extension field so that we might retrieve it
+  // in DeserializeQueryPartition().
+  if (query_partition.route_to_leader()) {
+    google::spanner::v1::ExecuteSqlRequest::GetReflection()
+        ->MutableUnknownFields(&proto)
+        ->AddVarint(kRouteToLeaderFieldNumber, 1);
+  }
 
   std::string serialized_proto;
   if (proto.SerializeToString(&serialized_proto)) {
@@ -91,7 +104,18 @@ StatusOr<QueryPartition> DeserializeQueryPartition(
     }
   }
 
-  QueryPartition query_partition(proto.transaction().id(),
+  bool route_to_leader = false;
+  auto const& unknown_fields =
+      google::spanner::v1::ExecuteSqlRequest::GetReflection()->GetUnknownFields(
+          proto);
+  for (int index = 0; index != unknown_fields.field_count(); ++index) {
+    auto const& field = unknown_fields.field(index);
+    if (field.number() == kRouteToLeaderFieldNumber) {
+      route_to_leader = field.varint() != 0;
+    }
+  }
+
+  QueryPartition query_partition(proto.transaction().id(), route_to_leader,
                                  proto.request_options().transaction_tag(),
                                  proto.session(), proto.partition_token(),
                                  SqlStatement(proto.sql(), sql_parameters));

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -121,17 +121,19 @@ class QueryPartition {
   friend StatusOr<QueryPartition> DeserializeQueryPartition(
       std::string const& serialized_query_partition);
 
-  QueryPartition(std::string transaction_id, std::string transaction_tag,
-                 std::string session_id, std::string partition_token,
-                 SqlStatement sql_statement);
+  QueryPartition(std::string transaction_id, bool route_to_leader,
+                 std::string transaction_tag, std::string session_id,
+                 std::string partition_token, SqlStatement sql_statement);
 
   // Accessor methods for use by friends.
-  std::string const& partition_token() const { return partition_token_; }
-  std::string const& session_id() const { return session_id_; }
-  std::string const& transaction_tag() const { return transaction_tag_; }
   std::string const& transaction_id() const { return transaction_id_; }
+  bool route_to_leader() const { return route_to_leader_; }
+  std::string const& transaction_tag() const { return transaction_tag_; }
+  std::string const& session_id() const { return session_id_; }
+  std::string const& partition_token() const { return partition_token_; }
 
   std::string transaction_id_;
+  bool route_to_leader_;
   std::string transaction_tag_;
   std::string session_id_;
   std::string partition_token_;
@@ -147,31 +149,35 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 struct QueryPartitionInternals {
   static spanner::QueryPartition MakeQueryPartition(
-      std::string const& transaction_id, std::string const& transaction_tag,
-      std::string const& session_id, std::string const& partition_token,
+      std::string const& transaction_id, bool route_to_leader,
+      std::string const& transaction_tag, std::string const& session_id,
+      std::string const& partition_token,
       spanner::SqlStatement const& sql_statement) {
-    return spanner::QueryPartition(transaction_id, transaction_tag, session_id,
-                                   partition_token, sql_statement);
+    return spanner::QueryPartition(transaction_id, route_to_leader,
+                                   transaction_tag, session_id, partition_token,
+                                   sql_statement);
   }
 
   static spanner::Connection::SqlParams MakeSqlParams(
       spanner::QueryPartition const& query_partition) {
     spanner::QueryOptions query_options;  // not serialized
-    return {MakeTransactionFromIds(
-                query_partition.session_id(), query_partition.transaction_id(),
-                /*route_to_leader=*/false, query_partition.transaction_tag()),
+    return {MakeTransactionFromIds(query_partition.session_id(),
+                                   query_partition.transaction_id(),
+                                   query_partition.route_to_leader(),
+                                   query_partition.transaction_tag()),
             query_partition.sql_statement(), query_options,
             query_partition.partition_token()};
   }
 };
 
 inline spanner::QueryPartition MakeQueryPartition(
-    std::string const& transaction_id, std::string const& transaction_tag,
-    std::string const& session_id, std::string const& partition_token,
+    std::string const& transaction_id, bool route_to_leader,
+    std::string const& transaction_tag, std::string const& session_id,
+    std::string const& partition_token,
     spanner::SqlStatement const& sql_statement) {
   return QueryPartitionInternals::MakeQueryPartition(
-      transaction_id, transaction_tag, session_id, partition_token,
-      sql_statement);
+      transaction_id, route_to_leader, transaction_tag, session_id,
+      partition_token, sql_statement);
 }
 
 inline spanner::Connection::SqlParams MakeSqlParams(

--- a/google/cloud/spanner/read_partition.cc
+++ b/google/cloud/spanner/read_partition.cc
@@ -20,7 +20,10 @@ namespace cloud {
 namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ReadPartition::ReadPartition(std::string transaction_id,
+// Local extension to google::spanner::v1::ReadRequest.
+constexpr int kRouteToLeaderFieldNumber = 511037315;
+
+ReadPartition::ReadPartition(std::string transaction_id, bool route_to_leader,
                              std::string transaction_tag,
                              std::string session_id,
                              std::string partition_token,
@@ -61,6 +64,11 @@ ReadPartition::ReadPartition(std::string transaction_id,
   }
   proto_.mutable_request_options()->set_transaction_tag(
       std::move(transaction_tag));
+  if (route_to_leader) {
+    google::spanner::v1::ReadRequest::GetReflection()
+        ->MutableUnknownFields(&proto_)
+        ->AddVarint(kRouteToLeaderFieldNumber, 1);
+  }
 }
 
 google::cloud::spanner::ReadOptions ReadPartition::ReadOptions() const {
@@ -88,8 +96,25 @@ google::cloud::spanner::ReadOptions ReadPartition::ReadOptions() const {
   return options;
 }
 
+bool ReadPartition::RouteToLeader() const {
+  auto const& unknown_fields =
+      google::spanner::v1::ReadRequest::GetReflection()->GetUnknownFields(
+          proto_);
+  for (int index = 0; index != unknown_fields.field_count(); ++index) {
+    auto const& field = unknown_fields.field(index);
+    if (field.number() == kRouteToLeaderFieldNumber) {
+      return field.varint() != 0;
+    }
+  }
+  return false;
+}
+
 bool operator==(ReadPartition const& lhs, ReadPartition const& rhs) {
   google::protobuf::util::MessageDifferencer differencer;
+  // This is the default comparison mode, but we set it explicitly
+  // to emphasize that unknown fields are included in the comparison.
+  differencer.set_message_field_comparison(
+      google::protobuf::util::MessageDifferencer::EQUAL);
   return differencer.Compare(lhs.proto_, rhs.proto_);
 }
 


### PR DESCRIPTION
Add "route to leader" support to `QueryPartition` and `ReadPartition` so that RPCs in the eventual partitioned `ExecuteQuery()` and `Read()` calls will be routed according to the transaction used in the original `PartitionQuery()` and `PartitionRead()` calls (respectively).

Note that we support (de)serialization of the `QueryPartition` and `ReadPartition` values so that they might be transferred to another address space, and that this is done using `ExecuteSqlRequest` and `ReadRequest` protobuf messages, which do not include route-to-leader fields.  The best (only?) way to handle this while maintaining backwards compatibility is to add the route-to-leader value to those messages using a protobuf unknown field.