### PR TITLE
cleanup(ci): de-dup enabled feature

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -30,8 +30,6 @@ read -r ENABLED_FEATURES < <(features::always_build_cmake)
 ENABLED_FEATURES="${ENABLED_FEATURES},experimental-storage-grpc"
 ENABLED_FEATURES="${ENABLED_FEATURES},generator"
 ENABLED_FEATURES="${ENABLED_FEATURES},internal-docfx"
-# TODO(#10830) - pick up experimental-bigquery_rest from `always_build_cmake`
-ENABLED_FEATURES="${ENABLED_FEATURES},experimental-bigquery_rest"
 readonly ENABLED_FEATURES
 
 mapfile -t cmake_args < <(cmake::common_args)


### PR DESCRIPTION
This feature is included: https://github.com/googleapis/google-cloud-cpp/blob/9ee0d20890064e3fe547e5f868eae86424a6180b/ci/cloudbuild/builds/lib/features.sh#L30

I just forgot to clean up the TODO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10956)
<!-- Reviewable:end -->
