### PR TITLE
ci: deflake Kokoro+Windows builds

### DIFF
--- a/ci/kokoro/windows/build-32.bat
+++ b/ci/kokoro/windows/build-32.bat
@@ -12,14 +12,10 @@
 @REM See the License for the specific language governing permissions and
 @REM limitations under the License.
 
-REM Install Bazelisk.
 @echo %date% %time%
-@cd github\google-cloud-cpp
-@powershell -exec bypass ci\kokoro\windows\lib\install-bazelisk.ps1
-@if ERRORLEVEL 1 exit /b 1
 
-REM Change PATH to install the Bazelisk version we just installed
-@set "PATH=C:\bin;%ProgramFiles(x86)%\Google\Cloud SDK\google-cloud-sdk\bin;%PATH%"
+@REM Change PATH to include the google cloud CLI (formerly SDK)
+@set "PATH=%ProgramFiles(x86)%\Google\Cloud SDK\google-cloud-sdk\bin;%PATH%"
 
 REM Configure the environment to use MSVC %MSVC_VERSION% and then switch to PowerShell.
 call "%ProgramFiles(x86)%\Microsoft Visual Studio\%MSVC_VERSION%\BuildTools\VC\Auxiliary\Build\vcvars32.bat"
@@ -28,6 +24,7 @@ set "VCPKG_OVERLAY_TRIPLETS=%cd%\ci\kokoro\windows\triplets"
 
 REM The remaining of the build script is implemented in PowerShell.
 @echo %date% %time%
+@cd github\google-cloud-cpp
 powershell -exec bypass ci\kokoro\windows\build.ps1
 @if ERRORLEVEL 1 exit /b 1
 

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -12,14 +12,10 @@
 @REM See the License for the specific language governing permissions and
 @REM limitations under the License.
 
-REM Install Bazelisk.
 @echo %date% %time%
-@cd github\google-cloud-cpp
-@powershell -exec bypass ci\kokoro\windows\lib\install-bazelisk.ps1
-@if ERRORLEVEL 1 exit /b 1
 
-REM Change PATH to install the Bazelisk version we just installed
-@set "PATH=C:\bin;%ProgramFiles(x86)%\Google\Cloud SDK\google-cloud-sdk\bin;%PATH%"
+@REM Change PATH to include the google cloud CLI (formerly SDK)
+@set "PATH=%ProgramFiles(x86)%\Google\Cloud SDK\google-cloud-sdk\bin;%PATH%"
 
 REM Configure the environment to use MSVC %MSVC_VERSION% and then switch to PowerShell.
 call "%ProgramFiles(x86)%\Microsoft Visual Studio\%MSVC_VERSION%\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
@@ -28,6 +24,7 @@ set "VCPKG_OVERLAY_TRIPLETS=%cd%\ci\kokoro\windows\triplets"
 
 REM The remaining of the build script is implemented in PowerShell.
 @echo %date% %time%
+@cd github\google-cloud-cpp
 powershell -exec bypass ci\kokoro\windows\build.ps1
 @if ERRORLEVEL 1 exit /b 1
 


### PR DESCRIPTION
There is no need to install `bazelisk` during the build, it is already installed in the base image.  The fewer things we install dynamically, the fewer things that can fail to download, the fewer flakes we have.

Fixes #10140

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10948)
<!-- Reviewable:end -->
