### PR TITLE
fix(bigtable): retries for `CheckConsistency` / `AsyncWaitForConsistency`

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -307,6 +307,9 @@ service {
   emulator_endpoint_env_var: "BIGTABLE_EMULATOR_HOST"
   gen_async_rpcs: ["CheckConsistency"]
   retryable_status_codes: ["kUnavailable", "kAborted"]
+  idempotency_overrides: [
+    {rpc_name: "BigtableTableAdmin.CheckConsistency", idempotency: IDEMPOTENT}
+  ]
 }
 
 # Billing

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.cc
@@ -84,7 +84,7 @@ BigtableTableAdminConnectionIdempotencyPolicy::GenerateConsistencyToken(
 
 Idempotency BigtableTableAdminConnectionIdempotencyPolicy::CheckConsistency(
     google::bigtable::admin::v2::CheckConsistencyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency BigtableTableAdminConnectionIdempotencyPolicy::CreateBackup(


### PR DESCRIPTION
Part of the work for #10413

Default `BigtableTableAdmin::(Async)CheckConsistency` to be idempotent. This will improve the success rate for the `bigtable_admin::AsyncWaitForConsistency(...)` helper.

This probably "fixes" #9870. Getting `UNAVAILABLE` is a fairly common flake when run against production in our CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10955)
<!-- Reviewable:end -->
