### PR TITLE
impl(otel): traced async backoffs

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -102,12 +102,13 @@ future<T> EndSpan(
 template <typename Rep, typename Period>
 future<StatusOr<std::chrono::system_clock::time_point>> TracedAsyncBackoff(
     CompletionQueue& cq, std::chrono::duration<Rep, Period> duration) {
+  auto timer = cq.MakeRelativeTimer(duration);
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   if (TracingEnabled(CurrentOptions())) {
-    return EndSpan(MakeSpan("Async Backoff"), cq.MakeRelativeTimer(duration));
+    return EndSpan(MakeSpan("Async Backoff"), std::move(timer));
   }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-  return cq.MakeRelativeTimer(duration);
+  return timer;
 }
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -105,7 +105,7 @@ future<StatusOr<std::chrono::system_clock::time_point>> TracedAsyncBackoff(
   auto timer = cq.MakeRelativeTimer(duration);
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   if (TracingEnabled(CurrentOptions())) {
-    return EndSpan(MakeSpan("Async Backoff"), std::move(timer));
+    timer = EndSpan(MakeSpan("Async Backoff"), std::move(timer));
   }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   return timer;

--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_OPENTELEMETRY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_OPENTELEMETRY_H
 
+#include "google/cloud/completion_queue.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -23,6 +24,8 @@
 #include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/trace/span.h>
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include <chrono>
+#include <functional>
 
 namespace google {
 namespace cloud {
@@ -92,6 +95,20 @@ future<T> EndSpan(
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+/**
+ * Returns a traced timer, if OpenTelemetry tracing is enabled.
+ */
+template <typename Rep, typename Period>
+future<StatusOr<std::chrono::system_clock::time_point>> TracedAsyncBackoff(
+    CompletionQueue& cq, std::chrono::duration<Rep, Period> duration) {
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+  if (TracingEnabled(CurrentOptions())) {
+    return EndSpan(MakeSpan("Async Backoff"), cq.MakeRelativeTimer(duration));
+  }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+  return cq.MakeRelativeTimer(duration);
+}
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #10618 

The analog of #10589, but async.

I will incorporate it in the `AsyncRetryLoop`s and `AsyncPollingLoop`s in separate PRs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11048)
<!-- Reviewable:end -->
