### PR TITLE
impl(storage): support upload hashing in `RawClient`

### DIFF
--- a/google/cloud/storage/internal/hash_function.h
+++ b/google/cloud/storage/internal/hash_function.h
@@ -17,6 +17,9 @@
 
 #include "google/cloud/storage/internal/hash_values.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status.h"
+#include "absl/strings/cord.h"
+#include "absl/strings/string_view.h"
 #include <memory>
 #include <string>
 
@@ -25,6 +28,11 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+
+class ReadObjectRangeRequest;
+class ResumableUploadRequest;
+class InsertObjectMediaRequest;
+
 /**
  * Defines the interface to compute hash values during uploads and downloads.
  *
@@ -64,30 +72,33 @@ class HashFunction {
   virtual std::string Name() const = 0;
 
   /// Update the computed hash value with some portion of the data.
-  virtual void Update(char const* buf, std::size_t n) = 0;
+  virtual void Update(absl::string_view buffer) = 0;
+  virtual Status Update(std::int64_t offset, absl::string_view buffer) = 0;
+  virtual Status Update(std::int64_t offset, absl::string_view buffer,
+                        std::uint32_t buffer_crc) = 0;
+  virtual Status Update(std::int64_t offset, absl::Cord const& buffer,
+                        std::uint32_t buffer_crc) = 0;
 
   /**
    * Compute the final hash values.
-   *
-   * We use a `&&` overload as some hash functions (notably MD5) cannot accept
-   * more data once the hash is finalized.
    */
-  virtual HashValues Finish() && = 0;
+  virtual HashValues Finish() = 0;
 };
 
 /// Create a no-op hash function
 std::unique_ptr<HashFunction> CreateNullHashFunction();
 
-class ReadObjectRangeRequest;
-class ResumableUploadRequest;
-
-/// Create a hash validator configured by @p request.
+/// Create a hash function configured by @p request.
 std::unique_ptr<HashFunction> CreateHashFunction(
     ReadObjectRangeRequest const& request);
 
-/// Create a hash validator configured by @p request.
+/// Create a hash function configured by @p request.
 std::unique_ptr<HashFunction> CreateHashFunction(
     ResumableUploadRequest const& request);
+
+/// Create a hash function configured by @p request.
+std::unique_ptr<HashFunction> CreateHashFunction(
+    InsertObjectMediaRequest const& request);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/hash_function_impl.cc
+++ b/google/cloud/storage/internal/hash_function_impl.cc
@@ -55,7 +55,7 @@ template <typename Buffer>
 bool AlreadyHashed(std::int64_t offset, Buffer const& buffer,
                    std::int64_t minimum_offset) {
   auto const end = offset + buffer.size();
-  return static_cast<std::int64_t>(end) < minimum_offset;
+  return static_cast<std::int64_t>(end) <= minimum_offset;
 }
 
 }  // namespace
