### PR TITLE
cleanup: use `std::make_shared<grpc::ClientContext>`

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
@@ -148,7 +148,7 @@ GoldenKitchenSinkConnectionImpl::StreamingRead(google::test::admin::database::v1
   auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
 
   auto factory = [stub](google::test::admin::database::v1::Request const& request) {
-    return stub->StreamingRead(absl::make_unique<grpc::ClientContext>(), request);
+    return stub->StreamingRead(std::make_shared<grpc::ClientContext>(), request);
   };
   auto resumable =
       internal::MakeResumableStreamingReadRpc<google::test::admin::database::v1::Response, google::test::admin::database::v1::Request>(

--- a/generator/integration_tests/golden/v1/internal/streaming.cc
+++ b/generator/integration_tests/golden/v1/internal/streaming.cc
@@ -26,7 +26,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::test::admin::database::v1::Response>>
 GoldenKitchenSinkConnectionImpl::AsyncStreamingReadWrite() {
   return stub_->AsyncStreamingReadWrite(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
+      background_->cq(), std::make_shared<grpc::ClientContext>());
 }
 
 void GoldenKitchenSinkStreamingReadStreamingUpdater(

--- a/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
@@ -129,13 +129,13 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, StreamingRead) {
   ::google::test::admin::database::v1::Request request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.StreamingRead(
-      absl::make_unique<grpc::ClientContext>(), request);
+      std::make_shared<grpc::ClientContext>(), request);
   auto v = auth_failure->Read();
   ASSERT_TRUE(absl::holds_alternative<Status>(v));
   EXPECT_THAT(absl::get<Status>(v), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.StreamingRead(
-      absl::make_unique<grpc::ClientContext>(), request);
+      std::make_shared<grpc::ClientContext>(), request);
   v = auth_success->Read();
   ASSERT_TRUE(absl::holds_alternative<Status>(v));
   EXPECT_THAT(absl::get<Status>(v), StatusIs(StatusCode::kPermissionDenied));
@@ -172,12 +172,12 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, StreamingWrite) {
 
   auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
   auto stream =
-      under_test.StreamingWrite(absl::make_unique<grpc::ClientContext>());
+      under_test.StreamingWrite(std::make_shared<grpc::ClientContext>());
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();
   EXPECT_THAT(response, StatusIs(StatusCode::kInvalidArgument));
 
-  stream = under_test.StreamingWrite(absl::make_unique<grpc::ClientContext>());
+  stream = under_test.StreamingWrite(std::make_shared<grpc::ClientContext>());
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   response = stream->Close();
@@ -197,14 +197,14 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, AsyncStreamingRead) {
   ::google::test::admin::database::v1::Request request;
 
   auto auth_failure = under_test.AsyncStreamingRead(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   auto start = auth_failure->Start().get();
   EXPECT_FALSE(start);
   auto finish = auth_failure->Finish().get();
   EXPECT_THAT(finish, StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncStreamingRead(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   start = auth_success->Start().get();
   EXPECT_FALSE(start);
   finish = auth_success->Finish().get();
@@ -223,14 +223,14 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, AsyncStreamingWrite) {
   auto under_test = GoldenKitchenSinkAuth(MakeTypicalAsyncMockAuth(), mock);
 
   auto auth_failure = under_test.AsyncStreamingWrite(
-      cq, absl::make_unique<grpc::ClientContext>());
+      cq, std::make_shared<grpc::ClientContext>());
   auto start = auth_failure->Start().get();
   EXPECT_FALSE(start);
   auto finish = auth_failure->Finish().get();
   EXPECT_THAT(finish, StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncStreamingWrite(
-      cq, absl::make_unique<grpc::ClientContext>());
+      cq, std::make_shared<grpc::ClientContext>());
   start = auth_success->Start().get();
   EXPECT_FALSE(start);
   finish = auth_success->Finish().get();

--- a/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -195,7 +195,7 @@ TEST_F(LoggingDecoratorTest, StreamingReadRpcNoRpcStreams) {
       .WillOnce(Return(ByMove(std::move(mock_response))));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   auto response =
-      stub.StreamingRead(absl::make_unique<grpc::ClientContext>(), Request{});
+      stub.StreamingRead(std::make_shared<grpc::ClientContext>(), Request{});
   EXPECT_THAT(absl::get<Status>(response->Read()), IsOk());
 
   auto const log_lines = log_.ExtractLines();
@@ -211,7 +211,7 @@ TEST_F(LoggingDecoratorTest, StreamingReadRpcWithRpcStreams) {
       .WillOnce(Return(ByMove(std::move(mock_response))));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {"rpc-streams"});
   auto response =
-      stub.StreamingRead(absl::make_unique<grpc::ClientContext>(), Request{});
+      stub.StreamingRead(std::make_shared<grpc::ClientContext>(), Request{});
   EXPECT_THAT(absl::get<Status>(response->Read()), IsOk());
 
   auto const log_lines = log_.ExtractLines();
@@ -230,7 +230,7 @@ TEST_F(LoggingDecoratorTest, StreamingWrite) {
     return stream;
   });
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
-  auto stream = stub.StreamingWrite(absl::make_unique<grpc::ClientContext>());
+  auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();
@@ -255,7 +255,7 @@ TEST_F(LoggingDecoratorTest, StreamingWriteFullTracing) {
     return stream;
   });
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {"rpc-streams"});
-  auto stream = stub.StreamingWrite(absl::make_unique<grpc::ClientContext>());
+  auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();
@@ -280,7 +280,7 @@ TEST_F(LoggingDecoratorTest, AsyncStreamingRead) {
 
   google::cloud::CompletionQueue cq;
   auto stream = stub.AsyncStreamingRead(
-      cq, absl::make_unique<grpc::ClientContext>(), Request{});
+      cq, std::make_shared<grpc::ClientContext>(), Request{});
 
   auto start = stream->Start().get();
   EXPECT_FALSE(start);
@@ -304,7 +304,7 @@ TEST_F(LoggingDecoratorTest, AsyncStreamingWrite) {
 
   google::cloud::CompletionQueue cq;
   auto stream =
-      stub.AsyncStreamingWrite(cq, absl::make_unique<grpc::ClientContext>());
+      stub.AsyncStreamingWrite(cq, std::make_shared<grpc::ClientContext>());
 
   auto start = stream->Start().get();
   EXPECT_FALSE(start);

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -227,7 +227,7 @@ TEST_F(MetadataDecoratorTest, StreamingRead) {
       });
   GoldenKitchenSinkMetadata stub(mock_);
   auto response =
-      stub.StreamingRead(absl::make_unique<grpc::ClientContext>(), Request{});
+      stub.StreamingRead(std::make_shared<grpc::ClientContext>(), Request{});
   EXPECT_THAT(absl::get<Status>(response->Read()), Not(IsOk()));
 }
 
@@ -247,7 +247,7 @@ TEST_F(MetadataDecoratorTest, StreamingWrite) {
   });
 
   GoldenKitchenSinkMetadata stub(mock_);
-  auto stream = stub.StreamingWrite(absl::make_unique<grpc::ClientContext>());
+  auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();
@@ -272,7 +272,7 @@ TEST_F(MetadataDecoratorTest, AsyncStreamingRead) {
 
   google::cloud::CompletionQueue cq;
   auto stream = stub.AsyncStreamingRead(
-      cq, absl::make_unique<grpc::ClientContext>(), Request{});
+      cq, std::make_shared<grpc::ClientContext>(), Request{});
 
   auto start = stream->Start().get();
   EXPECT_FALSE(start);
@@ -297,7 +297,7 @@ TEST_F(MetadataDecoratorTest, AsyncStreamingWrite) {
 
   google::cloud::CompletionQueue cq;
   auto stream =
-      stub.AsyncStreamingWrite(cq, absl::make_unique<grpc::ClientContext>());
+      stub.AsyncStreamingWrite(cq, std::make_shared<grpc::ClientContext>());
 
   auto start = stream->Start().get();
   EXPECT_FALSE(start);

--- a/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
@@ -82,7 +82,7 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, StreamingRead) {
   GoldenKitchenSinkRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto stream =
-        stub.StreamingRead(absl::make_unique<grpc::ClientContext>(), Request{});
+        stub.StreamingRead(std::make_shared<grpc::ClientContext>(), Request{});
     EXPECT_THAT(stream, NotNull());
   }
 }
@@ -100,7 +100,7 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, StreamingWrite) {
 
   GoldenKitchenSinkRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
-    auto stream = stub.StreamingWrite(absl::make_unique<grpc::ClientContext>());
+    auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
     EXPECT_THAT(stream, NotNull());
   }
 }
