### PR TITLE
fix: retries for GetIamPolicy, TestIamPermissions

### DIFF
--- a/generator/integration_tests/golden/v1/golden_thing_admin_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/v1/golden_thing_admin_connection_idempotency_policy.cc
@@ -65,11 +65,11 @@ Idempotency GoldenThingAdminConnectionIdempotencyPolicy::SetIamPolicy(
 }
 
 Idempotency GoldenThingAdminConnectionIdempotencyPolicy::GetIamPolicy(google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency GoldenThingAdminConnectionIdempotencyPolicy::TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency GoldenThingAdminConnectionIdempotencyPolicy::CreateBackup(google::test::admin::database::v1::CreateBackupRequest const&) {

--- a/generator/integration_tests/tests/golden_thing_admin_idempotency_policy_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_idempotency_policy_test.cc
@@ -73,12 +73,12 @@ TEST_F(GoldenIdempotencyPolicyTest, SetIamPolicy) {
 
 TEST_F(GoldenIdempotencyPolicyTest, GetIamPolicy) {
   google::iam::v1::GetIamPolicyRequest request;
-  EXPECT_EQ(policy_->GetIamPolicy(request), Idempotency::kNonIdempotent);
+  EXPECT_EQ(policy_->GetIamPolicy(request), Idempotency::kIdempotent);
 }
 
 TEST_F(GoldenIdempotencyPolicyTest, TestIamPermissions) {
   google::iam::v1::TestIamPermissionsRequest request;
-  EXPECT_EQ(policy_->TestIamPermissions(request), Idempotency::kNonIdempotent);
+  EXPECT_EQ(policy_->TestIamPermissions(request), Idempotency::kIdempotent);
 }
 
 TEST_F(GoldenIdempotencyPolicyTest, CreateBackup) {

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -430,6 +430,10 @@ void SetHttpGetQueryParameters(
 
 std::string DefaultIdempotencyFromHttpOperation(
     google::protobuf::MethodDescriptor const& method) {
+  if (method.name() == "GetIamPolicy" ||
+      method.name() == "TestIamPermissions") {
+    return "kIdempotent";
+  }
   if (method.options().HasExtension(google::api::http)) {
     google::api::HttpRule http_rule =
         method.options().GetExtension(google::api::http);

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -529,6 +529,20 @@ char const* const kServiceProto =
     "    option (google.api.method_signature) = \"name,parent,number\";\n"
     "    option (google.api.method_signature) = \"name,title,number\";\n"
     "  }\n"
+    "  // Test that the method defaults to kIdempotent.\n"
+    "  rpc GetIamPolicy(Empty) returns (Empty) {\n"
+    "    option (google.api.http) = {\n"
+    "       post: \"/v1/foo\"\n"
+    "       body: \"*\"\n"
+    "    };\n"
+    "  }\n"
+    "  // Test that the method defaults to kIdempotent.\n"
+    "  rpc TestIamPermissions(Empty) returns (Empty) {\n"
+    "    option (google.api.http) = {\n"
+    "       post: \"/v1/foo\"\n"
+    "       body: \"*\"\n"
+    "    };\n"
+    "  }\n"
     "}\n";
 
 char const* const kMethod6Deprecated1 =  // name,not_used_anymore
@@ -952,7 +966,12 @@ INSTANTIATE_TEST_SUITE_P(
                              R"""(,
       {std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token()),
-       std::make_pair("name", request.name())})""")),
+       std::make_pair("name", request.name())})"""),
+        // IAM idempotency defaults
+        MethodVarsTestValues("google.protobuf.Service.GetIamPolicy",
+                             "idempotency", "kIdempotent"),
+        MethodVarsTestValues("google.protobuf.Service.TestIamPermissions",
+                             "idempotency", "kIdempotent")),
     [](testing::TestParamInfo<CreateMethodVarsTest::ParamType> const& info) {
       std::vector<std::string> pieces = absl::StrSplit(info.param.method, '.');
       return pieces.back() + "_" + info.param.vars_key;

--- a/google/cloud/accesscontextmanager/v1/access_context_manager_connection_idempotency_policy.cc
+++ b/google/cloud/accesscontextmanager/v1/access_context_manager_connection_idempotency_policy.cc
@@ -192,12 +192,12 @@ Idempotency AccessContextManagerConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency AccessContextManagerConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency AccessContextManagerConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<AccessContextManagerConnectionIdempotencyPolicy>

--- a/google/cloud/artifactregistry/v1/artifact_registry_connection_idempotency_policy.cc
+++ b/google/cloud/artifactregistry/v1/artifact_registry_connection_idempotency_policy.cc
@@ -192,7 +192,7 @@ Idempotency ArtifactRegistryConnectionIdempotencyPolicy::GetIamPolicy(
 
 Idempotency ArtifactRegistryConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency ArtifactRegistryConnectionIdempotencyPolicy::GetProjectSettings(

--- a/google/cloud/bigquery/analyticshub/v1/analytics_hub_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/analyticshub/v1/analytics_hub_connection_idempotency_policy.cc
@@ -104,7 +104,7 @@ Idempotency AnalyticsHubServiceConnectionIdempotencyPolicy::SubscribeListing(
 
 Idempotency AnalyticsHubServiceConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency AnalyticsHubServiceConnectionIdempotencyPolicy::SetIamPolicy(
@@ -115,7 +115,7 @@ Idempotency AnalyticsHubServiceConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency AnalyticsHubServiceConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<AnalyticsHubServiceConnectionIdempotencyPolicy>

--- a/google/cloud/bigquery/connection/v1/connection_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/connection/v1/connection_connection_idempotency_policy.cc
@@ -63,7 +63,7 @@ Idempotency ConnectionServiceConnectionIdempotencyPolicy::DeleteConnection(
 
 Idempotency ConnectionServiceConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency ConnectionServiceConnectionIdempotencyPolicy::SetIamPolicy(
@@ -74,7 +74,7 @@ Idempotency ConnectionServiceConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency ConnectionServiceConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<ConnectionServiceConnectionIdempotencyPolicy>

--- a/google/cloud/bigquery/datapolicies/v1/data_policy_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/datapolicies/v1/data_policy_connection_idempotency_policy.cc
@@ -68,7 +68,7 @@ Idempotency DataPolicyServiceConnectionIdempotencyPolicy::ListDataPolicies(
 
 Idempotency DataPolicyServiceConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency DataPolicyServiceConnectionIdempotencyPolicy::SetIamPolicy(
@@ -79,7 +79,7 @@ Idempotency DataPolicyServiceConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency DataPolicyServiceConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<DataPolicyServiceConnectionIdempotencyPolicy>

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection_idempotency_policy.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection_idempotency_policy.cc
@@ -125,7 +125,7 @@ Idempotency BigtableInstanceAdminConnectionIdempotencyPolicy::DeleteAppProfile(
 
 Idempotency BigtableInstanceAdminConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency BigtableInstanceAdminConnectionIdempotencyPolicy::SetIamPolicy(
@@ -137,7 +137,7 @@ Idempotency BigtableInstanceAdminConnectionIdempotencyPolicy::SetIamPolicy(
 Idempotency
 BigtableInstanceAdminConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency BigtableInstanceAdminConnectionIdempotencyPolicy::ListHotTablets(

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.cc
@@ -119,7 +119,7 @@ Idempotency BigtableTableAdminConnectionIdempotencyPolicy::RestoreTable(
 
 Idempotency BigtableTableAdminConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency BigtableTableAdminConnectionIdempotencyPolicy::SetIamPolicy(
@@ -130,7 +130,7 @@ Idempotency BigtableTableAdminConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency BigtableTableAdminConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<BigtableTableAdminConnectionIdempotencyPolicy>

--- a/google/cloud/billing/v1/cloud_billing_connection_idempotency_policy.cc
+++ b/google/cloud/billing/v1/cloud_billing_connection_idempotency_policy.cc
@@ -83,7 +83,7 @@ Idempotency CloudBillingConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency CloudBillingConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<CloudBillingConnectionIdempotencyPolicy>

--- a/google/cloud/containeranalysis/v1/container_analysis_connection_idempotency_policy.cc
+++ b/google/cloud/containeranalysis/v1/container_analysis_connection_idempotency_policy.cc
@@ -43,12 +43,12 @@ Idempotency ContainerAnalysisConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency ContainerAnalysisConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency ContainerAnalysisConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency ContainerAnalysisConnectionIdempotencyPolicy::

--- a/google/cloud/datacatalog/v1/data_catalog_connection_idempotency_policy.cc
+++ b/google/cloud/datacatalog/v1/data_catalog_connection_idempotency_policy.cc
@@ -190,12 +190,12 @@ Idempotency DataCatalogConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency DataCatalogConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency DataCatalogConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<DataCatalogConnectionIdempotencyPolicy>

--- a/google/cloud/datacatalog/v1/policy_tag_manager_connection_idempotency_policy.cc
+++ b/google/cloud/datacatalog/v1/policy_tag_manager_connection_idempotency_policy.cc
@@ -87,7 +87,7 @@ Idempotency PolicyTagManagerConnectionIdempotencyPolicy::GetPolicyTag(
 
 Idempotency PolicyTagManagerConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency PolicyTagManagerConnectionIdempotencyPolicy::SetIamPolicy(
@@ -98,7 +98,7 @@ Idempotency PolicyTagManagerConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency PolicyTagManagerConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<PolicyTagManagerConnectionIdempotencyPolicy>

--- a/google/cloud/dataplex/v1/content_connection_idempotency_policy.cc
+++ b/google/cloud/dataplex/v1/content_connection_idempotency_policy.cc
@@ -68,7 +68,7 @@ Idempotency ContentServiceConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency ContentServiceConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency ContentServiceConnectionIdempotencyPolicy::ListContent(

--- a/google/cloud/functions/v1/cloud_functions_connection_idempotency_policy.cc
+++ b/google/cloud/functions/v1/cloud_functions_connection_idempotency_policy.cc
@@ -91,7 +91,7 @@ Idempotency CloudFunctionsServiceConnectionIdempotencyPolicy::GetIamPolicy(
 Idempotency
 CloudFunctionsServiceConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<CloudFunctionsServiceConnectionIdempotencyPolicy>

--- a/google/cloud/iam/admin/v1/iam_connection_idempotency_policy.cc
+++ b/google/cloud/iam/admin/v1/iam_connection_idempotency_policy.cc
@@ -111,7 +111,7 @@ Idempotency IAMConnectionIdempotencyPolicy::EnableServiceAccountKey(
 
 Idempotency IAMConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency IAMConnectionIdempotencyPolicy::SetIamPolicy(
@@ -122,7 +122,7 @@ Idempotency IAMConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency IAMConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency IAMConnectionIdempotencyPolicy::QueryGrantableRoles(

--- a/google/cloud/iam/v1/iam_policy_connection_idempotency_policy.cc
+++ b/google/cloud/iam/v1/iam_policy_connection_idempotency_policy.cc
@@ -43,12 +43,12 @@ Idempotency IAMPolicyConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency IAMPolicyConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency IAMPolicyConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<IAMPolicyConnectionIdempotencyPolicy>

--- a/google/cloud/iap/v1/identity_aware_proxy_admin_connection_idempotency_policy.cc
+++ b/google/cloud/iap/v1/identity_aware_proxy_admin_connection_idempotency_policy.cc
@@ -46,13 +46,13 @@ IdentityAwareProxyAdminServiceConnectionIdempotencyPolicy::SetIamPolicy(
 Idempotency
 IdentityAwareProxyAdminServiceConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency
 IdentityAwareProxyAdminServiceConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency

--- a/google/cloud/iot/v1/device_manager_connection_idempotency_policy.cc
+++ b/google/cloud/iot/v1/device_manager_connection_idempotency_policy.cc
@@ -108,12 +108,12 @@ Idempotency DeviceManagerConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency DeviceManagerConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency DeviceManagerConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency DeviceManagerConnectionIdempotencyPolicy::SendCommandToDevice(

--- a/google/cloud/resourcemanager/v3/folders_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/v3/folders_connection_idempotency_policy.cc
@@ -77,7 +77,7 @@ Idempotency FoldersConnectionIdempotencyPolicy::UndeleteFolder(
 
 Idempotency FoldersConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency FoldersConnectionIdempotencyPolicy::SetIamPolicy(
@@ -88,7 +88,7 @@ Idempotency FoldersConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency FoldersConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<FoldersConnectionIdempotencyPolicy>

--- a/google/cloud/resourcemanager/v3/organizations_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/v3/organizations_connection_idempotency_policy.cc
@@ -47,7 +47,7 @@ Idempotency OrganizationsConnectionIdempotencyPolicy::SearchOrganizations(
 
 Idempotency OrganizationsConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency OrganizationsConnectionIdempotencyPolicy::SetIamPolicy(
@@ -58,7 +58,7 @@ Idempotency OrganizationsConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency OrganizationsConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<OrganizationsConnectionIdempotencyPolicy>

--- a/google/cloud/resourcemanager/v3/projects_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/v3/projects_connection_idempotency_policy.cc
@@ -77,7 +77,7 @@ Idempotency ProjectsConnectionIdempotencyPolicy::UndeleteProject(
 
 Idempotency ProjectsConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency ProjectsConnectionIdempotencyPolicy::SetIamPolicy(
@@ -88,7 +88,7 @@ Idempotency ProjectsConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency ProjectsConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<ProjectsConnectionIdempotencyPolicy>

--- a/google/cloud/run/v2/services_connection_idempotency_policy.cc
+++ b/google/cloud/run/v2/services_connection_idempotency_policy.cc
@@ -73,7 +73,7 @@ Idempotency ServicesConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency ServicesConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<ServicesConnectionIdempotencyPolicy>

--- a/google/cloud/secretmanager/v1/secret_manager_connection_idempotency_policy.cc
+++ b/google/cloud/secretmanager/v1/secret_manager_connection_idempotency_policy.cc
@@ -113,7 +113,7 @@ Idempotency SecretManagerServiceConnectionIdempotencyPolicy::GetIamPolicy(
 
 Idempotency SecretManagerServiceConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<SecretManagerServiceConnectionIdempotencyPolicy>

--- a/google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.cc
+++ b/google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.cc
@@ -77,7 +77,7 @@ Idempotency SecurityCenterConnectionIdempotencyPolicy::GetBigQueryExport(
 
 Idempotency SecurityCenterConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency SecurityCenterConnectionIdempotencyPolicy::GetMuteConfig(
@@ -159,7 +159,7 @@ Idempotency SecurityCenterConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency SecurityCenterConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency SecurityCenterConnectionIdempotencyPolicy::UpdateExternalSystem(

--- a/google/cloud/servicedirectory/v1/registration_connection_idempotency_policy.cc
+++ b/google/cloud/servicedirectory/v1/registration_connection_idempotency_policy.cc
@@ -113,7 +113,7 @@ Idempotency RegistrationServiceConnectionIdempotencyPolicy::DeleteEndpoint(
 
 Idempotency RegistrationServiceConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency RegistrationServiceConnectionIdempotencyPolicy::SetIamPolicy(
@@ -124,7 +124,7 @@ Idempotency RegistrationServiceConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency RegistrationServiceConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<RegistrationServiceConnectionIdempotencyPolicy>

--- a/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.cc
+++ b/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.cc
@@ -73,12 +73,12 @@ Idempotency DatabaseAdminConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency DatabaseAdminConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency DatabaseAdminConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency DatabaseAdminConnectionIdempotencyPolicy::CreateBackup(

--- a/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.cc
@@ -101,12 +101,12 @@ Idempotency InstanceAdminConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency InstanceAdminConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency InstanceAdminConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<InstanceAdminConnectionIdempotencyPolicy>

--- a/google/cloud/tasks/v2/cloud_tasks_connection_idempotency_policy.cc
+++ b/google/cloud/tasks/v2/cloud_tasks_connection_idempotency_policy.cc
@@ -77,7 +77,7 @@ Idempotency CloudTasksConnectionIdempotencyPolicy::ResumeQueue(
 
 Idempotency CloudTasksConnectionIdempotencyPolicy::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency CloudTasksConnectionIdempotencyPolicy::SetIamPolicy(
@@ -88,7 +88,7 @@ Idempotency CloudTasksConnectionIdempotencyPolicy::SetIamPolicy(
 
 Idempotency CloudTasksConnectionIdempotencyPolicy::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency CloudTasksConnectionIdempotencyPolicy::ListTasks(


### PR DESCRIPTION
Part of the work for #10413 

It seemed better to add a special case to the generator's default idempotency method than to maintain the configuration in `generator_config.textproto` for `N` services. And the `N+1`th service will have the proper defaults for the IAM methods without manual intervention.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10957)
<!-- Reviewable:end -->
