### PR TITLE
impl(bigquery): Fixes googleapis/google-cloud-cpp#11027

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_options.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/bigquery/v2/minimal/internal/job_retry_policy.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include <memory>
+#include <thread>
 
 namespace google {
 namespace cloud {
@@ -26,7 +27,23 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace {
 auto constexpr kBackoffScaling = 2.0;
+std::size_t constexpr kJobDefaultConnectionPoolSize = 4;
+std::size_t constexpr kJobDefaultConnectionPoolSizeMax = 64;
 }  // namespace
+
+std::size_t DefaultConnectionPoolSize() {
+  // For better resource utilization and greater throughput, it is recommended
+  // to calculate the default pool size based on cores(CPU) available. However,
+  // as per C++11 documentation `std::thread::hardware_concurrency()` cannot be
+  // fully relied upon. It is only a hint and the value can be 0 if it is not
+  // well defined or not computable. Apart from CPU count, multiple channels
+  // can be opened for each CPU to increase throughput. The pool size is also
+  // capped so that servers with many cores do not create too many channels.
+  int cpu_count = std::thread::hardware_concurrency();
+  if (cpu_count == 0) return kJobDefaultConnectionPoolSize;
+  return (std::min)(kJobDefaultConnectionPoolSizeMax,
+                    cpu_count * kJobDefaultConnectionPoolSize);
+}
 
 Options BigQueryJobDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
@@ -46,6 +63,10 @@ Options BigQueryJobDefaultOptions(Options options) {
   if (!options.has<BigQueryJobIdempotencyPolicyOption>()) {
     options.set<BigQueryJobIdempotencyPolicyOption>(
         MakeDefaultBigQueryJobIdempotencyPolicy());
+  }
+  if (!options.has<BigQueryJobConnectionPoolSizeOption>()) {
+    options.set<BigQueryJobConnectionPoolSizeOption>(
+        DefaultConnectionPoolSize());
   }
 
   return options;

--- a/google/cloud/bigquery/v2/minimal/internal/job_options.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.cc
@@ -27,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace {
 auto constexpr kBackoffScaling = 2.0;
-std::size_t constexpr kJobDefaultConnectionPoolSize = 4;
-std::size_t constexpr kJobDefaultConnectionPoolSizeMax = 64;
-}  // namespace
+std::size_t constexpr kConnectionPoolSize = 4;
+std::size_t constexpr kConnectionPoolSizeMax = 64;
 
 std::size_t DefaultConnectionPoolSize() {
   // For better resource utilization and greater throughput, it is recommended
@@ -40,10 +39,10 @@ std::size_t DefaultConnectionPoolSize() {
   // can be opened for each CPU to increase throughput. The pool size is also
   // capped so that servers with many cores do not create too many channels.
   int cpu_count = std::thread::hardware_concurrency();
-  if (cpu_count == 0) return kJobDefaultConnectionPoolSize;
-  return (std::min)(kJobDefaultConnectionPoolSizeMax,
-                    cpu_count * kJobDefaultConnectionPoolSize);
+  if (cpu_count == 0) return kConnectionPoolSize;
+  return (std::min)(kConnectionPoolSizeMax, cpu_count * kConnectionPoolSize);
 }
+}  // namespace
 
 Options BigQueryJobDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(

--- a/google/cloud/bigquery/v2/minimal/internal/job_options.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options.h
@@ -51,11 +51,20 @@ struct BigQueryJobIdempotencyPolicyOption {
 };
 
 /**
+ * Use with `google::cloud::Options` to configure the connection pool size for
+ * rest client.
+ */
+struct BigQueryJobConnectionPoolSizeOption {
+  using Type = std::size_t;
+};
+
+/**
  *  The options applicable to BigQueryJob.
  */
 using BigQueryJobPolicyOptionList =
     OptionList<BigQueryJobRetryPolicyOption, BigQueryJobBackoffPolicyOption,
-               BigQueryJobIdempotencyPolicyOption>;
+               BigQueryJobIdempotencyPolicyOption,
+               BigQueryJobConnectionPoolSizeOption>;
 
 /**
  * Default options for

--- a/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
@@ -49,7 +49,6 @@ TEST(JobOptionstTest, DefaultOptions) {
 
   EXPECT_TRUE(actual.has<BigQueryJobBackoffPolicyOption>());
 
-  EXPECT_TRUE(actual.has<BigQueryJobConnectionPoolSizeOption>());
   EXPECT_GT(actual.get<BigQueryJobConnectionPoolSizeOption>(), 0);
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
@@ -48,6 +48,9 @@ TEST(JobOptionstTest, DefaultOptions) {
             expected_retry->IsExhausted());
 
   EXPECT_TRUE(actual.has<BigQueryJobBackoffPolicyOption>());
+
+  EXPECT_TRUE(actual.has<BigQueryJobConnectionPoolSizeOption>());
+  EXPECT_TRUE(actual.get<BigQueryJobConnectionPoolSizeOption>() > 0);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
@@ -50,7 +50,7 @@ TEST(JobOptionstTest, DefaultOptions) {
   EXPECT_TRUE(actual.has<BigQueryJobBackoffPolicyOption>());
 
   EXPECT_TRUE(actual.has<BigQueryJobConnectionPoolSizeOption>());
-  EXPECT_TRUE(actual.get<BigQueryJobConnectionPoolSizeOption>() > 0);
+  EXPECT_GT(actual.get<BigQueryJobConnectionPoolSizeOption>(), 0);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
@@ -32,8 +32,7 @@ std::shared_ptr<BigQueryJobRestStub> CreateDefaultBigQueryJobRestStub(
   if (!local_opts.has<UnifiedCredentialsOption>()) {
     local_opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());
   }
-  // TODO(#11027): Optimize to use a PooledRestClient.
-  auto curl_rest_client = rest_internal::MakeDefaultRestClient(
+  auto curl_rest_client = rest_internal::MakePooledRestClient(
       opts.get<EndpointOption>(), local_opts);
 
   std::shared_ptr<BigQueryJobRestStub> stub =


### PR DESCRIPTION
This replaces default rest client with pooled rest client. I looked at a few other examples in the repo for pooled rest clients especially 

https://github.com/googleapis/google-cloud-cpp/blob/ecf4413da87637e893601ac00f406cfc66b92660/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc 

and

https://github.com/googleapis/google-cloud-cpp/blob/ecf4413da87637e893601ac00f406cfc66b92660/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc

And it doesn't seem like I need to change rest request path for GetJob  but let me know if that is not the case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11043)
<!-- Reviewable:end -->
