### PR TITLE
cleanup(apikeys): apikeys is no longer experimental in v2.8.0

### DIFF
--- a/google/cloud/apikeys/quickstart/BUILD.bazel
+++ b/google/cloud/apikeys/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@google_cloud_cpp//:experimental-apikeys",
+        "@google_cloud_cpp//:apikeys",
     ],
 )

--- a/google/cloud/apikeys/quickstart/CMakeLists.txt
+++ b/google/cloud/apikeys/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-apikeys)
+target_link_libraries(quickstart google-cloud-cpp::apikeys)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10992)
<!-- Reviewable:end -->