@@ -120,7 +120,7 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, AsyncStreamingReadWrite) {
   GoldenKitchenSinkRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto stream = stub.AsyncStreamingReadWrite(
-        cq, absl::make_unique<grpc::ClientContext>());
+        cq, std::make_shared<grpc::ClientContext>());
     EXPECT_THAT(stream, NotNull());
   }
 }
@@ -140,7 +140,7 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, AsyncStreamingRead) {
   GoldenKitchenSinkRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto stream = stub.AsyncStreamingRead(
-        cq, absl::make_unique<grpc::ClientContext>(), Request{});
+        cq, std::make_shared<grpc::ClientContext>(), Request{});
     EXPECT_THAT(stream, NotNull());
   }
 }
@@ -160,7 +160,7 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, AsyncStreamingWrite) {
   GoldenKitchenSinkRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto stream =
-        stub.AsyncStreamingWrite(cq, absl::make_unique<grpc::ClientContext>());
+        stub.AsyncStreamingWrite(cq, std::make_shared<grpc::ClientContext>());
     EXPECT_THAT(stream, NotNull());
   }
 }

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -459,11 +459,11 @@ TEST_F(GoldenKitchenSinkStubTest, StreamingRead) {
       .WillOnce(Return(failure_response.release()));
   DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
   auto success_stream =
-      stub.StreamingRead(absl::make_unique<grpc::ClientContext>(), request);
+      stub.StreamingRead(std::make_shared<grpc::ClientContext>(), request);
   auto success_status = absl::get<Status>(success_stream->Read());
   EXPECT_THAT(success_status, IsOk());
   auto failure_stream =
-      stub.StreamingRead(absl::make_unique<grpc::ClientContext>(), request);
+      stub.StreamingRead(std::make_shared<grpc::ClientContext>(), request);
   auto failure_status = absl::get<Status>(failure_stream->Read());
   EXPECT_THAT(failure_status, StatusIs(StatusCode::kUnavailable));
 }
