### PR TITLE
ci: use ci/verify_quickstart on Windows

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -167,14 +167,14 @@ env -C "${out_dir}" ctest "${ctest_args[@]}"
 
 # Tests the installed artifacts by building and running the quickstarts.
 # shellcheck disable=SC2046
-libraries="$(printf "%s;" $(features::libraries))"
+feature_list="$(printf "%s;" $(features::libraries))"
 # GCS+gRPC is not a library, but it has a quickstart.
-libraries="${libraries}experimental-storage-grpc"
+feature_list="${feature_list}experimental-storage-grpc"
 cmake -G Ninja \
   -S "${PROJECT_ROOT}/ci/verify_quickstart" \
   -B "${PROJECT_ROOT}/cmake-out/quickstart" \
   "-DCMAKE_PREFIX_PATH=${INSTALL_PREFIX}" \
-  "-DLIBRARIES=${libraries}"
+  "-DFEATURES=${feature_list}"
 cmake --build "${PROJECT_ROOT}/cmake-out/quickstart"
 
 # Deletes all the installed artifacts, and installs only the runtime components

--- a/ci/cloudbuild/builds/quickstart-cmake.sh
+++ b/ci/cloudbuild/builds/quickstart-cmake.sh
@@ -38,5 +38,5 @@ cmake -G Ninja \
   -S "${PROJECT_ROOT}/ci/verify_quickstart" \
   -B "${PROJECT_ROOT}/cmake-out/quickstart" \
   -DCMAKE_TOOLCHAIN_FILE="${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake" \
-  -DLIBRARIES="${libraries}"
+  -DFEATURES="${libraries}"
 cmake --build "${PROJECT_ROOT}/cmake-out/quickstart" --target verify-quickstart-cmake

--- a/ci/kokoro/windows/builds/quickstart-cmake.ps1
+++ b/ci/kokoro/windows/builds/quickstart-cmake.ps1
@@ -75,7 +75,10 @@ $cmake_args=@(
     "-DFEATURES=${feature_list}",
     # Disable the Makefile tests on Windows. They do not work, and there is not
     # that much demand for them.
-    "-DGOOGLE_CLOUD_CPP_ENABLE_MAKE=OFF",
+    "-DVERIFY_QUICKSTART_ENABLE_MAKE=OFF",
+    # Disable CMAKE_PREFIX_PATH.  We are just going to rely on vcpkg to set the
+    # right environment.
+    "-DVERIFY_QUICKSTART_ENABLE_CMAKE_PREFIX_PATH=OFF",
     # The rest is just usual CMake configuration stuff.
     "-DCMAKE_TOOLCHAIN_FILE=`"${vcpkg_root}/scripts/buildsystems/vcpkg.cmake`"",
     "-DCMAKE_BUILD_TYPE=${env:CONFIG}",

--- a/ci/verify_quickstart/CMakeLists.txt
+++ b/ci/verify_quickstart/CMakeLists.txt
@@ -18,10 +18,13 @@ cmake_minimum_required(VERSION 3.14)
 project(verify-quickstart CXX)
 
 # The list of libraries must be provided in the command line
-if (NOT LIBRARIES)
-    message(FATAL_ERROR "Missing -DLIBRARIES argument, for example:"
-                        " -DLIBRARIES=\"storage;spanner\"")
+if (NOT FEATURES)
+    message(FATAL_ERROR "Missing -DFEATURES argument, for example:"
+                        " -DFEATURES=\"storage;spanner\"")
 endif ()
+
+option(GOOGLE_CLOUD_CPP_ENABLE_MAKE "Test with Make" ON)
+option(GOOGLE_CLOUD_CPP_ENABLE_CMAKE "Test with CMake" ON)
 
 add_custom_target(verify-quickstart-cmake ALL)
 add_custom_target(verify-quickstart-make ALL)
@@ -29,14 +32,17 @@ add_custom_target(verify-quickstart-make ALL)
 include(ExternalProject)
 
 function (add_cmake_quickstart_target feature library target)
-    set(COMMON_CMAKE_ARGS)
-    if (CMAKE_PREFIX_PATH)
-        list(APPEND COMMON_CMAKE_ARGS
-             "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}")
+    if (NOT GOOGLE_CLOUD_CPP_ENABLE_CMAKE)
+        return()
     endif ()
+    set(COMMON_CMAKE_ARGS)
     if (CMAKE_TOOLCHAIN_FILE)
         list(APPEND COMMON_CMAKE_ARGS
              "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+    endif ()
+    if (VCPKG_TARGET_TRIPLET)
+        list(APPEND COMMON_CMAKE_ARGS
+             "-DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}")
     endif ()
 
     externalproject_add(
@@ -59,6 +65,9 @@ function (add_cmake_quickstart_target feature library target)
 endfunction ()
 
 function (add_make_quickstart_target feature library target)
+    if (NOT GOOGLE_CLOUD_CPP_ENABLE_MAKE)
+        return()
+    endif ()
     externalproject_add(
         verify-quickstart-makefile-${feature}
         EXCLUDE_FROM_ALL ON
@@ -85,10 +94,22 @@ function (add_make_quickstart_target feature library target)
                      verify-quickstart-makefile-${feature})
 endfunction ()
 
-foreach (feature IN LISTS LIBRARIES)
+foreach (feature IN LISTS FEATURES)
     if ("${feature}" STREQUAL "experimental-storage-grpc")
         add_cmake_quickstart_target("${feature}" storage quickstart_grpc)
         add_make_quickstart_target("${feature}" storage quickstart_grpc)
+        continue()
+    endif ()
+    # In vcpkg we cannot use `_` in the name of a feature. We replace that with
+    # `-', but then need to convert the feature name back to a valid path.
+    if ("${feature}" STREQUAL "dialogflow-cx")
+        add_cmake_quickstart_target("${feature}" dialogflow_cx quickstart)
+        add_make_quickstart_target("${feature}" dialogflow_cx quickstart)
+        continue()
+    endif ()
+    if ("${feature}" STREQUAL "dialogflow-es")
+        add_cmake_quickstart_target("${feature}" dialogflow_es quickstart)
+        add_make_quickstart_target("${feature}" dialogflow_es quickstart)
         continue()
     endif ()
     add_cmake_quickstart_target("${feature}" "${feature}" quickstart)

--- a/ci/verify_quickstart/CMakeLists.txt
+++ b/ci/verify_quickstart/CMakeLists.txt
@@ -23,8 +23,9 @@ if (NOT FEATURES)
                         " -DFEATURES=\"storage;spanner\"")
 endif ()
 
