### PR TITLE
cleaup(spanner): rename the "update-database" snippet tag

### DIFF
--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -194,7 +194,7 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("DatabaseAdminClient")
    *   the statements.
    *
    * @par Example
-   * @snippet samples.cc update-database
+   * @snippet samples.cc add-column
    *
    * @see https://cloud.google.com/spanner/docs/data-definition-language for a
    *     full list of the DDL operations

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -910,7 +910,7 @@ void EnableFineGrainedAccess(
 }
 //! [END spanner_enable_fine_grained_access]
 
-//! [update-database] [START spanner_add_column]
+//! [add-column] [START spanner_add_column]
 void AddColumn(google::cloud::spanner_admin::DatabaseAdminClient client,
                std::string const& project_id, std::string const& instance_id,
                std::string const& database_id) {
@@ -927,7 +927,7 @@ void AddColumn(google::cloud::spanner_admin::DatabaseAdminClient client,
   if (!metadata) throw std::move(metadata).status();
   std::cout << "Added MarketingBudget column\n";
 }
-//! [update-database] [END spanner_add_column]
+//! [add-column] [END spanner_add_column]
 
 // [START spanner_add_timestamp_column]
 void AddTimestampColumn(


### PR DESCRIPTION
We made a poor choice in naming the (hand-written) `DatabaseAdminClient` interface to `rpc UpdateDatabaseDdl` as just `UpdateDatabase()`.  Soon there actually will be a database-admin `UpdateDatabase` RPC, which fortunately we'll only support in the generated API, but it will want to use the "update-database" tag.

So, use "add-column" for the old snippet tag instead.  It is also a closer match for the corresponding doc tag, "spanner_add_column".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10919)
<!-- Reviewable:end -->
