### PR TITLE
impl: fix updating of strip_prefix in renovate.sh

### DIFF
--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -28,11 +28,11 @@ rm -f "${DOWNLOAD}"
 
 # Update the Bazel dependency.
 sed -i -f - bazel/google_cloud_cpp_deps.bzl <<EOT
-  /name = "com_google_googleapis",/,/sha256 = "/ {
-    s;/${REPO}/archive/.*.tar.gz",;/${REPO}/archive/${COMMIT}.tar.gz",;
+  /name = "com_google_googleapis",/,/strip_prefix = "/ {
     s;/com_google_googleapis/.*.tar.gz",;/com_google_googleapis/${COMMIT}.tar.gz",;
-    s/strip_prefix = "googleapis-.*",/strip_prefix = "googleapis-${COMMIT}",/
+    s;/${REPO}/archive/.*.tar.gz",;/${REPO}/archive/${COMMIT}.tar.gz",;
     s/sha256 = ".*",/sha256 = "${SHA256}",/
+    s/strip_prefix = "googleapis-.*",/strip_prefix = "googleapis-${COMMIT}",/
   }
 EOT
 


### PR DESCRIPTION
`renovate.sh` knew that the editable `bazel/google_cloud_cpp_deps.bzl` elements were terminated by the "sha256" field ... until they weren't. (See "canonicalize the ordering of urls/sha256/strip_prefix fields" in #10851.)

The new sed script is just as fragile, but hopefully now a little more stable.

Also update the order of the substitution commands to match the file, for just a little more clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10946)
<!-- Reviewable:end -->
