### PR TITLE
impl(otel): trace captures LRO name

### DIFF
--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -87,7 +87,9 @@ class AsyncPollingLoopImpl
   }
 
   void OnStart(StatusOr<Operation> op) {
-    if (!op || op->done()) return promise_.set_value(std::move(op));
+    if (!op) return promise_.set_value(std::move(op));
+    AddSpanAttribute("gcloud.LRO_name", op->name());
+    if (op->done()) return promise_.set_value(std::move(op));
     GCP_LOG(DEBUG) << location_ << "() polling loop starting for "
                    << op->name();
     bool do_cancel = false;

--- a/google/cloud/internal/async_rest_polling_loop.cc
+++ b/google/cloud/internal/async_rest_polling_loop.cc
@@ -88,7 +88,9 @@ class AsyncRestPollingLoopImpl
   }
 
   void OnStart(StatusOr<Operation> op) {
-    if (!op || op->done()) return promise_.set_value(std::move(op));
+    if (!op) return promise_.set_value(std::move(op));
+    internal::AddSpanAttribute("gcloud.LRO_name", op->name());
+    if (op->done()) return promise_.set_value(std::move(op));
     GCP_LOG(DEBUG) << location_ << "() polling loop starting for "
                    << op->name();
     bool do_cancel = false;

--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -99,6 +99,16 @@ std::function<void(std::chrono::milliseconds)> MakeTracedSleeper(
   return sleeper;
 }
 
+// NOLINTNEXTLINE(misc-unused-value-param)
+void AddSpanAttribute(std::string const& key, std::string const& value) {
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+  if (TracingEnabled(CurrentOptions())) {
+    auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
+    span->SetAttribute(std::move(key), std::move(value));
+  }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -137,6 +137,9 @@ bool TracingEnabled(Options const& options);
 std::function<void(std::chrono::milliseconds)> MakeTracedSleeper(
     std::function<void(std::chrono::milliseconds)> const& sleeper);
 
+/// Adds an attribute to the active span, if tracing is enabled.
+void AddSpanAttribute(std::string const& key, std::string const& value);
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud


### PR DESCRIPTION
Part of the work for #10618 

Note that, at the moment, I only need to set one string attribute. I may want a more general interface (set numeric attributes, set multiple attributes at once). But I am not going to generalize until the need is clear.