@@ -114,7 +114,7 @@ Status CompositeFunction::Update(std::int64_t offset, absl::Cord const& buffer,
 }
 
 HashValues CompositeFunction::Finish() {
-  return Merge(std::move(*a_).Finish(), std::move(*b_).Finish());
+  return Merge(a_->Finish(), b_->Finish());
 }
 
 MD5HashFunction::MD5HashFunction() : impl_(CreateDigestCtx()) {
@@ -137,13 +137,7 @@ Status MD5HashFunction::Update(std::int64_t offset, absl::string_view buffer) {
 
 Status MD5HashFunction::Update(std::int64_t offset, absl::string_view buffer,
                                std::uint32_t /*buffer_crc*/) {
-  if (offset == minimum_offset_) {
-    Update(buffer);
-    minimum_offset_ += buffer.size();
-    return {};
-  }
-  if (AlreadyHashed(offset, buffer, minimum_offset_)) return {};
-  return InvalidArgumentError("mismatched offset", GCP_ERROR_INFO());
+  return Update(offset, buffer);
 }
 
 Status MD5HashFunction::Update(std::int64_t offset, absl::Cord const& buffer,

--- a/google/cloud/storage/internal/hash_function_impl.h
+++ b/google/cloud/storage/internal/hash_function_impl.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/version.h"
 #include "absl/types/optional.h"
 #include <openssl/evp.h>
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/google/cloud/storage/internal/hash_function_impl.h
+++ b/google/cloud/storage/internal/hash_function_impl.h
@@ -17,9 +17,8 @@
 
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/version.h"
+#include "absl/types/optional.h"
 #include <openssl/evp.h>
-#include <cstdint>
-#include <map>
 #include <memory>
 #include <string>
 
@@ -36,9 +35,14 @@ class NullHashFunction : public HashFunction {
  public:
   NullHashFunction() = default;
 
-  std::string Name() const override { return "null"; }
-  void Update(char const*, std::size_t) override {}
-  HashValues Finish() && override { return HashValues{}; }
+  std::string Name() const override;
+  void Update(absl::string_view) override;
+  Status Update(std::int64_t offset, absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer,
+                std::uint32_t buffer_crc) override;
+  Status Update(std::int64_t offset, absl::Cord const& buffer,
+                std::uint32_t buffer_crc) override;
+  HashValues Finish() override;
 };
 
 /**
@@ -51,8 +55,13 @@ class CompositeFunction : public HashFunction {
       : a_(std::move(a)), b_(std::move(b)) {}
 
   std::string Name() const override;
-  void Update(char const* buf, std::size_t n) override;
-  HashValues Finish() && override;
+  void Update(absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer,
+                std::uint32_t buffer_crc) override;
+  Status Update(std::int64_t offset, absl::Cord const& buffer,
+                std::uint32_t buffer_crc) override;
+  HashValues Finish() override;
 
  private:
   std::unique_ptr<HashFunction> a_;
@@ -70,8 +79,13 @@ class MD5HashFunction : public HashFunction {
   MD5HashFunction& operator=(MD5HashFunction const&) = delete;
 
   std::string Name() const override { return "md5"; }
-  void Update(char const* buf, std::size_t n) override;
-  HashValues Finish() && override;
+  void Update(absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer,
+                std::uint32_t buffer_crc) override;
+  Status Update(std::int64_t offset, absl::Cord const& buffer,
+                std::uint32_t buffer_crc) override;
+  HashValues Finish() override;
 
   struct ContextDeleter {
     void operator()(EVP_MD_CTX*);
@@ -79,6 +93,8 @@ class MD5HashFunction : public HashFunction {
 
  private:
   std::unique_ptr<EVP_MD_CTX, ContextDeleter> impl_;
+  std::int64_t minimum_offset_ = 0;
+  absl::optional<HashValues> hashes_;
 };
 
 /**
@@ -92,11 +108,17 @@ class Crc32cHashFunction : public HashFunction {
   Crc32cHashFunction& operator=(Crc32cHashFunction const&) = delete;
 
   std::string Name() const override { return "crc32c"; }
-  void Update(char const* buf, std::size_t n) override;
-  HashValues Finish() && override;
+  void Update(absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer,
+                std::uint32_t buffer_crc) override;
+  Status Update(std::int64_t offset, absl::Cord const& buffer,
+                std::uint32_t buffer_crc) override;
+  HashValues Finish() override;
 
  private:
-  std::uint32_t current_{0};
+  std::uint32_t current_ = 0;
+  std::int64_t minimum_offset_ = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/hash_function_impl_test.cc
+++ b/google/cloud/storage/internal/hash_function_impl_test.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/hash_function_impl.h"
+#include "google/cloud/storage/internal/crc32c.h"
 #include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 
@@ -24,6 +26,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::IsEmpty;
 
 // These values were obtained using:
@@ -35,63 +38,172 @@ auto constexpr kEmptyStringMD5Hash = "1B2M2Y8AsgTpgAmY7PhCfg==";
 // gsutil hash foo.txt
 auto constexpr kQuickFoxCrc32cChecksum = "ImIEBA==";
 auto constexpr kQuickFoxMD5Hash = "nhB9nTcrtoJr2B01QqQZ1g==";
+auto constexpr kQuickFox = "The quick brown fox jumps over the lazy dog";
 
-void Update(HashFunction& hash, std::string const& buffer) {
-  hash.Update(buffer.data(), buffer.size());
-}
-
-TEST(HasFunctionImplTest, EmptyNull) {
+TEST(HashFunctionImplTest, EmptyNull) {
   NullHashFunction function;
   auto result = std::move(function).Finish();
   EXPECT_THAT(result.crc32c, IsEmpty());
   EXPECT_THAT(result.md5, IsEmpty());
 }
 
-TEST(HasFunctionImplTest, QuickNull) {
+TEST(HashFunctionImplTest, QuickNull) {
   NullHashFunction function;
-  Update(function, "The quick");
-  Update(function, " brown");
-  Update(function, " fox jumps over the lazy dog");
+  function.Update("The quick");
+  function.Update(" brown");
+  function.Update(" fox jumps over the lazy dog");
   auto result = std::move(function).Finish();
   EXPECT_THAT(result.crc32c, IsEmpty());
   EXPECT_THAT(result.md5, IsEmpty());
 }
 
-TEST(HasFunctionImplTest, EmptyCrc32c) {
+TEST(HashFunctionImplTest, Crc32cEmpty) {
   Crc32cHashFunction function;
   auto result = std::move(function).Finish();
   EXPECT_THAT(result.crc32c, kEmptyStringCrc32cChecksum);
   EXPECT_THAT(result.md5, IsEmpty());
 }
 
-TEST(HasFunctionImplTest, QuickCrc32c) {
+TEST(HashFunctionImplTest, Crc32cQuickSimple) {
   Crc32cHashFunction function;
-  Update(function, "The quick");
-  Update(function, " brown");
-  Update(function, " fox jumps over the lazy dog");
+  function.Update("The quick");
+  function.Update(" brown");
+  function.Update(" fox jumps over the lazy dog");
   auto result = std::move(function).Finish();
   EXPECT_THAT(result.crc32c, kQuickFoxCrc32cChecksum);
   EXPECT_THAT(result.md5, IsEmpty());
 }
 
-TEST(HasFunctionImplTest, EmptyMD5) {
+TEST(HashFunctionImplTest, Crc32cStringView) {
+  Crc32cHashFunction function;
+  auto payload = absl::string_view{kQuickFox};
+  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
+    auto message = payload.substr(npos, 5);
+    EXPECT_STATUS_OK(function.Update(npos, message));
+    EXPECT_THAT(function.Update(npos, message),
+                StatusIs(StatusCode::kInvalidArgument));
+  }
+  auto const actual = function.Finish();
+  EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(actual.md5, IsEmpty());
+
+  auto const a2 = function.Finish();
+  EXPECT_EQ(a2.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(a2.md5, IsEmpty());
+}
+
+TEST(HashFunctionImplTest, Crc32cStringViewWithCrc) {
+  Crc32cHashFunction function;
+  auto payload = absl::string_view{kQuickFox};
+  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
+    auto message = payload.substr(npos, 5);
+    auto const message_crc = storage_internal::Crc32c(message);
+    EXPECT_STATUS_OK(function.Update(npos, message, message_crc));
+    EXPECT_THAT(function.Update(npos, message, message_crc),
+                StatusIs(StatusCode::kInvalidArgument));
+  }
+  auto const actual = function.Finish();
+  EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(actual.md5, IsEmpty());
+
+  auto const a2 = function.Finish();
+  EXPECT_EQ(a2.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(a2.md5, IsEmpty());
+}
+
+TEST(HashFunctionImplTest, Crc32cCord) {
+  Crc32cHashFunction function;
+  auto payload = absl::Cord(absl::string_view{kQuickFox});
+  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
+    auto message = payload.Subcord(npos, 5);
+    auto const message_crc = storage_internal::Crc32c(message);
+    EXPECT_STATUS_OK(function.Update(npos, message, message_crc));
+    EXPECT_THAT(function.Update(npos, message, message_crc),
+                StatusIs(StatusCode::kInvalidArgument));
+  }
+  auto const actual = function.Finish();
+  EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(actual.md5, IsEmpty());
+
+  auto const a2 = function.Finish();
+  EXPECT_EQ(a2.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(a2.md5, IsEmpty());
+}
+
+TEST(HashFunctionImplTest, MD5Empty) {
   MD5HashFunction function;
   auto result = std::move(function).Finish();
   EXPECT_THAT(result.crc32c, IsEmpty());
   EXPECT_THAT(result.md5, kEmptyStringMD5Hash);
 }
 
-TEST(HasFunctionImplTest, QuickMD5) {
+TEST(HashFunctionImplTest, MD5Quick) {
   MD5HashFunction function;
-  Update(function, "The quick");
-  Update(function, " brown");
-  Update(function, " fox jumps over the lazy dog");
+  function.Update("The quick");
+  function.Update(" brown");
+  function.Update(" fox jumps over the lazy dog");
   auto result = std::move(function).Finish();
   EXPECT_THAT(result.crc32c, IsEmpty());
   EXPECT_THAT(result.md5, kQuickFoxMD5Hash);
 }
 
-TEST(HasFunctionImplTest, EmptyComposite) {
+TEST(HashFunctionImplTest, MD5StringView) {
+  MD5HashFunction function;
+  auto payload = absl::string_view{kQuickFox};
+  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
+    auto message = payload.substr(npos, 5);
+    EXPECT_STATUS_OK(function.Update(npos, message));
+    EXPECT_THAT(function.Update(npos, message),
+                StatusIs(StatusCode::kInvalidArgument));
+  }
+  auto const actual = function.Finish();
+  EXPECT_THAT(actual.crc32c, IsEmpty());
+  EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
+
+  auto const a2 = function.Finish();
+  EXPECT_THAT(a2.crc32c, IsEmpty());
+  EXPECT_THAT(a2.md5, kQuickFoxMD5Hash);
+}
+
+TEST(HashFunctionImplTest, MD5StringViewWithCrc) {
+  MD5HashFunction function;
+  auto payload = absl::string_view{kQuickFox};
+  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
+    auto message = payload.substr(npos, 5);
+    auto const message_crc = storage_internal::Crc32c(message);
+    EXPECT_STATUS_OK(function.Update(npos, message, message_crc));
+    EXPECT_THAT(function.Update(npos, message, message_crc),
+                StatusIs(StatusCode::kInvalidArgument));
+  }
+  auto const actual = function.Finish();
+  EXPECT_THAT(actual.crc32c, IsEmpty());
+  EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
+
+  auto const a2 = function.Finish();
+  EXPECT_THAT(a2.crc32c, IsEmpty());
+  EXPECT_THAT(a2.md5, kQuickFoxMD5Hash);
+}
+
+TEST(HashFunctionImplTest, MD5Cord) {
+  MD5HashFunction function;
+  auto payload = absl::Cord(absl::string_view{kQuickFox});
+  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
+    auto message = payload.Subcord(npos, 5);
+    auto const message_crc = storage_internal::Crc32c(message);
+    EXPECT_STATUS_OK(function.Update(npos, message, message_crc));
+    EXPECT_THAT(function.Update(npos, message, message_crc),
+                StatusIs(StatusCode::kInvalidArgument));
+  }
+  auto const actual = function.Finish();
+  EXPECT_THAT(actual.crc32c, IsEmpty());
+  EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
+
+  auto const a2 = function.Finish();
+  EXPECT_THAT(a2.crc32c, IsEmpty());
+  EXPECT_THAT(a2.md5, kQuickFoxMD5Hash);
+}
+
+TEST(HashFunctionImplTest, CompositeEmpty) {
   CompositeFunction function(absl::make_unique<MD5HashFunction>(),
                              absl::make_unique<Crc32cHashFunction>());
   auto result = std::move(function).Finish();
@@ -99,18 +211,18 @@ TEST(HasFunctionImplTest, EmptyComposite) {
   EXPECT_THAT(result.md5, kEmptyStringMD5Hash);
 }
 
-TEST(HasFunctionImplTest, QuickComposite) {
+TEST(HashFunctionImplTest, CompositeQuick) {
   CompositeFunction function(absl::make_unique<MD5HashFunction>(),
                              absl::make_unique<Crc32cHashFunction>());
-  Update(function, "The quick");
-  Update(function, " brown");
-  Update(function, " fox jumps over the lazy dog");
+  function.Update("The quick");
+  function.Update(" brown");
+  function.Update(" fox jumps over the lazy dog");
   auto result = std::move(function).Finish();
   EXPECT_THAT(result.crc32c, kQuickFoxCrc32cChecksum);
   EXPECT_THAT(result.md5, kQuickFoxMD5Hash);
 }
 
-TEST(HasFunctionImplTest, CreateHashFunctionRead) {
+TEST(HashFunctionImplTest, CreateHashFunctionRead) {
   struct Test {
     std::string crc32c_expected;
     std::string md5_expected;
@@ -130,14 +242,14 @@ TEST(HasFunctionImplTest, CreateHashFunctionRead) {
     auto function = CreateHashFunction(
         ReadObjectRangeRequest("test-bucket", "test-object")
             .set_multiple_options(test.crc32_disabled, test.md5_disabled));
-    Update(*function, "The quick brown fox jumps over the lazy dog");
+    function->Update("The quick brown fox jumps over the lazy dog");
     auto const actual = std::move(*function).Finish();
     EXPECT_EQ(test.crc32c_expected, actual.crc32c);
     EXPECT_EQ(test.md5_expected, actual.md5);
   }
 }
 
-TEST(HasFunctionImplTest, CreateHashFunctionUpload) {
+TEST(HashFunctionImplTest, CreateHashFunctionUpload) {
   struct Test {
     std::string crc32c_expected;
     std::string md5_expected;
@@ -196,23 +308,43 @@ TEST(HasFunctionImplTest, CreateHashFunctionUpload) {
         ResumableUploadRequest("test-bucket", "test-object")
             .set_multiple_options(test.crc32_disabled, test.crc32_value,
                                   test.md5_disabled, test.md5_value));
-    Update(*function, "The quick brown fox jumps over the lazy dog");
+    function->Update("The quick brown fox jumps over the lazy dog");
     auto const actual = std::move(*function).Finish();
     EXPECT_EQ(test.crc32c_expected, actual.crc32c);
     EXPECT_EQ(test.md5_expected, actual.md5);
   }
 }
 
-TEST(HasFunctionImplTest, CreateHashFunctionUploadResumedSession) {
+TEST(HashFunctionImplTest, CreateHashFunctionUploadResumedSession) {
   auto function = CreateHashFunction(
       ResumableUploadRequest("test-bucket", "test-object")
           .set_multiple_options(UseResumableUploadSession("test-session-id"),
                                 DisableCrc32cChecksum(false),
                                 DisableMD5Hash(false)));
-  Update(*function, "The quick brown fox jumps over the lazy dog");
+  function->Update(kQuickFox);
   auto const actual = std::move(*function).Finish();
   EXPECT_THAT(actual.crc32c, IsEmpty());
-  EXPECT_THAT(actual.crc32c, IsEmpty());
+  EXPECT_THAT(actual.md5, IsEmpty());
+}
+
+TEST(HashFunctionImplTest, CreateHashFunctionInsertObjectMedia) {
+  struct Test {
+    DisableCrc32cChecksum crc32c;
+    DisableMD5Hash md5;
+    HashValues expected;
+  } const cases[] = {
+      {DisableCrc32cChecksum(false), DisableMD5Hash(false),
+       HashValues{kQuickFoxCrc32cChecksum, kQuickFoxMD5Hash}},
+  };
+  for (auto const& test : cases) {
+    auto function = CreateHashFunction(
+        InsertObjectMediaRequest("test-bucket", "test-object", kQuickFox)
+            .set_multiple_options(test.crc32c, test.md5));
+    ASSERT_STATUS_OK(function->Update(/*offset=*/0, kQuickFox));
+    auto const actual = function->Finish();
+    EXPECT_EQ(actual.crc32c, test.expected.crc32c);
+    EXPECT_EQ(actual.md5, test.expected.md5);
+  }
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/hash_function_impl_test.cc
+++ b/google/cloud/storage/internal/hash_function_impl_test.cc
@@ -77,57 +77,60 @@ TEST(HashFunctionImplTest, Crc32cQuickSimple) {
 TEST(HashFunctionImplTest, Crc32cStringView) {
   Crc32cHashFunction function;
   auto payload = absl::string_view{kQuickFox};
-  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
-    auto message = payload.substr(npos, 5);
-    EXPECT_STATUS_OK(function.Update(npos, message));
-    EXPECT_THAT(function.Update(npos, message),
+  for (std::size_t pos = 0; pos < payload.size(); pos += 5) {
+    auto message = payload.substr(pos, 5);
+    EXPECT_STATUS_OK(function.Update(pos, message));
+    EXPECT_STATUS_OK(function.Update(pos, message));
+    EXPECT_THAT(function.Update(pos, payload),
                 StatusIs(StatusCode::kInvalidArgument));
   }
-  auto const actual = function.Finish();
+  auto actual = function.Finish();
   EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
   EXPECT_THAT(actual.md5, IsEmpty());
 
-  auto const a2 = function.Finish();
-  EXPECT_EQ(a2.crc32c, kQuickFoxCrc32cChecksum);
-  EXPECT_THAT(a2.md5, IsEmpty());
+  actual = function.Finish();
+  EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(actual.md5, IsEmpty());
 }
 
 TEST(HashFunctionImplTest, Crc32cStringViewWithCrc) {
   Crc32cHashFunction function;
   auto payload = absl::string_view{kQuickFox};
-  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
-    auto message = payload.substr(npos, 5);
+  for (std::size_t pos = 0; pos < payload.size(); pos += 5) {
+    auto message = payload.substr(pos, 5);
     auto const message_crc = storage_internal::Crc32c(message);
-    EXPECT_STATUS_OK(function.Update(npos, message, message_crc));
-    EXPECT_THAT(function.Update(npos, message, message_crc),
+    EXPECT_STATUS_OK(function.Update(pos, message, message_crc));
+    EXPECT_STATUS_OK(function.Update(pos, message, message_crc));
+    EXPECT_THAT(function.Update(pos, payload, message_crc),
                 StatusIs(StatusCode::kInvalidArgument));
   }
-  auto const actual = function.Finish();
+  auto actual = function.Finish();
   EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
   EXPECT_THAT(actual.md5, IsEmpty());
 
-  auto const a2 = function.Finish();
-  EXPECT_EQ(a2.crc32c, kQuickFoxCrc32cChecksum);
-  EXPECT_THAT(a2.md5, IsEmpty());
+  actual = function.Finish();
+  EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(actual.md5, IsEmpty());
 }
 
 TEST(HashFunctionImplTest, Crc32cCord) {
   Crc32cHashFunction function;
   auto payload = absl::Cord(absl::string_view{kQuickFox});
-  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
-    auto message = payload.Subcord(npos, 5);
+  for (std::size_t pos = 0; pos < payload.size(); pos += 5) {
+    auto message = payload.Subcord(pos, 5);
     auto const message_crc = storage_internal::Crc32c(message);
-    EXPECT_STATUS_OK(function.Update(npos, message, message_crc));
-    EXPECT_THAT(function.Update(npos, message, message_crc),
+    EXPECT_STATUS_OK(function.Update(pos, message, message_crc));
+    EXPECT_STATUS_OK(function.Update(pos, message, message_crc));
+    EXPECT_THAT(function.Update(pos, payload, message_crc),
                 StatusIs(StatusCode::kInvalidArgument));
   }
-  auto const actual = function.Finish();
+  auto actual = function.Finish();
   EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
   EXPECT_THAT(actual.md5, IsEmpty());
 
-  auto const a2 = function.Finish();
-  EXPECT_EQ(a2.crc32c, kQuickFoxCrc32cChecksum);
-  EXPECT_THAT(a2.md5, IsEmpty());
+  actual = function.Finish();
+  EXPECT_EQ(actual.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(actual.md5, IsEmpty());
 }
 
 TEST(HashFunctionImplTest, MD5Empty) {
@@ -150,48 +153,51 @@ TEST(HashFunctionImplTest, MD5Quick) {
 TEST(HashFunctionImplTest, MD5StringView) {
   MD5HashFunction function;
   auto payload = absl::string_view{kQuickFox};
-  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
-    auto message = payload.substr(npos, 5);
-    EXPECT_STATUS_OK(function.Update(npos, message));
-    EXPECT_THAT(function.Update(npos, message),
+  for (std::size_t pos = 0; pos < payload.size(); pos += 5) {
+    auto message = payload.substr(pos, 5);
+    EXPECT_STATUS_OK(function.Update(pos, message));
+    EXPECT_STATUS_OK(function.Update(pos, message));
+    EXPECT_THAT(function.Update(pos, payload),
                 StatusIs(StatusCode::kInvalidArgument));
   }
-  auto const actual = function.Finish();
+  auto actual = function.Finish();
   EXPECT_THAT(actual.crc32c, IsEmpty());
   EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
 
-  auto const a2 = function.Finish();
-  EXPECT_THAT(a2.crc32c, IsEmpty());
-  EXPECT_THAT(a2.md5, kQuickFoxMD5Hash);
+  actual = function.Finish();
+  EXPECT_THAT(actual.crc32c, IsEmpty());
+  EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
 }
 
 TEST(HashFunctionImplTest, MD5StringViewWithCrc) {
   MD5HashFunction function;
   auto payload = absl::string_view{kQuickFox};
-  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
-    auto message = payload.substr(npos, 5);
-    auto const message_crc = storage_internal::Crc32c(message);
-    EXPECT_STATUS_OK(function.Update(npos, message, message_crc));
-    EXPECT_THAT(function.Update(npos, message, message_crc),
+  for (std::size_t pos = 0; pos < payload.size(); pos += 5) {
+    auto message = payload.substr(pos, 5);
+    auto const unused = std::uint32_t{0};
+    EXPECT_STATUS_OK(function.Update(pos, message, unused));
+    EXPECT_STATUS_OK(function.Update(pos, message, unused));
+    EXPECT_THAT(function.Update(pos, payload, unused),
                 StatusIs(StatusCode::kInvalidArgument));
   }
-  auto const actual = function.Finish();
+  auto actual = function.Finish();
   EXPECT_THAT(actual.crc32c, IsEmpty());
   EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
 
-  auto const a2 = function.Finish();
-  EXPECT_THAT(a2.crc32c, IsEmpty());
-  EXPECT_THAT(a2.md5, kQuickFoxMD5Hash);
+  actual = function.Finish();
+  EXPECT_THAT(actual.crc32c, IsEmpty());
+  EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
 }
 
 TEST(HashFunctionImplTest, MD5Cord) {
   MD5HashFunction function;
   auto payload = absl::Cord(absl::string_view{kQuickFox});
-  for (std::size_t npos = 0; npos < payload.size(); npos += 5) {
-    auto message = payload.Subcord(npos, 5);
-    auto const message_crc = storage_internal::Crc32c(message);
-    EXPECT_STATUS_OK(function.Update(npos, message, message_crc));
-    EXPECT_THAT(function.Update(npos, message, message_crc),
+  for (std::size_t pos = 0; pos < payload.size(); pos += 5) {
+    auto message = payload.Subcord(pos, 5);
+    auto const unused = std::uint32_t{0};
+    EXPECT_STATUS_OK(function.Update(pos, message, unused));
+    EXPECT_STATUS_OK(function.Update(pos, message, unused));
+    EXPECT_THAT(function.Update(pos, payload, unused),
                 StatusIs(StatusCode::kInvalidArgument));
   }
   auto const actual = function.Finish();
@@ -217,9 +223,13 @@ TEST(HashFunctionImplTest, CompositeQuick) {
   function.Update("The quick");
   function.Update(" brown");
   function.Update(" fox jumps over the lazy dog");
-  auto result = std::move(function).Finish();
-  EXPECT_THAT(result.crc32c, kQuickFoxCrc32cChecksum);
-  EXPECT_THAT(result.md5, kQuickFoxMD5Hash);
+  auto actual = function.Finish();
+  EXPECT_THAT(actual.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
+
+  actual = function.Finish();
+  EXPECT_THAT(actual.crc32c, kQuickFoxCrc32cChecksum);
+  EXPECT_THAT(actual.md5, kQuickFoxMD5Hash);
 }
 
 TEST(HashFunctionImplTest, CreateHashFunctionRead) {
@@ -242,7 +252,7 @@ TEST(HashFunctionImplTest, CreateHashFunctionRead) {
     auto function = CreateHashFunction(
         ReadObjectRangeRequest("test-bucket", "test-object")
             .set_multiple_options(test.crc32_disabled, test.md5_disabled));
-    function->Update("The quick brown fox jumps over the lazy dog");
+    function->Update(kQuickFox);
     auto const actual = std::move(*function).Finish();
     EXPECT_EQ(test.crc32c_expected, actual.crc32c);
     EXPECT_EQ(test.md5_expected, actual.md5);
@@ -308,7 +318,7 @@ TEST(HashFunctionImplTest, CreateHashFunctionUpload) {
         ResumableUploadRequest("test-bucket", "test-object")
             .set_multiple_options(test.crc32_disabled, test.crc32_value,
                                   test.md5_disabled, test.md5_value));
-    function->Update("The quick brown fox jumps over the lazy dog");
+    function->Update(kQuickFox);
     auto const actual = std::move(*function).Finish();
     EXPECT_EQ(test.crc32c_expected, actual.crc32c);
     EXPECT_EQ(test.md5_expected, actual.md5);
@@ -335,6 +345,11 @@ TEST(HashFunctionImplTest, CreateHashFunctionInsertObjectMedia) {
   } const cases[] = {
       {DisableCrc32cChecksum(false), DisableMD5Hash(false),
        HashValues{kQuickFoxCrc32cChecksum, kQuickFoxMD5Hash}},
+      {DisableCrc32cChecksum(false), DisableMD5Hash(true),
+       HashValues{kQuickFoxCrc32cChecksum, {}}},
+      {DisableCrc32cChecksum(true), DisableMD5Hash(false),
+       HashValues{{}, kQuickFoxMD5Hash}},
+      {DisableCrc32cChecksum(true), DisableMD5Hash(true), HashValues{{}, {}}},
   };
   for (auto const& test : cases) {
     auto function = CreateHashFunction(

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -44,8 +44,8 @@ HashValues HashEmpty(std::unique_ptr<HashFunction> function) {
 }
 
 HashValues HashQuick(std::unique_ptr<HashFunction> function) {
-  auto const text = std::string{"The quick brown fox jumps over the lazy dog"};
-  function->Update(text.data(), text.size());
+  function->Update(
+      absl::string_view{"The quick brown fox jumps over the lazy dog"});
   return std::move(*function).Finish();
 }
 

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -196,7 +196,7 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   // number of bytes.
   if (!read) return run_validator_if_closed(std::move(read).status());
 
-  hash_function_->Update(s + offset, read->bytes_received);
+  hash_function_->Update(absl::string_view{s + offset, read->bytes_received});
   hash_validator_->ProcessHashValues(read->hashes);
   offset += static_cast<std::streamsize>(read->bytes_received);
   source_pos_ += static_cast<std::streamoff>(read->bytes_received);

--- a/google/cloud/storage/internal/object_write_streambuf.cc
+++ b/google/cloud/storage/internal/object_write_streambuf.cc
@@ -142,7 +142,7 @@ void ObjectWriteStreambuf::FlushFinal() {
 
   // Calculate the portion of the buffer that needs to be uploaded, if any.
   auto const actual_size = put_area_size();
-  hash_function_->Update(pbase(), actual_size);
+  hash_function_->Update(absl::string_view{pbase(), actual_size});
 
   // After this point the session will be closed, and no more calls to the hash
   // function are possible.
@@ -194,7 +194,7 @@ void ObjectWriteStreambuf::FlushRoundChunk(ConstBufferSequence buffers) {
   }
 
   for (auto const& b : payload) {
-    hash_function_->Update(b.data(), b.size());
+    hash_function_->Update(absl::string_view{b.data(), b.size()});
   }
 
   // GCS upload returns an updated range header that sets the next expected


### PR DESCRIPTION
This changes the `storage::internal::HashFunction` classes to support calling them from `RawClient::InsertObjectMedia()` and `RawClient::UploadChunk()`. The new functionality is not used yet, but it is testable and thus can be merged as a separate PR.

Part of the work for #11060

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11065)
<!-- Reviewable:end -->
