### PR TITLE
doc(spanner): add GOOGLE_CLOUD_CPP_TRACING_OPTIONS description

### DIFF
--- a/google/cloud/bigtable/doc/environment-variables.dox
+++ b/google/cloud/bigtable/doc/environment-variables.dox
@@ -22,7 +22,7 @@ regular RPC calls and streaming RPC calls.
 
 @see google::cloud::TracingComponentsOption
 
-GOOGLE_CLOUD_CPP_TRACING_OPTIONS=...`: modifies the behavior of gRPC tracing,
+`GOOGLE_CLOUD_CPP_TRACING_OPTIONS=...`: modifies the behavior of gRPC tracing,
 including whether messages will be output on multiple lines, or whether
 string/bytes fields will be truncated.
 

--- a/google/cloud/spanner/doc/environment-variables.dox
+++ b/google/cloud/spanner/doc/environment-variables.dox
@@ -8,11 +8,11 @@ environment variables are convenient when troubleshooting problems.
 
 @section spanner-env-logging Logging
 
-`GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
-calls. The library injects an additional Stub decorator that prints each gRPC
-request and response.  Unless you have configured you own logging backend,
-you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
-the program's console.
+`GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC calls.
+The library injects an additional Stub decorator that prints each gRPC
+request and response.  Unless you have configured you own logging backend, you
+should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on the
+program's console.
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc-streams`: turns on tracing for streaming
 gRPC calls, such as `Client::Read()`, `Client::ExecuteQuery()`, and
@@ -24,7 +24,13 @@ regular RPC calls and streaming RPC calls.
 
 @see google::cloud::TracingComponentsOption
 
-`GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes`: turns on logging in the library, basically
+`GOOGLE_CLOUD_CPP_TRACING_OPTIONS=...`: modifies the behavior of gRPC tracing,
+including whether messages will be output on multiple lines, or whether
+string/bytes fields will be truncated.
+
+@see google::cloud::TracingOptionsOption
+
+`GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes`: turns on logging in the library. Basically
 the library always "logs" but the logging infrastructure has no backend to
 actually print anything until the application sets a backend or they set this
 environment variable.


### PR DESCRIPTION
The Spanner "env-logging" section was missing a description for `GOOGLE_CLOUD_CPP_TRACING_OPTIONS`, so add one, and make the shape of the entire section match that of Bigtable.

Also add a missing back quote to the Bigtable text.