### PR TITLE
feat(mocks): provide access to call options in client tests

### DIFF
--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -262,8 +262,9 @@ install(
 # for these, a regular library would not work on macOS (where the library needs
 # at least one .o file).
 add_library(google_cloud_cpp_mocks INTERFACE)
-set(google_cloud_cpp_mocks_hdrs # cmake-format: sort
-                                mocks/mock_stream_range.h)
+set(google_cloud_cpp_mocks_hdrs
+    # cmake-format: sort
+    mocks/current_options.h mocks/mock_stream_range.h)
 export_list_to_bazel("google_cloud_cpp_mocks.bzl" "google_cloud_cpp_mocks_hdrs"
                      YEAR "2022")
 target_link_libraries(
@@ -367,6 +368,7 @@ if (BUILD_TESTING)
         internal/utility_test.cc
         kms_key_name_test.cc
         log_test.cc
+        mocks/current_options_test.cc
         mocks/mock_stream_range_test.cc
         options_test.cc
         polling_policy_test.cc

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -64,6 +64,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/utility_test.cc",
     "kms_key_name_test.cc",
     "log_test.cc",
+    "mocks/current_options_test.cc",
     "mocks/mock_stream_range_test.cc",
     "options_test.cc",
     "polling_policy_test.cc",

--- a/google/cloud/google_cloud_cpp_mocks.bzl
+++ b/google/cloud/google_cloud_cpp_mocks.bzl
@@ -17,5 +17,6 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 google_cloud_cpp_mocks_hdrs = [
+    "mocks/current_options.h",
     "mocks/mock_stream_range.h",
 ]

--- a/google/cloud/mocks/current_options.h
+++ b/google/cloud/mocks/current_options.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * }
  * @endcode
  */
-Options CurrentOptions() { return internal::CurrentOptions(); }
+inline Options const& CurrentOptions() { return internal::CurrentOptions(); }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace mocks

--- a/google/cloud/mocks/current_options.h
+++ b/google/cloud/mocks/current_options.h
@@ -1,0 +1,51 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_MOCKS_CURRENT_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_MOCKS_CURRENT_OPTIONS_H
+
+#include "google/cloud/options.h"
+
+namespace google {
+namespace cloud {
+namespace mocks {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Retrieve options used in a client call.
+ *
+ * This would be used to verify configuration options from within a
+ * MockConnection. It provides a way for applications to test the difference
+ * between `client.Foo(request, options)` and `client.Foo(request)`.
+ *
+ * @code
+ * TEST(Foo, CallOptions) {
+ *   auto mock = std::make_shared<MockConnection>();
+ *   EXPECT_CALL(*mock, Foo).WillOnce([] {
+ *         auto const& options = google::cloud::mocks::CurrentOptions();
+ *         EXPECT_THAT(options, ...);
+ *       });
+ *   auto client = Client(mock);
+ *   DoThing(client);
+ * }
+ * @endcode
+ */
+Options CurrentOptions() { return internal::CurrentOptions(); }
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace mocks
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_MOCKS_CURRENT_OPTIONS_H

--- a/google/cloud/mocks/current_options.h
+++ b/google/cloud/mocks/current_options.h
@@ -37,7 +37,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *         EXPECT_THAT(options, ...);
  *       });
  *   auto client = Client(mock);
- *   DoThing(client);
+ *   MyFunctionThatCallsFoo(client);
  * }
  * @endcode
  */

--- a/google/cloud/mocks/current_options_test.cc
+++ b/google/cloud/mocks/current_options_test.cc
@@ -1,0 +1,47 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/mocks/current_options.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace mocks {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+TEST(CurrentOptionsTest, Basic) {
+  struct IntOption {
+    using Type = int;
+  };
+
+  EXPECT_FALSE(CurrentOptions().has<IntOption>());
+  {
+    internal::OptionsSpan span(Options{}.set<IntOption>(1));
+    EXPECT_EQ(CurrentOptions().get<IntOption>(), 1);
+    {
+      internal::OptionsSpan span(Options{}.set<IntOption>(2));
+      EXPECT_EQ(CurrentOptions().get<IntOption>(), 2);
+    }
+    EXPECT_EQ(CurrentOptions().get<IntOption>(), 1);
+  }
+  EXPECT_FALSE(CurrentOptions().has<IntOption>());
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace mocks
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/mocks/mock_stream_range_test.cc
+++ b/google/cloud/mocks/mock_stream_range_test.cc
@@ -20,6 +20,7 @@ namespace google {
 namespace cloud {
 namespace mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
 
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;
@@ -69,6 +70,7 @@ TEST(MakeStreamRangeTest, ValuesThenStatus) {
   EXPECT_THAT(result.final_status, StatusIs(StatusCode::kAborted));
 }
 
+}  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace mocks
 }  // namespace cloud


### PR DESCRIPTION
Fixes #10030 

If we think this should be more publicized, say the words and I will add it to our [mocking exemplar](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/bigquery/samples/mock_bigquery_read.cc).

Also, while we are here, put the other mock test in an anonymous namespace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11050)
<!-- Reviewable:end -->
