### PR TITLE
ci: consolidate GCS+gRPC tests

### DIFF
--- a/ci/cloudbuild/builds/integration-production.sh
+++ b/ci/cloudbuild/builds/integration-production.sh
@@ -36,8 +36,6 @@ excluded_rules=(
   # limited in production (at most 5 per service account).
   "-//google/cloud/storage/examples:storage_service_account_samples"
   "-//google/cloud/storage/tests:service_account_integration_test"
-  # TODO(#6268) - enable this once this last bit of production stabilizes
-  "-//google/cloud/storage/tests:grpc_integration_test"
 )
 
 io::log_h2 "Running the integration tests against prod"

--- a/ci/cloudbuild/builds/integration-production.sh
+++ b/ci/cloudbuild/builds/integration-production.sh
@@ -32,9 +32,10 @@ bazel test "${args[@]}" --test_tag_filters=-integration-test ...
 excluded_rules=(
   "-//examples:grpc_credential_types"
   "-//google/cloud/bigtable/examples:bigtable_grpc_credentials"
+  # These account integration tests / samples use HMAC keys, which are very
+  # limited in production (at most 5 per service account).
   "-//google/cloud/storage/examples:storage_service_account_samples"
   "-//google/cloud/storage/tests:service_account_integration_test"
-  "-//google/cloud/storage/tests:grpc_integration_test"
 )
 
 io::log_h2 "Running the integration tests against prod"
@@ -42,3 +43,19 @@ mapfile -t integration_args < <(integration::bazel_args)
 io::run bazel test "${args[@]}" "${integration_args[@]}" \
   --cache_test_results="auto" \
   --test_tag_filters="integration-test" -- ... "${excluded_rules[@]}"
+
+io::log_h2 "Running the GCS+gRPC integration tests against prod"
+mapfile -t integration_args < <(integration::bazel_args)
+io::run bazel test "${args[@]}" "${integration_args[@]}" \
+  --cache_test_results="auto" \
+  --test_tag_filters="integration-test" \
+  --test_env=GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media \
+  -- //google/cloud/storage/... "${excluded_rules[@]}"
+
+io::log_h2 "Running the GCS+gRPC integration tests against prod"
+mapfile -t integration_args < <(integration::bazel_args)
+io::run bazel test "${args[@]}" "${integration_args[@]}" \
+  --cache_test_results="auto" \
+  --test_tag_filters="integration-test" \
+  --test_env=GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=metadata \
+  -- //google/cloud/storage/... "${excluded_rules[@]}"

--- a/ci/cloudbuild/builds/integration-production.sh
+++ b/ci/cloudbuild/builds/integration-production.sh
@@ -36,6 +36,8 @@ excluded_rules=(
   # limited in production (at most 5 per service account).
   "-//google/cloud/storage/examples:storage_service_account_samples"
   "-//google/cloud/storage/tests:service_account_integration_test"
+  # TODO(#6268) - enable this once this last bit of production stabilizes
+  "-//google/cloud/storage/tests:grpc_integration_test"
 )
 
 io::log_h2 "Running the integration tests against prod"

--- a/ci/cloudbuild/builds/integration-production.sh
+++ b/ci/cloudbuild/builds/integration-production.sh
@@ -44,7 +44,7 @@ io::run bazel test "${args[@]}" "${integration_args[@]}" \
   --cache_test_results="auto" \
   --test_tag_filters="integration-test" -- ... "${excluded_rules[@]}"
 
-io::log_h2 "Running the GCS+gRPC integration tests against prod"
+io::log_h2 "Running the GCS+gRPC [media] integration tests against prod"
 mapfile -t integration_args < <(integration::bazel_args)
 io::run bazel test "${args[@]}" "${integration_args[@]}" \
   --cache_test_results="auto" \
@@ -52,7 +52,7 @@ io::run bazel test "${args[@]}" "${integration_args[@]}" \
   --test_env=GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media \
   -- //google/cloud/storage/... "${excluded_rules[@]}"
 
-io::log_h2 "Running the GCS+gRPC integration tests against prod"
+io::log_h2 "Running the GCS+gRPC [metadata] integration tests against prod"
 mapfile -t integration_args < <(integration::bazel_args)
 io::run bazel test "${args[@]}" "${integration_args[@]}" \
   --cache_test_results="auto" \

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -566,6 +566,8 @@ TEST_F(BucketIntegrationTest, GetMetadata) {
 }
 
 TEST_F(BucketIntegrationTest, GetMetadataFields) {
+  // TODO(#10991) - using `Fields()` is not working in GCS+gRPC production
+  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -218,6 +218,8 @@ TEST_P(GrpcIntegrationTest, QuotaUser) {
 }
 
 TEST_P(GrpcIntegrationTest, FieldFilter) {
+  // TODO(#10991) - using `Fields()` is not working in GCS+gRPC production
+  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
I am planning to remove the gcs-grpc build and consolidate what it tests into the `integration-production` build. That will make it easier to reason about "what builds use production".

Part of the work for #6268

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10989)
<!-- Reviewable:end -->
