### PR TITLE
impl(docfx): initial table of contents file

### DIFF
--- a/docfx/CMakeLists.txt
+++ b/docfx/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(
     config.h
     doxygen2markdown.cc
     doxygen2markdown.h
+    doxygen2toc.cc
+    doxygen2toc.h
     doxygen_pages.cc
     doxygen_pages.h
     parse_arguments.cc
@@ -61,7 +63,8 @@ endif ()
 
 set(unit_tests
     # cmake-format: sort
-    doxygen2markdown_test.cc doxygen_pages_test.cc parse_arguments_test.cc)
+    doxygen2markdown_test.cc doxygen2toc_test.cc doxygen_pages_test.cc
+    parse_arguments_test.cc)
 
 # Export the list of unit tests to a .bzl file so we do not need to maintain the
 # list in two places.

--- a/docfx/docfx.bzl
+++ b/docfx/docfx.bzl
@@ -19,6 +19,7 @@
 docfx_hdrs = [
     "config.h",
     "doxygen2markdown.h",
+    "doxygen2toc.h",
     "doxygen_pages.h",
     "parse_arguments.h",
     "toc_entry.h",
@@ -26,6 +27,7 @@ docfx_hdrs = [
 
 docfx_srcs = [
     "doxygen2markdown.cc",
+    "doxygen2toc.cc",
     "doxygen_pages.cc",
     "parse_arguments.cc",
     "toc_entry.cc",

--- a/docfx/doxygen2toc.cc
+++ b/docfx/doxygen2toc.cc
@@ -1,0 +1,45 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "docfx/doxygen2toc.h"
+#include "docfx/doxygen_pages.h"
+#include <yaml-cpp/yaml.h>
+#include <sstream>
+
+namespace docfx {
+
+std::string Doxygen2Toc(Config const& config, pugi::xml_document const& doc) {
+  auto const pages = PagesToc(doc);
+  auto const uid = std::string{"cloud.google.com/cpp/"} + config.library;
+  YAML::Emitter out;
+  out << YAML::BeginSeq << YAML::BeginMap           //
+      << YAML::Key << "uid" << YAML::Value << uid   //
+      << YAML::Key << "name" << YAML::Value << uid  //
+      << YAML::Key << "items" << YAML::Value        //
+      << YAML::BeginSeq                             //
+      ;
+  for (auto const& [filename, name] : pages) {
+    out << YAML::BeginMap                                  //
+        << YAML::Key << "name" << YAML::Value << name      //
+        << YAML::Key << "href" << YAML::Value << filename  //
+        << YAML::EndMap;
+  }
+  out << YAML::EndSeq << YAML::EndMap << YAML::EndSeq;
+
+  std::ostringstream os;
+  os << "### YamlMime:TableOfContent\n" << out.c_str() << "\n";
+  return std::move(os).str();
+}
+
+}  // namespace docfx

--- a/docfx/doxygen2toc.cc
+++ b/docfx/doxygen2toc.cc
@@ -27,8 +27,7 @@ std::string Doxygen2Toc(Config const& config, pugi::xml_document const& doc) {
       << YAML::Key << "uid" << YAML::Value << uid   //
       << YAML::Key << "name" << YAML::Value << uid  //
       << YAML::Key << "items" << YAML::Value        //
-      << YAML::BeginSeq                             //
-      ;
+      << YAML::BeginSeq;
   for (auto const& [filename, name] : pages) {
     out << YAML::BeginMap                                  //
         << YAML::Key << "name" << YAML::Value << name      //

--- a/docfx/doxygen2toc.h
+++ b/docfx/doxygen2toc.h
@@ -12,27 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN_PAGES_H
-#define GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN_PAGES_H
+#ifndef GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2TOC_H
+#define GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2TOC_H
 
 #include "docfx/config.h"
-#include "docfx/toc_entry.h"
 #include <pugixml.hpp>
 #include <string>
-#include <vector>
 
 namespace docfx {
 
-/**
- * Handle "page" nodes, such as the landing page of a library.
- *
- * This creates the root MarkdownContext, so no need to consume it.
- */
-std::string Page2Markdown(pugi::xml_node const& node);
-
-// Get the table of contents for pages.
-std::vector<TocEntry> PagesToc(pugi::xml_document const& doc);
+/// Generates the YAML table of contents.
+std::string Doxygen2Toc(Config const& config, pugi::xml_document const& doc);
 
 }  // namespace docfx
 
-#endif  // GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN_PAGES_H
+#endif  // GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2TOC_H

--- a/docfx/doxygen2toc_test.cc
+++ b/docfx/doxygen2toc_test.cc
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "docfx/doxygen2toc.h"
+#include <gmock/gmock.h>
+
+namespace docfx {
+namespace {
+
+TEST(Doxygen2Toc, Simple) {
+  auto constexpr kXml =
+      R"xml(<?xml version="1.0" standalone="yes"?><doxygen version="1.9.1" xml:lang="en-US">
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="common-error-handling" kind="page">
+          <compoundname>common-error-handling</compoundname>
+          <title>Error Handling</title>
+          <briefdescription><para>An overview of error handling in the Google Cloud C++ client libraries.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about error handling.</para></detaileddescription>
+        </compounddef>
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="indexpage" kind="page">
+          <compoundname>index</compoundname>
+          <title>The Page Title: unused in this test</title>
+          <briefdescription><para>Some brief description.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about the index.</para></detaileddescription>
+        </compounddef>
+      </doxygen>)xml";
+
+  auto constexpr kExpected = R"""(### YamlMime:TableOfContent
+- uid: cloud.google.com/cpp/common
+  name: cloud.google.com/cpp/common
+  items:
+    - name: common-error-handling
+      href: common-error-handling.md
+    - name: README
+      href: indexpage.md
+)""";
+
+  pugi::xml_document doc;
+  ASSERT_TRUE(doc.load_string(kXml));
+  auto const config = Config{"test-only-no-input-file", "common"};
+  auto const actual = Doxygen2Toc(config, doc);
+
+  EXPECT_EQ(kExpected, actual);
+}
+
+}  // namespace
+}  // namespace docfx

--- a/docfx/unit_tests.bzl
+++ b/docfx/unit_tests.bzl
@@ -18,6 +18,7 @@
 
 unit_tests = [
     "doxygen2markdown_test.cc",
+    "doxygen2toc_test.cc",
     "doxygen_pages_test.cc",
     "parse_arguments_test.cc",
 ]


### PR DESCRIPTION
Generate an initial table of contents files, with just the Doxygen `@page` documents for now.  This introduces the first YAML output.

Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10972)
<!-- Reviewable:end -->