-option(GOOGLE_CLOUD_CPP_ENABLE_MAKE "Test with Make" ON)
-option(GOOGLE_CLOUD_CPP_ENABLE_CMAKE "Test with CMake" ON)
+option(VERIFY_QUICKSTART_ENABLE_MAKE "Test with Make" ON)
+option(VERIFY_QUICKSTART_ENABLE_CMAKE "Test with CMake" ON)
+option(VERIFY_QUICKSTART_ENABLE_CMAKE_PREFIX_PATH "Use CMAKE_PREFIX_PATH" ON)
 
 add_custom_target(verify-quickstart-cmake ALL)
 add_custom_target(verify-quickstart-make ALL)
@@ -32,10 +33,14 @@ add_custom_target(verify-quickstart-make ALL)
 include(ExternalProject)
 
 function (add_cmake_quickstart_target feature library target)
-    if (NOT GOOGLE_CLOUD_CPP_ENABLE_CMAKE)
+    if (NOT VERIFY_QUICKSTART_ENABLE_CMAKE)
         return()
     endif ()
     set(COMMON_CMAKE_ARGS)
+    if (VERIFY_QUICKSTART_ENABLE_CMAKE_PREFIX_PATH AND CMAKE_PREFIX_PATH)
+        list(APPEND COMMON_CMAKE_ARGS
+             "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}")
+    endif ()
     if (CMAKE_TOOLCHAIN_FILE)
         list(APPEND COMMON_CMAKE_ARGS
              "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
@@ -65,7 +70,7 @@ function (add_cmake_quickstart_target feature library target)
 endfunction ()
 
 function (add_make_quickstart_target feature library target)
-    if (NOT GOOGLE_CLOUD_CPP_ENABLE_MAKE)
+    if (NOT VERIFY_QUICKSTART_ENABLE_MAKE)
         return()
     endif ()
     externalproject_add(


### PR DESCRIPTION
This will speed up the Windows build, by parallelizing all the quickstart tests.  We may be able to use these changes to test more quickstarts with vcpkg on Linux and macOS too.

Fixes #9925

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10985)
<!-- Reviewable:end -->
