### PR TITLE
cleanup(spanner): pass QueryOptions to MakeSqlParams()

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -130,9 +130,8 @@ RowStream Client::ExecuteQuery(Transaction transaction, SqlStatement statement,
 
 RowStream Client::ExecuteQuery(QueryPartition const& partition, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), opts_));
-  auto params = spanner_internal::MakeSqlParams(partition);
-  params.query_options = QueryOptions(internal::CurrentOptions());
-  return conn_->ExecuteQuery(std::move(params));
+  return conn_->ExecuteQuery(spanner_internal::MakeSqlParams(
+      partition, QueryOptions(internal::CurrentOptions())));
 }
 
 ProfileQueryResult Client::ProfileQuery(SqlStatement statement, Options opts) {

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -159,8 +159,8 @@ struct QueryPartitionInternals {
   }
 
   static spanner::Connection::SqlParams MakeSqlParams(
-      spanner::QueryPartition const& query_partition) {
-    spanner::QueryOptions query_options;  // not serialized
+      spanner::QueryPartition const& query_partition,
+      spanner::QueryOptions const& query_options) {
     return {MakeTransactionFromIds(query_partition.session_id(),
                                    query_partition.transaction_id(),
                                    query_partition.route_to_leader(),
@@ -181,8 +181,9 @@ inline spanner::QueryPartition MakeQueryPartition(
 }
 
 inline spanner::Connection::SqlParams MakeSqlParams(
-    spanner::QueryPartition const& query_partition) {
-  return QueryPartitionInternals::MakeSqlParams(query_partition);
+    spanner::QueryPartition const& query_partition,
+    spanner::QueryOptions const& query_options) {
+  return QueryPartitionInternals::MakeSqlParams(query_partition, query_options);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/query_partition_test.cc
+++ b/google/cloud/spanner/query_partition_test.cc
@@ -165,8 +165,9 @@ TEST(QueryPartitionTest, MakeSqlParams) {
       SqlStatement("SELECT * FROM foo WHERE name = @name",
                    {{"name", Value("Bob")}})));
 
-  Connection::SqlParams params =
-      spanner_internal::MakeSqlParams(expected_partition.Partition());
+  Connection::SqlParams params = spanner_internal::MakeSqlParams(
+      expected_partition.Partition(),
+      QueryOptions{}.set_request_tag("request_tag"));
 
   EXPECT_EQ(params.statement,
             SqlStatement("SELECT * FROM foo WHERE name = @name",
@@ -174,6 +175,7 @@ TEST(QueryPartitionTest, MakeSqlParams) {
   EXPECT_EQ(*params.partition_token, "token");
   EXPECT_THAT(params.transaction,
               HasSessionAndTransaction("session", "txn-id", true, "tag"));
+  EXPECT_EQ(*params.query_options.request_tag(), "request_tag");
 }
 
 }  // namespace


### PR DESCRIPTION
Clarify how `SqlParams` receives its `QueryOptions`.  Previously `MakeSqlParams()` produced an empty `.query_options` member, which `Client::ExecuteQuery()` then promptly over-wrote.  Let's take the `QueryOptions` as a `MakeSqlParams()` parameter instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10938)
<!-- Reviewable:end -->
