### PR TITLE
cleanup: remove gRPC+macOS workaround

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,11 +15,6 @@
 # NOTE: This file is not loaded if google-cloud-cpp is built as part of a
 # larger project.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -28,8 +28,6 @@ export USE_BAZEL_VERSION
 bazelisk version || rm -fr "$HOME"/Library/Caches/bazelisk || bazelisk version
 
 bazel_args=(
-  # On macOS gRPC does not compile correctly unless one defines this:
-  "--copt=-DGRPC_BAZEL_BUILD"
   # We need this environment variable because on macOS gRPC crashes if it
   # cannot find the credentials, even if you do not use them. Some of the
   # unit tests do exactly that.

--- a/ci/kokoro/macos/builds/quickstart-bazel.sh
+++ b/ci/kokoro/macos/builds/quickstart-bazel.sh
@@ -33,8 +33,6 @@ bazelisk version || rm -fr "$HOME"/Library/Caches/bazelisk || bazelisk version
 bazelisk shutdown
 
 bazel_args=(
-  # On macOS gRPC does not compile correctly unless one defines this:
-  "--copt=-DGRPC_BAZEL_BUILD"
   # We need this environment variable because on macOS gRPC crashes if it
   # cannot find the credentials, even if you do not use them. Some of the
   # unit tests do exactly that.

--- a/ci/verify_current_targets/.bazelrc
+++ b/ci/verify_current_targets/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/ci/verify_deprecated_targets/.bazelrc
+++ b/ci/verify_deprecated_targets/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -827,14 +827,6 @@ curl -Lo roots.pem https://pki.google.com/roots.pem
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$$PWD/roots.pem"
 ```
 
-To workaround a [bug in Bazel][bazel-grpc-macos-bug], gRPC requires this flag on
-macOS builds, you can add the option manually or include it in your `.bazelrc`
-file:
-
-```bash
-bazel build --copt=-DGRPC_BAZEL_BUILD ...
-```
-
 ### Windows
 
 Bazel tends to create very long file names and paths. You may need to use a
@@ -1061,11 +1053,6 @@ void GenerateQuickstartBazelrc(
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
 
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true

--- a/google/cloud/accessapproval/quickstart/.bazelrc
+++ b/google/cloud/accessapproval/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/accesscontextmanager/quickstart/.bazelrc
+++ b/google/cloud/accesscontextmanager/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/advisorynotifications/quickstart/.bazelrc
+++ b/google/cloud/advisorynotifications/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/apigateway/quickstart/.bazelrc
+++ b/google/cloud/apigateway/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/apigeeconnect/quickstart/.bazelrc
+++ b/google/cloud/apigeeconnect/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/apikeys/quickstart/.bazelrc
+++ b/google/cloud/apikeys/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/appengine/quickstart/.bazelrc
+++ b/google/cloud/appengine/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/artifactregistry/quickstart/.bazelrc
+++ b/google/cloud/artifactregistry/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/asset/quickstart/.bazelrc
+++ b/google/cloud/asset/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/assuredworkloads/quickstart/.bazelrc
+++ b/google/cloud/assuredworkloads/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/automl/quickstart/.bazelrc
+++ b/google/cloud/automl/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/baremetalsolution/quickstart/.bazelrc
+++ b/google/cloud/baremetalsolution/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/batch/quickstart/.bazelrc
+++ b/google/cloud/batch/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/beyondcorp/quickstart/.bazelrc
+++ b/google/cloud/beyondcorp/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/bigquery/quickstart/.bazelrc
+++ b/google/cloud/bigquery/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/bigtable/quickstart/.bazelrc
+++ b/google/cloud/bigtable/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/billing/quickstart/.bazelrc
+++ b/google/cloud/billing/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/binaryauthorization/quickstart/.bazelrc
+++ b/google/cloud/binaryauthorization/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/certificatemanager/quickstart/.bazelrc
+++ b/google/cloud/certificatemanager/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/channel/quickstart/.bazelrc
+++ b/google/cloud/channel/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/cloudbuild/quickstart/.bazelrc
+++ b/google/cloud/cloudbuild/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/composer/quickstart/.bazelrc
+++ b/google/cloud/composer/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/connectors/quickstart/.bazelrc
+++ b/google/cloud/connectors/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/contactcenterinsights/quickstart/.bazelrc
+++ b/google/cloud/contactcenterinsights/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/container/quickstart/.bazelrc
+++ b/google/cloud/container/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/containeranalysis/quickstart/.bazelrc
+++ b/google/cloud/containeranalysis/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/datacatalog/quickstart/.bazelrc
+++ b/google/cloud/datacatalog/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/datamigration/quickstart/.bazelrc
+++ b/google/cloud/datamigration/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/dataplex/quickstart/.bazelrc
+++ b/google/cloud/dataplex/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/dataproc/quickstart/.bazelrc
+++ b/google/cloud/dataproc/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/datastream/quickstart/.bazelrc
+++ b/google/cloud/datastream/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/debugger/quickstart/.bazelrc
+++ b/google/cloud/debugger/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/deploy/quickstart/.bazelrc
+++ b/google/cloud/deploy/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/dialogflow_cx/quickstart/.bazelrc
+++ b/google/cloud/dialogflow_cx/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/dialogflow_es/quickstart/.bazelrc
+++ b/google/cloud/dialogflow_es/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/dlp/quickstart/.bazelrc
+++ b/google/cloud/dlp/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/documentai/quickstart/.bazelrc
+++ b/google/cloud/documentai/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/edgecontainer/quickstart/.bazelrc
+++ b/google/cloud/edgecontainer/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/eventarc/quickstart/.bazelrc
+++ b/google/cloud/eventarc/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/filestore/quickstart/.bazelrc
+++ b/google/cloud/filestore/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/functions/quickstart/.bazelrc
+++ b/google/cloud/functions/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/gameservices/quickstart/.bazelrc
+++ b/google/cloud/gameservices/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/gkehub/quickstart/.bazelrc
+++ b/google/cloud/gkehub/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/gkemulticloud/quickstart/.bazelrc
+++ b/google/cloud/gkemulticloud/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/iam/quickstart/.bazelrc
+++ b/google/cloud/iam/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/iap/quickstart/.bazelrc
+++ b/google/cloud/iap/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/ids/quickstart/.bazelrc
+++ b/google/cloud/ids/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/iot/quickstart/.bazelrc
+++ b/google/cloud/iot/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/kms/quickstart/.bazelrc
+++ b/google/cloud/kms/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/language/quickstart/.bazelrc
+++ b/google/cloud/language/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/logging/quickstart/.bazelrc
+++ b/google/cloud/logging/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/managedidentities/quickstart/.bazelrc
+++ b/google/cloud/managedidentities/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/memcache/quickstart/.bazelrc
+++ b/google/cloud/memcache/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/monitoring/quickstart/.bazelrc
+++ b/google/cloud/monitoring/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/networkconnectivity/quickstart/.bazelrc
+++ b/google/cloud/networkconnectivity/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/networkmanagement/quickstart/.bazelrc
+++ b/google/cloud/networkmanagement/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/notebooks/quickstart/.bazelrc
+++ b/google/cloud/notebooks/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/optimization/quickstart/.bazelrc
+++ b/google/cloud/optimization/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/orgpolicy/quickstart/.bazelrc
+++ b/google/cloud/orgpolicy/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/osconfig/quickstart/.bazelrc
+++ b/google/cloud/osconfig/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/oslogin/quickstart/.bazelrc
+++ b/google/cloud/oslogin/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/policytroubleshooter/quickstart/.bazelrc
+++ b/google/cloud/policytroubleshooter/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/privateca/quickstart/.bazelrc
+++ b/google/cloud/privateca/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/profiler/quickstart/.bazelrc
+++ b/google/cloud/profiler/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/pubsub/quickstart/.bazelrc
+++ b/google/cloud/pubsub/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/pubsublite/quickstart/.bazelrc
+++ b/google/cloud/pubsublite/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/recommender/quickstart/.bazelrc
+++ b/google/cloud/recommender/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/redis/quickstart/.bazelrc
+++ b/google/cloud/redis/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/resourcemanager/quickstart/.bazelrc
+++ b/google/cloud/resourcemanager/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/resourcesettings/quickstart/.bazelrc
+++ b/google/cloud/resourcesettings/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/retail/quickstart/.bazelrc
+++ b/google/cloud/retail/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/run/quickstart/.bazelrc
+++ b/google/cloud/run/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/scheduler/quickstart/.bazelrc
+++ b/google/cloud/scheduler/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/secretmanager/quickstart/.bazelrc
+++ b/google/cloud/secretmanager/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/securitycenter/quickstart/.bazelrc
+++ b/google/cloud/securitycenter/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/servicecontrol/quickstart/.bazelrc
+++ b/google/cloud/servicecontrol/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/servicedirectory/quickstart/.bazelrc
+++ b/google/cloud/servicedirectory/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/servicemanagement/quickstart/.bazelrc
+++ b/google/cloud/servicemanagement/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/serviceusage/quickstart/.bazelrc
+++ b/google/cloud/serviceusage/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/shell/quickstart/.bazelrc
+++ b/google/cloud/shell/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/spanner/quickstart/.bazelrc
+++ b/google/cloud/spanner/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/speech/quickstart/.bazelrc
+++ b/google/cloud/speech/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/storage/quickstart/.bazelrc
+++ b/google/cloud/storage/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/storagetransfer/quickstart/.bazelrc
+++ b/google/cloud/storagetransfer/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/talent/quickstart/.bazelrc
+++ b/google/cloud/talent/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/tasks/quickstart/.bazelrc
+++ b/google/cloud/tasks/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/texttospeech/quickstart/.bazelrc
+++ b/google/cloud/texttospeech/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/tpu/quickstart/.bazelrc
+++ b/google/cloud/tpu/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/trace/quickstart/.bazelrc
+++ b/google/cloud/trace/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/translate/quickstart/.bazelrc
+++ b/google/cloud/translate/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/video/quickstart/.bazelrc
+++ b/google/cloud/video/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/videointelligence/quickstart/.bazelrc
+++ b/google/cloud/videointelligence/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/vision/quickstart/.bazelrc
+++ b/google/cloud/vision/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/vmmigration/quickstart/.bazelrc
+++ b/google/cloud/vmmigration/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/vmwareengine/quickstart/.bazelrc
+++ b/google/cloud/vmwareengine/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/vpcaccess/quickstart/.bazelrc
+++ b/google/cloud/vpcaccess/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/webrisk/quickstart/.bazelrc
+++ b/google/cloud/webrisk/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/websecurityscanner/quickstart/.bazelrc
+++ b/google/cloud/websecurityscanner/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 

--- a/google/cloud/workflows/quickstart/.bazelrc
+++ b/google/cloud/workflows/quickstart/.bazelrc
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
-# and there is (AFAIK) no way to "inherit" their definitions.
-#   [1]: https://github.com/bazelbuild/bazel/issues/4341
-build --copt=-DGRPC_BAZEL_BUILD
-
 # Use host-OS-specific config lines from bazelrc files.
 build --enable_platform_specific_config=true
 


### PR DESCRIPTION
Modern versions of gRPC no longer need `-DGRPC_BAZEL_BUILD` on macOS.

Fixes #10279

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10966)
<!-- Reviewable:end -->
