### PR TITLE
cleanup(generator): remove obsolete parameter comment substitutions

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -39,6 +39,7 @@ if [ -z "${GENERATE_GOLDEN_ONLY}" ]; then
     --protobuf_proto_path="${bazel_output_base}"/external/com_google_protobuf/src \
     --googleapis_proto_path="${bazel_output_base}"/external/com_google_googleapis \
     --output_path="${PROJECT_ROOT}" \
+    --check_parameter_comment_substitutions=true \
     --config_file="${PROJECT_ROOT}/generator/generator_config.textproto"
 else
   io::log_red "Skipping update of generated libraries."

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -472,7 +472,7 @@ std::string EscapePrinterDelimiter(std::string const& text) {
 // Apply substitutions to the comments snarfed from the proto file for
 // method_signature parameters. This is mostly for the benefit of Doxygen,
 // but is also to fix mismatched quotes, etc.
-struct ParameterCommentSubtitution {
+struct ParameterCommentSubstitution {
   absl::string_view before;
   absl::string_view after;
   std::size_t uses = 0;
@@ -604,7 +604,7 @@ auto constexpr kDialogflowESSessionEntityTypeDisplayNameCpp = R"""(
  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
  @endcode)""";
 
-ParameterCommentSubtitution substitutions[] = {
+ParameterCommentSubstitution substitutions[] = {
     // From dialogflow/cx/v3.
     {kDialogflowCXEnvironmentIdProto1, kDialogflowCXEnvironmentIdCpp1},
     {kDialogflowCXEnvironmentIdProto2, kDialogflowCXEnvironmentIdCpp2},
@@ -839,7 +839,7 @@ std::string FormatMethodCommentsProtobufRequest(
   return FormatMethodComments(method, std::move(parameter_comment));
 }
 
-bool CheckParameterCommentSubtitutions() {
+bool CheckParameterCommentSubstitutions() {
   bool all_substitutions_used = true;
   for (auto& sub : substitutions) {
     if (sub.uses == 0) {

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -98,7 +98,7 @@ std::string FormatMethodCommentsProtobufRequest(
  * If there were any parameter comment substitutions that went unused, log
  * errors about them and return false. Otherwise do nothing and return true.
  */
-bool CheckParameterCommentSubtitutions();
+bool CheckParameterCommentSubstitutions();
 
 struct HttpSimpleInfo {
   std::string http_verb;

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -94,6 +94,12 @@ std::string FormatMethodCommentsMethodSignature(
 std::string FormatMethodCommentsProtobufRequest(
     google::protobuf::MethodDescriptor const& method);
 
+/**
+ * If there were any parameter comment substitutions that went unused, log
+ * errors about them and return false. Otherwise do nothing and return true.
+ */
+bool CheckParameterCommentSubtitutions();
+
 struct HttpSimpleInfo {
   std::string http_verb;
   std::string url_path;

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -411,7 +411,8 @@ int main(int argc, char** argv) {
   // being built in) so that the check could be unconditional (instead of
   // flag-based).
   if (absl::GetFlag(FLAGS_check_parameter_comment_substitutions) &&
-      !google::cloud::generator_internal::CheckParameterCommentSubtitutions()) {
+      !google::cloud::generator_internal::
+          CheckParameterCommentSubstitutions()) {
     GCP_LOG(FATAL) << "Remove unused parameter comment substitution(s)";
   }
 


### PR DESCRIPTION
A couple of the ad hoc substitutions we apply to the comments for method_signature parameters are no longer needed (the ones from google/pubsub/v1/schema.proto), so remove them.

How do we know they're obsolete?  By making it a fatal error for a substitution to fail to match.  This will make it easy for us to remove dead cruft.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11021)
<!-- Reviewable:end -->
