### PR TITLE
refactor(docfx): split Config to its own file

### DIFF
--- a/docfx/CMakeLists.txt
+++ b/docfx/CMakeLists.txt
@@ -30,6 +30,7 @@ include(EnableWerror)
 
 add_library(
     docfx # cmake-format: sort
+    config.h
     doxygen2markdown.cc
     doxygen2markdown.h
     doxygen_pages.cc

--- a/docfx/config.h
+++ b/docfx/config.h
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_DOCFX_PARSE_ARGUMENTS_H
-#define GOOGLE_CLOUD_CPP_DOCFX_PARSE_ARGUMENTS_H
+#ifndef GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
+#define GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
 
-#include "docfx/config.h"
 #include <string>
-#include <vector>
 
 namespace docfx {
 
-Config ParseArguments(std::vector<std::string> const& args);
+struct Config {
+  std::string input_filename;
+  std::string library;
+};
 
 }  // namespace docfx
 
-#endif  // GOOGLE_CLOUD_CPP_DOCFX_PARSE_ARGUMENTS_H
+#endif  // GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H

--- a/docfx/docfx.bzl
+++ b/docfx/docfx.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for docfx - DO NOT EDIT."""
 
 docfx_hdrs = [
+    "config.h",
     "doxygen2markdown.h",
     "doxygen_pages.h",
     "parse_arguments.h",


### PR DESCRIPTION
Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10970)
<!-- Reviewable:end -->
