### PR TITLE
impl(otel): `CallContext` for `Async(Rest)RetryLoop`

### DIFF
--- a/google/cloud/internal/async_rest_retry_loop.h
+++ b/google/cloud/internal/async_rest_retry_loop.h
@@ -19,11 +19,11 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/idempotency.h"
+#include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/rest_context.h"
 #include "google/cloud/internal/retry_loop_helpers.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include "absl/meta/type_traits.h"
@@ -199,7 +199,7 @@ class AsyncRestRetryLoopImpl
     auto weak = std::weak_ptr<AsyncRestRetryLoopImpl>(this->shared_from_this());
     result_ = promise<T>([weak]() mutable {
       if (auto self = weak.lock()) {
-        internal::OptionsSpan span(self->options_);
+        internal::ScopedCallContext scope(self->call_context_);
         self->Cancel();
       }
     });
@@ -328,7 +328,7 @@ class AsyncRestRetryLoopImpl
   absl::decay_t<Functor> functor_;
   Request request_;
   char const* location_ = "unknown";
-  Options options_ = internal::CurrentOptions();
+  internal::CallContext call_context_;
   Status last_status_ = Status(StatusCode::kUnknown, "Retry policy exhausted");
   promise<T> result_;
 

--- a/google/cloud/internal/async_rest_retry_loop_test.cc
+++ b/google/cloud/internal/async_rest_retry_loop_test.cc
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 #include "google/cloud/internal/async_rest_retry_loop.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/opentelemetry_options.h"
 #include "google/cloud/internal/rest_background_threads_impl.h"
 #include "google/cloud/options.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/mock_backoff_policy.h"
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <deque>
@@ -544,6 +548,61 @@ TEST_F(AsyncRestRetryLoopCancelTest, ShutdownDuringTimer) {
                               AllOf(HasSubstr("Timer failure in"),
                                     HasSubstr("test-location"))));
 }
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+TEST(AsyncRestRetryLoopTest, CallSpanActiveThroughout) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  AsyncSequencer<StatusOr<int>> sequencer;
+  auto span = internal::MakeSpan("span");
+  auto scope = opentelemetry::trace::Scope(span);
+  internal::OptionsSpan o(
+      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+
+  AutomaticallyCreatedRestBackgroundThreads background;
+  future<StatusOr<int>> actual = AsyncRestRetryLoop(
+      TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
+      background.cq(),
+      [&](auto, auto, auto) {
+        using testing_util::IsActive;
+        EXPECT_THAT(span, IsActive());
+        return sequencer.PushBack();
+      },
+      42, "error message");
+
+  sequencer.PopFront().set_value(internal::UnavailableError("try again"));
+  sequencer.PopFront().set_value(0);
+  auto overlay = opentelemetry::trace::Scope(internal::MakeSpan("overlay"));
+  (void)actual.get();
+}
+
+TEST(AsyncRestRetryLoopTest, CallSpanActiveDuringCancel) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = internal::MakeSpan("span");
+  auto scope = opentelemetry::trace::Scope(span);
+  internal::OptionsSpan o(
+      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+
+  promise<StatusOr<int>> p([&] {
+    using testing_util::IsActive;
+    EXPECT_THAT(span, IsActive());
+  });
+
+  AutomaticallyCreatedRestBackgroundThreads background;
+  future<StatusOr<int>> actual = AsyncRestRetryLoop(
+      TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
+      background.cq(), [&](auto, auto, auto) { return p.get_future(); }, 42,
+      "error message");
+
+  auto overlay = opentelemetry::trace::Scope(internal::MakeSpan("overlay"));
+  actual.cancel();
+  p.set_value(0);
+  (void)actual.get();
+}
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -18,7 +18,7 @@
 #include "google/cloud/async_operation.h"
 #include "google/cloud/future.h"
 #include "google/cloud/grpc_error_delegate.h"
