### PR TITLE
test(storage): simplify testing transport variants

### DIFF
--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -55,12 +55,6 @@ GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance"
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators coverage "${args[@]}" "${integration_args[@]}"
 
-io::log_h2 "Running Storage integration tests (with emulator and Legacy http)"
-"google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh" \
-  bazel coverage "${args[@]}" "${integration_args[@]}" \
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP=yes" \
-  "--test_tag_filters=integration-test"
-
 # Where does this token come from? For triggered ci/pr builds GCB will securely
 # inject this into the environment. See the "secretEnv" setting in the
 # cloudbuild.yaml file. The value is stored in Secret Manager. You can store

--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -24,21 +24,15 @@ export CC=clang
 export CXX=clang++
 
 excluded_rules=(
+  # This sample uses HMAC keys, which are very limited in production (at most
+  # 5 per service account). Disabled for now.
   "-//google/cloud/storage/examples:storage_service_account_samples"
-  "-//google/cloud/storage/tests:service_account_integration_test"
 )
 
 mapfile -t args < <(bazel::common_args)
 mapfile -t integration_args < <(integration::bazel_args)
 
-io::log_h2 "Running the GCS+gRPC [media] integration tests against prod"
+io::log_h2 "Running the GCS+gRPC integration tests against prod"
 io::run bazel test "${args[@]}" "${integration_args[@]}" \
   --test_tag_filters="integration-test" \
-  --test_env=GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media \
-  -- //google/cloud/storage/... "${excluded_rules[@]}"
-
-io::log_h2 "Running the GCS+gRPC [metadata] integration tests against prod"
-io::run bazel test "${args[@]}" "${integration_args[@]}" \
-  --test_tag_filters="integration-test" \
-  --test_env=GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=metadata \
   -- //google/cloud/storage/... "${excluded_rules[@]}"

--- a/ci/cloudbuild/builds/integration-production.sh
+++ b/ci/cloudbuild/builds/integration-production.sh
@@ -32,14 +32,17 @@ bazel test "${args[@]}" --test_tag_filters=-integration-test ...
 excluded_rules=(
   "-//examples:grpc_credential_types"
   "-//google/cloud/bigtable/examples:bigtable_grpc_credentials"
-  # These account integration tests / samples use HMAC keys, which are very
-  # limited in production (at most 5 per service account).
+  # This sample uses HMAC keys, which are very limited in production (at most
+  # 5 per service account). Disabled for now.
   "-//google/cloud/storage/examples:storage_service_account_samples"
-  "-//google/cloud/storage/tests:service_account_integration_test"
 )
 
 io::log_h2 "Running the integration tests against prod"
 mapfile -t integration_args < <(integration::bazel_args)
+# TODO(#6268) - disable the GCS+gRPC integration tests for now.  Eventually they
+# should run here, but they are too unstable. A custom build (gcs-grpc), which
+# is not required for PRs, runs them.
 io::run bazel test "${args[@]}" "${integration_args[@]}" \
   --cache_test_results="auto" \
-  --test_tag_filters="integration-test" -- ... "${excluded_rules[@]}"
+  --test_tag_filters="integration-test,-integration-test-grpc-media,-integration-test-grpc-metadata" \
+  -- ... "${excluded_rules[@]}"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -57,16 +57,16 @@ readonly PRODUCTION_ONLY_BASE=(
   "//google/cloud/storage/tests:signed_url_integration_test"
   "//google/cloud/storage/tests:unified_credentials_integration_test"
 )
-for base in "${PROJECTION_ONLY_BASE[@]}"; do
+for base in "${PRODUCTION_ONLY_BASE[@]}"; do
   production_only_targets+=(
     "${base}-default"
+    "${base}-legacy-http"
     "${base}-grpc-media"
     "${base}-grpc-metadata"
-    "${base}-legacy-http"
   )
 done
 
-"${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
+io::run "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
   -- "${production_only_targets[@]}" "${excluded_targets[@]}"
 
 # `start_emulator` creates unsightly *.log files in the current directory
