### PR TITLE
fix(generator): ensure warnings and errors are sent to std::clog

### DIFF
--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -338,13 +338,14 @@ int main(int argc, char** argv) {
   if (!log_level || *log_level > google::cloud::Severity::GCP_LS_NOTICE) {
     log_level = google::cloud::Severity::GCP_LS_NOTICE;
   }
+  // A default backend is already in place, so we must remove it first.
   google::cloud::LogSink::DisableStdClog();
   google::cloud::LogSink::EnableStdClog(*log_level);
   if (*log_level <
       google::cloud::Severity::GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED) {
     GCP_LOG(WARNING)
         << "Log level " << *log_level
-        << " is less that the minimum enabled level of "
+        << " is less than the minimum enabled level of "
         << google::cloud::Severity::
                GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED
         << "; you'll need to recompile everything for that to work";

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -31,6 +31,8 @@
 #include <future>
 #include <iostream>
 
+ABSL_FLAG(std::string, log_level, "NOTICE",
+          "Set to \"INFO\", \"DEBUG\", or \"TRACE\" for additional logging.");
 ABSL_FLAG(std::string, config_file, "",
           "Text proto configuration file specifying the code to be generated.");
 ABSL_FLAG(std::string, protobuf_proto_path, "",
@@ -332,8 +334,21 @@ std::vector<std::future<google::cloud::Status>> GenerateCodeFromProtos(
 int main(int argc, char** argv) {
   int rc = 0;
   absl::ParseCommandLine(argc, argv);
-  google::cloud::LogSink::EnableStdClog(
-      google::cloud::Severity::GCP_LS_WARNING);
+  auto log_level = google::cloud::ParseSeverity(absl::GetFlag(FLAGS_log_level));
+  if (!log_level || *log_level > google::cloud::Severity::GCP_LS_NOTICE) {
+    log_level = google::cloud::Severity::GCP_LS_NOTICE;
+  }
+  google::cloud::LogSink::DisableStdClog();
+  google::cloud::LogSink::EnableStdClog(*log_level);
+  if (*log_level <
+      google::cloud::Severity::GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED) {
+    GCP_LOG(WARNING)
+        << "Log level " << *log_level
+        << " is less that the minimum enabled level of "
+        << google::cloud::Severity::
+               GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED
+        << "; you'll need to recompile everything for that to work";
+  }
 
   CommandLineArgs const args{absl::GetFlag(FLAGS_config_file),
                              absl::GetFlag(FLAGS_protobuf_proto_path),

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/internal/log_impl.h"
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include <array>
 #include <thread>
 
@@ -55,15 +54,6 @@ std::array<char const*, kSeverityCount> constexpr kSeverityNames{
     "ERROR", "CRITICAL", "ALERT", "FATAL",
 };
 
-absl::optional<Severity> ParseSeverity(std::string const& name) {
-  int i = 0;
-  for (auto const* n : kSeverityNames) {
-    if (name == n) return static_cast<Severity>(i);
-    ++i;
-  }
-  return {};
-}
-
 absl::optional<std::size_t> ParseSize(std::string const& str) {
   std::size_t econv = -1;
   auto const val = std::stol(str, &econv);
@@ -73,6 +63,15 @@ absl::optional<std::size_t> ParseSize(std::string const& str) {
 }
 
 }  // namespace
+
+absl::optional<Severity> ParseSeverity(std::string const& name) {
+  int i = 0;
+  for (auto const* n : kSeverityNames) {
+    if (name == n) return static_cast<Severity>(i);
+    ++i;
+  }
+  return {};
+}
 
 std::ostream& operator<<(std::ostream& os, Severity x) {
   auto index = static_cast<int>(x);

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/version.h"
 #include "absl/memory/memory.h"
+#include "absl/types/optional.h"
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -142,7 +143,10 @@ enum class Severity : int {
   GCP_LS_LOWEST_ENABLED = GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED,
 };
 
-/// Streaming operator, writes a human readable representation.
+/// Convert a human-readable representation to a Severity.
+absl::optional<Severity> ParseSeverity(std::string const& name);
+
+/// Streaming operator, writes a human-readable representation.
 std::ostream& operator<<(std::ostream& os, Severity x);
 
 /**

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 #include <chrono>
+#include <string>
 #include <thread>
 
 namespace google {
@@ -30,10 +31,28 @@ using ::testing::HasSubstr;
 auto constexpr kLogConfig = "GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG";
 auto constexpr kEnableClog = "GOOGLE_CLOUD_CPP_ENABLE_CLOG";
 
-TEST(LogSeverityTest, Streaming) {
-  std::ostringstream os;
-  os << Severity::GCP_LS_TRACE;
-  EXPECT_EQ("TRACE", os.str());
+TEST(LogSeverityTest, StreamingParsing) {
+  struct {
+    Severity severity;
+    std::string rep;
+  } cases[] = {
+      {Severity::GCP_LS_TRACE, "TRACE"},
+      {Severity::GCP_LS_DEBUG, "DEBUG"},
+      {Severity::GCP_LS_INFO, "INFO"},
+      {Severity::GCP_LS_NOTICE, "NOTICE"},
+      {Severity::GCP_LS_WARNING, "WARNING"},
+      {Severity::GCP_LS_ERROR, "ERROR"},
+      {Severity::GCP_LS_CRITICAL, "CRITICAL"},
+      {Severity::GCP_LS_ALERT, "ALERT"},
+      {Severity::GCP_LS_FATAL, "FATAL"},
+  };
+
+  for (auto const& test : cases) {
+    std::ostringstream os;
+    os << test.severity;
+    EXPECT_EQ(test.rep, os.str());
+    EXPECT_EQ(test.severity, ParseSeverity(test.rep));
+  }
 }
 
 TEST(LogRecordTest, Streaming) {


### PR DESCRIPTION
If the generator is to use `GCP_LOG()` to report problems, then we must ensure that logging messages end up on the "stderr" output stream. The easiest way to do that is enable the `std::clog` backend on the `LogSink` (flush/tie aside), which we were already attempting.

Unfortunately the `EnableStdClog()` call was doing nothing because a default backend was already in place.  So, we must remove that backend first, and the easiest was to do that is to call `DisableStdClog()`.

Also lower the default minimum log severity to NOTICE, which is the first level that is an indication of a problem.

And finally add a `--log_level` flag so that the minimum can be lowered all the way down to the compile-time limit.  Parsing this flag required exposing `ParseSeverity()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11017)
<!-- Reviewable:end -->
