### PR TITLE
feat(storage): reduce copies in `InsertObject()`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,4 +47,4 @@ RawStringFormats:
   - 'proto'
   BasedOnStyle: Google
 
-CommentPragmas: '(@copydoc|@copybrief|@see)'
+CommentPragmas: '(@copydoc|@copybrief|@see|@overload)'

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -140,10 +140,9 @@ class SimpleUpload : public ThroughputExperiment {
     // truncate the object to the right size.
     auto const start = std::chrono::system_clock::now();
     auto timer = Timer::PerThread();
-    std::string data =
-        random_data_->substr(0, static_cast<std::size_t>(config.object_size));
+    auto data = absl::string_view{random_data_->data(), config.object_size};
     auto object_metadata =
-        client_.InsertObject(bucket_name, object_name, std::move(data),
+        client_.InsertObject(bucket_name, object_name, data,
                              gcs::DisableCrc32cChecksum(!config.enable_crc32c),
                              gcs::DisableMD5Hash(!config.enable_md5));
     auto const usage = timer.Sample();

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -140,7 +140,8 @@ class SimpleUpload : public ThroughputExperiment {
     // truncate the object to the right size.
     auto const start = std::chrono::system_clock::now();
     auto timer = Timer::PerThread();
-    auto data = absl::string_view{random_data_->data(), config.object_size};
+    auto data = absl::string_view{*random_data_}.substr(
+        0, static_cast<std::size_t>(config.object_size));
     auto object_metadata =
         client_.InsertObject(bucket_name, object_name, data,
                              gcs::DisableCrc32cChecksum(!config.enable_crc32c),

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -165,7 +165,7 @@ StatusOr<ObjectMetadata> Client::UploadFileSimple(
     return Status(StatusCode::kInternal, std::move(os).str());
   }
   is.close();
-  request.set_contents(std::move(payload));
+  request.set_payload(payload);
 
   return raw_client_->InsertObjectMedia(request);
 }

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -892,7 +892,7 @@ class Client {
                                         Options&&... options) {
     auto c =
         contents == nullptr ? absl::string_view{} : absl::string_view{contents};
-    return InsertObject(bucket_name, object_name, std::move(c),
+    return InsertObject(bucket_name, object_name, c,
                         std::forward<Options>(options)...);
   }
 

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -40,6 +40,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "absl/meta/type_traits.h"
+#include "absl/strings/string_view.h"
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -863,14 +864,34 @@ class Client {
   template <typename... Options>
   StatusOr<ObjectMetadata> InsertObject(std::string const& bucket_name,
                                         std::string const& object_name,
-                                        std::string contents,
+                                        absl::string_view contents,
                                         Options&&... options) {
     google::cloud::internal::OptionsSpan const span(
         SpanOptions(std::forward<Options>(options)...));
     internal::InsertObjectMediaRequest request(bucket_name, object_name,
-                                               std::move(contents));
+                                               contents);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->InsertObjectMedia(request);
+  }
+
+  /// @overload InsertObject(std::string const& bucket_name, std::string const& object_name, absl::string_view contents, Options&&... options)
+  template <typename... Options>
+  StatusOr<ObjectMetadata> InsertObject(std::string const& bucket_name,
+                                        std::string const& object_name,
+                                        std::string const& contents,
+                                        Options&&... options) {
+    return InsertObject(bucket_name, object_name, absl::string_view(contents),
+                        std::forward<Options>(options)...);
+  }
+
+  /// @overload InsertObject(std::string const& bucket_name, std::string const& object_name, absl::string_view contents, Options&&... options)
+  template <typename... Options>
+  StatusOr<ObjectMetadata> InsertObject(std::string const& bucket_name,
+                                        std::string const& object_name,
+                                        char const* contents,
+                                        Options&&... options) {
+    return InsertObject(bucket_name, object_name, absl::string_view(contents),
+                        std::forward<Options>(options)...);
   }
 
   /**

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -890,7 +890,9 @@ class Client {
                                         std::string const& object_name,
                                         char const* contents,
                                         Options&&... options) {
-    return InsertObject(bucket_name, object_name, absl::string_view(contents),
+    auto c =
+        contents == nullptr ? absl::string_view{} : absl::string_view{contents};
+    return InsertObject(bucket_name, object_name, std::move(c),
                         std::forward<Options>(options)...);
   }
 

--- a/google/cloud/storage/client_object_test.cc
+++ b/google/cloud/storage/client_object_test.cc
@@ -79,7 +79,7 @@ TEST_F(ObjectTest, InsertObjectMedia) {
         EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket-name", request.bucket_name());
         EXPECT_EQ("test-object-name", request.object_name());
-        EXPECT_EQ("test object contents", request.contents());
+        EXPECT_EQ("test object contents", request.payload());
         return make_status_or(expected);
       });
 
@@ -358,7 +358,7 @@ TEST_F(ObjectTest, UploadFile) {
         EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket-name", request.bucket_name());
         EXPECT_EQ("test-object-name", request.object_name());
-        EXPECT_EQ(contents, request.contents());
+        EXPECT_EQ(contents, request.payload());
         return make_status_or(expected);
       });
 

--- a/google/cloud/storage/compose_many_test.cc
+++ b/google/cloud/storage/compose_many_test.cc
@@ -73,7 +73,7 @@ TEST(ComposeMany, One) {
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
-        EXPECT_EQ("", request.contents());
+        EXPECT_EQ("", request.payload());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
   EXPECT_CALL(*mock, DeleteObject)
@@ -112,7 +112,7 @@ TEST(ComposeMany, Three) {
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
-        EXPECT_EQ("", request.contents());
+        EXPECT_EQ("", request.payload());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
   EXPECT_CALL(*mock, DeleteObject)
@@ -184,7 +184,7 @@ TEST(ComposeMany, ThreeLayers) {
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
-        EXPECT_EQ("", request.contents());
+        EXPECT_EQ("", request.payload());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
   EXPECT_CALL(*mock, DeleteObject)
@@ -234,7 +234,7 @@ TEST(ComposeMany, ComposeFails) {
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
-        EXPECT_EQ("", request.contents());
+        EXPECT_EQ("", request.payload());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
 
@@ -285,7 +285,7 @@ TEST(ComposeMany, CleanupFailsLoudly) {
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
-        EXPECT_EQ("", request.contents());
+        EXPECT_EQ("", request.payload());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
 
@@ -324,7 +324,7 @@ TEST(ComposeMany, CleanupFailsSilently) {
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
-        EXPECT_EQ("", request.contents());
+        EXPECT_EQ("", request.payload());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
 

--- a/google/cloud/storage/hashing_options.cc
+++ b/google/cloud/storage/hashing_options.cc
@@ -22,11 +22,11 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-std::string ComputeMD5Hash(std::string const& payload) {
+std::string ComputeMD5Hash(absl::string_view payload) {
   return internal::Base64Encode(internal::MD5Hash(payload));
 }
 
-std::string ComputeCrc32cChecksum(std::string const& payload) {
+std::string ComputeCrc32cChecksum(absl::string_view payload) {
   auto checksum = crc32c::Extend(
       0, reinterpret_cast<std::uint8_t const*>(payload.data()), payload.size());
   std::string const hash = google::cloud::internal::EncodeBigEndian(checksum);

--- a/google/cloud/storage/hashing_options.cc
+++ b/google/cloud/storage/hashing_options.cc
@@ -26,11 +26,19 @@ std::string ComputeMD5Hash(absl::string_view payload) {
   return internal::Base64Encode(internal::MD5Hash(payload));
 }
 
+std::string ComputeMD5Hash(std::string const& payload) {
+  return ComputeMD5Hash(absl::string_view(payload));
+}
+
 std::string ComputeCrc32cChecksum(absl::string_view payload) {
   auto checksum = crc32c::Extend(
       0, reinterpret_cast<std::uint8_t const*>(payload.data()), payload.size());
   std::string const hash = google::cloud::internal::EncodeBigEndian(checksum);
   return internal::Base64Encode(hash);
+}
+
+std::string ComputeCrc32cChecksum(std::string const& payload) {
+  return ComputeCrc32cChecksum(absl::string_view(payload));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/complex_option.h"
 #include "google/cloud/storage/version.h"
+#include "absl/strings/string_view.h"
 #include <string>
 
 namespace google {
@@ -45,9 +46,19 @@ struct MD5HashValue
 };
 
 /**
- * Compute the MD5 Hash of a string in the format preferred by GCS.
+ * Compute the MD5 Hash of a buffer in the format preferred by GCS.
  */
-std::string ComputeMD5Hash(std::string const& payload);
+std::string ComputeMD5Hash(absl::string_view payload);
+
+/// @overload ComputeMD5Hash(absl::string_view)
+inline std::string ComputeMD5Hash(std::string const& payload) {
+  return ComputeMD5Hash(absl::string_view(payload));
+}
+
+/// @overload ComputeMD5Hash(absl::string_view)
+inline std::string ComputeMD5Hash(char const* payload) {
+  return ComputeMD5Hash(absl::string_view(payload));
+}
 
 /**
  * Disable or enable MD5 Hashing computations.
@@ -99,9 +110,19 @@ struct Crc32cChecksumValue
 };
 
 /**
- * Compute the CRC32C checksum of a string in the format preferred by GCS.
+ * Compute the CRC32C checksum of a buffer in the format preferred by GCS.
  */
-std::string ComputeCrc32cChecksum(std::string const& payload);
+std::string ComputeCrc32cChecksum(absl::string_view payload);
+
+/// @overload ComputeCrc32cChecksum(absl::string_view payload)
+inline std::string ComputeCrc32cChecksum(std::string const& payload) {
+  return ComputeCrc32cChecksum(absl::string_view(payload));
+}
+
+/// @overload ComputeCrc32cChecksum(absl::string_view payload)
+inline std::string ComputeCrc32cChecksum(char const* payload) {
+  return ComputeCrc32cChecksum(absl::string_view(payload));
+}
 
 /**
  * Disable CRC32C checksum computations.

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -55,9 +55,8 @@ std::string ComputeMD5Hash(std::string const& payload);
 
 /// @copydoc ComputeMD5Hash(absl::string_view)
 inline std::string ComputeMD5Hash(char const* payload) {
-  auto p =
-      payload == nullptr ? absl::string_view{} : absl::string_view{payload};
-  return ComputeMD5Hash(std::move(p));
+  return ComputeMD5Hash(payload == nullptr ? absl::string_view{}
+                                           : absl::string_view{payload});
 }
 
 /**
@@ -119,9 +118,8 @@ std::string ComputeCrc32cChecksum(std::string const& payload);
 
 /// @copydoc ComputeCrc32cChecksum(absl::string_view payload)
 inline std::string ComputeCrc32cChecksum(char const* payload) {
-  auto p =
-      payload == nullptr ? absl::string_view{} : absl::string_view{payload};
-  return ComputeCrc32cChecksum(std::move(p));
+  return ComputeCrc32cChecksum(payload == nullptr ? absl::string_view{}
+                                                  : absl::string_view{payload});
 }
 
 /**

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -55,7 +55,9 @@ std::string ComputeMD5Hash(std::string const& payload);
 
 /// @copydoc ComputeMD5Hash(absl::string_view)
 inline std::string ComputeMD5Hash(char const* payload) {
-  return ComputeMD5Hash(absl::string_view(payload));
+  auto p =
+      payload == nullptr ? absl::string_view{} : absl::string_view{payload};
+  return ComputeMD5Hash(std::move(p));
 }
 
 /**
@@ -117,7 +119,9 @@ std::string ComputeCrc32cChecksum(std::string const& payload);
 
 /// @copydoc ComputeCrc32cChecksum(absl::string_view payload)
 inline std::string ComputeCrc32cChecksum(char const* payload) {
-  return ComputeCrc32cChecksum(absl::string_view(payload));
+  auto p =
+      payload == nullptr ? absl::string_view{} : absl::string_view{payload};
+  return ComputeCrc32cChecksum(std::move(p));
 }
 
 /**

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -50,12 +50,10 @@ struct MD5HashValue
  */
 std::string ComputeMD5Hash(absl::string_view payload);
 
-/// @overload ComputeMD5Hash(absl::string_view)
-inline std::string ComputeMD5Hash(std::string const& payload) {
-  return ComputeMD5Hash(absl::string_view(payload));
-}
+/// @copydoc ComputeMD5Hash(absl::string_view)
+std::string ComputeMD5Hash(std::string const& payload);
 
-/// @overload ComputeMD5Hash(absl::string_view)
+/// @copydoc ComputeMD5Hash(absl::string_view)
 inline std::string ComputeMD5Hash(char const* payload) {
   return ComputeMD5Hash(absl::string_view(payload));
 }
@@ -114,12 +112,10 @@ struct Crc32cChecksumValue
  */
 std::string ComputeCrc32cChecksum(absl::string_view payload);
 
-/// @overload ComputeCrc32cChecksum(absl::string_view payload)
-inline std::string ComputeCrc32cChecksum(std::string const& payload) {
-  return ComputeCrc32cChecksum(absl::string_view(payload));
-}
+/// @copydoc ComputeCrc32cChecksum(absl::string_view payload)
+std::string ComputeCrc32cChecksum(std::string const& payload);
 
-/// @overload ComputeCrc32cChecksum(absl::string_view payload)
+/// @copydoc ComputeCrc32cChecksum(absl::string_view payload)
 inline std::string ComputeCrc32cChecksum(char const* payload) {
   return ComputeCrc32cChecksum(absl::string_view(payload));
 }

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1122,13 +1122,13 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
   if (request.HasOption<MD5HashValue>()) {
     metadata["md5Hash"] = request.GetOption<MD5HashValue>().value();
   } else if (!request.GetOption<DisableMD5Hash>().value_or(false)) {
-    metadata["md5Hash"] = ComputeMD5Hash(request.contents());
+    metadata["md5Hash"] = ComputeMD5Hash(request.payload());
   }
 
   if (request.HasOption<Crc32cChecksumValue>()) {
     metadata["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
   } else if (!request.GetOption<DisableCrc32cChecksum>().value_or(false)) {
-    metadata["crc32c"] = ComputeCrc32cChecksum(request.contents());
+    metadata["crc32c"] = ComputeCrc32cChecksum(request.payload());
   }
 
   std::string crlf = "\r\n";
@@ -1149,7 +1149,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
   } else {
     writer << "content-type: application/octet-stream" << crlf;
   }
-  writer << crlf << request.contents() << crlf << marker << "--" << crlf;
+  writer << crlf << request.payload() << crlf << marker << "--" << crlf;
 
   // 6. Return the results as usual.
   auto contents = std::move(writer).str();
@@ -1179,9 +1179,9 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaSimple(
   builder.AddQueryParameter("uploadType", "media");
   builder.AddQueryParameter("name", request.object_name());
   builder.AddHeader("Content-Length: " +
-                    std::to_string(request.contents().size()));
+                    std::to_string(request.payload().size()));
   return CheckedFromString<ObjectMetadataParser>(
-      std::move(builder).BuildRequest().MakeRequest(request.contents()));
+      std::move(builder).BuildRequest().MakeRequest(request.payload()));
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -68,11 +68,11 @@ CurlRequest::~CurlRequest() {
   if (factory_) CurlHandle::ReturnToPool(*factory_, std::move(handle_));
 }
 
-StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) && {
+StatusOr<HttpResponse> CurlRequest::MakeRequest(absl::string_view payload) && {
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
   if (!payload.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
-    handle_.SetOption(CURLOPT_POSTFIELDS, payload.c_str());
+    handle_.SetOption(CURLOPT_POSTFIELDS, payload.data());
   }
   return MakeRequestImpl();
 }

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -71,7 +71,7 @@ CurlRequest::~CurlRequest() {
 StatusOr<HttpResponse> CurlRequest::MakeRequest(absl::string_view payload) && {
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
   if (!payload.empty()) {
-    handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
+    handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.size());
     handle_.SetOption(CURLOPT_POSTFIELDS, payload.data());
   }
   return MakeRequestImpl();

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -55,9 +55,8 @@ class CurlRequest {
 
   /// @overload MakeRequest(absl::string_view)
   StatusOr<HttpResponse> MakeRequest(char const* payload) && {
-    auto p =
-        payload == nullptr ? absl::string_view{} : absl::string_view{payload};
-    return std::move(*this).MakeRequest(std::move(p));
+    return std::move(*this).MakeRequest(
+        payload == nullptr ? absl::string_view{} : absl::string_view{payload});
   }
 
   /// @copydoc MakeRequest(absl::string_view)

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -55,7 +55,9 @@ class CurlRequest {
 
   /// @overload MakeRequest(absl::string_view)
   StatusOr<HttpResponse> MakeRequest(char const* payload) && {
-    return std::move(*this).MakeRequest(absl::string_view(payload));
+    auto p =
+        payload == nullptr ? absl::string_view{} : absl::string_view{payload};
+    return std::move(*this).MakeRequest(std::move(p));
   }
 
   /// @copydoc MakeRequest(absl::string_view)

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/internal/curl_handle_factory.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
+#include "absl/strings/string_view.h"
 #include <string>
 
 namespace google {
@@ -43,13 +44,21 @@ class CurlRequest {
   /**
    * Makes the prepared request.
    *
-   * This function can be called multiple times on the same request.
-   *
    * @return The response HTTP error code, the headers and an empty payload.
    */
-  StatusOr<HttpResponse> MakeRequest(std::string const& payload) &&;
+  StatusOr<HttpResponse> MakeRequest(absl::string_view payload) &&;
 
-  /// @copydoc MakeRequest(std::string const&)
+  /// @overload MakeRequest(absl::string_view)
+  StatusOr<HttpResponse> MakeRequest(std::string const& payload) && {
+    return std::move(*this).MakeRequest(absl::string_view(payload));
+  }
+
+  /// @overload MakeRequest(absl::string_view)
+  StatusOr<HttpResponse> MakeRequest(char const* payload) && {
+    return std::move(*this).MakeRequest(absl::string_view(payload));
+  }
+
+  /// @copydoc MakeRequest(absl::string_view)
   StatusOr<HttpResponse> MakeUploadRequest(ConstBufferSequence payload) &&;
 
  private:

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -449,7 +449,7 @@ StatusOr<storage::ObjectMetadata> GrpcClient::InsertObjectMedia(
   using ContentType = std::remove_const_t<std::remove_reference_t<
       decltype(std::declval<google::storage::v2::ChecksummedData>()
                    .content())>>;
-  auto splitter = SplitObjectWriteData<ContentType>(request.contents());
+  auto splitter = SplitObjectWriteData<ContentType>(request.payload());
   std::int64_t offset = 0;
 
   // This loop must run at least once because we need to send at least one

--- a/google/cloud/storage/internal/grpc_object_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_metadata_parser.cc
@@ -68,7 +68,7 @@ StatusOr<std::string> MD5ToProto(std::string const& v) {
   return std::string{binary->begin(), binary->end()};
 }
 
-std::string ComputeMD5Hash(std::string const& payload) {
+std::string ComputeMD5Hash(absl::string_view payload) {
   auto b = storage::internal::MD5Hash(payload);
   return std::string{b.begin(), b.end()};
 }

--- a/google/cloud/storage/internal/grpc_object_metadata_parser.h
+++ b/google/cloud/storage/internal/grpc_object_metadata_parser.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/options.h"
+#include "absl/strings/string_view.h"
 #include <google/storage/v2/storage.pb.h>
 
 namespace google {
@@ -34,7 +35,7 @@ std::string Crc32cFromProto(std::uint32_t);
 StatusOr<std::uint32_t> Crc32cToProto(std::string const&);
 std::string MD5FromProto(std::string const&);
 StatusOr<std::string> MD5ToProto(std::string const&);
-std::string ComputeMD5Hash(std::string const& payload);
+std::string ComputeMD5Hash(absl::string_view payload);
 
 storage::ObjectMetadata FromProto(google::storage::v2::Object object,
                                   Options const& options);

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -489,7 +489,8 @@ StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
                  false)) {
     // Nothing to do, the option is disabled (mostly useful in tests).
   } else {
-    checksums.set_crc32c(crc32c::Crc32c(request.contents()));
+    checksums.set_crc32c(
+        crc32c::Crc32c(request.payload().data(), request.payload().size()));
   }
 
   if (request.HasOption<storage::MD5HashValue>()) {
@@ -500,8 +501,7 @@ StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
   } else if (request.GetOption<storage::DisableMD5Hash>().value_or(false)) {
     // Nothing to do, the option is disabled.
   } else {
-    checksums.set_md5_hash(
-        storage_internal::ComputeMD5Hash(request.contents()));
+    checksums.set_md5_hash(storage_internal::ComputeMD5Hash(request.payload()));
   }
 
   return r;

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -161,14 +161,32 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r) {
   return os << "}";
 }
 
+void InsertObjectMediaRequest::set_payload(absl::string_view payload) {
+  payload_ = payload;
+  dirty_ = true;
+}
+
+std::string const& InsertObjectMediaRequest::contents() const {
+  if (!dirty_) return contents_;
+  contents_ = std::string{payload_};
+  dirty_ = false;
+  return contents_;
+}
+
+void InsertObjectMediaRequest::set_contents(std::string v) {
+  contents_ = std::move(v);
+  payload_ = contents_;
+  dirty_ = false;
+}
+
 std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r) {
   os << "InsertObjectMediaRequest={bucket_name=" << r.bucket_name()
      << ", object_name=" << r.object_name();
   r.DumpOptions(os, ", ");
   std::size_t constexpr kMaxDumpSize = 128;
+  auto const payload = r.payload();
   os << ", contents="
-     << BinaryDataAsDebugString(r.contents().data(), r.contents().size(),
-                                kMaxDumpSize);
+     << BinaryDataAsDebugString(payload.data(), payload.size(), kMaxDumpSize);
   return os << "}";
 }
 

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -115,7 +115,7 @@ class InsertObjectMediaRequest
                                     std::string object_name,
                                     absl::string_view payload)
       : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
-        payload_(std::move(payload)) {}
+        payload_(payload) {}
 
   absl::string_view payload() const { return payload_; }
   void set_payload(absl::string_view payload);

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -26,6 +26,7 @@
 #include "google/cloud/storage/upload_options.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_parameters.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include <map>
@@ -112,18 +113,32 @@ class InsertObjectMediaRequest
 
   explicit InsertObjectMediaRequest(std::string bucket_name,
                                     std::string object_name,
-                                    std::string contents)
+                                    absl::string_view payload)
       : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
-        contents_(std::move(contents)) {}
+        payload_(std::move(payload)) {}
 
-  std::string const& contents() const { return contents_; }
-  InsertObjectMediaRequest& set_contents(std::string&& v) {
-    contents_ = std::move(v);
-    return *this;
-  }
+  absl::string_view payload() const { return payload_; }
+  void set_payload(absl::string_view payload);
+
+  ///@{
+  /**
+   * @name Backwards compatibility.
+   *
+   * While this class is in the internal namespace, the storage library
+   * requires applications to use parts of the internal namespace in mocks.
+   *
+   * These functions are only provided for backwards compatibility. The library
+   * no longer uses them, and mocks (if any) should migrate to payload() and
+   * set_payload().
+   */
+  [[deprecated("use payload() instead")]] std::string const& contents() const;
+  [[deprecated("use set_payload() instead")]] void set_contents(std::string v);
+  ///@}
 
  private:
-  std::string contents_;
+  absl::string_view payload_;
+  mutable std::string contents_;
+  mutable bool dirty_ = true;
 };
 
 std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -176,10 +176,24 @@ TEST(ObjectRequestsTest, InsertObjectMedia) {
 
 TEST(ObjectRequestsTest, InsertObjectMediaUpdateContents) {
   InsertObjectMediaRequest request("my-bucket", "my-object", "object contents");
-  EXPECT_EQ("object contents", request.contents());
-  request.set_contents("new contents");
-  EXPECT_EQ("new contents", request.contents());
+  EXPECT_EQ("object contents", request.payload());
+  request.set_payload("new contents");
+  EXPECT_EQ("new contents", request.payload());
 }
+
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
+TEST(ObjectRequestsTest, InsertObjectBackwardsCompat) {
+  auto const payload =
+      std::string("The quick brown fox jumps over the lazy dog");
+  auto const zebras = std::string("How quickly daft jumping zebras vex");
+  InsertObjectMediaRequest request("my-bucket", "my-object", payload);
+  EXPECT_EQ(payload, request.payload());
+  EXPECT_EQ(payload, request.contents());
+  request.set_contents(zebras);
+  EXPECT_EQ(zebras, request.payload());
+  EXPECT_EQ(zebras, request.contents());
+}
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 TEST(ObjectRequestsTest, Copy) {
   CopyObjectRequest request("source-bucket", "source-object", "my-bucket",

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -170,7 +170,7 @@ StatusOr<std::vector<std::uint8_t>> UrlsafeBase64Decode(
   return Base64Decode(b64str);
 }
 
-std::vector<std::uint8_t> MD5Hash(absl::Span<char const> payload) {
+std::vector<std::uint8_t> MD5Hash(absl::string_view payload) {
   std::array<unsigned char, EVP_MAX_MD_SIZE> digest;
 
   unsigned int size = 0;

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -170,7 +170,7 @@ StatusOr<std::vector<std::uint8_t>> UrlsafeBase64Decode(
   return Base64Decode(b64str);
 }
 
-std::vector<std::uint8_t> MD5Hash(std::string const& payload) {
+std::vector<std::uint8_t> MD5Hash(absl::Span<char const> payload) {
   std::array<unsigned char, EVP_MAX_MD_SIZE> digest;
 
   unsigned int size = 0;

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -88,6 +88,7 @@ inline std::vector<std::uint8_t> MD5Hash(absl::string_view payload) {
 }
 
 inline std::vector<std::uint8_t> MD5Hash(char const* payload) {
+  if (payload == nullptr) return MD5Hash(absl::Span<char const>{});
   return MD5Hash(absl::string_view(payload));
 }
 

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -81,15 +81,11 @@ inline std::string UrlsafeBase64Encode(Collection const& bytes) {
 StatusOr<std::vector<std::uint8_t>> UrlsafeBase64Decode(std::string const& str);
 
 /// Compute the MD5 hash of @p payload
-std::vector<std::uint8_t> MD5Hash(absl::Span<char const> payload);
-
-inline std::vector<std::uint8_t> MD5Hash(absl::string_view payload) {
-  return MD5Hash(absl::Span<char const>(payload.data(), payload.size()));
-}
+std::vector<std::uint8_t> MD5Hash(absl::string_view payload);
 
 inline std::vector<std::uint8_t> MD5Hash(char const* payload) {
-  if (payload == nullptr) return MD5Hash(absl::Span<char const>{});
-  return MD5Hash(absl::string_view(payload));
+  return MD5Hash(payload == nullptr ? absl::string_view{}
+                                    : absl::string_view(payload));
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/oauth2/credential_constants.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include <algorithm>
 #include <string>
@@ -80,7 +81,15 @@ inline std::string UrlsafeBase64Encode(Collection const& bytes) {
 StatusOr<std::vector<std::uint8_t>> UrlsafeBase64Decode(std::string const& str);
 
 /// Compute the MD5 hash of @p payload
-std::vector<std::uint8_t> MD5Hash(std::string const& payload);
+std::vector<std::uint8_t> MD5Hash(absl::Span<char const> payload);
+
+inline std::vector<std::uint8_t> MD5Hash(absl::string_view payload) {
+  return MD5Hash(absl::Span<char const>(payload.data(), payload.size()));
+}
+
+inline std::vector<std::uint8_t> MD5Hash(char const* payload) {
+  return MD5Hash(absl::string_view(payload));
+}
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/openssl_util_test.cc
+++ b/google/cloud/storage/internal/openssl_util_test.cc
@@ -93,7 +93,6 @@ TEST(OpensslUtilTest, MD5HashEmpty) {
       MD5Hash(nullptr),
       MD5Hash(""),
       MD5Hash(absl::string_view{}),
-      MD5Hash(absl::Span<char const>{}),
   };
 
   for (auto const& actual : values) {

--- a/google/cloud/storage/internal/openssl_util_test.cc
+++ b/google/cloud/storage/internal/openssl_util_test.cc
@@ -92,7 +92,7 @@ TEST(OpensslUtilTest, MD5HashEmpty) {
       MD5Hash({}),
       MD5Hash(nullptr),
       MD5Hash(""),
-      MD5Hash(std::string_view{}),
+      MD5Hash(absl::string_view{}),
       MD5Hash(absl::Span<char const>{}),
   };
 

--- a/google/cloud/storage/internal/openssl_util_test.cc
+++ b/google/cloud/storage/internal/openssl_util_test.cc
@@ -81,13 +81,24 @@ TEST(OpensslUtilTest, Base64DecodePadding) {
 }
 
 TEST(OpensslUtilTest, MD5HashEmpty) {
-  auto const actual = MD5Hash({});
   // I used this command to get the expected value:
   // /bin/echo -n "" | openssl md5
   auto const expected =
       std::vector<std::uint8_t>{0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04,
                                 0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e};
-  EXPECT_THAT(actual, ElementsAreArray(expected));
+
+  // There are many ways to represent the "empty" string:
+  std::vector<std::vector<std::uint8_t>> const values{
+      MD5Hash({}),
+      MD5Hash(nullptr),
+      MD5Hash(""),
+      MD5Hash(std::string_view{}),
+      MD5Hash(absl::Span<char const>{}),
+  };
+
+  for (auto const& actual : values) {
+    EXPECT_THAT(actual, ElementsAreArray(expected));
+  }
 }
 
 TEST(OpensslUtilTest, MD5HashSimple) {

--- a/google/cloud/storage/internal/openssl_util_test.cc
+++ b/google/cloud/storage/internal/openssl_util_test.cc
@@ -81,7 +81,7 @@ TEST(OpensslUtilTest, Base64DecodePadding) {
 }
 
 TEST(OpensslUtilTest, MD5HashEmpty) {
-  auto const actual = MD5Hash("");
+  auto const actual = MD5Hash({});
   // I used this command to get the expected value:
   // /bin/echo -n "" | openssl md5
   auto const expected =

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -372,13 +372,13 @@ StatusOr<ObjectMetadata> RestClient::InsertObjectMediaMultipart(
   if (request.HasOption<MD5HashValue>()) {
     metadata["md5Hash"] = request.GetOption<MD5HashValue>().value();
   } else if (!request.GetOption<DisableMD5Hash>().value_or(false)) {
-    metadata["md5Hash"] = ComputeMD5Hash(request.contents());
+    metadata["md5Hash"] = ComputeMD5Hash(request.payload());
   }
 
   if (request.HasOption<Crc32cChecksumValue>()) {
     metadata["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
   } else if (!request.GetOption<DisableCrc32cChecksum>().value_or(false)) {
-    metadata["crc32c"] = ComputeCrc32cChecksum(request.contents());
+    metadata["crc32c"] = ComputeCrc32cChecksum(request.payload());
   }
 
   std::string crlf = "\r\n";
@@ -407,7 +407,7 @@ StatusOr<ObjectMetadata> RestClient::InsertObjectMediaMultipart(
   // 6. Return the results as usual.
   return CheckedFromString<ObjectMetadataParser>(storage_rest_client_->Post(
       std::move(builder).BuildRequest(),
-      {absl::MakeConstSpan(header), absl::MakeConstSpan(request.contents()),
+      {absl::MakeConstSpan(header), absl::MakeConstSpan(request.payload()),
        absl::MakeConstSpan(trailer)}));
 }
 
@@ -434,7 +434,7 @@ StatusOr<ObjectMetadata> RestClient::InsertObjectMediaSimple(
   builder.AddQueryParameter("name", request.object_name());
   return CheckedFromString<ObjectMetadataParser>(
       storage_rest_client_->Post(std::move(builder).BuildRequest(),
-                                 {absl::MakeConstSpan(request.contents())}));
+                                 {absl::MakeConstSpan(request.payload())}));
 }
 
 StatusOr<ObjectMetadata> RestClient::InsertObjectMedia(

--- a/google/cloud/storage/parallel_uploads_test.cc
+++ b/google/cloud/storage/parallel_uploads_test.cc
@@ -329,7 +329,7 @@ auto expect_new_object = [](std::string const& object_name, int generation) {
           generation](internal::InsertObjectMediaRequest const& request) {
     EXPECT_EQ(kBucketName, request.bucket_name());
     EXPECT_EQ(object_name, request.object_name());
-    EXPECT_EQ("", request.contents());
+    EXPECT_EQ("", request.payload());
     return make_status_or(MockObject(object_name, generation));
   };
 };
@@ -340,7 +340,7 @@ auto expect_persistent_state = [](std::string const& state_name, int generation,
           state](internal::InsertObjectMediaRequest const& request) {
     EXPECT_EQ(kBucketName, request.bucket_name());
     EXPECT_EQ(state_name, request.object_name());
-    EXPECT_EQ(state.dump(), request.contents());
+    EXPECT_EQ(state.dump(), request.payload());
     return make_status_or(MockObject(state_name, generation));
   };
 };

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -604,6 +604,70 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadInternalError) {
   }
 }
 
+TEST_F(ObjectMediaIntegrationTest, StringView) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const contents = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  StatusOr<ObjectMetadata> meta =
+      client->InsertObject(bucket_name_, object_name,
+                           absl::string_view(contents), IfGenerationMatch(0));
+  ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+  EXPECT_EQ(object_name, meta->name());
+  EXPECT_EQ(bucket_name_, meta->bucket());
+
+  // Create an iostream to read the object back.
+  auto stream = client->ReadObject(bucket_name_, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(contents, actual);
+}
+
+TEST_F(ObjectMediaIntegrationTest, String) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  std::string const contents = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  StatusOr<ObjectMetadata> meta = client->InsertObject(
+      bucket_name_, object_name, contents, IfGenerationMatch(0));
+  ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+  EXPECT_EQ(object_name, meta->name());
+  EXPECT_EQ(bucket_name_, meta->bucket());
+
+  // Create an iostream to read the object back.
+  auto stream = client->ReadObject(bucket_name_, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(contents, actual);
+}
+
+TEST_F(ObjectMediaIntegrationTest, CharConstPointer) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  std::string const contents = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  StatusOr<ObjectMetadata> meta = client->InsertObject(
+      bucket_name_, object_name, contents.c_str(), IfGenerationMatch(0));
+  ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+  EXPECT_EQ(object_name, meta->name());
+  EXPECT_EQ(bucket_name_, meta->bucket());
+
+  // Create an iostream to read the object back.
+  auto stream = client->ReadObject(bucket_name_, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(contents, actual);
+}
+
 }  // anonymous namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage


### PR DESCRIPTION
We can avoid a data copy if we use `absl::string_view` to contain the object payload.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11014)
<!-- Reviewable:end -->
