### PR TITLE
impl(otel): trace context across gRPC channel refresh

### DIFF
--- a/google/cloud/internal/async_connection_ready.h
+++ b/google/cloud/internal/async_connection_ready.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_CONNECTION_READY_H
 
 #include "google/cloud/future.h"
+#include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/completion_queue_impl.h"
-#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include <grpcpp/channel.h>
@@ -74,7 +74,7 @@ class NotifyOnStateChange
 
  private:
   promise<bool> promise_;
-  google::cloud::Options options_ = CurrentOptions();
+  CallContext call_context_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
Part of the work for #10618 

This is a more obscure API that only affects handwritten libraries. But we might as well make all the `OptionsSpan` -> `ScopedCallContext` conversions at one time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11041)
<!-- Reviewable:end -->
