### PR TITLE
test: only use emulator for low-level HTTP tests

### DIFF
--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -43,11 +43,8 @@ class RestClientIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override {
     auto httpbin_endpoint = google::cloud::internal::GetEnv("HTTPBIN_ENDPOINT");
-    if (httpbin_endpoint) {
-      url_ = *httpbin_endpoint;
-    } else {
-      url_ = "https://httpbin.org";
-    }
+    if (!httpbin_endpoint) GTEST_SKIP();
+    url_ = *httpbin_endpoint;
 
     json_payload_ = R"""({
     "type": "service_account",

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -37,9 +37,9 @@ using ::testing::HasSubstr;
 using ::testing::Pair;
 using ::testing::StartsWith;
 
-std::string HttpBinEndpoint() { return GetEnv("HTTPBIN_ENDPOINT").value(); }
-
 bool UsingEmulator() { return GetEnv("HTTPBIN_ENDPOINT").has_value(); }
+
+std::string HttpBinEndpoint() { return GetEnv("HTTPBIN_ENDPOINT").value(); }
 
 Status Make3Attempts(std::function<Status()> const& attempt) {
   Status status;

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -41,9 +41,9 @@ using ::testing::Not;
 using ::testing::Pair;
 using ::testing::StartsWith;
 
-std::string HttpBinEndpoint() { return GetEnv("HTTPBIN_ENDPOINT").value(); }
-
 bool UsingEmulator() { return GetEnv("HTTPBIN_ENDPOINT").has_value(); }
+
+std::string HttpBinEndpoint() { return GetEnv("HTTPBIN_ENDPOINT").value(); }
 
 // The integration tests sometimes flake (e.g. DNS failures) if we do not have a
 // retry loop.
@@ -365,7 +365,6 @@ TEST(CurlRequestTest, UserAgent) {
 }
 
 #if CURL_AT_LEAST_VERSION(7, 43, 0)
-
 /// @test Verify the HTTP Version option.
 TEST(CurlRequestTest, HttpVersion) {
   if (!UsingEmulator()) GTEST_SKIP();


### PR DESCRIPTION
We do not gain more information by using httpbin.org, and that fails sometimes.


Part of the work for #10413

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10961)
<!-- Reviewable:end -->
