### PR TITLE
refactor: MakeUnaryRpc that is not a CQ member

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -292,7 +292,7 @@ TEST(CompletionQueueTest, MakeUnaryRpcImpl) {
   btadmin::GetTableRequest request;
   request.set_name("test-table-name");
   future<void> done =
-      internal::MakeUnaryRpcImpl(
+      internal::MakeUnaryRpcImpl<btadmin::GetTableRequest, btadmin::Table>(
           cq,
           [&mock_client](grpc::ClientContext* context,
                          btadmin::GetTableRequest const& request,
@@ -389,7 +389,7 @@ TEST(CompletionQueueTest, MakeRpcsAfterShutdown) {
   btadmin::GetTableRequest get_table_request;
   get_table_request.set_name("test-table-name");
   future<void> done =
-      internal::MakeUnaryRpcImpl(
+      internal::MakeUnaryRpcImpl<btadmin::GetTableRequest, btadmin::Table>(
           cq,
           [&mock_client](grpc::ClientContext* context,
                          btadmin::GetTableRequest const& request,

--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -261,6 +261,59 @@ TEST(CompletionQueueTest, MakeUnaryRpc) {
   runner.join();
 }
 
+TEST(CompletionQueueTest, MakeUnaryRpcImpl) {
+  using ms = std::chrono::milliseconds;
+
+  auto mock_cq = std::make_shared<FakeCompletionQueueImpl>();
+  CompletionQueue cq(mock_cq);
+
+  auto mock_reader = absl::make_unique<MockTableReader>();
+  EXPECT_CALL(*mock_reader, Finish)
+      .WillOnce([](btadmin::Table* table, grpc::Status* status, void*) {
+        table->set_name("test-table-name");
+        *status = grpc::Status::OK;
+      });
+  MockClient mock_client;
+  EXPECT_CALL(mock_client, AsyncGetTable)
+      .WillOnce([&mock_reader](grpc::ClientContext*,
+                               btadmin::GetTableRequest const& request,
+                               grpc::CompletionQueue*) {
+        EXPECT_EQ("test-table-name", request.name());
+        // This looks like a double delete, but it is not because
+        // std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<T>> is
+        // specialized to not delete. :shrug:
+        return std::unique_ptr<
+            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(
+            mock_reader.get());
+      });
+
+  std::thread runner([&cq] { cq.Run(); });
+
+  btadmin::GetTableRequest request;
+  request.set_name("test-table-name");
+  future<void> done =
+      internal::MakeUnaryRpcImpl(
+          cq,
+          [&mock_client](grpc::ClientContext* context,
+                         btadmin::GetTableRequest const& request,
+                         grpc::CompletionQueue* cq) {
+            return mock_client.AsyncGetTable(context, request, cq);
+          },
+          request, std::make_shared<grpc::ClientContext>())
+          .then([](future<StatusOr<btadmin::Table>> f) {
+            auto table = f.get();
+            ASSERT_STATUS_OK(table);
+            EXPECT_EQ("test-table-name", table->name());
+          });
+
+  mock_cq->SimulateCompletion(true);
+
+  EXPECT_EQ(std::future_status::ready, done.wait_for(ms(0)));
+
+  cq.Shutdown();
+  runner.join();
+}
+
 TEST(CompletionQueueTest, MakeStreamingReadRpc) {
   auto mock_cq = std::make_shared<FakeCompletionQueueImpl>();
   CompletionQueue cq(mock_cq);
@@ -336,13 +389,14 @@ TEST(CompletionQueueTest, MakeRpcsAfterShutdown) {
   btadmin::GetTableRequest get_table_request;
   get_table_request.set_name("test-table-name");
   future<void> done =
-      cq.MakeUnaryRpc(
-            [&mock_client](grpc::ClientContext* context,
-                           btadmin::GetTableRequest const& request,
-                           grpc::CompletionQueue* cq) {
-              return mock_client.AsyncGetTable(context, request, cq);
-            },
-            get_table_request, absl::make_unique<grpc::ClientContext>())
+      internal::MakeUnaryRpcImpl(
+          cq,
+          [&mock_client](grpc::ClientContext* context,
+                         btadmin::GetTableRequest const& request,
+                         grpc::CompletionQueue* cq) {
+            return mock_client.AsyncGetTable(context, request, cq);
+          },
+          get_table_request, absl::make_unique<grpc::ClientContext>())
           .then([](future<StatusOr<btadmin::Table>> f) {
             EXPECT_EQ(StatusCode::kCancelled, f.get().status().code());
           });

--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -57,10 +57,9 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
   /// Prepare the operation to receive the response and start the RPC.
   template <typename AsyncFunctionType>
   void Start(AsyncFunctionType async_call,
-             std::unique_ptr<grpc::ClientContext> ctx, Request const& request,
-             grpc::CompletionQueue* cq, void* tag) {
-    // Need a copyable holder to use in the `std::function<>` callback:
-    auto context = std::shared_ptr<grpc::ClientContext>(std::move(ctx));
+             // NOLINTNEXTLINE(performance-unnecessary-value-param)
+             std::shared_ptr<grpc::ClientContext> context,
+             Request const& request, grpc::CompletionQueue* cq, void* tag) {
     promise_ = promise<StatusOr<Response>>([context] { context->TryCancel(); });
     auto rpc = async_call(context.get(), request, cq);
     rpc->Finish(&response_, &status_, tag);

--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -21,6 +21,7 @@
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include "absl/functional/function_ref.h"
 #include <grpcpp/support/async_unary_call.h>
 
 namespace google {
@@ -88,7 +89,7 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
  private:
   // These are the parameters for the RPC, most of them have obvious semantics.
   // The promise will hold the grpc::ClientContext (in its cancel callback). It
-  // uses a `unique_ptr` because (a) we need to receive it as a parameter,
+  // uses a `shared_ptr` because (a) we need to receive it as a parameter,
   // otherwise the caller could not set timeouts, metadata, or any other
   // attributes, and (b) there is no move or assignment operator for
   // `grpc::ClientContext`.
@@ -187,6 +188,11 @@ using AsyncCallResponseType = AsyncCallResponseTypeUnwrap<
     typename google::cloud::internal::invoke_result_t<
         AsyncCallType, grpc::ClientContext*, RequestType const&,
         grpc::CompletionQueue*>>;
+
+template <typename Request, typename Response>
+using GrpcAsyncCall = absl::FunctionRef<
+    std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<Response>>(
+        grpc::ClientContext*, Request const&, grpc::CompletionQueue*)>;
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #10618 

Introduce `MakeUnaryRpcImpl(...)` which exists outside of the CQ. Note that it accepts a `std::shared_ptr<grpc::ClientContext>`. Update `AsyncUnaryRpcFuture` to interact with a `std::shared_ptr<grpc::ClientContext>`.

I could use double checking on the templates when split into definition vs. declaration. Also on moving the context into the lambda. I am fairly sure I want the lambda to own the context.

Note that the new test is just a copy of the existing `TEST(CompletionQueueTest, MakeUnaryRpc)`. I considered updating the test to use a MockCQ, but it was more trouble than it's worth. (Just mocking `StartOperation` then calling `op->Notify(true);` will not actually test the stuff in `AsyncUnaryRpcFuture::Start()`.)

We should deprecate `CQ::MakeUnaryRpc` and `CQ::MakeStreamingReadRpc` later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11004)
<!-- Reviewable:end -->