@@ -122,8 +122,9 @@ emulator_args=(
 # We need to forward some environment variables suitable for running against
 # the emulator. Note that the HMAC service account is completely invalid and
 # it is not unique to each test, neither is a problem when using the emulator.
-"${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" "${emulator_args[@]}" \
-  -- "//google/cloud/storage/...:all" "${excluded_targets[@]}"
+io::run "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
+  "${emulator_args[@]}" -- \
+  "//google/cloud/storage/...:all" "${excluded_targets[@]}"
 exit_status=$?
 
 if [[ "$exit_status" -ne 0 ]]; then

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -34,10 +34,18 @@ cc_proto_library(
     deps = [":storage_conformance_tests_proto"],
 )
 
+VARIATIONS = {
+    "default": {},
+    "grpc-media": {"GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG": "media"},
+    "grpc-metadata": {"GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG": "metadata"},
+    "legacy-http": {"GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP": "yes"},
+}
+
 [cc_test(
-    name = test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", "") + "-" + v_label,
     timeout = "long",
     srcs = [test],
+    env = v_env,
     linkopts = select({
         "@platforms//os:windows": [],
         "//conditions:default": [
@@ -47,6 +55,7 @@ cc_proto_library(
     }),
     tags = [
         "integration-test",
+        "integration-test-" + v_label,
     ],
     deps = [
         ":storage_conformance_tests_cc_proto",
@@ -57,4 +66,4 @@ cc_proto_library(
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
-) for test in storage_client_integration_tests]
+) for test in storage_client_integration_tests for v_label, v_env in VARIATIONS.items()]

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -63,6 +63,10 @@ TEST_F(ServiceAccountIntegrationTest, Get) {
 }
 
 TEST_F(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
+  // HMAC keys are a scarse resource. Testing in production would require
+  // redesigning the tests to use a random service account (or creating one) on
+  // dynamically.  For now, simply skip these tests.
+  if (!UsingEmulator()) GTEST_SKIP();
   Client client(Options{}.set<ProjectIdOption>(project_id_));
 
   StatusOr<std::pair<HmacKeyMetadata, std::string>> key = client.CreateHmacKey(
@@ -81,6 +85,10 @@ TEST_F(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
 }
 
 TEST_F(ServiceAccountIntegrationTest, HmacKeyCRUD) {
+  // HMAC keys are a scarse resource. Testing in production would require
+  // redesigning the tests to use a random service account (or creating one) on
+  // dynamically.  For now, simply skip these tests.
+  if (!UsingEmulator()) GTEST_SKIP();
   Client client(Options{}.set<ProjectIdOption>(project_id_));
 
   auto get_current_access_ids = [&client, this]() {

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -63,8 +63,8 @@ TEST_F(ServiceAccountIntegrationTest, Get) {
 }
 
 TEST_F(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
-  // HMAC keys are a scarse resource. Testing in production would require
-  // redesigning the tests to use a random service account (or creating one) on
+  // HMAC keys are a scarce resource. Testing in production would require
+  // redesigning the tests to use a random service account (or creating one)
   // dynamically.  For now, simply skip these tests.
   if (!UsingEmulator()) GTEST_SKIP();
   Client client(Options{}.set<ProjectIdOption>(project_id_));
@@ -85,8 +85,8 @@ TEST_F(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
 }
 
 TEST_F(ServiceAccountIntegrationTest, HmacKeyCRUD) {
-  // HMAC keys are a scarse resource. Testing in production would require
-  // redesigning the tests to use a random service account (or creating one) on
+  // HMAC keys are a scarce resource. Testing in production would require
+  // redesigning the tests to use a random service account (or creating one)
   // dynamically.  For now, simply skip these tests.
   if (!UsingEmulator()) GTEST_SKIP();
   Client client(Options{}.set<ProjectIdOption>(project_id_));


### PR DESCRIPTION
The storage library integration tests can run using (1) the normal HTTP transport, (2) the legacy HTTP implementation, (3) use GCS+gRPC for only media operations, or (4) use GCS+gRPC for media and metadata operations. We were testing all these variations by calling `bazel` with different environment variables, that made our test scripts more complicated, it wastes parallelism opportunities, and it pays the bazel startup costs multiple times. It also seems that running the same test with different environment variables disables test result caching.

This PR moves the complexity to the Bazel file: it creates multiple "variants" of each integration test, with different environment variables. The program drivers can exclude some variants using test tags.

Part of the work for #6268

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10996)
<!-- Reviewable:end -->