-#include "google/cloud/options.h"
+#include "google/cloud/internal/call_context.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
@@ -69,7 +69,7 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
   void Cancel() override {}
 
   bool Notify(bool ok) override {
-    OptionsSpan span(options_);
+    ScopedCallContext scope(call_context_);
     if (!ok) {
       // `Finish()` always returns `true` for unary RPCs, so the only time we
       // get `!ok` is after `Shutdown()` was called; treat that as "cancelled".
@@ -97,7 +97,7 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
   Response response_;
 
   promise<StatusOr<Response>> promise_;
-  Options options_ = CurrentOptions();
+  CallContext call_context_;
 };
 
 /// Verify that @p Functor meets the requirements for an AsyncUnaryRpc callback.

--- a/google/cloud/internal/default_completion_queue_impl.cc
+++ b/google/cloud/internal/default_completion_queue_impl.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/internal/default_completion_queue_impl.h"
+#include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/throw_delegate.h"
-#include "google/cloud/options.h"
 #include "absl/memory/memory.h"
 #include <grpcpp/alarm.h>
 #include <sstream>
@@ -47,7 +47,7 @@ namespace {
  * Note that this class is an implementation detail, hidden from the
  * application developers.
  */
-class AsyncTimerFuture : public internal::AsyncGrpcOperation {
+class AsyncTimerFuture : public AsyncGrpcOperation {
  public:
   using ValueType = StatusOr<std::chrono::system_clock::time_point>;
 
@@ -70,7 +70,7 @@ class AsyncTimerFuture : public internal::AsyncGrpcOperation {
   }
 
   void Cancel() override {
-    OptionsSpan span(options_);
+    ScopedCallContext scope(call_context_);
     alarm_.Cancel();
   }
 
@@ -78,7 +78,7 @@ class AsyncTimerFuture : public internal::AsyncGrpcOperation {
   explicit AsyncTimerFuture() : promise_(null_promise_t{}) {}
 
   bool Notify(bool ok) override {
-    OptionsSpan span(options_);
+    ScopedCallContext scope(call_context_);
     promise_.set_value(ok ? ValueType(deadline_) : Canceled());
     return true;
   }
@@ -90,7 +90,7 @@ class AsyncTimerFuture : public internal::AsyncGrpcOperation {
   promise<ValueType> promise_;
   std::chrono::system_clock::time_point deadline_;
   grpc::Alarm alarm_;
-  Options options_ = CurrentOptions();
+  CallContext call_context_;
 };
 
 }  // namespace
@@ -98,7 +98,7 @@ class AsyncTimerFuture : public internal::AsyncGrpcOperation {
 // A helper class to wake up the asynchronous thread and drain the RunAsync()
 // queue in a loop.
 class DefaultCompletionQueueImpl::WakeUpRunAsyncLoop
-    : public internal::AsyncGrpcOperation {
+    : public AsyncGrpcOperation {
  public:
   explicit WakeUpRunAsyncLoop(std::weak_ptr<DefaultCompletionQueueImpl> w)
       : weak_(std::move(w)) {}
@@ -111,7 +111,7 @@ class DefaultCompletionQueueImpl::WakeUpRunAsyncLoop
 
  private:
   bool Notify(bool ok) override {
-    OptionsSpan span(options_);
+    ScopedCallContext scope(call_context_);
     if (!ok) return true;  // do not run async operations on shutdown CQs
     if (auto self = weak_.lock()) self->DrainRunAsyncLoop();
     return true;
@@ -119,13 +119,13 @@ class DefaultCompletionQueueImpl::WakeUpRunAsyncLoop
 
   std::weak_ptr<DefaultCompletionQueueImpl> weak_;
   grpc::Alarm alarm_;
-  Options options_ = CurrentOptions();
+  CallContext call_context_;
 };
 
 // A helper class to wake up the asynchronous thread and drain the RunAsync()
 // one element at a time.
 class DefaultCompletionQueueImpl::WakeUpRunAsyncOnIdle
-    : public internal::AsyncGrpcOperation {
+    : public AsyncGrpcOperation {
  public:
   explicit WakeUpRunAsyncOnIdle(std::weak_ptr<DefaultCompletionQueueImpl> w)
       : weak_(std::move(w)) {}
@@ -138,7 +138,7 @@ class DefaultCompletionQueueImpl::WakeUpRunAsyncOnIdle
 
  private:
   bool Notify(bool ok) override {
-    OptionsSpan span(options_);
+    ScopedCallContext scope(call_context_);
     if (!ok) return true;  // do not run async operations on shutdown CQs
     if (auto self = weak_.lock()) self->DrainRunAsyncOnIdle();
     return true;
@@ -146,7 +146,7 @@ class DefaultCompletionQueueImpl::WakeUpRunAsyncOnIdle
 
   std::weak_ptr<DefaultCompletionQueueImpl> weak_;
   grpc::Alarm alarm_;
-  Options options_ = CurrentOptions();
+  CallContext call_context_;
 };
 
 DefaultCompletionQueueImpl::DefaultCompletionQueueImpl()


### PR DESCRIPTION
Part of the work for #10618 

Propagate trace context across the `AsyncGrpcOperation`s involved in an async unary client call.

Also, include the REST version of things so the async retry loop tests stay in sync.

Note that (to my knowledge) nothing is really testing context propagation in some of the individual async operations, e.g. `AsyncUnaryRpcFuture`. (call options and parent span)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11035)
<!-- Reviewable:end -->
