### PR TITLE
impl(GCS+gRPC): use new spec for `CreateBucket()`

### DIFF
--- a/google/cloud/storage/internal/grpc_bucket_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser.cc
@@ -354,7 +354,7 @@ google::storage::v2::GetBucketRequest ToProto(
 google::storage::v2::CreateBucketRequest ToProto(
     storage::internal::CreateBucketRequest const& request) {
   google::storage::v2::CreateBucketRequest result;
-  result.set_parent("projects/" + request.project_id());
+  result.set_parent("projects/_");
   result.set_bucket_id(request.metadata().name());
   if (request.HasOption<storage::PredefinedAcl>()) {
     result.set_predefined_acl(
@@ -365,12 +365,12 @@ google::storage::v2::CreateBucketRequest ToProto(
         request.GetOption<storage::PredefinedDefaultObjectAcl>().value());
   }
   *result.mutable_bucket() = storage_internal::ToProto(request.metadata());
+  result.mutable_bucket()->set_project("projects/" + request.project_id());
   // Ignore fields commonly set by ToProto().
   result.mutable_bucket()->set_name("");
   result.mutable_bucket()->set_bucket_id("");
   result.mutable_bucket()->clear_create_time();
   result.mutable_bucket()->clear_update_time();
-  result.mutable_bucket()->clear_project();
   return result;
 }
 

--- a/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
@@ -79,9 +79,10 @@ TEST(GrpcBucketRequestParser, CreateBucketMetadataAllOptions) {
   v2::CreateBucketRequest expected;
   ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
-        parent: "projects/test-project"
+        parent: "projects/_"
         bucket_id: "test-bucket"
         bucket {
+          project: "projects/test-project"
           location: "us-central1"
           storage_class: "NEARLINE"
           rpo: "ASYNC_TURBO"


### PR DESCRIPTION
How to create a bucket is changing. This is the "new and improved" way to specify what project owns the bucket.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10986)
<!-- Reviewable:end -->
