### PR TITLE
impl(otel): async unary gRPC stub tracing

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_stub.cc
@@ -204,14 +204,26 @@ future<StatusOr<google::test::admin::database::v1::Database>> GoldenThingAdminTr
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::GetDatabaseRequest const& request) {
-  return child_->AsyncGetDatabase(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.test.admin.database.v1.GoldenThingAdmin", "GetDatabase");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncGetDatabase(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<Status> GoldenThingAdminTracingStub::AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::DropDatabaseRequest const& request) {
-  return child_->AsyncDropDatabase(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.test.admin.database.v1.GoldenThingAdmin", "DropDatabase");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncDropDatabase(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_tracing_stub.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_tracing_stub.cc
@@ -242,7 +242,14 @@ BigtableTableAdminTracingStub::AsyncCheckConsistency(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
-  return child_->AsyncCheckConsistency(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc(
+      "google.bigtable.admin.v2.BigtableTableAdmin", "CheckConsistency");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncCheckConsistency(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/bigtable/internal/bigtable_tracing_stub.cc
+++ b/google/cloud/bigtable/internal/bigtable_tracing_stub.cc
@@ -123,7 +123,14 @@ BigtableTracingStub::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::bigtable::v2::MutateRowRequest const& request) {
-  return child_->AsyncMutateRow(cq, std::move(context), request);
+  auto span =
+      internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "MutateRow");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncMutateRow(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -140,7 +147,14 @@ BigtableTracingStub::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-  return child_->AsyncCheckAndMutateRow(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
+                                     "CheckAndMutateRow");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncCheckAndMutateRow(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
@@ -148,7 +162,14 @@ BigtableTracingStub::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-  return child_->AsyncReadModifyWriteRow(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
+                                     "ReadModifyWriteRow");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncReadModifyWriteRow(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/logging/v2/internal/logging_service_v2_tracing_stub.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_tracing_stub.cc
@@ -103,7 +103,14 @@ LoggingServiceV2TracingStub::AsyncWriteLogEntries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::logging::v2::WriteLogEntriesRequest const& request) {
-  return child_->AsyncWriteLogEntries(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.logging.v2.LoggingServiceV2",
+                                     "WriteLogEntries");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncWriteLogEntries(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/monitoring/v3/internal/metric_tracing_stub.cc
+++ b/google/cloud/monitoring/v3/internal/metric_tracing_stub.cc
@@ -142,7 +142,14 @@ future<Status> MetricServiceTracingStub::AsyncCreateTimeSeries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::monitoring::v3::CreateTimeSeriesRequest const& request) {
-  return child_->AsyncCreateTimeSeries(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.monitoring.v3.MetricService",
+                                     "CreateTimeSeries");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncCreateTimeSeries(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/pubsub/internal/publisher_tracing_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_stub.cc
@@ -132,7 +132,13 @@ PublisherTracingStub::AsyncPublish(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::pubsub::v1::PublishRequest const& request) {
-  return child_->AsyncPublish(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.pubsub.v1.Publisher", "Publish");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncPublish(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/pubsub/internal/subscriber_tracing_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_tracing_stub.cc
@@ -187,14 +187,28 @@ future<Status> SubscriberTracingStub::AsyncModifyAckDeadline(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  return child_->AsyncModifyAckDeadline(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.pubsub.v1.Subscriber",
+                                     "ModifyAckDeadline");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncModifyAckDeadline(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<Status> SubscriberTracingStub::AsyncAcknowledge(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::pubsub::v1::AcknowledgeRequest const& request) {
-  return child_->AsyncAcknowledge(cq, std::move(context), request);
+  auto span =
+      internal::MakeSpanGrpc("google.pubsub.v1.Subscriber", "Acknowledge");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncAcknowledge(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/pubsublite/internal/admin_tracing_stub.cc
+++ b/google/cloud/pubsublite/internal/admin_tracing_stub.cc
@@ -257,7 +257,14 @@ AdminServiceTracingStub::AsyncGetTopicPartitions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request) {
-  return child_->AsyncGetTopicPartitions(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.cloud.pubsublite.v1.AdminService",
+                                     "GetTopicPartitions");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncGetTopicPartitions(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/storage/internal/storage_tracing_stub.cc
+++ b/google/cloud/storage/internal/storage_tracing_stub.cc
@@ -366,7 +366,14 @@ future<Status> StorageTracingStub::AsyncDeleteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::storage::v2::DeleteObjectRequest const& request) {
-  return child_->AsyncDeleteObject(cq, std::move(context), request);
+  auto span =
+      internal::MakeSpanGrpc("google.storage.v2.Storage", "DeleteObject");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncDeleteObject(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -392,7 +399,14 @@ StorageTracingStub::AsyncStartResumableWrite(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::storage::v2::StartResumableWriteRequest const& request) {
-  return child_->AsyncStartResumableWrite(cq, std::move(context), request);
+  auto span = internal::MakeSpanGrpc("google.storage.v2.Storage",
+                                     "StartResumableWrite");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncStartResumableWrite(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
@@ -400,7 +414,14 @@ StorageTracingStub::AsyncQueryWriteStatus(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::storage::v2::QueryWriteStatusRequest const& request) {
-  return child_->AsyncQueryWriteStatus(cq, std::move(context), request);
+  auto span =
+      internal::MakeSpanGrpc("google.storage.v2.Storage", "QueryWriteStatus");
+  {
+    auto scope = opentelemetry::trace::Scope(span);
+    internal::InjectTraceContext(*context, internal::CurrentOptions());
+  }
+  auto f = child_->AsyncQueryWriteStatus(cq, context, request);
+  return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY


### PR DESCRIPTION
Part of the work for #10620 

As per the design, we do only mark the span for the async call as active in order to inject the trace context. By closing the scope, we ensure that the parent span (to be started by the connection) is propagated. This way subsequent backoffs / retries are siblings of each other.

Get/Cancel for LROs are also async unary stub calls. I will add them in a follow up though, so I can embellish my productivity before the OSPO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11044)
<!-- Reviewable:end -->