@@ -478,7 +478,7 @@ class MockWriteObjectResponse
 };
 
 TEST_F(GoldenKitchenSinkStubTest, StreamingWrite) {
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   Request request;
   EXPECT_CALL(*grpc_stub_, StreamingWriteRaw(context.get(), _))
       .WillOnce([](::grpc::ClientContext*, Response*) {
@@ -544,8 +544,8 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWriteRead) {
 
   DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
 
-  auto stream = stub.AsyncStreamingReadWrite(
-      cq, absl::make_unique<grpc::ClientContext>());
+  auto stream =
+      stub.AsyncStreamingReadWrite(cq, std::make_shared<grpc::ClientContext>());
   auto start = stream->Start();
   notify_next_op(true);
   EXPECT_TRUE(start.get());
@@ -617,7 +617,7 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingRead) {
 
   Request request;
   auto stream = stub.AsyncStreamingRead(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   auto start = stream->Start();
   notify_next_op(true);
   EXPECT_TRUE(start.get());
@@ -687,7 +687,7 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWrite) {
   DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
 
   auto stream =
-      stub.AsyncStreamingWrite(cq, absl::make_unique<grpc::ClientContext>());
+      stub.AsyncStreamingWrite(cq, std::make_shared<grpc::ClientContext>());
   auto start = stream->Start();
   notify_next_op(true);
   EXPECT_TRUE(start.get());

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -183,7 +183,7 @@ TEST(GoldenKitchenSinkTracingStubTest, StreamingRead) {
 
   auto under_test = GoldenKitchenSinkTracingStub(mock);
   auto stream = under_test.StreamingRead(
-      absl::make_unique<grpc::ClientContext>(), Request{});
+      std::make_shared<grpc::ClientContext>(), Request{});
   auto v = stream->Read();
   EXPECT_THAT(v, VariantWith<Status>(StatusIs(StatusCode::kAborted)));
 }
@@ -260,7 +260,7 @@ TEST(GoldenKitchenSinkTracingStubTest, StreamingWrite) {
 
   auto under_test = GoldenKitchenSinkTracingStub(mock);
   auto stream =
-      under_test.StreamingWrite(absl::make_unique<grpc::ClientContext>());
+      under_test.StreamingWrite(std::make_shared<grpc::ClientContext>());
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();
   EXPECT_THAT(response, StatusIs(StatusCode::kAborted));
@@ -277,7 +277,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingRead) {
   google::cloud::CompletionQueue cq;
   auto under_test = GoldenKitchenSinkTracingStub(mock);
   auto stream = under_test.AsyncStreamingRead(
-      cq, absl::make_unique<grpc::ClientContext>(), Request{});
+      cq, std::make_shared<grpc::ClientContext>(), Request{});
   auto start = stream->Start().get();
   EXPECT_FALSE(start);
   auto finish = stream->Finish().get();
@@ -296,7 +296,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingWrite) {
   auto under_test = GoldenKitchenSinkTracingStub(mock);
 
   auto stream = under_test.AsyncStreamingWrite(
-      cq, absl::make_unique<grpc::ClientContext>());
+      cq, std::make_shared<grpc::ClientContext>());
   auto start = stream->Start().get();
   EXPECT_FALSE(start);
   auto finish = stream->Finish().get();
@@ -316,7 +316,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingReadWrite) {
   auto under_test = GoldenKitchenSinkTracingStub(mock);
 
   auto stream = under_test.AsyncStreamingReadWrite(
-      cq, absl::make_unique<grpc::ClientContext>());
+      cq, std::make_shared<grpc::ClientContext>());
   auto start = stream->Start().get();
   EXPECT_FALSE(start);
   auto finish = stream->Finish().get();

--- a/generator/integration_tests/tests/golden_thing_admin_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_auth_decorator_test.cc
@@ -70,11 +70,11 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncCreateDatabase) {
   google::test::admin::database::v1::CreateDatabaseRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncCreateDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncCreateDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -103,11 +103,11 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncUpdateDatabaseDdl) {
   google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncUpdateDatabaseDdl(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncUpdateDatabaseDdl(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -204,11 +204,11 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncCreateBackup) {
   google::test::admin::database::v1::CreateBackupRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncCreateBackup(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncCreateBackup(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -288,11 +288,11 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncRestoreDatabase) {
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncRestoreDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncRestoreDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -342,11 +342,11 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncGetDatabase) {
   google::test::admin::database::v1::GetDatabaseRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncGetDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncGetDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -360,11 +360,11 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncDropDatabase) {
   google::test::admin::database::v1::DropDatabaseRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncDropDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncDropDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -376,11 +376,11 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncGetOperation) {
   google::longrunning::GetOperationRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncGetOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncGetOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -394,11 +394,11 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncCancelOperation) {
   google::longrunning::CancelOperationRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncCancelOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncCancelOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_logging_decorator_test.cc
@@ -102,7 +102,7 @@ TEST_F(LoggingDecoratorTest, CreateDatabase) {
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   CompletionQueue cq;
   auto status = stub.AsyncCreateDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(),
+      cq, std::make_shared<grpc::ClientContext>(),
       google::test::admin::database::v1::CreateDatabaseRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
@@ -118,7 +118,7 @@ TEST_F(LoggingDecoratorTest, UpdateDatabaseDdl) {
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   CompletionQueue cq;
   auto status = stub.AsyncUpdateDatabaseDdl(
-      cq, absl::make_unique<grpc::ClientContext>(),
+      cq, std::make_shared<grpc::ClientContext>(),
       google::test::admin::database::v1::UpdateDatabaseDdlRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
@@ -203,7 +203,7 @@ TEST_F(LoggingDecoratorTest, CreateBackup) {
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   CompletionQueue cq;
   auto status = stub.AsyncCreateBackup(
-      cq, absl::make_unique<grpc::ClientContext>(),
+      cq, std::make_shared<grpc::ClientContext>(),
       google::test::admin::database::v1::CreateBackupRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
@@ -274,7 +274,7 @@ TEST_F(LoggingDecoratorTest, RestoreDatabase) {
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   CompletionQueue cq;
   auto status = stub.AsyncRestoreDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(),
+      cq, std::make_shared<grpc::ClientContext>(),
       google::test::admin::database::v1::RestoreDatabaseRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
@@ -324,7 +324,7 @@ TEST_F(LoggingDecoratorTest, AsyncGetDatabase) {
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   CompletionQueue cq;
   auto status = stub.AsyncGetDatabase(
-                        cq, absl::make_unique<grpc::ClientContext>(),
+                        cq, std::make_shared<grpc::ClientContext>(),
                         google::test::admin::database::v1::GetDatabaseRequest())
                     .get();
   EXPECT_EQ(TransientError(), status.status());
@@ -343,7 +343,7 @@ TEST_F(LoggingDecoratorTest, AsyncDropDatabase) {
   CompletionQueue cq;
   auto status =
       stub.AsyncDropDatabase(
-              cq, absl::make_unique<grpc::ClientContext>(),
+              cq, std::make_shared<grpc::ClientContext>(),
               google::test::admin::database::v1::DropDatabaseRequest())
           .get();
   EXPECT_EQ(TransientError(), status);
@@ -359,7 +359,7 @@ TEST_F(LoggingDecoratorTest, GetOperation) {
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   CompletionQueue cq;
   auto status =
-      stub.AsyncGetOperation(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncGetOperation(cq, std::make_shared<grpc::ClientContext>(),
                              google::longrunning::GetOperationRequest());
   EXPECT_EQ(TransientError(), status.get().status());
 
@@ -375,7 +375,7 @@ TEST_F(LoggingDecoratorTest, CancelOperation) {
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   CompletionQueue cq;
   auto status =
-      stub.AsyncCancelOperation(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncCancelOperation(cq, std::make_shared<grpc::ClientContext>(),
                                 google::longrunning::CancelOperationRequest());
   EXPECT_EQ(TransientError(), status.get());
 

--- a/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -119,7 +119,7 @@ TEST_F(MetadataDecoratorTest, CreateDatabase) {
   google::test::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
   auto status = stub.AsyncCreateDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -143,7 +143,7 @@ TEST_F(MetadataDecoratorTest, UpdateDatabaseDdl) {
   request.set_database(
       "projects/my_project/instances/my_instance/databases/my_database");
   auto status = stub.AsyncUpdateDatabaseDdl(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -270,7 +270,7 @@ TEST_F(MetadataDecoratorTest, CreateBackup) {
   google::test::admin::database::v1::CreateBackupRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
   auto status = stub.AsyncCreateBackup(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -377,7 +377,7 @@ TEST_F(MetadataDecoratorTest, RestoreDatabase) {
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
   auto status = stub.AsyncRestoreDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -442,7 +442,7 @@ TEST_F(MetadataDecoratorTest, AsyncGetDatabase) {
   request.set_name(
       "projects/my_project/instances/my_instance/databases/my_database");
   auto status = stub.AsyncGetDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -465,7 +465,7 @@ TEST_F(MetadataDecoratorTest, AsyncDropDatabase) {
   request.set_database(
       "projects/my_project/instances/my_instance/databases/my_database");
   auto status = stub.AsyncDropDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get());
 }
 
@@ -488,7 +488,7 @@ TEST_F(MetadataDecoratorTest, LongRunningWithoutRouting) {
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
   auto status = stub.AsyncLongRunningWithoutRouting(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -507,7 +507,7 @@ TEST_F(MetadataDecoratorTest, GetOperation) {
   google::longrunning::GetOperationRequest request;
   request.set_name("operations/my_operation");
   auto status = stub.AsyncGetOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
@@ -527,7 +527,7 @@ TEST_F(MetadataDecoratorTest, CancelOperation) {
   google::longrunning::CancelOperationRequest request;
   request.set_name("operations/my_operation");
   auto status = stub.AsyncCancelOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get());
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_round_robin_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_round_robin_decorator_test.cc
@@ -63,7 +63,7 @@ TEST(GoldenThingAdminRoundRobinDecoratorTest, AsyncCreateDatabase) {
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto status =
         stub.AsyncCreateDatabase(
-                cq, absl::make_unique<grpc::ClientContext>(),
+                cq, std::make_shared<grpc::ClientContext>(),
                 google::test::admin::database::v1::CreateDatabaseRequest{})
             .get();
     EXPECT_STATUS_OK(status);
@@ -105,7 +105,7 @@ TEST(GoldenThingAdminRoundRobinDecoratorTest, AsyncGetDatabase) {
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto status =
         stub.AsyncGetDatabase(
-                cq, absl::make_unique<grpc::ClientContext>(),
+                cq, std::make_shared<grpc::ClientContext>(),
                 google::test::admin::database::v1::GetDatabaseRequest{})
             .get();
     EXPECT_STATUS_OK(status);
@@ -127,7 +127,7 @@ TEST(GoldenThingAdminRoundRobinDecoratorTest, AsyncDropDatabase) {
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto status =
         stub.AsyncDropDatabase(
-                cq, absl::make_unique<grpc::ClientContext>(),
+                cq, std::make_shared<grpc::ClientContext>(),
                 google::test::admin::database::v1::DropDatabaseRequest{})
             .get();
     EXPECT_STATUS_OK(status);
@@ -149,7 +149,7 @@ TEST(GoldenThingAdminRoundRobinDecoratorTest, AsyncGetOperation) {
   GoldenThingAdminRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto status =
-        stub.AsyncGetOperation(cq, absl::make_unique<grpc::ClientContext>(),
+        stub.AsyncGetOperation(cq, std::make_shared<grpc::ClientContext>(),
                                google::longrunning::GetOperationRequest{})
             .get();
     EXPECT_STATUS_OK(status);
@@ -170,7 +170,7 @@ TEST(GoldenThingAdminRoundRobinDecoratorTest, AsyncCancelOperation) {
   GoldenThingAdminRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto status =
-        stub.AsyncCancelOperation(cq, absl::make_unique<grpc::ClientContext>(),
+        stub.AsyncCancelOperation(cq, std::make_shared<grpc::ClientContext>(),
                                   google::longrunning::CancelOperationRequest{})
             .get();
     EXPECT_STATUS_OK(status);

--- a/generator/integration_tests/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_stub_test.cc
@@ -606,7 +606,7 @@ TEST_F(GoldenStubTest, AsyncCreateDatabase) {
                                    std::move(longrunning_stub_));
   google::test::admin::database::v1::CreateDatabaseRequest request;
   auto failure = stub.AsyncCreateDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 
@@ -643,7 +643,7 @@ TEST_F(GoldenStubTest, AsyncUpdateDatabaseDdl) {
                                    std::move(longrunning_stub_));
   google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   auto failure = stub.AsyncUpdateDatabaseDdl(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 
@@ -739,7 +739,7 @@ TEST_F(GoldenStubTest, AsyncCreateBackup) {
                                    std::move(longrunning_stub_));
   google::test::admin::database::v1::CreateBackupRequest request;
   auto failure = stub.AsyncCreateBackup(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 
@@ -821,7 +821,7 @@ TEST_F(GoldenStubTest, AsyncRestoreDatabase) {
                                    std::move(longrunning_stub_));
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   auto failure = stub.AsyncRestoreDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 
@@ -873,7 +873,7 @@ TEST_F(GoldenStubTest, AsyncGetDatabase) {
                                    std::move(longrunning_stub_));
   google::test::admin::database::v1::GetDatabaseRequest request;
   auto failure = stub.AsyncGetDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 
@@ -894,7 +894,7 @@ TEST_F(GoldenStubTest, AsyncDropDatabase) {
                                    std::move(longrunning_stub_));
   google::test::admin::database::v1::DropDatabaseRequest request;
   auto failure = stub.AsyncDropDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 
@@ -916,7 +916,7 @@ TEST_F(GoldenStubTest, AsyncGetOperation) {
                                    std::move(longrunning_stub_));
   google::longrunning::GetOperationRequest request;
   auto failure = stub.AsyncGetOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 
@@ -938,7 +938,7 @@ TEST_F(GoldenStubTest, AsyncCancelOperation) {
                                    std::move(longrunning_stub_));
   google::longrunning::CancelOperationRequest request;
   auto failure = stub.AsyncCancelOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
@@ -93,7 +93,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCreateDatabase) {
   google::test::admin::database::v1::CreateDatabaseRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncCreateDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 }
 
@@ -135,7 +135,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncUpdateDatabaseDdl) {
   google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncUpdateDatabaseDdl(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 }
 
@@ -297,7 +297,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCreateBackup) {
   google::test::admin::database::v1::CreateBackupRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncCreateBackup(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 }
 
@@ -428,7 +428,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncRestoreDatabase) {
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncRestoreDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 }
 
@@ -503,7 +503,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncGetDatabase) {
   google::test::admin::database::v1::GetDatabaseRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncGetDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 }
 
@@ -517,7 +517,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncDropDatabase) {
   google::test::admin::database::v1::DropDatabaseRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncDropDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 }
 
@@ -529,7 +529,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncGetOperation) {
   google::longrunning::GetOperationRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncGetOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 }
 
@@ -543,7 +543,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCancelOperation) {
   google::longrunning::CancelOperationRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncCancelOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 }
 

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -316,7 +316,7 @@ $connection_class_name$Impl::$method_name$($request_type$ const& request) {
   auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
 
   auto factory = [stub]($request_type$ const& request) {
-    return stub->$method_name$(absl::make_unique<grpc::ClientContext>(), request);
+    return stub->$method_name$(std::make_shared<grpc::ClientContext>(), request);
   };
   auto resumable =
       internal::MakeResumableStreamingReadRpc<$response_type$, $request_type$>(

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_connection_impl.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_connection_impl.cc
@@ -66,8 +66,7 @@ BigQueryReadConnectionImpl::ReadRows(
   auto factory =
       [stub](google::cloud::bigquery::storage::v1::ReadRowsRequest const&
                  request) {
-        return stub->ReadRows(absl::make_unique<grpc::ClientContext>(),
-                              request);
+        return stub->ReadRows(std::make_shared<grpc::ClientContext>(), request);
       };
   auto resumable = internal::MakeResumableStreamingReadRpc<
       google::cloud::bigquery::storage::v1::ReadRowsResponse,

--- a/google/cloud/bigquery/storage/v1/internal/streaming.cc
+++ b/google/cloud/bigquery/storage/v1/internal/streaming.cc
@@ -32,7 +32,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::cloud::bigquery::storage::v1::AppendRowsResponse>>
 BigQueryWriteConnectionImpl::AsyncAppendRows() {
   return stub_->AsyncAppendRows(background_->cq(),
-                                absl::make_unique<grpc::ClientContext>());
+                                std::make_shared<grpc::ClientContext>());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -56,7 +56,7 @@ AsyncBulkApplier::AsyncBulkApplier(
 
 void AsyncBulkApplier::StartIteration() {
   internal::OptionsSpan span(options_);
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   internal::ConfigureContext(*context, internal::CurrentOptions());
 
   auto self = this->shared_from_this();

--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -41,7 +41,7 @@ void AsyncRowReader::MakeRequest() {
   parser_ = bigtable::internal::ReadRowsParserFactory().Create();
 
   internal::OptionsSpan span(options_);
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   internal::ConfigureContext(*context, internal::CurrentOptions());
 
   auto self = this->shared_from_this();

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -55,7 +55,7 @@ void AsyncRowSampler::StartIteration() {
   request.set_table_name(table_name_);
 
   internal::OptionsSpan span(options_);
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   internal::ConfigureContext(*context, internal::CurrentOptions());
 
   auto self = this->shared_from_this();

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -121,7 +121,7 @@ TEST_F(BigtableStubFactory, ReadRows) {
   req.set_table_name(
       "projects/the-project/instances/the-instance/tables/the-table");
   auto stub = CreateTestStub(cq, factory.AsStdFunction());
-  auto stream = stub->ReadRows(absl::make_unique<grpc::ClientContext>(), req);
+  auto stream = stub->ReadRows(std::make_shared<grpc::ClientContext>(), req);
   auto read = stream->Read();
   ASSERT_TRUE(absl::holds_alternative<Status>(read));
   EXPECT_THAT(absl::get<Status>(read), StatusIs(StatusCode::kUnavailable));
@@ -204,7 +204,7 @@ TEST_F(BigtableStubFactory, AsyncReadRows) {
       "projects/the-project/instances/the-instance/tables/the-table");
   auto stub = CreateTestStub(cq, factory.AsStdFunction());
   auto stream =
-      stub->AsyncReadRows(cq, absl::make_unique<grpc::ClientContext>(), req);
+      stub->AsyncReadRows(cq, std::make_shared<grpc::ClientContext>(), req);
   auto start = stream->Start().get();
   EXPECT_FALSE(start);
   auto finish = stream->Finish().get();
@@ -247,7 +247,7 @@ TEST_F(BigtableStubFactory, AsyncMutateRow) {
       "projects/the-project/instances/the-instance/tables/the-table");
   auto stub = CreateTestStub(cq, factory.AsStdFunction());
   auto response =
-      stub->AsyncMutateRow(cq, absl::make_unique<grpc::ClientContext>(), req);
+      stub->AsyncMutateRow(cq, std::make_shared<grpc::ClientContext>(), req);
   EXPECT_THAT(response.get(), StatusIs(StatusCode::kUnavailable));
   EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("AsyncMutateRow")));
 }

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -209,7 +209,7 @@ Status BulkMutator::MakeOneRequest(bigtable_internal::BigtableStub& stub) {
 
   // Configure the context
   auto const& options = google::cloud::internal::CurrentOptions();
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   google::cloud::internal::ConfigureContext(*context, options);
 
   struct UnpackVariant {

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -288,7 +288,7 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
   std::unique_ptr<bigtable::DataRetryPolicy> retry;
   std::unique_ptr<BackoffPolicy> backoff;
   while (true) {
-    auto context = absl::make_unique<grpc::ClientContext>();
+    auto context = std::make_shared<grpc::ClientContext>();
     internal::ConfigureContext(*context, internal::CurrentOptions());
     auto stream = stub_->SampleRowKeys(std::move(context), request);
 

--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -57,7 +57,7 @@ void DefaultRowReader::MakeRequest() {
   }
 
   auto const& options = internal::CurrentOptions();
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   internal::ConfigureContext(*context, options);
   stream_ = stub_->ReadRows(std::move(context), request);
   stream_is_open_ = true;

--- a/google/cloud/dialogflow_cx/internal/streaming.cc
+++ b/google/cloud/dialogflow_cx/internal/streaming.cc
@@ -24,7 +24,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::cloud::dialogflow::cx::v3::StreamingDetectIntentResponse>>
 SessionsConnectionImpl::AsyncStreamingDetectIntent() {
   return stub_->AsyncStreamingDetectIntent(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
+      background_->cq(), std::make_shared<grpc::ClientContext>());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/internal/streaming.cc
+++ b/google/cloud/dialogflow_es/internal/streaming.cc
@@ -25,7 +25,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::cloud::dialogflow::v2::StreamingDetectIntentResponse>>
 SessionsConnectionImpl::AsyncStreamingDetectIntent() {
   return stub_->AsyncStreamingDetectIntent(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
+      background_->cq(), std::make_shared<grpc::ClientContext>());
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -33,7 +33,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::cloud::dialogflow::v2::StreamingAnalyzeContentResponse>>
 ParticipantsConnectionImpl::AsyncStreamingAnalyzeContent() {
   return stub_->AsyncStreamingAnalyzeContent(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
+      background_->cq(), std::make_shared<grpc::ClientContext>());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -74,7 +74,7 @@ class AsyncPollingLoopImpl
     }
     // Cancels are best effort, so we use weak pointers.
     auto w = WeakFromThis();
-    auto context = absl::make_unique<grpc::ClientContext>();
+    auto context = std::make_shared<grpc::ClientContext>();
     ConfigurePollContext(*context, CurrentOptions());
     cancel_(cq_, std::move(context), request).then([w](future<Status> f) {
       if (auto self = w.lock()) self->OnCancel(f.get());
@@ -118,7 +118,7 @@ class AsyncPollingLoopImpl
       request.set_name(op_name_);
     }
     auto self = shared_from_this();
-    auto context = absl::make_unique<grpc::ClientContext>();
+    auto context = std::make_shared<grpc::ClientContext>();
     ConfigurePollContext(*context, CurrentOptions());
     poll_(cq_, std::move(context), request)
         .then([self](future<StatusOr<Operation>> g) {

--- a/google/cloud/internal/async_read_write_stream_auth_test.cc
+++ b/google/cloud/internal/async_read_write_stream_auth_test.cc
@@ -78,7 +78,7 @@ TEST(AsyncStreamReadWriteAuth, Start) {
     return make_ready_future(make_status_or(std::move(context)));
   });
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   EXPECT_TRUE(uut->Start().get());
   EXPECT_TRUE(uut->Write(FakeRequest{"k"}, grpc::WriteOptions()).get());
   auto response = uut->Read().get();

--- a/google/cloud/internal/async_read_write_stream_impl_test.cc
+++ b/google/cloud/internal/async_read_write_stream_impl_test.cc
@@ -114,7 +114,7 @@ TEST(AsyncReadWriteStreamingRpcTest, Basic) {
 
   google::cloud::CompletionQueue cq(mock_cq);
   auto stream = MakeStreamingReadWriteRpc<FakeRequest, FakeResponse>(
-      cq, absl::make_unique<grpc::ClientContext>(),
+      cq, std::make_shared<grpc::ClientContext>(),
       [&mock](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
         return mock.FakeRpc(context, cq);
       });

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -228,7 +228,7 @@ class AsyncRetryLoopImpl
     }
     auto state = StartOperation();
     if (state.cancelled) return;
-    auto context = absl::make_unique<grpc::ClientContext>();
+    auto context = std::make_shared<grpc::ClientContext>();
     ConfigureContext(*context, options_);
     SetupContext<RetryPolicyType>::Setup(*retry_policy_, *context);
     SetPending(

--- a/google/cloud/internal/async_streaming_read_rpc_auth_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_auth_test.cc
@@ -70,7 +70,7 @@ TEST(AsyncStreamReadWriteAuth, Start) {
     return make_ready_future(make_status_or(std::move(context)));
   });
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   EXPECT_TRUE(uut->Start().get());
   auto response = uut->Read().get();
   ASSERT_TRUE(response.has_value());
@@ -93,7 +93,7 @@ TEST(AsyncStreamReadWriteAuth, AuthFails) {
         Status(StatusCode::kPermissionDenied, "uh-oh")));
   });
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   EXPECT_FALSE(uut->Start().get());
   EXPECT_THAT(uut->Finish().get(), StatusIs(StatusCode::kPermissionDenied));
 }
@@ -112,7 +112,7 @@ TEST(AsyncStreamReadWriteAuth, CancelDuringAuth) {
   });
 
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   auto start = uut->Start();
   uut->Cancel();
   start_promise.set_value();
@@ -142,7 +142,7 @@ TEST(AsyncStreamReadWriteAuth, CancelAfterStart) {
     return make_ready_future(make_status_or(std::move(context)));
   });
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   EXPECT_TRUE(uut->Start().get());
   auto response = uut->Read().get();
   ASSERT_TRUE(response.has_value());

--- a/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
@@ -112,7 +112,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
 
   OptionsSpan span(user_project("create"));
   auto stream = MakeStreamingReadRpc<FakeRequest, FakeResponse>(
-      cq, absl::make_unique<grpc::ClientContext>(), FakeRequest{},
+      cq, std::make_shared<grpc::ClientContext>(), FakeRequest{},
       [&mock](grpc::ClientContext* context, FakeRequest const& request,
               grpc::CompletionQueue* cq) {
         return mock.FakeRpc(context, request, cq);

--- a/google/cloud/internal/async_streaming_write_rpc_auth_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_auth_test.cc
@@ -77,7 +77,7 @@ TEST(AsyncStreamingWriteRpcAuth, Start) {
     return make_ready_future(make_status_or(std::move(context)));
   });
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   EXPECT_TRUE(uut->Start().get());
   ASSERT_TRUE(uut->Write(FakeRequest{}, grpc::WriteOptions()).get());
   ASSERT_TRUE(uut->WritesDone().get());
@@ -102,7 +102,7 @@ TEST(AsyncStreamingWriteRpcAuth, AuthFails) {
         Status(StatusCode::kPermissionDenied, "uh-oh")));
   });
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   EXPECT_FALSE(uut->Start().get());
   EXPECT_THAT(uut->Finish().get(), StatusIs(StatusCode::kPermissionDenied));
 }
@@ -121,7 +121,7 @@ TEST(AsyncStreamingWriteRpcAuth, CancelDuringAuth) {
   });
 
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   auto start = uut->Start();
   uut->Cancel();
   start_promise.set_value();
@@ -147,7 +147,7 @@ TEST(AsyncStreamingWriteRpcAuth, CancelAfterStart) {
     return make_ready_future(make_status_or(std::move(context)));
   });
   auto uut = absl::make_unique<AuthStream>(
-      absl::make_unique<grpc::ClientContext>(), strategy, factory);
+      std::make_shared<grpc::ClientContext>(), strategy, factory);
   EXPECT_TRUE(uut->Start().get());
   EXPECT_TRUE(uut->Write(FakeRequest{}, grpc::WriteOptions()).get());
   uut->Cancel();

--- a/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
@@ -116,7 +116,7 @@ TEST(AsyncStreamingWriteRpcTest, Basic) {
 
   OptionsSpan span(user_project("create"));
   auto stream = MakeStreamingWriteRpc<FakeRequest, FakeResponse>(
-      cq, absl::make_unique<grpc::ClientContext>(),
+      cq, std::make_shared<grpc::ClientContext>(),
       [&mock](grpc::ClientContext* context, FakeResponse* response,
               grpc::CompletionQueue* cq) {
         return mock.FakeRpc(context, response, cq);

--- a/google/cloud/internal/grpc_impersonate_service_account.cc
+++ b/google/cloud/internal/grpc_impersonate_service_account.cc
@@ -43,7 +43,7 @@ AsyncAccessTokenSource MakeSource(ImpersonateServiceAccountConfig const& config,
 
   return [stub, request](CompletionQueue& cq) {
     return stub
-        ->AsyncGenerateAccessToken(cq, absl::make_unique<grpc::ClientContext>(),
+        ->AsyncGenerateAccessToken(cq, std::make_shared<grpc::ClientContext>(),
                                    request)
         .then([](future<StatusOr<GenerateAccessTokenResponse>> f)
                   -> StatusOr<AccessToken> {

--- a/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
+++ b/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
@@ -255,7 +255,7 @@ TEST_F(GrpcImpersonateServiceAccountIntegrationTest, AsyncCallWithToken) {
   auto async_get_table =
       [&](google::cloud::CompletionQueue& cq,
           GetTableRequest const& request) -> future<StatusOr<Table>> {
-    return stub->AsyncGetTable(cq, absl::make_unique<grpc::ClientContext>(),
+    return stub->AsyncGetTable(cq, std::make_shared<grpc::ClientContext>(),
                                request);
   };
 

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -134,7 +134,7 @@ TEST(LogWrapper, FutureStatusOrValueWithContextAndCQ) {
   testing_util::ScopedLog log;
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context;
+  std::shared_ptr<grpc::ClientContext> context;
   LogWrapper(mock, cq, std::move(context), MakeMutation(), "in-test", {});
 
   auto const log_lines = log.ExtractLines();
@@ -158,7 +158,7 @@ TEST(LogWrapper, FutureStatusOrErrorWithContextAndCQ) {
   testing_util::ScopedLog log;
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context;
+  std::shared_ptr<grpc::ClientContext> context;
   LogWrapper(mock, cq, std::move(context), MakeMutation(), "in-test", {});
 
   auto const log_lines = log.ExtractLines();
@@ -184,7 +184,7 @@ TEST(LogWrapper, FutureStatusWithContextAndCQ) {
   testing_util::ScopedLog log;
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context;
+  std::shared_ptr<grpc::ClientContext> context;
   LogWrapper(mock, cq, std::move(context), MakeMutation(), "in-test", {});
 
   std::ostringstream os;

--- a/google/cloud/internal/minimal_iam_credentials_stub_test.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub_test.cc
@@ -76,7 +76,7 @@ TEST_F(MinimalIamCredentialsStubTest, AsyncGenerateAccessTokenLogging) {
   request.set_name("projects/-/serviceAccounts/test-only-sa@not-valid");
   CompletionQueue cq;
   auto response = stub->AsyncGenerateAccessToken(
-                          cq, absl::make_unique<grpc::ClientContext>(), request)
+                          cq, std::make_shared<grpc::ClientContext>(), request)
                       .get();
   ASSERT_THAT(response, IsOk());
   auto const lines = log_.ExtractLines();
@@ -99,7 +99,7 @@ TEST_F(MinimalIamCredentialsStubTest, AsyncGenerateAccessTokenNoLogging) {
   request.set_name("projects/-/serviceAccounts/test-only-sa@not-valid");
   CompletionQueue cq;
   auto response = stub->AsyncGenerateAccessToken(
-                          cq, absl::make_unique<grpc::ClientContext>(), request)
+                          cq, std::make_shared<grpc::ClientContext>(), request)
                       .get();
   ASSERT_THAT(response, IsOk());
   auto const lines = log_.ExtractLines();
@@ -152,7 +152,7 @@ TEST_F(MinimalIamCredentialsStubTest, Invalid) {
   AutomaticallyCreatedBackgroundThreads background;
   auto cq = background.cq();
   auto response = stub->AsyncGenerateAccessToken(
-                          cq, absl::make_unique<grpc::ClientContext>(), request)
+                          cq, std::make_shared<grpc::ClientContext>(), request)
                       .get();
   EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
@@ -179,7 +179,7 @@ TEST_F(MinimalIamCredentialsStubTest,
   request.set_name("projects/-/serviceAccounts/test-only-sa@not-valid");
   CompletionQueue cq;
   auto response = stub->AsyncGenerateAccessToken(
-                          cq, absl::make_unique<grpc::ClientContext>(), request)
+                          cq, std::make_shared<grpc::ClientContext>(), request)
                       .get();
   ASSERT_THAT(response, IsOk());
   auto const lines = log_.ExtractLines();

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -67,7 +67,7 @@ TEST(StreamingReadRpcImpl, SuccessfulStream) {
   EXPECT_CALL(*mock, Finish).WillOnce(Return(grpc::Status::OK));
 
   StreamingReadRpcImpl<FakeResponse> impl(
-      absl::make_unique<grpc::ClientContext>(), std::move(mock));
+      std::make_shared<grpc::ClientContext>(), std::move(mock));
   std::vector<std::string> values;
   for (;;) {
     auto v = impl.Read();
@@ -87,7 +87,7 @@ TEST(StreamingReadRpcImpl, EmptyStream) {
   EXPECT_CALL(*mock, Finish).WillOnce(Return(grpc::Status::OK));
 
   StreamingReadRpcImpl<FakeResponse> impl(
-      absl::make_unique<grpc::ClientContext>(), std::move(mock));
+      std::make_shared<grpc::ClientContext>(), std::move(mock));
   auto v = impl.Read();
   ASSERT_FALSE(absl::holds_alternative<FakeResponse>(v));
   EXPECT_THAT(absl::get<Status>(std::move(v)), IsOk());
@@ -101,7 +101,7 @@ TEST(StreamingReadRpcImpl, EmptyWithError) {
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
 
   StreamingReadRpcImpl<FakeResponse> impl(
-      absl::make_unique<grpc::ClientContext>(), std::move(mock));
+      std::make_shared<grpc::ClientContext>(), std::move(mock));
   auto v = impl.Read();
   ASSERT_FALSE(absl::holds_alternative<FakeResponse>(v));
   EXPECT_THAT(absl::get<Status>(std::move(v)),
@@ -121,7 +121,7 @@ TEST(StreamingReadRpcImpl, ErrorAfterData) {
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
 
   StreamingReadRpcImpl<FakeResponse> impl(
-      absl::make_unique<grpc::ClientContext>(), std::move(mock));
+      std::make_shared<grpc::ClientContext>(), std::move(mock));
   std::vector<std::string> values;
   for (;;) {
     auto v = impl.Read();
@@ -155,7 +155,7 @@ TEST(StreamingReadRpcImpl, HandleUnfinished) {
 
   {
     StreamingReadRpcImpl<FakeResponse> impl(
-        absl::make_unique<grpc::ClientContext>(), std::move(mock));
+        std::make_shared<grpc::ClientContext>(), std::move(mock));
     std::vector<std::string> values;
     values.push_back(absl::get<FakeResponse>(impl.Read()).value);
     values.push_back(absl::get<FakeResponse>(impl.Read()).value);
@@ -183,7 +183,7 @@ TEST(StreamingReadRpcImpl, HandleUnfinishedExpected) {
     testing_util::ScopedLog log;
     {
       StreamingReadRpcImpl<FakeResponse> impl(
-          absl::make_unique<grpc::ClientContext>(), std::move(mock));
+          std::make_shared<grpc::ClientContext>(), std::move(mock));
       std::vector<std::string> values;
       values.push_back(absl::get<FakeResponse>(impl.Read()).value);
       values.push_back(absl::get<FakeResponse>(impl.Read()).value);

--- a/google/cloud/internal/streaming_write_rpc_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_test.cc
@@ -60,7 +60,7 @@ TEST(StreamingWriteRpcImpl, SuccessfulStream) {
   });
 
   StreamingWriteRpcImpl<FakeRequest, FakeResponse> impl(
-      absl::make_unique<grpc::ClientContext>(), std::move(response),
+      std::make_shared<grpc::ClientContext>(), std::move(response),
       std::move(mock));
   for (std::string key : {"w0", "w1", "w2"}) {
     EXPECT_TRUE(impl.Write(FakeRequest{key}, grpc::WriteOptions{}));
@@ -83,7 +83,7 @@ TEST(StreamingWriteRpcImpl, ErrorInWrite) {
   });
 
   StreamingWriteRpcImpl<FakeRequest, FakeResponse> impl(
-      absl::make_unique<grpc::ClientContext>(), std::move(response),
+      std::make_shared<grpc::ClientContext>(), std::move(response),
       std::move(mock));
   for (std::string key : {"w0", "w1"}) {
     EXPECT_TRUE(impl.Write(FakeRequest{key}, grpc::WriteOptions{}));
@@ -102,7 +102,7 @@ TEST(StreamingWriteRpcImpl, ErrorInWritesDone) {
   });
 
   StreamingWriteRpcImpl<FakeRequest, FakeResponse> impl(
-      absl::make_unique<grpc::ClientContext>(), std::move(response),
+      std::make_shared<grpc::ClientContext>(), std::move(response),
       std::move(mock));
   for (std::string key : {"w0", "w1"}) {
     EXPECT_TRUE(impl.Write(FakeRequest{key}, grpc::WriteOptions{}));
@@ -117,7 +117,7 @@ TEST(StreamingWriteRpcImpl, NoWritesDoneWithLastMessage) {
   EXPECT_CALL(*mock, Finish).WillOnce(Return(grpc::Status::OK));
 
   StreamingWriteRpcImpl<FakeRequest, FakeResponse> impl(
-      absl::make_unique<grpc::ClientContext>(), std::move(response),
+      std::make_shared<grpc::ClientContext>(), std::move(response),
       std::move(mock));
   EXPECT_TRUE(impl.Write(FakeRequest{"w0"}, grpc::WriteOptions{}));
   EXPECT_TRUE(

--- a/google/cloud/logging/v2/internal/streaming.cc
+++ b/google/cloud/logging/v2/internal/streaming.cc
@@ -26,7 +26,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 LoggingServiceV2ConnectionImpl::AsyncTailLogEntries() {
   // TODO(#7796) - add resume loop
   return stub_->AsyncTailLogEntries(background_->cq(),
-                                    absl::make_unique<grpc::ClientContext>());
+                                    std::make_shared<grpc::ClientContext>());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_connection_impl.cc
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_connection_impl.cc
@@ -56,7 +56,7 @@ AgentEndpointServiceConnectionImpl::ReceiveTaskNotification(
   auto factory = [stub](google::cloud::osconfig::agentendpoint::v1::
                             ReceiveTaskNotificationRequest const& request) {
     return stub->ReceiveTaskNotification(
-        absl::make_unique<grpc::ClientContext>(), request);
+        std::make_shared<grpc::ClientContext>(), request);
   };
   auto resumable = internal::MakeResumableStreamingReadRpc<
       google::cloud::osconfig::agentendpoint::v1::

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -181,8 +181,7 @@ TEST_F(SubscriberIntegrationTest, RawStub) {
   request.set_stream_ack_deadline_seconds(600);
 
   auto stream = [&stub](CompletionQueue const& cq) {
-    auto context = absl::make_unique<grpc::ClientContext>();
-
+    auto context = std::make_shared<grpc::ClientContext>();
     return stub->AsyncStreamingPull(cq, std::move(context));
   }(background.cq());
 

--- a/google/cloud/pubsub/internal/extend_leases_with_retry.cc
+++ b/google/cloud/pubsub/internal/extend_leases_with_retry.cc
@@ -78,7 +78,7 @@ google::pubsub::v1::ModifyAckDeadlineRequest UpdateRequest(
  *   Status last_status;
  *   for (int attempts = 0; attempts != 3; ++i) {
  *     last_status = co_await stub->AsyncModifyAckDeadline(
- *         cq, absl::make_unique<grpc::ClientContext>(), request);
+ *         cq, std::make_shared<grpc::ClientContext>(), request);
  *     if (status.ok()) co_return last_status;
  *     request = UpdateRequest(std::move(request), status);
  *     if (request.ack_ids().empty()) co_return last_status;
@@ -107,7 +107,7 @@ class ExtendLeasesWithRetryHandle
  private:
   void MakeAttempt() {
     ++attempts_;
-    auto context = absl::make_unique<grpc::ClientContext>();
+    auto context = std::make_shared<grpc::ClientContext>();
     stub_->AsyncModifyAckDeadline(cq_, std::move(context), request_)
         .then(
             [self = shared_from_this()](auto f) { self->OnAttempt(f.get()); });

--- a/google/cloud/pubsublite/internal/stream_factory.h
+++ b/google/cloud/pubsublite/internal/stream_factory.h
@@ -37,9 +37,9 @@ using StreamFactory = std::function<
 
 using ClientMetadata = std::unordered_map<std::string, std::string>;
 
-inline std::unique_ptr<grpc::ClientContext> MakeGrpcClientContext(
+inline std::shared_ptr<grpc::ClientContext> MakeGrpcClientContext(
     ClientMetadata const& metadata) {
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   for (auto const& kv : metadata) {
     context->AddMetadata(kv.first, kv.second);
   }

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -446,7 +446,7 @@ spanner::RowStream ConnectionImpl::ReadImpl(
   auto factory = [stub, request, tracing_enabled,
                   tracing_options](std::string const& resume_token) mutable {
     if (!resume_token.empty()) request->set_resume_token(resume_token);
-    auto context = absl::make_unique<grpc::ClientContext>();
+    auto context = std::make_shared<grpc::ClientContext>();
     internal::ConfigureContext(*context, internal::CurrentOptions());
     auto grpc_reader = stub->StreamingRead(*context, *request);
     std::unique_ptr<PartialResultSetReader> reader =
@@ -675,7 +675,7 @@ ResultType ConnectionImpl::CommonQueryImpl(
     auto factory = [stub, request, tracing_enabled,
                     tracing_options](std::string const& resume_token) mutable {
       if (!resume_token.empty()) request.set_resume_token(resume_token);
-      auto context = absl::make_unique<grpc::ClientContext>();
+      auto context = std::make_shared<grpc::ClientContext>();
       internal::ConfigureContext(*context, internal::CurrentOptions());
       auto grpc_reader = stub->ExecuteStreamingSql(*context, request);
       std::unique_ptr<PartialResultSetReader> reader =

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -60,7 +60,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
 
   CompletionQueue cq;
   auto response =
-      stub.AsyncCreateDatabase(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncCreateDatabase(cq, std::make_shared<grpc::ClientContext>(),
                                gsad::v1::CreateDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
@@ -110,7 +110,7 @@ TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
 
   CompletionQueue cq;
   auto response =
-      stub.AsyncUpdateDatabaseDdl(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncUpdateDatabaseDdl(cq, std::make_shared<grpc::ClientContext>(),
                                   gsad::v1::UpdateDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
@@ -159,7 +159,7 @@ TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
 
   CompletionQueue cq;
   auto response =
-      stub.AsyncRestoreDatabase(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncRestoreDatabase(cq, std::make_shared<grpc::ClientContext>(),
                                 gsad::v1::RestoreDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
@@ -225,7 +225,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
 
   CompletionQueue cq;
   auto response =
-      stub.AsyncCreateBackup(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncCreateBackup(cq, std::make_shared<grpc::ClientContext>(),
                              gsad::v1::CreateBackupRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
@@ -333,7 +333,7 @@ TEST_F(DatabaseAdminLoggingTest, GetOperation) {
 
   CompletionQueue cq;
   auto response =
-      stub.AsyncGetOperation(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncGetOperation(cq, std::make_shared<grpc::ClientContext>(),
                              google::longrunning::GetOperationRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
@@ -353,7 +353,7 @@ TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
 
   CompletionQueue cq;
   auto status =
-      stub.AsyncCancelOperation(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncCancelOperation(cq, std::make_shared<grpc::ClientContext>(),
                                 google::longrunning::CancelOperationRequest{});
   EXPECT_EQ(TransientError(), status.get());
 

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -76,7 +76,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
           google::cloud::Project("test-project-id"), "test-instance-id")
           .FullName());
   auto response = stub.AsyncCreateDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -102,7 +102,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
           "test-database")
           .FullName());
   auto response = stub.AsyncUpdateDatabaseDdl(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -172,7 +172,7 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
           google::cloud::Project("test-project-id"), "test-instance-id")
           .FullName());
   auto response = stub.AsyncRestoreDatabase(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -275,7 +275,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
           google::cloud::Project("test-project-id"), "test-instance-id")
           .FullName());
   auto response = stub.AsyncCreateBackup(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -433,7 +433,7 @@ TEST_F(DatabaseAdminMetadataTest, GetOperation) {
   google::longrunning::GetOperationRequest request;
   request.set_name("operations/fake-operation-name");
   auto response = stub.AsyncGetOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -453,7 +453,7 @@ TEST_F(DatabaseAdminMetadataTest, CancelOperation) {
   google::longrunning::CancelOperationRequest request;
   request.set_name("operations/fake-operation-name");
   auto status = stub.AsyncCancelOperation(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get());
 }
 

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -74,7 +74,7 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
 
   CompletionQueue cq;
   auto response =
-      stub.AsyncCreateInstance(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncCreateInstance(cq, std::make_shared<grpc::ClientContext>(),
                                gsai::v1::CreateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
@@ -95,7 +95,7 @@ TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
 
   CompletionQueue cq;
   auto response =
-      stub.AsyncUpdateInstance(cq, absl::make_unique<grpc::ClientContext>(),
+      stub.AsyncUpdateInstance(cq, std::make_shared<grpc::ClientContext>(),
                                gsai::v1::UpdateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -134,7 +134,7 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
   request.set_parent(google::cloud::Project("test-project-id").FullName());
   request.set_instance_id("test-instance-id");
   auto response = stub.AsyncCreateInstance(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -158,7 +158,7 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
           google::cloud::Project("test-project-id"), "test-instance-id")
           .FullName());
   auto response = stub.AsyncUpdateInstance(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 

--- a/google/cloud/spanner/internal/spanner_auth_test.cc
+++ b/google/cloud/spanner/internal/spanner_auth_test.cc
@@ -270,11 +270,11 @@ TEST(SpannerAuthTest, AsyncBatchCreateSessions) {
   google::spanner::v1::BatchCreateSessionsRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncBatchCreateSessions(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncBatchCreateSessions(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -291,11 +291,11 @@ TEST(SpannerAuthTest, AsyncDeleteSession) {
   google::spanner::v1::DeleteSessionRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncDeleteSession(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncDeleteSession(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -312,11 +312,11 @@ TEST(SpannerAuthTest, AsyncExecuteSql) {
   google::spanner::v1::ExecuteSqlRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncExecuteSql(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncExecuteSql(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 

--- a/google/cloud/speech/v1/internal/streaming.cc
+++ b/google/cloud/speech/v1/internal/streaming.cc
@@ -25,7 +25,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::cloud::speech::v1::StreamingRecognizeResponse>>
 SpeechConnectionImpl::AsyncStreamingRecognize() {
   return stub_->AsyncStreamingRecognize(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
+      background_->cq(), std::make_shared<grpc::ClientContext>());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/speech/v2/streaming.cc
+++ b/google/cloud/speech/v2/streaming.cc
@@ -25,7 +25,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::cloud::speech::v2::StreamingRecognizeResponse>>
 SpeechConnectionImpl::AsyncStreamingRecognize() {
   return stub_->AsyncStreamingRecognize(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
+      background_->cq(), std::make_shared<grpc::ClientContext>());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async_accumulate_read_object.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object.cc
@@ -200,7 +200,7 @@ class AsyncAccumulateReadObjectFullHandle
  public:
   AsyncAccumulateReadObjectFullHandle(
       CompletionQueue cq, std::shared_ptr<StorageStub> stub,
-      std::function<std::unique_ptr<grpc::ClientContext>()> context_factory,
+      std::function<std::shared_ptr<grpc::ClientContext>()> context_factory,
       google::storage::v2::ReadObjectRequest request, Options const& options)
       : cq_(std::move(cq)),
         stub_(std::move(stub)),
@@ -294,7 +294,7 @@ class AsyncAccumulateReadObjectFullHandle
   AsyncAccumulateReadObjectResult accumulator_;
   CompletionQueue cq_;
   std::shared_ptr<StorageStub> stub_;
-  std::function<std::unique_ptr<grpc::ClientContext>()> context_factory_;
+  std::function<std::shared_ptr<grpc::ClientContext>()> context_factory_;
   google::storage::v2::ReadObjectRequest request_;
   std::chrono::milliseconds timeout_;
   std::unique_ptr<storage::RetryPolicy> retry_;
@@ -316,7 +316,7 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectPartial(
 
 future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectFull(
     CompletionQueue cq, std::shared_ptr<StorageStub> stub,
-    std::function<std::unique_ptr<grpc::ClientContext>()> context_factory,
+    std::function<std::shared_ptr<grpc::ClientContext>()> context_factory,
     google::storage::v2::ReadObjectRequest request, Options const& options) {
   auto handle = std::make_shared<AsyncAccumulateReadObjectFullHandle>(
       std::move(cq), std::move(stub), std::move(context_factory),

--- a/google/cloud/storage/internal/async_accumulate_read_object.h
+++ b/google/cloud/storage/internal/async_accumulate_read_object.h
@@ -104,7 +104,7 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectPartial(
  * future<AsyncAccumulateReadObject::Result> AsyncAccumulateReadObjectFull(
  *     CompletionQueue cq,
  *     std::shared_ptr<StorageStub> stub,
- *     std::function<std::unique_ptr<grpc::ClientContext>()> context_factory,
+ *     std::function<std::shared_ptr<grpc::ClientContext>()> context_factory,
  *     google::storage::v2::ReadObjectRequest request,
  *     std::chrono::milliseconds timeout,
  *     Options const& options) {
@@ -167,7 +167,7 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectPartial(
  */
 future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectFull(
     CompletionQueue cq, std::shared_ptr<StorageStub> stub,
-    std::function<std::unique_ptr<grpc::ClientContext>()> context_factory,
+    std::function<std::shared_ptr<grpc::ClientContext>()> context_factory,
     google::storage::v2::ReadObjectRequest request, Options const& options);
 
 /// Convert the proto into a representation more familiar to our customers.

--- a/google/cloud/storage/internal/async_accumulate_read_object_test.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object_test.cc
@@ -360,9 +360,9 @@ TEST(AsyncAccumulateReadObjectTest, FullSimple) {
         return MakeMockStreamPartial(1, r1);
       });
 
-  MockFunction<std::unique_ptr<grpc::ClientContext>()> context_factory;
+  MockFunction<std::shared_ptr<grpc::ClientContext>()> context_factory;
   EXPECT_CALL(context_factory, Call).Times(2).WillRepeatedly([] {
-    return absl::make_unique<grpc::ClientContext>();
+    return std::make_shared<grpc::ClientContext>();
   });
 
   CompletionQueue cq;
@@ -416,7 +416,7 @@ TEST(AsyncAccumulateReadObjectTest, FullTooManyTransients) {
           .set<storage::DownloadStallTimeoutOption>(std::chrono::minutes(1));
   auto response =
       AsyncAccumulateReadObjectFull(
-          cq, mock, []() { return absl::make_unique<grpc::ClientContext>(); },
+          cq, mock, []() { return std::make_shared<grpc::ClientContext>(); },
           ReadObjectRequest{}, options)
           .get();
   EXPECT_THAT(response.status, StatusIs(StatusCode::kUnavailable));
@@ -444,7 +444,7 @@ TEST(AsyncAccumulateReadObjectTest, PermanentFailure) {
           .set<storage::DownloadStallTimeoutOption>(std::chrono::minutes(1));
   auto response =
       AsyncAccumulateReadObjectFull(
-          cq, mock, []() { return absl::make_unique<grpc::ClientContext>(); },
+          cq, mock, []() { return std::make_shared<grpc::ClientContext>(); },
           ReadObjectRequest{}, options)
           .get();
   EXPECT_THAT(response.status, StatusIs(StatusCode::kPermissionDenied));

--- a/google/cloud/storage/internal/async_connection_impl.cc
+++ b/google/cloud/storage/internal/async_connection_impl.cc
@@ -63,7 +63,7 @@ AsyncConnectionImpl::AsyncReadObjectRange(
   }
 
   auto context_factory = [request = std::move(request)]() {
-    auto context = absl::make_unique<grpc::ClientContext>();
+    auto context = std::make_shared<grpc::ClientContext>();
     ApplyQueryParameters(*context, request);
     return context;
   };

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -437,7 +437,7 @@ StatusOr<storage::ObjectMetadata> GrpcClient::InsertObjectMedia(
         [](auto f) { return f.get().ok(); });
   };
 
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   // The REST response is just the object metadata (aka the "resource"). In the
   // gRPC response the object metadata is in a "resource" field. Passing an
   // extra prefix to ApplyQueryParameters sends the right
@@ -529,7 +529,7 @@ GrpcClient::ReadObject(
         StatusCode::kOutOfRange,
         "ReadLast(0) is invalid in REST and produces incorrect output in gRPC");
   }
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   ApplyQueryParameters(*context, request);
   auto proto_request = ToProto(request);
   if (!proto_request) return std::move(proto_request).status();
@@ -684,7 +684,7 @@ GrpcClient::UploadChunk(storage::internal::UploadChunkRequest const& request) {
         [](auto f) { return f.get().ok(); });
   };
 
-  auto context = absl::make_unique<grpc::ClientContext>();
+  auto context = std::make_shared<grpc::ClientContext>();
   // The REST response is just the object metadata (aka the "resource"). In the
   // gRPC response the object metadata is in a "resource" field. Passing an
   // extra prefix to ApplyQueryParameters sends the right

--- a/google/cloud/storage/internal/storage_round_robin_test.cc
+++ b/google/cloud/storage/internal/storage_round_robin_test.cc
@@ -431,8 +431,8 @@ TEST(StorageRoundRobinTest, ReadObject) {
   StorageRoundRobin under_test(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     google::storage::v2::ReadObjectRequest request;
-    auto response = under_test.ReadObject(
-        absl::make_unique<grpc::ClientContext>(), request);
+    auto response =
+        under_test.ReadObject(std::make_shared<grpc::ClientContext>(), request);
     auto v = response->Read();
     ASSERT_TRUE(absl::holds_alternative<Status>(v));
     EXPECT_THAT(absl::get<Status>(v), StatusIs(StatusCode::kPermissionDenied));
@@ -470,7 +470,7 @@ TEST(StorageRoundRobinTest, WriteObject) {
   StorageRoundRobin under_test(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto response =
-        under_test.WriteObject(absl::make_unique<grpc::ClientContext>());
+        under_test.WriteObject(std::make_shared<grpc::ClientContext>());
     EXPECT_THAT(response->Close(), StatusIs(StatusCode::kPermissionDenied));
   }
 }
@@ -682,7 +682,7 @@ TEST(StorageRoundRobinTest, AsyncDeleteObject) {
     google::storage::v2::DeleteObjectRequest request;
     auto response =
         under_test
-            .AsyncDeleteObject(cq, absl::make_unique<grpc::ClientContext>(),
+            .AsyncDeleteObject(cq, std::make_shared<grpc::ClientContext>(),
                                request)
             .get();
     EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
@@ -703,7 +703,7 @@ TEST(StorageRoundRobinTest, AsyncReadObject) {
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     google::storage::v2::ReadObjectRequest request;
     auto response = under_test.AsyncReadObject(
-        cq, absl::make_unique<grpc::ClientContext>(), request);
+        cq, std::make_shared<grpc::ClientContext>(), request);
     EXPECT_FALSE(response->Read().get());
     auto status = response->Finish().get();
     EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
@@ -723,7 +723,7 @@ TEST(StorageRoundRobinTest, AsyncWriteObject) {
   google::cloud::CompletionQueue cq;
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto stream = under_test.AsyncWriteObject(
-        cq, absl::make_unique<grpc::ClientContext>());
+        cq, std::make_shared<grpc::ClientContext>());
     EXPECT_FALSE(stream->WritesDone().get());
     auto response = stream->Finish().get();
     EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
@@ -751,7 +751,7 @@ TEST(StorageRoundRobinTest, AsyncStartResumableWrite) {
     auto response =
         under_test
             .AsyncStartResumableWrite(
-                cq, absl::make_unique<grpc::ClientContext>(), request)
+                cq, std::make_shared<grpc::ClientContext>(), request)
             .get();
     EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
   }
@@ -776,7 +776,7 @@ TEST(StorageRoundRobinTest, AsyncQueryWriteStatus) {
     google::storage::v2::QueryWriteStatusRequest request;
     auto response =
         under_test
-            .AsyncQueryWriteStatus(cq, absl::make_unique<grpc::ClientContext>(),
+            .AsyncQueryWriteStatus(cq, std::make_shared<grpc::ClientContext>(),
                                    request)
             .get();
     EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -117,7 +117,7 @@ TEST_F(StorageStubFactory, ReadObject) {
   ScopedLog log;
   CompletionQueue cq;
   auto stub = CreateTestStub(cq, factory.AsStdFunction());
-  auto stream = stub->ReadObject(absl::make_unique<grpc::ClientContext>(),
+  auto stream = stub->ReadObject(std::make_shared<grpc::ClientContext>(),
                                  google::storage::v2::ReadObjectRequest{});
   auto response = stream->Read();
   ASSERT_TRUE(absl::holds_alternative<Status>(response));
@@ -162,7 +162,7 @@ TEST_F(StorageStubFactory, WriteObject) {
   CompletionQueue cq;
   auto stub = CreateTestStub(cq, factory.AsStdFunction());
   auto stream =
-      stub->AsyncWriteObject(cq, absl::make_unique<grpc::ClientContext>());
+      stub->AsyncWriteObject(cq, std::make_shared<grpc::ClientContext>());
   EXPECT_TRUE(stream->Start().get());
   auto close = stream->Finish().get();
   EXPECT_THAT(close, StatusIs(StatusCode::kUnavailable));


### PR DESCRIPTION
While not necessary, it seems like if the interfaces accept a `shared_ptr<grpc::ClientContext>`, we should supply it a `shared_ptr<>` (instead of a `unique_ptr<>`).

Note that the bar for "interesting" is very low. Deleting a blank line qualifies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11029)
<!-- Reviewable:end -->
