### PR TITLE
refactor: prepare for `shared_ptr<grpc::ClientContext>` in tests

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
@@ -161,17 +161,14 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, ListServiceAccountKeys) {
 
 TEST(GoldenKitchenSinkAuthDecoratorTest, StreamingWrite) {
   auto mock = std::make_shared<MockGoldenKitchenSinkStub>();
-  EXPECT_CALL(*mock, StreamingWrite)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>) {
-        auto stream = absl::make_unique<MockStreamingWriteRpc>();
-        EXPECT_CALL(*stream, Write)
-            .WillOnce(Return(true))
-            .WillOnce(Return(false));
-        EXPECT_CALL(*stream, Close)
-            .WillOnce(Return(StatusOr<Response>(
-                Status(StatusCode::kPermissionDenied, "uh-oh"))));
-        return stream;
-      });
+  EXPECT_CALL(*mock, StreamingWrite).WillOnce([](auto) {
+    auto stream = absl::make_unique<MockStreamingWriteRpc>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(true)).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Close)
+        .WillOnce(Return(StatusOr<Response>(
+            Status(StatusCode::kPermissionDenied, "uh-oh"))));
+    return stream;
+  });
 
   auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
   auto stream =

--- a/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -221,17 +221,14 @@ TEST_F(LoggingDecoratorTest, StreamingReadRpcWithRpcStreams) {
 }
 
 TEST_F(LoggingDecoratorTest, StreamingWrite) {
-  EXPECT_CALL(*mock_, StreamingWrite)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>) {
-        auto stream = absl::make_unique<MockStreamingWriteRpc>();
-        EXPECT_CALL(*stream, Write)
-            .WillOnce(Return(true))
-            .WillOnce(Return(false));
-        auto response = Response{};
-        response.set_response("test-only");
-        EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
-        return stream;
-      });
+  EXPECT_CALL(*mock_, StreamingWrite).WillOnce([](auto) {
+    auto stream = absl::make_unique<MockStreamingWriteRpc>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(true)).WillOnce(Return(false));
+    auto response = Response{};
+    response.set_response("test-only");
+    EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
+    return stream;
+  });
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   auto stream = stub.StreamingWrite(absl::make_unique<grpc::ClientContext>());
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
@@ -249,17 +246,14 @@ TEST_F(LoggingDecoratorTest, StreamingWrite) {
 }
 
 TEST_F(LoggingDecoratorTest, StreamingWriteFullTracing) {
-  EXPECT_CALL(*mock_, StreamingWrite)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>) {
-        auto stream = absl::make_unique<MockStreamingWriteRpc>();
-        EXPECT_CALL(*stream, Write)
-            .WillOnce(Return(true))
-            .WillOnce(Return(false));
-        auto response = Response{};
-        response.set_response("test-only");
-        EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
-        return stream;
-      });
+  EXPECT_CALL(*mock_, StreamingWrite).WillOnce([](auto) {
+    auto stream = absl::make_unique<MockStreamingWriteRpc>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(true)).WillOnce(Return(false));
+    auto response = Response{};
+    response.set_response("test-only");
+    EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
+    return stream;
+  });
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {"rpc-streams"});
   auto stream = stub.StreamingWrite(absl::make_unique<grpc::ClientContext>());
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -215,8 +215,7 @@ TEST_F(MetadataDecoratorTest, ListServiceAccountKeys) {
 
 TEST_F(MetadataDecoratorTest, StreamingRead) {
   EXPECT_CALL(*mock_, StreamingRead)
-      .WillOnce([this](std::unique_ptr<grpc::ClientContext> context,
-                       Request const& request) {
+      .WillOnce([this](auto context, Request const& request) {
         auto mock_response = absl::make_unique<MockStreamingReadRpc>();
         EXPECT_CALL(*mock_response, Read)
             .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
@@ -233,22 +232,19 @@ TEST_F(MetadataDecoratorTest, StreamingRead) {
 }
 
 TEST_F(MetadataDecoratorTest, StreamingWrite) {
-  EXPECT_CALL(*mock_, StreamingWrite)
-      .WillOnce([this](std::unique_ptr<grpc::ClientContext> context) {
-        IsContextMDValid(
-            *context,
-            "google.test.admin.database.v1.GoldenKitchenSink.StreamingWrite",
-            Request{});
+  EXPECT_CALL(*mock_, StreamingWrite).WillOnce([this](auto context) {
+    IsContextMDValid(
+        *context,
+        "google.test.admin.database.v1.GoldenKitchenSink.StreamingWrite",
+        Request{});
 
-        auto stream = absl::make_unique<MockStreamingWriteRpc>();
-        EXPECT_CALL(*stream, Write)
-            .WillOnce(Return(true))
-            .WillOnce(Return(false));
-        auto response = Response{};
-        response.set_response("test-only");
-        EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
-        return stream;
-      });
+    auto stream = absl::make_unique<MockStreamingWriteRpc>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(true)).WillOnce(Return(false));
+    auto response = Response{};
+    response.set_response("test-only");
+    EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
+    return stream;
+  });
 
   GoldenKitchenSinkMetadata stub(mock_);
   auto stream = stub.StreamingWrite(absl::make_unique<grpc::ClientContext>());
@@ -261,8 +257,7 @@ TEST_F(MetadataDecoratorTest, StreamingWrite) {
 
 TEST_F(MetadataDecoratorTest, AsyncStreamingRead) {
   EXPECT_CALL(*mock_, AsyncStreamingRead)
-      .WillOnce([this](google::cloud::CompletionQueue const&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](google::cloud::CompletionQueue const&, auto context,
                        Request const& request) {
         IsContextMDValid(
             *context,
@@ -287,8 +282,7 @@ TEST_F(MetadataDecoratorTest, AsyncStreamingRead) {
 
 TEST_F(MetadataDecoratorTest, AsyncStreamingWrite) {
   EXPECT_CALL(*mock_, AsyncStreamingWrite)
-      .WillOnce([this](google::cloud::CompletionQueue const&,
-                       std::unique_ptr<grpc::ClientContext> context) {
+      .WillOnce([this](google::cloud::CompletionQueue const&, auto context) {
         IsContextMDValid(
             *context,
             "google.test.admin.database.v1.GoldenKitchenSink.StreamingWrite",

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -250,15 +250,13 @@ TEST(GoldenKitchenSinkTracingStubTest, DoNothing) {
 
 TEST(GoldenKitchenSinkTracingStubTest, StreamingWrite) {
   auto mock = std::make_shared<MockGoldenKitchenSinkStub>();
-  EXPECT_CALL(*mock, StreamingWrite)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>) {
-        auto stream = absl::make_unique<MockStreamingWriteRpc>();
-        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-        EXPECT_CALL(*stream, Close)
-            .WillOnce(
-                Return(StatusOr<Response>(internal::AbortedError("fail"))));
-        return stream;
-      });
+  EXPECT_CALL(*mock, StreamingWrite).WillOnce([](auto) {
+    auto stream = absl::make_unique<MockStreamingWriteRpc>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Close)
+        .WillOnce(Return(StatusOr<Response>(internal::AbortedError("fail"))));
+    return stream;
+  });
 
   auto under_test = GoldenKitchenSinkTracingStub(mock);
   auto stream =

--- a/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
@@ -173,7 +173,7 @@ TEST(GoldenThingAdminConnectionTest, ListDatabasesTooManyFailures) {
 TEST(GoldenThingAdminConnectionTest, CreateDatabaseSuccess) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncCreateDatabase)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    ::google::test::admin::database::v1::
                        CreateDatabaseRequest const&) {
         google::longrunning::Operation op;
@@ -182,7 +182,7 @@ TEST(GoldenThingAdminConnectionTest, CreateDatabaseSuccess) {
         return make_ready_future(make_status_or(op));
       });
   EXPECT_CALL(*mock, AsyncGetOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         google::longrunning::Operation op;
@@ -206,7 +206,7 @@ TEST(GoldenThingAdminConnectionTest, CreateDatabaseCancel) {
   auto const op = CreateStartingOperation();
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncCreateDatabase)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](CompletionQueue&, auto,
                     ::google::test::admin::database::v1::
                         CreateDatabaseRequest const&) {
         return make_ready_future(make_status_or(op));
@@ -215,14 +215,13 @@ TEST(GoldenThingAdminConnectionTest, CreateDatabaseCancel) {
   AsyncSequencer<StatusOr<google::longrunning::Operation>> get;
   EXPECT_CALL(*mock, AsyncGetOperation)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([&](CompletionQueue&, auto,
                           google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         return get.PushBack();
       });
   EXPECT_CALL(*mock, AsyncCancelOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::CancelOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         return make_ready_future(Status{});
@@ -300,7 +299,7 @@ TEST(GoldenThingAdminConnectionTest, GetDatabaseTooManyTransients) {
 TEST(GoldenThingAdminConnectionTest, UpdateDatabaseDdlSuccess) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncUpdateDatabaseDdl)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    ::google::test::admin::database::v1::
                        UpdateDatabaseDdlRequest const&) {
         ::google::test::admin::database::v1::UpdateDatabaseDdlMetadata metadata;
@@ -311,7 +310,7 @@ TEST(GoldenThingAdminConnectionTest, UpdateDatabaseDdlSuccess) {
         return make_ready_future(make_status_or(op));
       });
   EXPECT_CALL(*mock, AsyncGetOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         google::longrunning::Operation op;
@@ -339,7 +338,7 @@ TEST(GoldenThingAdminConnectionTest, UpdateDatabaseDdlCancel) {
   auto const op = CreateStartingOperation();
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncUpdateDatabaseDdl)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](CompletionQueue&, auto,
                     ::google::test::admin::database::v1::
                         UpdateDatabaseDdlRequest const&) {
         return make_ready_future(make_status_or(op));
@@ -348,14 +347,13 @@ TEST(GoldenThingAdminConnectionTest, UpdateDatabaseDdlCancel) {
   AsyncSequencer<StatusOr<google::longrunning::Operation>> get;
   EXPECT_CALL(*mock, AsyncGetOperation)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([&](CompletionQueue&, auto,
                           google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         return get.PushBack();
       });
   EXPECT_CALL(*mock, AsyncCancelOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::CancelOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         return make_ready_future(Status{});
@@ -658,7 +656,7 @@ TEST(GoldenThingAdminConnectionTest, CreateBackupSuccess) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncCreateBackup)
       .WillOnce(
-          [](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+          [](CompletionQueue&, auto,
              ::google::test::admin::database::v1::CreateBackupRequest const&) {
             google::longrunning::Operation op;
             op.set_name("test-operation-name");
@@ -666,7 +664,7 @@ TEST(GoldenThingAdminConnectionTest, CreateBackupSuccess) {
             return make_ready_future(make_status_or(op));
           });
   EXPECT_CALL(*mock, AsyncGetOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         google::longrunning::Operation op;
@@ -694,7 +692,7 @@ TEST(GoldenThingAdminConnectionTest, CreateBackupCancel) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncCreateBackup)
       .WillOnce(
-          [&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+          [&](CompletionQueue&, auto,
               ::google::test::admin::database::v1::CreateBackupRequest const&) {
             return make_ready_future(make_status_or(op));
           });
@@ -702,14 +700,13 @@ TEST(GoldenThingAdminConnectionTest, CreateBackupCancel) {
   AsyncSequencer<StatusOr<google::longrunning::Operation>> get;
   EXPECT_CALL(*mock, AsyncGetOperation)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([&](CompletionQueue&, auto,
                           google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         return get.PushBack();
       });
   EXPECT_CALL(*mock, AsyncCancelOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::CancelOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         return make_ready_future(Status{});
@@ -964,7 +961,7 @@ TEST(GoldenThingAdminConnectionTest, ListBackupsTooManyFailures) {
 TEST(GoldenThingAdminConnectionTest, RestoreDatabaseSuccess) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncRestoreDatabase)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    ::google::test::admin::database::v1::
                        RestoreDatabaseRequest const&) {
         google::longrunning::Operation op;
@@ -973,7 +970,7 @@ TEST(GoldenThingAdminConnectionTest, RestoreDatabaseSuccess) {
         return make_ready_future(make_status_or(op));
       });
   EXPECT_CALL(*mock, AsyncGetOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         google::longrunning::Operation op;
@@ -1002,7 +999,7 @@ TEST(GoldenThingAdminConnectionTest, RestoreBackupCancel) {
   auto const op = CreateStartingOperation();
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncRestoreDatabase)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](CompletionQueue&, auto,
                     ::google::test::admin::database::v1::
                         RestoreDatabaseRequest const&) {
         return make_ready_future(make_status_or(op));
@@ -1011,14 +1008,13 @@ TEST(GoldenThingAdminConnectionTest, RestoreBackupCancel) {
   AsyncSequencer<StatusOr<google::longrunning::Operation>> get;
   EXPECT_CALL(*mock, AsyncGetOperation)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([&](CompletionQueue&, auto,
                           google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         return get.PushBack();
       });
   EXPECT_CALL(*mock, AsyncCancelOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::CancelOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
         return make_ready_future(Status{});
@@ -1207,7 +1203,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseSuccess) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncGetDatabase)
       .WillOnce(
-          [](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+          [](CompletionQueue&, auto,
              ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             google::test::admin::database::v1::Database db;
             db.set_name("test-database");
@@ -1227,7 +1223,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseTooManyFailures) {
   EXPECT_CALL(*mock, AsyncGetDatabase)
       .Times(AtLeast(2))
       .WillRepeatedly(
-          [](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+          [](CompletionQueue&, auto,
              ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             return make_ready_future<
                 StatusOr<google::test::admin::database::v1::Database>>(
@@ -1257,7 +1253,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseCancel) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncGetDatabase)
       .WillOnce(
-          [&p](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+          [&p](CompletionQueue&, auto,
                ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             return p.get_future();
           });
@@ -1284,7 +1280,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseSuccess) {
   EXPECT_CALL(*mock, AsyncDropDatabase)
       .WillOnce(
           [&expected_name](
-              CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+              CompletionQueue&, auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());
@@ -1308,7 +1304,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseFailure) {
       .Times(AtLeast(2))
       .WillRepeatedly(
           [&expected_name](
-              CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+              CompletionQueue&, auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());
@@ -1343,7 +1339,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseCancel) {
   EXPECT_CALL(*mock, AsyncDropDatabase)
       .WillOnce(
           [&p, &expected_name](
-              CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+              CompletionQueue&, auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());

--- a/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -104,8 +104,7 @@ TEST_F(MetadataDecoratorTest, ListDatabases) {
 TEST_F(MetadataDecoratorTest, CreateDatabase) {
   EXPECT_CALL(*mock_, AsyncCreateDatabase)
       .WillOnce(
-          [this](google::cloud::CompletionQueue&,
-                 std::unique_ptr<grpc::ClientContext> context,
+          [this](google::cloud::CompletionQueue&, auto context,
                  google::test::admin::database::v1::CreateDatabaseRequest const&
                      request) {
             IsContextMDValid(*context,
@@ -128,8 +127,7 @@ TEST_F(MetadataDecoratorTest, UpdateDatabaseDdl) {
   EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
       .WillOnce(
           [this](
-              google::cloud::CompletionQueue&,
-              std::unique_ptr<grpc::ClientContext> context,
+              google::cloud::CompletionQueue&, auto context,
               google::test::admin::database::v1::UpdateDatabaseDdlRequest const&
                   request) {
             IsContextMDValid(*context,
@@ -257,8 +255,7 @@ TEST_F(MetadataDecoratorTest, TestIamPermissions) {
 TEST_F(MetadataDecoratorTest, CreateBackup) {
   EXPECT_CALL(*mock_, AsyncCreateBackup)
       .WillOnce(
-          [this](google::cloud::CompletionQueue&,
-                 std::unique_ptr<grpc::ClientContext> context,
+          [this](google::cloud::CompletionQueue&, auto context,
                  google::test::admin::database::v1::CreateBackupRequest const&
                      request) {
             IsContextMDValid(
@@ -365,8 +362,7 @@ TEST_F(MetadataDecoratorTest, ListBackups) {
 
 TEST_F(MetadataDecoratorTest, RestoreDatabase) {
   EXPECT_CALL(*mock_, AsyncRestoreDatabase)
-      .WillOnce([this](google::cloud::CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](google::cloud::CompletionQueue&, auto context,
                        google::test::admin::database::v1::
                            RestoreDatabaseRequest const& request) {
         IsContextMDValid(
@@ -428,8 +424,7 @@ TEST_F(MetadataDecoratorTest, ListBackupOperations) {
 TEST_F(MetadataDecoratorTest, AsyncGetDatabase) {
   EXPECT_CALL(*mock_, AsyncGetDatabase)
       .WillOnce(
-          [this](google::cloud::CompletionQueue&,
-                 std::unique_ptr<grpc::ClientContext> context,
+          [this](google::cloud::CompletionQueue&, auto context,
                  google::test::admin::database::v1::GetDatabaseRequest const&
                      request) {
             IsContextMDValid(*context,
@@ -454,8 +449,7 @@ TEST_F(MetadataDecoratorTest, AsyncGetDatabase) {
 TEST_F(MetadataDecoratorTest, AsyncDropDatabase) {
   EXPECT_CALL(*mock_, AsyncDropDatabase)
       .WillOnce(
-          [this](google::cloud::CompletionQueue&,
-                 std::unique_ptr<grpc::ClientContext> context,
+          [this](google::cloud::CompletionQueue&, auto context,
                  google::test::admin::database::v1::DropDatabaseRequest const&
                      request) {
             IsContextMDValid(*context,
@@ -479,8 +473,7 @@ TEST_F(MetadataDecoratorTest, LongRunningWithoutRouting) {
   EXPECT_CALL(*mock_, AsyncLongRunningWithoutRouting)
       .WillOnce(
           [this](
-              google::cloud::CompletionQueue&,
-              std::unique_ptr<grpc::ClientContext> context,
+              google::cloud::CompletionQueue&, auto context,
               google::test::admin::database::v1::RestoreDatabaseRequest const&
                   request) {
             IsContextMDValid(*context,
@@ -502,8 +495,7 @@ TEST_F(MetadataDecoratorTest, LongRunningWithoutRouting) {
 TEST_F(MetadataDecoratorTest, GetOperation) {
   EXPECT_CALL(*mock_, AsyncGetOperation)
       .WillOnce([this](
-                    google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext> context,
+                    google::cloud::CompletionQueue&, auto context,
                     google::longrunning::GetOperationRequest const& request) {
         IsContextMDValid(*context, "google.longrunning.Operations.GetOperation",
                          request);
@@ -522,8 +514,7 @@ TEST_F(MetadataDecoratorTest, GetOperation) {
 TEST_F(MetadataDecoratorTest, CancelOperation) {
   EXPECT_CALL(*mock_, AsyncCancelOperation)
       .WillOnce(
-          [this](google::cloud::CompletionQueue&,
-                 std::unique_ptr<grpc::ClientContext> context,
+          [this](google::cloud::CompletionQueue&, auto context,
                  google::longrunning::CancelOperationRequest const& request) {
             IsContextMDValid(*context,
                              "google.longrunning.Operations.CancelOperation",

--- a/generator/integration_tests/tests/plumbing_test.cc
+++ b/generator/integration_tests/tests/plumbing_test.cc
@@ -101,7 +101,7 @@ TEST(PlumbingTest, PollingLoopUsesPerCallPolicies) {
 
   auto stub = std::make_shared<golden_v1_internal::MockGoldenThingAdminStub>();
   EXPECT_CALL(*stub, AsyncCreateDatabase)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    ::google::test::admin::database::v1::
                        CreateDatabaseRequest const&) {
         google::longrunning::Operation op;
@@ -110,7 +110,7 @@ TEST(PlumbingTest, PollingLoopUsesPerCallPolicies) {
         return make_ready_future(make_status_or(op));
       });
   EXPECT_CALL(*stub, AsyncGetOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::GetOperationRequest const&) {
         google::longrunning::Operation op;
         op.set_name("test-operation-name");

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -93,7 +93,7 @@ TEST_F(BigtableStubFactory, ReadRows) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, ReadRows)
             .WillOnce(
-                [this](std::unique_ptr<grpc::ClientContext> context,
+                [this](auto context,
                        google::bigtable::v2::ReadRowsRequest const& request) {
                   // Verify the Auth decorator is present
                   EXPECT_THAT(context->credentials(), NotNull());
@@ -175,8 +175,7 @@ TEST_F(BigtableStubFactory, AsyncReadRows) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, AsyncReadRows)
             .WillOnce(
-                [this](CompletionQueue const&,
-                       std::unique_ptr<grpc::ClientContext> context,
+                [this](CompletionQueue const&, auto context,
                        google::bigtable::v2::ReadRowsRequest const& request) {
                   // Verify the Auth decorator is present
                   EXPECT_THAT(context->credentials(), NotNull());
@@ -221,8 +220,7 @@ TEST_F(BigtableStubFactory, AsyncMutateRow) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, AsyncMutateRow)
             .WillOnce(
-                [this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+                [this](CompletionQueue&, auto context,
                        google::bigtable::v2::MutateRowRequest const& request) {
                   // Verify the Auth decorator is present
                   EXPECT_THAT(context->credentials(), NotNull());

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -73,16 +73,16 @@ TEST(BulkMutatorTest, Simple) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse(
-                {{0, grpc::StatusCode::OK}, {1, grpc::StatusCode::OK}})))
-            .WillOnce(Return(Status()));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(Return(MakeResponse(
+                    {{0, grpc::StatusCode::OK}, {1, grpc::StatusCode::OK}})))
+                .WillOnce(Return(Status()));
+            return stream;
+          });
 
   auto policy = DefaultIdempotentMutationPolicy();
   internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
@@ -104,7 +104,7 @@ TEST(BulkMutatorTest, RetryPartialFailure) {
   EXPECT_CALL(*mock, MutateRows)
       // Prepare the mocks for the request.  First create a stream response
       // which indicates a partial failure.
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](auto,
                    google::bigtable::v2::MutateRowsRequest const& request) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = absl::make_unique<MockMutateRowsStream>();
@@ -116,15 +116,15 @@ TEST(BulkMutatorTest, RetryPartialFailure) {
       })
       // Prepare a second stream response, because the client should retry after
       // the partial failure.
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
-            .WillOnce(Return(Status()));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+                .WillOnce(Return(Status()));
+            return stream;
+          });
 
   auto policy = DefaultIdempotentMutationPolicy();
   internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
@@ -149,28 +149,28 @@ TEST(BulkMutatorTest, PermanentFailure) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       // The first RPC return one recoverable and one unrecoverable failure.
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(
-                Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
-                                     {1, grpc::StatusCode::OUT_OF_RANGE}})))
-            .WillOnce(Return(Status()));
-        return stream;
-      })
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(
+                    Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
+                                         {1, grpc::StatusCode::OUT_OF_RANGE}})))
+                .WillOnce(Return(Status()));
+            return stream;
+          })
       // The BulkMutator should issue a second request, which will return
       // success for the remaining mutation.
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
-            .WillOnce(Return(Status()));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+                .WillOnce(Return(Status()));
+            return stream;
+          });
 
   auto policy = DefaultIdempotentMutationPolicy();
   internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
@@ -198,27 +198,27 @@ TEST(BulkMutatorTest, PartialStream) {
   EXPECT_CALL(*mock, MutateRows)
       // This will be the stream returned by the first request.  It is missing
       // information about one of the mutations.
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
-            .WillOnce(Return(Status()));
-        return stream;
-      })
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+                .WillOnce(Return(Status()));
+            return stream;
+          })
       // The BulkMutation should issue a second request, this is the stream
       // returned by the second request, which indicates success for the missed
       // mutation on r1.
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
-            .WillOnce(Return(Status()));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+                .WillOnce(Return(Status()));
+            return stream;
+          });
 
   auto policy = DefaultIdempotentMutationPolicy();
   internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
@@ -253,22 +253,22 @@ TEST(BulkMutatorTest, RetryOnlyIdempotent) {
   EXPECT_CALL(*mock, MutateRows)
       // We will setup the mock to return recoverable transient errors for all
       // mutations.
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        EXPECT_EQ(2, request.entries_size());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(
-                Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
-                                     {1, grpc::StatusCode::UNAVAILABLE}})))
-            .WillOnce(Return(Status()));
-        return stream;
-      })
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            EXPECT_EQ(2, request.entries_size());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(
+                    Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
+                                         {1, grpc::StatusCode::UNAVAILABLE}})))
+                .WillOnce(Return(Status()));
+            return stream;
+          })
       // The BulkMutator should issue a second request, with only the
       // idempotent mutation. Make the mock return success for it.
       .WillOnce(
-          [expect_r2](std::unique_ptr<grpc::ClientContext>,
+          [expect_r2](auto,
                       google::bigtable::v2::MutateRowsRequest const& request) {
             EXPECT_THAT(request, HasCorrectResourceNames());
             expect_r2(request);
@@ -307,7 +307,7 @@ TEST(BulkMutatorTest, UnconfirmedAreFailed) {
   EXPECT_CALL(*mock, MutateRows)
       // We will setup the mock to return recoverable failures for idempotent
       // mutations.
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](auto,
                    google::bigtable::v2::MutateRowsRequest const& request) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_EQ(3, request.entries_size());
@@ -340,13 +340,13 @@ TEST(BulkMutatorTest, ConfiguresContext) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));
+            return stream;
+          });
 
   auto policy = DefaultIdempotentMutationPolicy();
   internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
@@ -366,16 +366,16 @@ TEST(BulkMutatorTest, MutationStatusReportedOnOkStream) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(
-                Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE}})))
-            .WillOnce(Return(Status()));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(
+                    Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE}})))
+                .WillOnce(Return(Status()));
+            return stream;
+          });
 
   auto policy = DefaultIdempotentMutationPolicy();
   internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
@@ -401,16 +401,16 @@ TEST(BulkMutatorTest, ReportEitherRetryableMutationFailOrStreamFail) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(
-                Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE}})))
-            .WillOnce(Return(Status(StatusCode::kDataLoss, "stream fail")));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(
+                    Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE}})))
+                .WillOnce(Return(Status(StatusCode::kDataLoss, "stream fail")));
+            return stream;
+          });
 
   auto policy = DefaultIdempotentMutationPolicy();
   internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
@@ -438,7 +438,7 @@ TEST(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](auto,
                    google::bigtable::v2::MutateRowsRequest const& request) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = absl::make_unique<MockMutateRowsStream>();
@@ -447,14 +447,14 @@ TEST(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
             .WillOnce(Return(Status(StatusCode::kUnavailable, "try again")));
         return stream;
       })
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-        EXPECT_THAT(request, HasCorrectResourceNames());
-        auto stream = absl::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(Status(StatusCode::kDataLoss, "fail")));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+            EXPECT_THAT(request, HasCorrectResourceNames());
+            auto stream = absl::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce(Return(Status(StatusCode::kDataLoss, "fail")));
+            return stream;
+          });
 
   auto policy = DefaultIdempotentMutationPolicy();
   internal::BulkMutator mutator(kAppProfile, kTableName, *policy,

--- a/google/cloud/internal/async_long_running_operation_test.cc
+++ b/google/cloud/internal/async_long_running_operation_test.cc
@@ -86,21 +86,21 @@ using StartOperation =
         CreateInstanceRequest const&)>;
 
 StartOperation MakeStart(std::shared_ptr<MockStub> const& m) {
-  return [m](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+  return [m](CompletionQueue& cq, auto context,
              CreateInstanceRequest const& request) {
     return m->AsyncCreateInstance(cq, std::move(context), request);
   };
 }
 
 AsyncPollLongRunningOperation MakePoll(std::shared_ptr<MockStub> const& m) {
-  return [m](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+  return [m](CompletionQueue& cq, auto context,
              google::longrunning::GetOperationRequest const& request) {
     return m->AsyncGetOperation(cq, std::move(context), request);
   };
 }
 
 AsyncCancelLongRunningOperation MakeCancel(std::shared_ptr<MockStub> const& m) {
-  return [m](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+  return [m](CompletionQueue& cq, auto context,
              google::longrunning::CancelOperationRequest const& request) {
     return m->AsyncCancelOperation(cq, std::move(context), request);
   };
@@ -125,14 +125,13 @@ TEST(AsyncLongRunningTest, RequestPollThenSuccessMetadata) {
 
   auto mock = std::make_shared<MockStub>();
   EXPECT_CALL(*mock, AsyncCreateInstance)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                    CreateInstanceRequest const&) {
+      .WillOnce([&](CompletionQueue&, auto, CreateInstanceRequest const&) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(),
                   "RequestPollThenSuccessMetadata");
         return make_ready_future(make_status_or(starting_op));
       });
   EXPECT_CALL(*mock, AsyncGetOperation)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](CompletionQueue&, auto,
                     google::longrunning::GetOperationRequest const&) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(),
                   "RequestPollThenSuccessMetadata");
@@ -179,14 +178,13 @@ TEST(AsyncLongRunningTest, RequestPollThenSuccessResponse) {
 
   auto mock = std::make_shared<MockStub>();
   EXPECT_CALL(*mock, AsyncCreateInstance)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                    CreateInstanceRequest const&) {
+      .WillOnce([&](CompletionQueue&, auto, CreateInstanceRequest const&) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(),
                   "RequestPollThenSuccessResponse");
         return make_ready_future(make_status_or(starting_op));
       });
   EXPECT_CALL(*mock, AsyncGetOperation)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](CompletionQueue&, auto,
                     google::longrunning::GetOperationRequest const&) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(),
                   "RequestPollThenSuccessResponse");
@@ -230,20 +228,19 @@ TEST(AsyncLongRunningTest, RequestPollThenCancel) {
 
   auto mock = std::make_shared<MockStub>();
   EXPECT_CALL(*mock, AsyncCreateInstance)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                    CreateInstanceRequest const&) {
+      .WillOnce([&](CompletionQueue&, auto, CreateInstanceRequest const&) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(),
                   "RequestPollThenCancel");
         return make_ready_future(make_status_or(starting_op));
       });
   EXPECT_CALL(*mock, AsyncGetOperation)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](CompletionQueue&, auto,
                     google::longrunning::GetOperationRequest const&) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(),
                   "RequestPollThenCancel");
         return make_ready_future(make_status_or(starting_op));
       })
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](CompletionQueue&, auto,
                     google::longrunning::GetOperationRequest const&) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(),
                   "RequestPollThenCancel");
@@ -251,7 +248,7 @@ TEST(AsyncLongRunningTest, RequestPollThenCancel) {
             Status{StatusCode::kCancelled, "cancelled"}));
       });
   EXPECT_CALL(*mock, AsyncCancelOperation)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](CompletionQueue&, auto,
                     google::longrunning::CancelOperationRequest const&) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(),
                   "RequestPollThenCancel");

--- a/google/cloud/internal/async_read_write_stream_auth_test.cc
+++ b/google/cloud/internal/async_read_write_stream_auth_test.cc
@@ -55,8 +55,7 @@ class MockStream : public BaseStream {
 };
 
 TEST(AsyncStreamReadWriteAuth, Start) {
-  auto factory = AuthStream::StreamFactory([](std::unique_ptr<
-                                               grpc::ClientContext>) {
+  auto factory = AuthStream::StreamFactory([](auto) {
     auto mock = absl::make_unique<StrictMock<MockStream>>();
     EXPECT_CALL(*mock, Start).WillOnce([] { return make_ready_future(true); });
     EXPECT_CALL(*mock, Write)
@@ -75,10 +74,9 @@ TEST(AsyncStreamReadWriteAuth, Start) {
     return std::unique_ptr<BaseStream>(std::move(mock));
   });
   auto strategy = std::make_shared<StrictMock<MockAuthenticationStrategy>>();
-  EXPECT_CALL(*strategy, AsyncConfigureContext)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext> context) {
-        return make_ready_future(make_status_or(std::move(context)));
-      });
+  EXPECT_CALL(*strategy, AsyncConfigureContext).WillOnce([](auto context) {
+    return make_ready_future(make_status_or(std::move(context)));
+  });
   auto uut = absl::make_unique<AuthStream>(
       absl::make_unique<grpc::ClientContext>(), strategy, factory);
   EXPECT_TRUE(uut->Start().get());

--- a/google/cloud/internal/async_streaming_write_rpc_auth_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_auth_test.cc
@@ -74,10 +74,9 @@ TEST(AsyncStreamingWriteRpcAuth, Start) {
     return std::unique_ptr<BaseStream>(std::move(mock));
   });
   auto strategy = std::make_shared<StrictMock<MockAuthenticationStrategy>>();
-  EXPECT_CALL(*strategy, AsyncConfigureContext)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext> context) {
-        return make_ready_future(make_status_or(std::move(context)));
-      });
+  EXPECT_CALL(*strategy, AsyncConfigureContext).WillOnce([](auto context) {
+    return make_ready_future(make_status_or(std::move(context)));
+  });
   auto uut = absl::make_unique<AuthStream>(
       absl::make_unique<grpc::ClientContext>(), strategy, factory);
   EXPECT_TRUE(uut->Start().get());
@@ -92,19 +91,17 @@ TEST(AsyncStreamingWriteRpcAuth, Start) {
 }
 
 TEST(AsyncStreamingWriteRpcAuth, AuthFails) {
-  auto factory =
-      AuthStream::StreamFactory([](std::unique_ptr<grpc::ClientContext>) {
-        auto mock = absl::make_unique<StrictMock<MockStream>>();
-        EXPECT_CALL(*mock, Start).Times(0);
-        EXPECT_CALL(*mock, Finish).Times(0);
-        return std::unique_ptr<BaseStream>(std::move(mock));
-      });
+  auto factory = AuthStream::StreamFactory([](auto) {
+    auto mock = absl::make_unique<StrictMock<MockStream>>();
+    EXPECT_CALL(*mock, Start).Times(0);
+    EXPECT_CALL(*mock, Finish).Times(0);
+    return std::unique_ptr<BaseStream>(std::move(mock));
+  });
   auto strategy = std::make_shared<StrictMock<MockAuthenticationStrategy>>();
-  EXPECT_CALL(*strategy, AsyncConfigureContext)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>) {
-        return make_ready_future(StatusOr<std::unique_ptr<grpc::ClientContext>>(
-            Status(StatusCode::kPermissionDenied, "uh-oh")));
-      });
+  EXPECT_CALL(*strategy, AsyncConfigureContext).WillOnce([](auto) {
+    return make_ready_future(StatusOr<std::unique_ptr<grpc::ClientContext>>(
+        Status(StatusCode::kPermissionDenied, "uh-oh")));
+  });
   auto uut = absl::make_unique<AuthStream>(
       absl::make_unique<grpc::ClientContext>(), strategy, factory);
   EXPECT_FALSE(uut->Start().get());
@@ -112,18 +109,17 @@ TEST(AsyncStreamingWriteRpcAuth, AuthFails) {
 }
 
 TEST(AsyncStreamingWriteRpcAuth, CancelDuringAuth) {
-  auto factory = [](std::unique_ptr<grpc::ClientContext>) {
+  auto factory = [](auto) {
     return std::unique_ptr<BaseStream>(absl::make_unique<MockStream>());
   };
   auto strategy = std::make_shared<StrictMock<MockAuthenticationStrategy>>();
   auto start_promise = promise<void>();
-  EXPECT_CALL(*strategy, AsyncConfigureContext)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext> context) {
-        return start_promise.get_future().then(
-            [c = std::move(context)](auto) mutable {
-              return make_status_or(std::move(c));
-            });
-      });
+  EXPECT_CALL(*strategy, AsyncConfigureContext).WillOnce([&](auto context) {
+    return start_promise.get_future().then(
+        [c = std::move(context)](auto) mutable {
+          return make_status_or(std::move(c));
+        });
+  });
 
   auto uut = absl::make_unique<AuthStream>(
       absl::make_unique<grpc::ClientContext>(), strategy, factory);
@@ -135,30 +131,22 @@ TEST(AsyncStreamingWriteRpcAuth, CancelDuringAuth) {
 }
 
 TEST(AsyncStreamingWriteRpcAuth, CancelAfterStart) {
-  auto factory =
-      AuthStream::StreamFactory([](std::unique_ptr<grpc::ClientContext>) {
-        auto mock = absl::make_unique<StrictMock<MockStream>>();
-        ::testing::InSequence sequence;
-        EXPECT_CALL(*mock, Start).WillOnce([] {
-          return make_ready_future(true);
-        });
-        EXPECT_CALL(*mock, Write).WillOnce([] {
-          return make_ready_future(true);
-        });
-        EXPECT_CALL(*mock, Cancel).Times(1);
-        EXPECT_CALL(*mock, Write).WillOnce([] {
-          return make_ready_future(false);
-        });
-        EXPECT_CALL(*mock, Finish).WillOnce([] {
-          return make_ready_future(make_status_or(FakeResponse{"k0", "v0"}));
-        });
-        return std::unique_ptr<BaseStream>(std::move(mock));
-      });
+  auto factory = AuthStream::StreamFactory([](auto) {
+    auto mock = absl::make_unique<StrictMock<MockStream>>();
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*mock, Start).WillOnce([] { return make_ready_future(true); });
+    EXPECT_CALL(*mock, Write).WillOnce([] { return make_ready_future(true); });
+    EXPECT_CALL(*mock, Cancel).Times(1);
+    EXPECT_CALL(*mock, Write).WillOnce([] { return make_ready_future(false); });
+    EXPECT_CALL(*mock, Finish).WillOnce([] {
+      return make_ready_future(make_status_or(FakeResponse{"k0", "v0"}));
+    });
+    return std::unique_ptr<BaseStream>(std::move(mock));
+  });
   auto strategy = std::make_shared<StrictMock<MockAuthenticationStrategy>>();
-  EXPECT_CALL(*strategy, AsyncConfigureContext)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext> context) {
-        return make_ready_future(make_status_or(std::move(context)));
-      });
+  EXPECT_CALL(*strategy, AsyncConfigureContext).WillOnce([](auto context) {
+    return make_ready_future(make_status_or(std::move(context)));
+  });
   auto uut = absl::make_unique<AuthStream>(
       absl::make_unique<grpc::ClientContext>(), strategy, factory);
   EXPECT_TRUE(uut->Start().get());

--- a/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
+++ b/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
@@ -137,9 +137,7 @@ class TestStubAuth : public TestStub,
       GetTableRequest const& request) override {
     auto self = shared_from_this();
     return auth_->AsyncConfigureContext(std::move(context))
-        .then([self, cq,
-               request](future<StatusOr<std::unique_ptr<grpc::ClientContext>>>
-                            f) mutable {
+        .then([self, cq, request](auto f) mutable {
           auto context = f.get();
           if (!context)
             return make_ready_future<StatusOr<Table>>(
@@ -174,8 +172,7 @@ class TestStubLogging : public TestStub {
       std::unique_ptr<grpc::ClientContext> context,
       GetTableRequest const& request) override {
     return LogWrapper(
-        [this](google::cloud::CompletionQueue& cq,
-               std::unique_ptr<grpc::ClientContext> context,
+        [this](google::cloud::CompletionQueue& cq, auto context,
                GetTableRequest const& request) {
           return child_->AsyncGetTable(cq, std::move(context), request);
         },

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -126,8 +126,7 @@ TEST(LogWrapper, FutureStatusOrError) {
 /// @test the overload for functions returning FutureStatusOr and using
 /// CompletionQueue as input
 TEST(LogWrapper, FutureStatusOrValueWithContextAndCQ) {
-  auto mock = [](google::cloud::CompletionQueue&,
-                 std::unique_ptr<grpc::ClientContext>,
+  auto mock = [](google::cloud::CompletionQueue&, auto,
                  google::spanner::v1::Mutation m) {
     return make_ready_future(make_status_or(std::move(m)));
   };
@@ -150,8 +149,7 @@ TEST(LogWrapper, FutureStatusOrValueWithContextAndCQ) {
 /// @test the overload for functions returning FutureStatusOr and using
 /// CompletionQueue as input
 TEST(LogWrapper, FutureStatusOrErrorWithContextAndCQ) {
-  auto mock = [](google::cloud::CompletionQueue&,
-                 std::unique_ptr<grpc::ClientContext>,
+  auto mock = [](google::cloud::CompletionQueue&, auto,
                  google::spanner::v1::Mutation const&) {
     return make_ready_future(StatusOr<google::spanner::v1::Mutation>(
         Status(StatusCode::kPermissionDenied, "uh-oh")));
@@ -178,8 +176,7 @@ TEST(LogWrapper, FutureStatusOrErrorWithContextAndCQ) {
 /// CompletionQueue as input
 TEST(LogWrapper, FutureStatusWithContextAndCQ) {
   auto const status = Status(StatusCode::kPermissionDenied, "uh-oh");
-  auto mock = [&](google::cloud::CompletionQueue&,
-                  std::unique_ptr<grpc::ClientContext>,
+  auto mock = [&](google::cloud::CompletionQueue&, auto,
                   google::spanner::v1::Mutation const&) {
     return make_ready_future(status);
   };

--- a/google/cloud/internal/minimal_iam_credentials_stub_test.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub_test.cc
@@ -62,8 +62,7 @@ class MinimalIamCredentialsStubTest : public ::testing::Test {
 TEST_F(MinimalIamCredentialsStubTest, AsyncGenerateAccessTokenLogging) {
   auto mock = std::make_shared<MockMinimalIamCredentialsStub>();
   EXPECT_CALL(*mock, AsyncGenerateAccessToken)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   GenerateAccessTokenRequest const&) {
+      .WillOnce([](CompletionQueue&, auto, GenerateAccessTokenRequest const&) {
         GenerateAccessTokenResponse response;
         response.set_access_token("test-only-token");
         return make_ready_future(make_status_or(response));
@@ -89,8 +88,7 @@ TEST_F(MinimalIamCredentialsStubTest, AsyncGenerateAccessTokenLogging) {
 TEST_F(MinimalIamCredentialsStubTest, AsyncGenerateAccessTokenNoLogging) {
   auto mock = std::make_shared<MockMinimalIamCredentialsStub>();
   EXPECT_CALL(*mock, AsyncGenerateAccessToken)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   GenerateAccessTokenRequest const&) {
+      .WillOnce([](CompletionQueue&, auto, GenerateAccessTokenRequest const&) {
         GenerateAccessTokenResponse response;
         response.set_access_token("test-only-token");
         return make_ready_future(make_status_or(response));
@@ -164,8 +162,7 @@ TEST_F(MinimalIamCredentialsStubTest,
        DISABLED_AsyncGenerateAccessTokenMetadata) {
   auto mock = std::make_shared<MockMinimalIamCredentialsStub>();
   EXPECT_CALL(*mock, AsyncGenerateAccessToken)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](CompletionQueue&, auto context,
                        GenerateAccessTokenRequest const& request) {
         IsContextMDValid(
             *context,

--- a/google/cloud/pubsub/internal/default_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/default_batch_sink_test.cc
@@ -123,7 +123,7 @@ TEST(DefaultBatchSinkTest, TooManyTransients) {
 TEST(DefaultBatchSinkTest, BasicWithCompression) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([](Unused, std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([](Unused, auto context,
                    google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(context->compression_algorithm(), GRPC_COMPRESS_GZIP);
         EXPECT_THAT(request, IsProtoEqual(MakeRequest(3)));

--- a/google/cloud/pubsub/internal/subscriber_connection_impl_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_connection_impl_test.cc
@@ -70,8 +70,7 @@ using StreamingPullMock =
 StreamingPullMock MakeAsyncStreamingPullMock(
     std::string const& expected_subscription_name) {
   return [expected_subscription_name](
-             google::cloud::CompletionQueue const& completion_queue,
-             std::unique_ptr<grpc::ClientContext>) {
+             google::cloud::CompletionQueue const& completion_queue, auto) {
     using us = std::chrono::microseconds;
 
     auto cq = completion_queue;
@@ -146,14 +145,12 @@ TEST(SubscriberConnectionTest, Subscribe) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&,
-                   std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](google::cloud::CompletionQueue&, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(Status{});
@@ -191,14 +188,12 @@ TEST(SubscriberConnectionTest, SubscribeOverrideSubscription) {
   auto const s2 = Subscription("test-project", "test-override-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&,
-                   std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](google::cloud::CompletionQueue&, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(Status{});
@@ -236,14 +231,12 @@ TEST(SubscriberConnectionTest, ExactlyOnce) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&,
-                   std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](google::cloud::CompletionQueue&, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(
@@ -283,14 +276,12 @@ TEST(SubscriberConnectionTest, ExactlyOnceOverrideSubscription) {
   auto const s2 = Subscription("test-project", "test-override-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&,
-                   std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](google::cloud::CompletionQueue&, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(Status{});
@@ -330,21 +321,18 @@ TEST(SubscriberConnectionTest, StreamingPullFailure) {
 
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncStreamingPull)
       .Times(AtLeast(1))
-      .WillRepeatedly([](google::cloud::CompletionQueue const& cq,
-                         std::unique_ptr<grpc::ClientContext>) {
+      .WillRepeatedly([](google::cloud::CompletionQueue const& cq, auto) {
         using TimerFuture =
             future<StatusOr<std::chrono::system_clock::time_point>>;
         using us = std::chrono::microseconds;
@@ -380,14 +368,12 @@ TEST(SubscriberConnectionTest, Pull) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&,
-                   std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](google::cloud::CompletionQueue&, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(
@@ -428,14 +414,12 @@ TEST(SubscriberConnectionTest, PullOverrideSubscription) {
   auto const s2 = Subscription("test-project", "test-override-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&,
-                   std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](google::cloud::CompletionQueue&, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -51,8 +51,7 @@ TEST(PublisherConnectionTest, Basic) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
                     google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(topic.FullName(), request.topic());
         EXPECT_EQ(1, request.messages_size());
@@ -76,8 +75,7 @@ TEST(PublisherConnectionTest, Metadata) {
 
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext> context,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto context,
                           google::pubsub::v1::PublishRequest const& request) {
         google::cloud::testing_util::ValidateMetadataFixture fixture;
         fixture.IsContextMDValid(
@@ -105,8 +103,7 @@ TEST(PublisherConnectionTest, Logging) {
 
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto,
                           google::pubsub::v1::PublishRequest const& request) {
         google::pubsub::v1::PublishResponse response;
         for (auto const& m : request.messages()) {
@@ -139,8 +136,7 @@ TEST(PublisherConnectionTest, FlowControl) {
   AsyncSequencer<void> publish;
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto,
                           google::pubsub::v1::PublishRequest const& request) {
         {
           std::lock_guard<std::mutex> lk(mu);
@@ -191,8 +187,7 @@ TEST(PublisherConnectionTest, OrderingKey) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
                     google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(topic.FullName(), request.topic());
         EXPECT_EQ(1, request.messages_size());
@@ -232,8 +227,7 @@ TEST(PublisherConnectionTest, HandleInvalidResponse) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
                     google::pubsub::v1::PublishRequest const&) {
         google::pubsub::v1::PublishResponse response;
         return make_ready_future(make_status_or(response));
@@ -257,8 +251,7 @@ TEST(PublisherConnectionTest, HandleTooManyFailures) {
 
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(2))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto,
                           google::pubsub::v1::PublishRequest const&) {
         return make_ready_future(StatusOr<google::pubsub::v1::PublishResponse>(
             Status(StatusCode::kUnavailable, "try-again")));
@@ -277,8 +270,7 @@ TEST(PublisherConnectionTest, HandlePermanentError) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
                     google::pubsub::v1::PublishRequest const&) {
         return make_ready_future(StatusOr<google::pubsub::v1::PublishResponse>(
             Status(StatusCode::kPermissionDenied, "uh-oh")));
@@ -297,8 +289,7 @@ TEST(PublisherConnectionTest, HandleTransientDisabledRetry) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
                     google::pubsub::v1::PublishRequest const&) {
         return make_ready_future(StatusOr<google::pubsub::v1::PublishResponse>(
             Status(StatusCode::kUnavailable, "try-again")));
@@ -320,14 +311,12 @@ TEST(PublisherConnectionTest, HandleTransientEnabledRetry) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
                     google::pubsub::v1::PublishRequest const&) {
         return make_ready_future(StatusOr<google::pubsub::v1::PublishResponse>(
             Status(StatusCode::kUnavailable, "try-again")));
       })
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
                     google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(topic.FullName(), request.topic());
         EXPECT_EQ(1, request.messages_size());

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -50,11 +50,11 @@ class DatabaseAdminLoggingTest : public ::testing::Test {
 
 TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
   EXPECT_CALL(*mock_, AsyncCreateDatabase)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gsad::v1::CreateDatabaseRequest const&) {
-        return make_ready_future(
-            StatusOr<google::longrunning::Operation>(TransientError()));
-      });
+      .WillOnce(
+          [](CompletionQueue&, auto, gsad::v1::CreateDatabaseRequest const&) {
+            return make_ready_future(
+                StatusOr<google::longrunning::Operation>(TransientError()));
+          });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -100,7 +100,7 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
 
 TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
   EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    gsad::v1::UpdateDatabaseDdlRequest const&) {
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
@@ -149,11 +149,11 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
 
 TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
   EXPECT_CALL(*mock_, AsyncRestoreDatabase)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gsad::v1::RestoreDatabaseRequest const&) {
-        return make_ready_future(
-            StatusOr<google::longrunning::Operation>(TransientError()));
-      });
+      .WillOnce(
+          [](CompletionQueue&, auto, gsad::v1::RestoreDatabaseRequest const&) {
+            return make_ready_future(
+                StatusOr<google::longrunning::Operation>(TransientError()));
+          });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -215,11 +215,11 @@ TEST_F(DatabaseAdminLoggingTest, TestIamPermissions) {
 
 TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
   EXPECT_CALL(*mock_, AsyncCreateBackup)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gsad::v1::CreateBackupRequest const&) {
-        return make_ready_future(
-            StatusOr<google::longrunning::Operation>(TransientError()));
-      });
+      .WillOnce(
+          [](CompletionQueue&, auto, gsad::v1::CreateBackupRequest const&) {
+            return make_ready_future(
+                StatusOr<google::longrunning::Operation>(TransientError()));
+          });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -323,7 +323,7 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabaseOperations) {
 
 TEST_F(DatabaseAdminLoggingTest, GetOperation) {
   EXPECT_CALL(*mock_, AsyncGetOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::GetOperationRequest const&) {
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
@@ -344,7 +344,7 @@ TEST_F(DatabaseAdminLoggingTest, GetOperation) {
 
 TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
   EXPECT_CALL(*mock_, AsyncCancelOperation)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::longrunning::CancelOperationRequest const&) {
         return make_ready_future(TransientError());
       });

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -58,8 +58,7 @@ class DatabaseAdminMetadataTest : public ::testing::Test {
 
 TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
   EXPECT_CALL(*mock_, AsyncCreateDatabase)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](CompletionQueue&, auto context,
                        gsad::v1::CreateDatabaseRequest const& request) {
         IsContextMDValid(*context,
                          "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -83,8 +82,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
 
 TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
   EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](CompletionQueue&, auto context,
                        gsad::v1::UpdateDatabaseDdlRequest const& request) {
         IsContextMDValid(*context,
                          "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -156,8 +154,7 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
 
 TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
   EXPECT_CALL(*mock_, AsyncRestoreDatabase)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](CompletionQueue&, auto context,
                        gsad::v1::RestoreDatabaseRequest const& request) {
         IsContextMDValid(*context,
                          "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -260,8 +257,7 @@ TEST_F(DatabaseAdminMetadataTest, TestIamPermissions) {
 
 TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
   EXPECT_CALL(*mock_, AsyncCreateBackup)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](CompletionQueue&, auto context,
                        gsad::v1::CreateBackupRequest const& request) {
         IsContextMDValid(*context,
                          "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -423,15 +419,14 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
 
 TEST_F(DatabaseAdminMetadataTest, GetOperation) {
   EXPECT_CALL(*mock_, AsyncGetOperation)
-      .WillOnce(
-          [this](CompletionQueue&, std::unique_ptr<grpc::ClientContext> context,
-                 google::longrunning::GetOperationRequest const& request) {
-            IsContextMDValid(*context,
-                             "google.longrunning.Operations.GetOperation",
-                             request);
-            return make_ready_future(
-                StatusOr<google::longrunning::Operation>(TransientError()));
-          });
+      .WillOnce([this](
+                    CompletionQueue&, auto context,
+                    google::longrunning::GetOperationRequest const& request) {
+        IsContextMDValid(*context, "google.longrunning.Operations.GetOperation",
+                         request);
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
+      });
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
@@ -445,7 +440,7 @@ TEST_F(DatabaseAdminMetadataTest, GetOperation) {
 TEST_F(DatabaseAdminMetadataTest, CancelOperation) {
   EXPECT_CALL(*mock_, AsyncCancelOperation)
       .WillOnce(
-          [this](CompletionQueue&, std::unique_ptr<grpc::ClientContext> context,
+          [this](CompletionQueue&, auto context,
                  google::longrunning::CancelOperationRequest const& request) {
             IsContextMDValid(*context,
                              "google.longrunning.Operations.CancelOperation",

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -64,11 +64,11 @@ TEST_F(InstanceAdminLoggingTest, GetInstance) {
 
 TEST_F(InstanceAdminLoggingTest, CreateInstance) {
   EXPECT_CALL(*mock_, AsyncCreateInstance)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gsai::v1::CreateInstanceRequest const&) {
-        return make_ready_future(
-            StatusOr<google::longrunning::Operation>(TransientError()));
-      });
+      .WillOnce(
+          [](CompletionQueue&, auto, gsai::v1::CreateInstanceRequest const&) {
+            return make_ready_future(
+                StatusOr<google::longrunning::Operation>(TransientError()));
+          });
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -85,11 +85,11 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
 
 TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
   EXPECT_CALL(*mock_, AsyncUpdateInstance)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gsai::v1::UpdateInstanceRequest const&) {
-        return make_ready_future(
-            StatusOr<google::longrunning::Operation>(TransientError()));
-      });
+      .WillOnce(
+          [](CompletionQueue&, auto, gsai::v1::UpdateInstanceRequest const&) {
+            return make_ready_future(
+                StatusOr<google::longrunning::Operation>(TransientError()));
+          });
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -118,8 +118,7 @@ TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
 
 TEST_F(InstanceAdminMetadataTest, CreateInstance) {
   EXPECT_CALL(*mock_, AsyncCreateInstance)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](CompletionQueue&, auto context,
                        gsai::v1::CreateInstanceRequest const& request) {
         IsContextMDValid(*context,
                          "google.spanner.admin.instance.v1.InstanceAdmin."
@@ -141,8 +140,7 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
 
 TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
   EXPECT_CALL(*mock_, AsyncUpdateInstance)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
+      .WillOnce([this](CompletionQueue&, auto context,
                        gsai::v1::UpdateInstanceRequest const& request) {
         IsContextMDValid(*context,
                          "google.spanner.admin.instance.v1.InstanceAdmin."

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -454,7 +454,7 @@ TEST(SessionPool, SessionRefresh) {
 
   EXPECT_CALL(*mock, AsyncExecuteSql)
       .WillOnce(
-          [&result](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+          [&result](CompletionQueue&, auto,
                     google::spanner::v1::ExecuteSqlRequest const& request) {
             EXPECT_EQ("s2", request.session());
             return make_ready_future(make_status_or(std::move(result)));
@@ -507,7 +507,7 @@ TEST(SessionPool, SessionRefreshNotFound) {
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s3"}))));
 
   EXPECT_CALL(*mock, AsyncExecuteSql)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::spanner::v1::ExecuteSqlRequest const& request) {
         EXPECT_EQ("s2", request.session());
         // The "SELECT 1" refresh returns "Session not found".

--- a/google/cloud/spanner/internal/spanner_auth_test.cc
+++ b/google/cloud/spanner/internal/spanner_auth_test.cc
@@ -259,7 +259,7 @@ TEST(SpannerAuthTest, PartitionRead) {
 TEST(SpannerAuthTest, AsyncBatchCreateSessions) {
   auto mock = std::make_shared<MockSpannerStub>();
   EXPECT_CALL(*mock, AsyncBatchCreateSessions)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::spanner::v1::BatchCreateSessionsRequest const&) {
         return make_ready_future(
             StatusOr<google::spanner::v1::BatchCreateSessionsResponse>(
@@ -281,7 +281,7 @@ TEST(SpannerAuthTest, AsyncBatchCreateSessions) {
 TEST(SpannerAuthTest, AsyncDeleteSession) {
   auto mock = std::make_shared<MockSpannerStub>();
   EXPECT_CALL(*mock, AsyncDeleteSession)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::spanner::v1::DeleteSessionRequest const&) {
         return make_ready_future(
             Status(StatusCode::kPermissionDenied, "uh-oh"));
@@ -302,7 +302,7 @@ TEST(SpannerAuthTest, AsyncDeleteSession) {
 TEST(SpannerAuthTest, AsyncExecuteSql) {
   auto mock = std::make_shared<MockSpannerStub>();
   EXPECT_CALL(*mock, AsyncExecuteSql)
-      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      .WillOnce([](CompletionQueue&, auto,
                    google::spanner::v1::ExecuteSqlRequest const&) {
         return make_ready_future(StatusOr<google::spanner::v1::ResultSet>(
             Status(StatusCode::kPermissionDenied, "uh-oh")));

--- a/google/cloud/storage/internal/async_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async_connection_impl_test.cc
@@ -59,21 +59,20 @@ std::shared_ptr<AsyncConnection> MakeTestConnection(
 TEST_F(AsyncConnectionImplTest, AsyncDeleteObject) {
   auto mock = std::make_shared<storage::testing::MockStorageStub>();
   EXPECT_CALL(*mock, AsyncDeleteObject)
-      .WillOnce(
-          [this](CompletionQueue&, std::unique_ptr<grpc::ClientContext> context,
-                 google::storage::v2::DeleteObjectRequest const& request) {
-            // Verify at least one option is initialized with the correct
-            // values.
-            EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
-            auto metadata = GetMetadata(*context);
-            EXPECT_THAT(metadata,
-                        UnorderedElementsAre(
-                            Pair("x-goog-quota-user", "test-quota-user"),
-                            Pair("x-goog-fieldmask", "field1,field2")));
-            EXPECT_THAT(request.bucket(), "projects/_/buckets/test-bucket");
-            EXPECT_THAT(request.object(), "test-object");
-            return make_ready_future(PermanentError());
-          });
+      .WillOnce([this](
+                    CompletionQueue&, auto context,
+                    google::storage::v2::DeleteObjectRequest const& request) {
+        // Verify at least one option is initialized with the correct
+        // values.
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
+        auto metadata = GetMetadata(*context);
+        EXPECT_THAT(metadata, UnorderedElementsAre(
+                                  Pair("x-goog-quota-user", "test-quota-user"),
+                                  Pair("x-goog-fieldmask", "field1,field2")));
+        EXPECT_THAT(request.bucket(), "projects/_/buckets/test-bucket");
+        EXPECT_THAT(request.object(), "test-object");
+        return make_ready_future(PermanentError());
+      });
   CompletionQueue cq;
   auto connection = MakeTestConnection(cq, mock);
   // Simulate the option span created by the `*Client` class. The

--- a/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
@@ -73,15 +73,14 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
   ASSERT_TRUE(TextFormat::ParseFromString(kWriteRequestText, &write_request));
 
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
-        EXPECT_CALL(*stream, Write(IsProtoEqual(write_request), _))
-            .WillOnce(Return(true));
-        EXPECT_CALL(*stream, Close).WillOnce(Return(response));
-        return stream;
-      });
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+    ::testing::InSequence sequence;
+    auto stream = absl::make_unique<MockInsertStream>();
+    EXPECT_CALL(*stream, Write(IsProtoEqual(write_request), _))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*stream, Close).WillOnce(Return(response));
+    return stream;
+  });
 
   auto client = GrpcClient::CreateMock(mock);
   auto metadata = client->InsertObjectMedia(
@@ -96,16 +95,15 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientInsertObjectMediaTest, StallTimeoutWrite) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
-        EXPECT_CALL(*stream, Cancel).Times(1);
-        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-        EXPECT_CALL(*stream, Close)
-            .WillOnce(Return(google::storage::v2::WriteObjectResponse{}));
-        return stream;
-      });
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+    ::testing::InSequence sequence;
+    auto stream = absl::make_unique<MockInsertStream>();
+    EXPECT_CALL(*stream, Cancel).Times(1);
+    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Close)
+        .WillOnce(Return(google::storage::v2::WriteObjectResponse{}));
+    return stream;
+  });
 
   auto const expected = std::chrono::seconds(42);
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
@@ -130,16 +128,15 @@ TEST(GrpcClientInsertObjectMediaTest, StallTimeoutWrite) {
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientInsertObjectMediaTest, StallTimeoutClose) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
-        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-        EXPECT_CALL(*stream, Cancel).Times(1);
-        EXPECT_CALL(*stream, Close)
-            .WillOnce(Return(google::storage::v2::WriteObjectResponse{}));
-        return stream;
-      });
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+    ::testing::InSequence sequence;
+    auto stream = absl::make_unique<MockInsertStream>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Cancel).Times(1);
+    EXPECT_CALL(*stream, Close)
+        .WillOnce(Return(google::storage::v2::WriteObjectResponse{}));
+    return stream;
+  });
 
   auto const expected = std::chrono::seconds(42);
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();

--- a/google/cloud/storage/internal/grpc_client_read_object_test.cc
+++ b/google/cloud/storage/internal/grpc_client_read_object_test.cc
@@ -52,8 +52,7 @@ TEST(GrpcClientReadObjectTest, WithDefaultTimeout) {
 
   auto mock = std::make_shared<MockStorageStub>();
   EXPECT_CALL(*mock, ReadObject)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext>,
-                    ReadObjectRequest const& request) {
+      .WillOnce([&](auto, ReadObjectRequest const& request) {
         EXPECT_THAT(request, IsProtoEqual(expected_request));
         auto stream = absl::make_unique<MockObjectMediaStream>();
         EXPECT_CALL(*stream, Read).WillOnce(Return(Status{}));
@@ -94,8 +93,7 @@ TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
 
   auto mock = std::make_shared<MockStorageStub>();
   EXPECT_CALL(*mock, ReadObject)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext>,
-                    ReadObjectRequest const& request) {
+      .WillOnce([&](auto, ReadObjectRequest const& request) {
         EXPECT_THAT(request, IsProtoEqual(expected_request));
         auto stream = absl::make_unique<MockObjectMediaStream>();
         EXPECT_CALL(*stream, Read).WillOnce(Return(Status{}));

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -167,22 +167,21 @@ TEST_F(GrpcClientTest, DeleteResumableUpload) {
 
 TEST_F(GrpcClientTest, UploadChunk) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject)
-      .WillOnce([this](std::unique_ptr<grpc::ClientContext> context) {
-        auto metadata = GetMetadata(*context);
-        EXPECT_THAT(metadata,
-                    UnorderedElementsAre(
-                        Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map JSON names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)"),
-                        Pair("x-goog-request-params",
-                             "bucket=projects/_/buckets/test-bucket")));
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
-        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-        EXPECT_CALL(*stream, Close).WillOnce(Return(PermanentError()));
-        return stream;
-      });
+  EXPECT_CALL(*mock, WriteObject).WillOnce([this](auto context) {
+    auto metadata = GetMetadata(*context);
+    EXPECT_THAT(metadata,
+                UnorderedElementsAre(
+                    Pair("x-goog-quota-user", "test-quota-user"),
+                    // Map JSON names to the `resource` subobject
+                    Pair("x-goog-fieldmask", "resource(field1,field2)"),
+                    Pair("x-goog-request-params",
+                         "bucket=projects/_/buckets/test-bucket")));
+    ::testing::InSequence sequence;
+    auto stream = absl::make_unique<MockInsertStream>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Close).WillOnce(Return(PermanentError()));
+    return stream;
+  });
   auto client = CreateTestClient(mock);
   auto response = client->UploadChunk(
       storage::internal::UploadChunkRequest(
@@ -430,22 +429,21 @@ TEST_F(GrpcClientTest, TestBucketIamPermissions) {
 
 TEST_F(GrpcClientTest, InsertObjectMedia) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject)
-      .WillOnce([this](std::unique_ptr<grpc::ClientContext> context) {
-        auto metadata = GetMetadata(*context);
-        EXPECT_THAT(metadata,
-                    UnorderedElementsAre(
-                        Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map JSON names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)"),
-                        Pair("x-goog-request-params",
-                             "bucket=projects/_/buckets/test-bucket")));
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
-        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-        EXPECT_CALL(*stream, Close).WillOnce(Return(PermanentError()));
-        return stream;
-      });
+  EXPECT_CALL(*mock, WriteObject).WillOnce([this](auto context) {
+    auto metadata = GetMetadata(*context);
+    EXPECT_THAT(metadata,
+                UnorderedElementsAre(
+                    Pair("x-goog-quota-user", "test-quota-user"),
+                    // Map JSON names to the `resource` subobject
+                    Pair("x-goog-fieldmask", "resource(field1,field2)"),
+                    Pair("x-goog-request-params",
+                         "bucket=projects/_/buckets/test-bucket")));
+    ::testing::InSequence sequence;
+    auto stream = absl::make_unique<MockInsertStream>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Close).WillOnce(Return(PermanentError()));
+    return stream;
+  });
   auto client = CreateTestClient(mock);
   auto response = client->InsertObjectMedia(
       storage::internal::InsertObjectMediaRequest(
@@ -540,8 +538,7 @@ TEST_F(GrpcClientTest, GetObjectMetadata) {
 TEST_F(GrpcClientTest, ReadObject) {
   auto mock = std::make_shared<MockStorageStub>();
   EXPECT_CALL(*mock, ReadObject)
-      .WillOnce([this](std::unique_ptr<grpc::ClientContext> context,
-                       v2::ReadObjectRequest const& request) {
+      .WillOnce([this](auto context, v2::ReadObjectRequest const& request) {
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),

--- a/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
+++ b/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
@@ -48,17 +48,16 @@ static_assert(
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
-        EXPECT_CALL(*stream, Cancel).Times(1);
-        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-        EXPECT_CALL(*stream, Close)
-            .WillOnce(Return(
-                make_status_or(google::storage::v2::WriteObjectResponse{})));
-        return stream;
-      });
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+    ::testing::InSequence sequence;
+    auto stream = absl::make_unique<MockInsertStream>();
+    EXPECT_CALL(*stream, Cancel).Times(1);
+    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Close)
+        .WillOnce(
+            Return(make_status_or(google::storage::v2::WriteObjectResponse{})));
+    return stream;
+  });
 
   auto const expected = std::chrono::seconds(42);
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
@@ -83,17 +82,16 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
-        EXPECT_CALL(*stream, Write).WillOnce(Return(true));
-        EXPECT_CALL(*stream, Cancel).Times(1);
-        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-        EXPECT_CALL(*stream, Close)
-            .WillOnce(Return(google::storage::v2::WriteObjectResponse{}));
-        return stream;
-      });
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+    ::testing::InSequence sequence;
+    auto stream = absl::make_unique<MockInsertStream>();
+    EXPECT_CALL(*stream, Write).WillOnce(Return(true));
+    EXPECT_CALL(*stream, Cancel).Times(1);
+    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Close)
+        .WillOnce(Return(google::storage::v2::WriteObjectResponse{}));
+    return stream;
+  });
 
   auto const expected = std::chrono::seconds(42);
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
@@ -122,17 +120,16 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientUploadChunkTest, StallTimeoutClose) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject)
-      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
-        EXPECT_CALL(*stream, Write).Times(2).WillRepeatedly(Return(true));
-        EXPECT_CALL(*stream, Cancel).Times(1);
-        EXPECT_CALL(*stream, Close)
-            .WillOnce(Return(
-                make_status_or(google::storage::v2::WriteObjectResponse{})));
-        return stream;
-      });
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+    ::testing::InSequence sequence;
+    auto stream = absl::make_unique<MockInsertStream>();
+    EXPECT_CALL(*stream, Write).Times(2).WillRepeatedly(Return(true));
+    EXPECT_CALL(*stream, Cancel).Times(1);
+    EXPECT_CALL(*stream, Close)
+        .WillOnce(
+            Return(make_status_or(google::storage::v2::WriteObjectResponse{})));
+    return stream;
+  });
 
   auto const expected = std::chrono::seconds(42);
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();

--- a/google/cloud/storage/internal/storage_round_robin_test.cc
+++ b/google/cloud/storage/internal/storage_round_robin_test.cc
@@ -32,6 +32,7 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::ByMove;
 using ::testing::InSequence;
 using ::testing::Return;
+using ::testing::Unused;
 
 // All the tests have nearly identical structure. They create 3 mocks, setup
 // each mock to receive 2 calls of some function, then call the
@@ -56,8 +57,7 @@ std::vector<std::shared_ptr<StorageStub>> AsPlainStubs(
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
-MakeReadObjectStream(std::unique_ptr<grpc::ClientContext>,
-                     google::storage::v2::ReadObjectRequest const&) {
+MakeReadObjectStream(Unused, google::storage::v2::ReadObjectRequest const&) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::storage::v2::ReadObjectResponse>;
   return absl::make_unique<ErrorStream>(
@@ -66,8 +66,7 @@ MakeReadObjectStream(std::unique_ptr<grpc::ClientContext>,
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
-MakeAsyncReadObjectStream(google::cloud::CompletionQueue const&,
-                          std::unique_ptr<grpc::ClientContext>,
+MakeAsyncReadObjectStream(google::cloud::CompletionQueue const&, Unused,
                           google::storage::v2::ReadObjectRequest const&) {
   using ErrorStream = ::google::cloud::internal::AsyncStreamingReadRpcError<
       google::storage::v2::ReadObjectResponse>;
@@ -78,8 +77,7 @@ MakeAsyncReadObjectStream(google::cloud::CompletionQueue const&,
 std::unique_ptr<google::cloud::internal::AsyncStreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-MakeAsyncWriteObjectStream(google::cloud::CompletionQueue const&,
-                           std::unique_ptr<grpc::ClientContext>) {
+MakeAsyncWriteObjectStream(google::cloud::CompletionQueue const&, Unused) {
   using ErrorStream = ::google::cloud::internal::AsyncStreamingWriteRpcError<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
@@ -90,7 +88,7 @@ MakeAsyncWriteObjectStream(google::cloud::CompletionQueue const&,
 std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-MakeInsertStream(std::unique_ptr<grpc::ClientContext>) {
+MakeInsertStream(Unused) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -92,7 +92,7 @@ TEST_F(StorageStubFactory, ReadObject) {
         auto mock = std::make_shared<MockStorageStub>();
         EXPECT_CALL(*mock, ReadObject)
             .WillOnce(
-                [this](std::unique_ptr<grpc::ClientContext> context,
+                [this](auto context,
                        google::storage::v2::ReadObjectRequest const& request) {
                   // Verify the Auth decorator is present
                   EXPECT_THAT(context->credentials(), NotNull());
@@ -134,7 +134,7 @@ TEST_F(StorageStubFactory, WriteObject) {
         auto mock = std::make_shared<MockStorageStub>();
         EXPECT_CALL(*mock, AsyncWriteObject)
             .WillOnce([this](google::cloud::CompletionQueue const&,
-                             std::unique_ptr<grpc::ClientContext> context) {
+                             auto context) {
               // Verify the Auth decorator is present
               EXPECT_THAT(context->credentials(), NotNull());
               // Verify the Metadata decorator is present


### PR DESCRIPTION
Part of the work for #10618 

This goofy looking changes just uses `auto` instead of `unique_ptr<grpc::ClientContext>` in unit tests.

We are going to change the `unique_ptr` to `shared_ptr`. Unless the `context` is moved, clang-tidy will yell at us for having a performance unnecessary value parameter. clang-tidy is apparently not smart enough to warn when we use `auto` instead. 

This also lets me break a chunk off of the larger refactor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11002)
<!-- Reviewable:end -->
