### PR TITLE
ci: improve `*san` output on failures

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-37-bazel.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-bazel.Dockerfile
@@ -19,7 +19,7 @@ ARG ARCH=amd64
 # Install the minimal packages needed to install Bazel, and then compile our
 # code.
 RUN dnf install -y clang diffutils findutils gcc-c++ git lcov libcxx-devel \
-        libcxxabi-devel libasan libubsan libtsan patch python python3 \
+        libcxxabi-devel libasan libubsan libtsan llvm patch python python3 \
         python-pip tar unzip w3m wget which zip zlib-devel
 
 # Install the Python modules needed to run the storage emulator

--- a/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
@@ -23,7 +23,7 @@ RUN dnf makecache && \
     dnf install -y abi-compliance-checker autoconf automake \
         ccache clang clang-analyzer clang-tools-extra \
         cmake diffutils doxygen findutils gcc-c++ git \
-        libcurl-devel make ninja-build \
+        libcurl-devel llvm make ninja-build \
         openssl-devel patch python python3 \
         python-pip tar unzip w3m wget which zip zlib-devel
 

--- a/ci/cloudbuild/dockerfiles/fedora-37-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cxx14.Dockerfile
@@ -23,7 +23,7 @@ RUN dnf makecache && \
     dnf install -y autoconf automake c-ares-devel \
         ccache clang clang-analyzer clang-tools-extra \
         cmake diffutils doxygen findutils gcc-c++ git \
-        libcurl-devel make ninja-build \
+        libcurl-devel llvm make ninja-build \
         openssl-devel patch python python3.8 \
         python-pip tar unzip wget which zip zlib-devel
 

--- a/ci/cloudbuild/dockerfiles/fedora-37-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cxx20.Dockerfile
@@ -23,7 +23,7 @@ RUN dnf makecache && \
     dnf install -y autoconf automake \
         ccache clang clang-analyzer clang-tools-extra \
         cmake diffutils findutils gcc-c++ git \
-        libcurl-devel make ninja-build \
+        libcurl-devel llvm make ninja-build \
         openssl-devel patch python python3 \
         python-pip tar unzip wget which zip zlib-devel
 

--- a/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
@@ -20,7 +20,7 @@ ARG ARCH=amd64
 # then compile our code.
 RUN dnf makecache && \
     dnf install -y ccache clang clang-tools-extra cmake findutils \
-        git make ninja-build openssl-devel patch python \
+        git llvm make ninja-build openssl-devel patch python \
         python3 python3-devel python3-lit python-pip tar unzip which wget xz
 
 # Install the Python modules needed to run the storage emulator


### PR DESCRIPTION
Install the `llvm` package to get the `llvm-symbolizer(1)` tool. This should improve the output from any `*san` failures. I installed this even on images that are not used for `*san` because it seems generally useful.
