### PR TITLE
impl(otel): trace context across AsyncPollingLoop

### DIFF
--- a/google/cloud/internal/async_rest_polling_loop.cc
+++ b/google/cloud/internal/async_rest_polling_loop.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/async_rest_polling_loop.h"
+#include "google/cloud/internal/call_context.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
 #include "absl/memory/memory.h"
@@ -45,13 +46,14 @@ class AsyncRestPollingLoopImpl
   future<StatusOr<Operation>> Start(future<StatusOr<Operation>> op) {
     auto self = shared_from_this();
     auto w = WeakFromThis();
-    auto const& options = internal::CurrentOptions();
-    promise_ = promise<StatusOr<Operation>>([w, options]() mutable {
-      if (auto self = w.lock()) {
-        internal::OptionsSpan span(std::move(options));
-        self->DoCancel();
-      }
-    });
+    internal::CallContext call_context;
+    promise_ = promise<StatusOr<Operation>>(
+        [w, c = std::move(call_context)]() mutable {
+          if (auto self = w.lock()) {
+            internal::ScopedCallContext scope(std::move(c));
+            self->DoCancel();
+          }
+        });
     op.then([self](future<StatusOr<Operation>> f) { self->OnStart(f.get()); });
     return promise_.get_future();
   }

--- a/google/cloud/internal/async_rest_polling_loop.cc
+++ b/google/cloud/internal/async_rest_polling_loop.cc
@@ -46,9 +46,8 @@ class AsyncRestPollingLoopImpl
   future<StatusOr<Operation>> Start(future<StatusOr<Operation>> op) {
     auto self = shared_from_this();
     auto w = WeakFromThis();
-    internal::CallContext call_context;
     promise_ = promise<StatusOr<Operation>>(
-        [w, c = std::move(call_context)]() mutable {
+        [w, c = internal::CallContext{}]() mutable {
           if (auto self = w.lock()) {
             internal::ScopedCallContext scope(std::move(c));
             self->DoCancel();

--- a/google/cloud/internal/async_rest_polling_loop_test.cc
+++ b/google/cloud/internal/async_rest_polling_loop_test.cc
@@ -51,7 +51,8 @@ struct StringOption {
 
 class MockStub {
  public:
-  MOCK_METHOD(future<StatusOr<Operation>>, AsyncGetOperation,
+  MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>,
+              AsyncGetOperation,
               (CompletionQueue&, std::unique_ptr<RestContext>,
                google::longrunning::GetOperationRequest const&),
               ());
@@ -127,8 +128,9 @@ TEST(AsyncRestPollingLoopTest, ImmediateCancel) {
                    google::longrunning::GetOperationRequest const&) {
         EXPECT_EQ(internal::CurrentOptions().get<StringOption>(),
                   "ImmediateCancel");
-        return make_ready_future(StatusOr<Operation>(Status{
-            StatusCode::kCancelled, "test-function: operation cancelled"}));
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(Status{
+                StatusCode::kCancelled, "test-function: operation cancelled"}));
       });
   EXPECT_CALL(*mock, AsyncCancelOperation)
       .WillOnce([](CompletionQueue&, std::unique_ptr<RestContext>,
@@ -262,8 +264,8 @@ TEST(AsyncRestPollingLoopTest, PollThenEventualSuccess) {
                    google::longrunning::GetOperationRequest const&) {
         EXPECT_EQ(internal::CurrentOptions().get<StringOption>(),
                   "PollThenEventualSuccess");
-        return make_ready_future(
-            StatusOr<Operation>(Status(StatusCode::kUnavailable, "try-again")));
+        return make_ready_future(StatusOr<google::longrunning::Operation>(
+            Status(StatusCode::kUnavailable, "try-again")));
       })
       .WillOnce([&](CompletionQueue&, std::unique_ptr<RestContext>,
                     google::longrunning::GetOperationRequest const&) {
@@ -364,8 +366,8 @@ TEST(AsyncRestPollingLoopTest, PollThenExhaustedPollingPolicyWithFailure) {
                           google::longrunning::GetOperationRequest const&) {
         EXPECT_EQ(internal::CurrentOptions().get<StringOption>(),
                   "PollThenExhaustedPollingPolicyWithFailure");
-        return make_ready_future(
-            StatusOr<Operation>(Status{StatusCode::kUnavailable, "try-again"}));
+        return make_ready_future(StatusOr<google::longrunning::Operation>(
+            Status{StatusCode::kUnavailable, "try-again"}));
       });
   auto policy = absl::make_unique<MockPollingPolicy>();
   EXPECT_CALL(*policy, clone()).Times(0);
@@ -404,7 +406,7 @@ TEST(AsyncRestPollingLoopTest, PollLifetime) {
           [&](std::chrono::nanoseconds) { return timer_sequencer.PushBack(); });
   CompletionQueue cq(mock_cq);
 
-  AsyncSequencer<StatusOr<Operation>> get_sequencer;
+  AsyncSequencer<StatusOr<google::longrunning::Operation>> get_sequencer;
   auto mock = std::make_shared<MockStub>();
   EXPECT_CALL(*mock, AsyncGetOperation)
       .Times(4)
@@ -450,7 +452,7 @@ TEST(AsyncRestPollingLoopTest, PollThenCancelDuringTimer) {
           [&](std::chrono::nanoseconds) { return timer_sequencer.PushBack(); });
   CompletionQueue cq(mock_cq);
 
-  AsyncSequencer<StatusOr<Operation>> get_sequencer;
+  AsyncSequencer<StatusOr<google::longrunning::Operation>> get_sequencer;
   auto mock = std::make_shared<MockStub>();
   EXPECT_CALL(*mock, AsyncGetOperation)
       .Times(AtLeast(1))
@@ -514,7 +516,7 @@ TEST(AsyncRestPollingLoopTest, PollThenCancelDuringPoll) {
           [&](std::chrono::nanoseconds) { return timer_sequencer.PushBack(); });
   CompletionQueue cq(mock_cq);
 
-  AsyncSequencer<StatusOr<Operation>> get_sequencer;
+  AsyncSequencer<StatusOr<google::longrunning::Operation>> get_sequencer;
   auto mock = std::make_shared<MockStub>();
   EXPECT_CALL(*mock, AsyncGetOperation)
       .Times(AtLeast(1))
@@ -586,7 +588,7 @@ TEST(AsyncRestPollingLoopTest, SpanActiveThroughout) {
       });
   CompletionQueue cq(mock_cq);
 
-  AsyncSequencer<StatusOr<Operation>> get_sequencer;
+  AsyncSequencer<StatusOr<google::longrunning::Operation>> get_sequencer;
   auto mock = std::make_shared<MockStub>();
   EXPECT_CALL(*mock, AsyncGetOperation)
       .Times(AtLeast(1))

--- a/google/cloud/internal/async_rest_polling_loop_test.cc
+++ b/google/cloud/internal/async_rest_polling_loop_test.cc
@@ -14,9 +14,13 @@
 
 #include "google/cloud/internal/async_rest_polling_loop.h"
 #include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/opentelemetry_options.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
@@ -560,6 +564,75 @@ TEST(AsyncRestPollingLoopTest, PollThenCancelDuringPoll) {
                                AllOf(HasSubstr("test-function"),
                                      HasSubstr("operation cancelled"))));
 }
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+TEST(AsyncRestPollingLoopTest, SpanActiveThroughout) {
+  using testing_util::IsActive;
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = internal::MakeSpan("span");
+  google::longrunning::Operation starting_op;
+  starting_op.set_name("test-op-name");
+
+  using TimerType = StatusOr<std::chrono::system_clock::time_point>;
+  AsyncSequencer<TimerType> timer_sequencer;
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .Times(AtLeast(1))
+      .WillRepeatedly([&](std::chrono::nanoseconds) {
+        EXPECT_THAT(span, IsActive());
+        return timer_sequencer.PushBack();
+      });
+  CompletionQueue cq(mock_cq);
+
+  AsyncSequencer<StatusOr<Operation>> get_sequencer;
+  auto mock = std::make_shared<MockStub>();
+  EXPECT_CALL(*mock, AsyncGetOperation)
+      .Times(AtLeast(1))
+      .WillRepeatedly([&](CompletionQueue&, auto,
+                          google::longrunning::GetOperationRequest const&) {
+        EXPECT_THAT(span, IsActive());
+        return get_sequencer.PushBack();
+      });
+  EXPECT_CALL(*mock, AsyncCancelOperation)
+      .WillOnce([&](CompletionQueue&, auto,
+                    google::longrunning::CancelOperationRequest const&) {
+        EXPECT_THAT(span, IsActive());
+        return make_ready_future(Status{});
+      });
+  auto policy = absl::make_unique<MockPollingPolicy>();
+  EXPECT_CALL(*policy, clone()).Times(0);
+  EXPECT_CALL(*policy, OnFailure)
+      .Times(2)
+      .WillRepeatedly([](Status const& status) {
+        return status.code() != StatusCode::kCancelled;
+      });
+  EXPECT_CALL(*policy, WaitPeriod)
+      .WillRepeatedly(Return(std::chrono::milliseconds(1)));
+
+  auto scope = opentelemetry::trace::Scope(span);
+  internal::OptionsSpan o(
+      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  auto pending = AsyncRestPollingLoop(
+      cq, make_ready_future(make_status_or(starting_op)), MakePoll(mock),
+      MakeCancel(mock), std::move(policy), "test-function");
+
+  timer_sequencer.PopFront().set_value(std::chrono::system_clock::now());
+  get_sequencer.PopFront().set_value(starting_op);
+  timer_sequencer.PopFront().set_value(std::chrono::system_clock::now());
+  auto g = get_sequencer.PopFront();
+  {
+    auto overlay = opentelemetry::trace::Scope(internal::MakeSpan("overlay"));
+    pending.cancel();
+  }
+  g.set_value(internal::CancelledError("cancelled"));
+
+  auto overlay = opentelemetry::trace::Scope(internal::MakeSpan("overlay"));
+  (void)pending.get();
+}
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #10618 

Propagate trace context across an `Async(Rest)PollingLoop`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11040)
<!-- Reviewable:end -->
