### PR TITLE
feat(GCS+gRPC): more efficient CRC32C computations

### DIFF
--- a/google/cloud/storage/hashing_options.cc
+++ b/google/cloud/storage/hashing_options.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/hashing_options.h"
+#include "google/cloud/storage/internal/crc32c.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/internal/big_endian.h"
-#include <crc32c/crc32c.h>
 
 namespace google {
 namespace cloud {
@@ -31,8 +31,7 @@ std::string ComputeMD5Hash(std::string const& payload) {
 }
 
 std::string ComputeCrc32cChecksum(absl::string_view payload) {
-  auto checksum = crc32c::Extend(
-      0, reinterpret_cast<std::uint8_t const*>(payload.data()), payload.size());
+  auto checksum = storage_internal::Crc32c(payload);
   std::string const hash = google::cloud::internal::EncodeBigEndian(checksum);
   return internal::Base64Encode(hash);
 }

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -618,7 +618,8 @@ TEST(StrictIdempotencyPolicyTest, ResumableUploadIfGenerationMatch) {
 TEST(StrictIdempotencyPolicyTest, UploadChunk) {
   StrictIdempotencyPolicy policy;
   internal::UploadChunkRequest request("https://test-url.example.com", 0,
-                                       {internal::ConstBuffer{"test-payload"}});
+                                       {internal::ConstBuffer{"test-payload"}},
+                                       internal::CreateNullHashFunction());
   EXPECT_TRUE(policy.IsIdempotent(request));
 }
 

--- a/google/cloud/storage/internal/async_accumulate_read_object.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/async_accumulate_read_object.h"
+#include "google/cloud/storage/internal/crc32c.h"
 #include "google/cloud/storage/internal/grpc_object_metadata_parser.h"
-#include <crc32c/crc32c.h>
 #include <iterator>
 #include <numeric>
 #include <sstream>
@@ -333,7 +333,7 @@ storage_experimental::AsyncReadObjectRangeResponse ToResponse(
   for (auto& r : accumulated.payload) {
     if (!r.has_checksummed_data()) continue;
     auto& data = *r.mutable_checksummed_data();
-    if (data.has_crc32c() && crc32c::Crc32c(data.content()) != data.crc32c()) {
+    if (data.has_crc32c() && Crc32c(data.content()) != data.crc32c()) {
       response.status = Status(StatusCode::kDataLoss,
                                "Mismatched CRC32C checksum in downloaded data");
       return response;

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -628,6 +628,12 @@ StatusOr<QueryResumableUploadResponse> CurlClient::UploadChunk(
   // default (at least in this case), and that wastes bandwidth as the content
   // length is known.
   builder.AddHeader("Transfer-Encoding:");
+  auto offset = request.offset();
+  for (auto const& b : request.payload()) {
+    request.hash_function().Update(offset,
+                                   absl::string_view{b.data(), b.size()});
+    offset += b.size();
+  }
   auto response =
       std::move(builder).BuildRequest().MakeUploadRequest(request.payload());
   if (!response.ok()) return std::move(response).status();
@@ -1119,17 +1125,10 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
     metadata = ObjectMetadataJsonForInsert(
         request.GetOption<WithObjectMetadata>().value());
   }
-  if (request.HasOption<MD5HashValue>()) {
-    metadata["md5Hash"] = request.GetOption<MD5HashValue>().value();
-  } else if (!request.GetOption<DisableMD5Hash>().value_or(false)) {
-    metadata["md5Hash"] = ComputeMD5Hash(request.payload());
-  }
-
-  if (request.HasOption<Crc32cChecksumValue>()) {
-    metadata["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
-  } else if (!request.GetOption<DisableCrc32cChecksum>().value_or(false)) {
-    metadata["crc32c"] = ComputeCrc32cChecksum(request.payload());
-  }
+  request.hash_function().Update(/*offset=*/0, request.payload());
+  auto hashes = storage::internal::FinishHashes(request);
+  if (!hashes.crc32c.empty()) metadata["crc32c"] = hashes.crc32c;
+  if (!hashes.md5.empty()) metadata["md5Hash"] = hashes.md5;
 
   std::string crlf = "\r\n";
   std::string marker = "--" + boundary;

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -145,11 +145,12 @@ TEST(CurlClientStandaloneFunctions, HostHeader) {
 TEST_P(CurlClientTest, UploadChunk) {
   // Use http://localhost:1 to force a libcurl failure
   OptionsSpan const span(client_->options());
-  auto actual = client_
-                    ->UploadChunk(UploadChunkRequest(
-                        "http://localhost:1/invalid-session-id", 0,
-                        {ConstBuffer{std::string{}}}))
-                    .status();
+  auto actual =
+      client_
+          ->UploadChunk(UploadChunkRequest(
+              "http://localhost:1/invalid-session-id", 0,
+              {ConstBuffer{std::string{}}}, internal::CreateNullHashFunction()))
+          .status();
   CheckStatus(actual);
 }
 

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -36,6 +36,7 @@ using ::google::cloud::storage::BucketMetadata;
 using ::google::cloud::storage::Fields;
 using ::google::cloud::storage::ObjectMetadata;
 using ::google::cloud::storage::QuotaUser;
+using ::google::cloud::storage::internal::CreateNullHashFunction;
 using ::google::cloud::storage::testing::MockInsertStream;
 using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::testing_util::ScopedEnvironment;
@@ -185,7 +186,8 @@ TEST_F(GrpcClientTest, UploadChunk) {
   auto client = CreateTestClient(mock);
   auto response = client->UploadChunk(
       storage::internal::UploadChunkRequest(
-          "projects/_/buckets/test-bucket/test-upload-id", 0, {})
+          "projects/_/buckets/test-bucket/test-upload-id", 0, {},
+          CreateNullHashFunction())
           .set_multiple_options(Fields("field1,field2"),
                                 QuotaUser("test-quota-user")));
   EXPECT_EQ(response.status(), PermanentError());

--- a/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
+++ b/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
@@ -30,6 +30,7 @@ namespace {
 
 using ::google::cloud::storage::TransferStallTimeoutOption;
 using ::google::cloud::storage::internal::ConstBuffer;
+using ::google::cloud::storage::internal::CreateNullHashFunction;
 using ::google::cloud::storage::internal::UploadChunkRequest;
 using ::google::cloud::storage::testing::MockInsertStream;
 using ::google::cloud::storage::testing::MockStorageStub;
@@ -73,8 +74,9 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
   google::cloud::internal::OptionsSpan const span(
       Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
-  auto response = client->UploadChunk(UploadChunkRequest(
-      "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", /*offset=*/0,
+                         {ConstBuffer{payload}}, CreateNullHashFunction()));
   EXPECT_THAT(response,
               StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("Write()")));
 }
@@ -111,8 +113,9 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
       Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(
       kExpectedWriteSize + UploadChunkRequest::kChunkSizeQuantum, 'A');
-  auto response = client->UploadChunk(UploadChunkRequest(
-      "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", /*offset=*/0,
+                         {ConstBuffer{payload}}, CreateNullHashFunction()));
   EXPECT_THAT(response,
               StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("Write()")));
 }
@@ -152,8 +155,9 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutClose) {
       Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(
       kExpectedWriteSize + UploadChunkRequest::kChunkSizeQuantum, 'A');
-  auto response = client->UploadChunk(UploadChunkRequest(
-      "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", /*offset=*/0,
+                         {ConstBuffer{payload}}, CreateNullHashFunction()));
   EXPECT_THAT(response,
               StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("Close()")));
 }

--- a/google/cloud/storage/internal/grpc_configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc_configure_client_context_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/grpc_configure_client_context.h"
+#include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
@@ -23,6 +24,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::storage::internal::CreateNullHashFunction;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::_;
 using ::testing::Contains;
@@ -133,7 +135,8 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersInsertObjectMedia) {
 
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatch) {
   storage::internal::UploadChunkRequest req(
-      "projects/_/buckets/test-bucket/blah/blah", 0, {});
+      "projects/_/buckets/test-bucket/blah/blah", 0, {},
+      CreateNullHashFunction());
 
   grpc::ClientContext context;
   ApplyRoutingHeaders(context, req);
@@ -144,7 +147,8 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatch) {
 }
 
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkNoMatch) {
-  storage::internal::UploadChunkRequest req("does-not-match", 0, {});
+  storage::internal::UploadChunkRequest req("does-not-match", 0, {},
+                                            CreateNullHashFunction());
 
   grpc::ClientContext context;
   ApplyRoutingHeaders(context, req);

--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -75,6 +75,16 @@ storage::internal::QueryResumableUploadResponse FromProto(
 google::storage::v2::CancelResumableWriteRequest ToProto(
     storage::internal::DeleteResumableUploadRequest const& request);
 
+Status MaybeFinalize(google::storage::v2::WriteObjectRequest& write_request,
+                     grpc::WriteOptions& options,
+                     storage::internal::InsertObjectMediaRequest const& request,
+                     bool chunk_has_more);
+
+Status MaybeFinalize(google::storage::v2::WriteObjectRequest& write_request,
+                     grpc::WriteOptions& options,
+                     storage::internal::UploadChunkRequest const& request,
+                     bool chunk_has_more);
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal
 }  // namespace cloud

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -161,6 +161,17 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r) {
   return os << "}";
 }
 
+InsertObjectMediaRequest::InsertObjectMediaRequest(std::string bucket_name,
+                                                   std::string object_name,
+                                                   absl::string_view payload)
+    : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
+      payload_(payload),
+      hash_function_(CreateHashFunction(*this)) {}
+
+void InsertObjectMediaRequest::reset_hash_function() {
+  hash_function_ = CreateHashFunction(*this);
+}
+
 void InsertObjectMediaRequest::set_payload(absl::string_view payload) {
   payload_ = payload;
   dirty_ = true;
@@ -177,6 +188,17 @@ void InsertObjectMediaRequest::set_contents(std::string v) {
   contents_ = std::move(v);
   payload_ = contents_;
   dirty_ = false;
+}
+
+HashValues FinishHashes(InsertObjectMediaRequest const& request) {
+  auto hashes = HashValues{
+      /*.crc32c=*/request.GetOption<Crc32cChecksumValue>().value_or(
+          std::string{}),
+      /*.md5=*/request.GetOption<MD5HashValue>().value_or(std::string{}),
+  };
+  // Prefer the hashes provided via *Value options in the request. If those
+  // are not set, use the computed hashes from the data.
+  return Merge(std::move(hashes), request.hash_function().Finish());
 }
 
 std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r) {
@@ -426,6 +448,25 @@ std::ostream& operator<<(std::ostream& os,
             << "}";
 }
 
+UploadChunkRequest::UploadChunkRequest(
+    std::string upload_session_url, std::uint64_t offset,
+    ConstBufferSequence payload, std::shared_ptr<HashFunction> hash_function)
+    : upload_session_url_(std::move(upload_session_url)),
+      offset_(offset),
+      payload_(std::move(payload)),
+      hash_function_(std::move(hash_function)) {}
+
+UploadChunkRequest::UploadChunkRequest(
+    std::string upload_session_url, std::uint64_t offset,
+    ConstBufferSequence payload, std::shared_ptr<HashFunction> hash_function,
+    HashValues known_hashes)
+    : upload_session_url_(std::move(upload_session_url)),
+      offset_(offset),
+      upload_size_(offset + TotalBytes(payload)),
+      payload_(std::move(payload)),
+      hash_function_(std::move(hash_function)),
+      known_object_hashes_(std::move(known_hashes)) {}
+
 std::string UploadChunkRequest::RangeHeaderValue() const {
   std::ostringstream os;
   os << "bytes ";
@@ -468,10 +509,16 @@ UploadChunkRequest UploadChunkRequest::RemainingChunk(
   return result;
 }
 
+HashValues FinishHashes(UploadChunkRequest const& request) {
+  // Prefer the hashes provided via *Value options in the request. If those
+  // are not set, use the computed hashes from the data.
+  return Merge(request.known_object_hashes(), request.hash_function().Finish());
+}
+
 std::ostream& operator<<(std::ostream& os, UploadChunkRequest const& r) {
   os << "UploadChunkRequest={upload_session_url=" << r.upload_session_url()
      << ", range=<" << r.RangeHeader() << ">"
-     << ", full_object_hashes={" << Format(r.full_object_hashes()) << "}";
+     << ", known_object_hashes={" << Format(r.known_object_hashes()) << "}";
   r.DumpOptions(os, ", ");
   os << ", payload={";
   auto constexpr kMaxOutputBytes = 128;

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -546,7 +546,8 @@ TEST(ObjectRequestsTest, UploadChunk) {
       "myBucket/o?uploadType=resumable"
       "&upload_id=xa298sd_sdlkj2";
   auto const payload = std::string(2048, 'A');
-  UploadChunkRequest request(url, 0, {{payload}}, HashValues{});
+  UploadChunkRequest request(url, 0, {{payload}}, CreateNullHashFunction(),
+                             HashValues{});
   EXPECT_EQ(url, request.upload_session_url());
   EXPECT_EQ(0, request.offset());
   EXPECT_EQ(2048, request.upload_size().value_or(0));
@@ -564,7 +565,8 @@ TEST(ObjectRequestsTest, UploadChunkRemainingChunk) {
   auto const p1 = std::string(256, '1');
   auto const p2 = std::string(1024, '2');
   auto const base_offset = 123456;
-  auto request = UploadChunkRequest("unused", base_offset, {{p0, p1, p2}});
+  auto request = UploadChunkRequest("unused", base_offset, {{p0, p1, p2}},
+                                    CreateNullHashFunction());
   EXPECT_EQ(request.offset(), base_offset);
   EXPECT_THAT(request.payload(), ElementsAre(p0, p1, p2));
   auto remaining = request.RemainingChunk(base_offset + 42);
@@ -577,33 +579,37 @@ TEST(ObjectRequestsTest, UploadChunkRemainingChunk) {
 
 TEST(ObjectRequestsTest, UploadChunkContentRangeNotLast) {
   std::string const url = "https://unused.googleapis.com/test-only";
-  UploadChunkRequest request(url, 1024, {ConstBuffer{"1234", 4}});
+  UploadChunkRequest request(url, 1024, {ConstBuffer{"1234", 4}},
+                             CreateNullHashFunction());
   EXPECT_EQ("Content-Range: bytes 1024-1027/*", request.RangeHeader());
 }
 
 TEST(ObjectRequestsTest, UploadChunkContentRangeLast) {
   std::string const url = "https://unused.googleapis.com/test-only";
-  UploadChunkRequest request(url, 2045, {ConstBuffer{"1234", 4}}, HashValues{});
+  UploadChunkRequest request(url, 2045, {ConstBuffer{"1234", 4}},
+                             CreateNullHashFunction(), HashValues{});
   EXPECT_EQ("Content-Range: bytes 2045-2048/2049", request.RangeHeader());
 }
 
 TEST(ObjectRequestsTest, UploadChunkContentRangeEmptyPayloadNotLast) {
   std::string const url = "https://unused.googleapis.com/test-only";
-  UploadChunkRequest request(url, 1024, {});
+  UploadChunkRequest request(url, 1024, {}, CreateNullHashFunction());
   EXPECT_EQ("Content-Range: bytes */*", request.RangeHeader());
 }
 
 TEST(ObjectRequestsTest, UploadChunkContentRangeEmptyPayloadLast) {
   std::string const url = "https://unused.googleapis.com/test-only";
-  UploadChunkRequest request(url, 2047, {}, HashValues{});
+  UploadChunkRequest request(url, 2047, {}, CreateNullHashFunction(),
+                             HashValues{});
   EXPECT_EQ("Content-Range: bytes */2047", request.RangeHeader());
 }
 
 TEST(ObjectRequestsTest, UploadChunkContentRangeEmptyPayloadEmpty) {
   std::string const url = "https://unused.googleapis.com/test-only";
-  UploadChunkRequest r0(url, 1024, {}, HashValues{});
+  UploadChunkRequest r0(url, 1024, {}, CreateNullHashFunction(), HashValues{});
   EXPECT_EQ("Content-Range: bytes */1024", r0.RangeHeader());
-  UploadChunkRequest r1(url, 1024, {{}, {}, {}}, HashValues{});
+  UploadChunkRequest r1(url, 1024, {{}, {}, {}}, CreateNullHashFunction(),
+                        HashValues{});
   EXPECT_EQ("Content-Range: bytes */1024", r1.RangeHeader());
 }
 

--- a/google/cloud/storage/internal/object_write_streambuf.cc
+++ b/google/cloud/storage/internal/object_write_streambuf.cc
@@ -142,25 +142,26 @@ void ObjectWriteStreambuf::FlushFinal() {
 
   // Calculate the portion of the buffer that needs to be uploaded, if any.
   auto const actual_size = put_area_size();
-  hash_function_->Update(absl::string_view{pbase(), actual_size});
 
   // After this point the session will be closed, and no more calls to the hash
   // function are possible.
-  auto function = std::move(hash_function_);
-  hash_values_ = std::move(*function).Finish();
   auto upload_request = UploadChunkRequest(upload_id_, committed_size_,
                                            {ConstBuffer(pbase(), actual_size)},
-                                           Merge(known_hashes_, hash_values_));
+                                           hash_function_, known_hashes_);
   request_.ForEachOption(internal::CopyCommonOptions(upload_request));
   OptionsSpan const span(span_options_);
   auto response = client_->UploadChunk(upload_request);
   if (!response) {
     last_status_ = std::move(response).status();
-  } else {
-    committed_size_ = response->committed_size.value_or(0);
-    metadata_ = std::move(response->payload);
-    headers_ = std::move(response->request_metadata);
+    return;
   }
+
+  auto function = std::move(hash_function_);
+  hash_values_ = std::move(*function).Finish();
+
+  committed_size_ = response->committed_size.value_or(0);
+  metadata_ = std::move(response->payload);
+  headers_ = std::move(response->request_metadata);
 
   // Reset the iostream put area with valid pointers, but empty.
   current_ios_buffer_.resize(1);
@@ -193,16 +194,12 @@ void ObjectWriteStreambuf::FlushRoundChunk(ConstBufferSequence buffers) {
     if (payload.back().empty()) payload.pop_back();
   }
 
-  for (auto const& b : payload) {
-    hash_function_->Update(absl::string_view{b.data(), b.size()});
-  }
-
   // GCS upload returns an updated range header that sets the next expected
   // byte. Check to make sure it remains consistent with the bytes stored in the
   // buffer.
   auto const expected_committed_size = committed_size_ + actual_size;
   auto upload_request =
-      UploadChunkRequest(upload_id_, committed_size_, payload);
+      UploadChunkRequest(upload_id_, committed_size_, payload, hash_function_);
   request_.ForEachOption(internal::CopyCommonOptions(upload_request));
   OptionsSpan const span(span_options_);
   auto response = client_->UploadChunk(upload_request);
@@ -212,34 +209,35 @@ void ObjectWriteStreambuf::FlushRoundChunk(ConstBufferSequence buffers) {
     // next.  Replace it with a SessionError so next_expected_byte and
     // resumable_session_id can still be retrieved.
     last_status_ = std::move(response).status();
-  } else {
-    // Reset the internal buffer and copy any trailing bytes from `buffers` to
-    // it.
-    auto* pbeg = current_ios_buffer_.data();
-    setp(pbeg, pbeg + current_ios_buffer_.size());
-    PopFrontBytes(buffers, rounded_size);
-    for (auto const& b : buffers) {
-      std::copy(b.begin(), b.end(), pptr());
-      pbump(static_cast<int>(b.size()));
-    }
+    return;
+  }
 
-    metadata_ = std::move(response->payload);
-    committed_size_ = response->committed_size.value_or(0);
+  // Reset the internal buffer and copy any trailing bytes from `buffers` to
+  // it.
+  auto* pbeg = current_ios_buffer_.data();
+  setp(pbeg, pbeg + current_ios_buffer_.size());
+  PopFrontBytes(buffers, rounded_size);
+  for (auto const& b : buffers) {
+    std::copy(b.begin(), b.end(), pptr());
+    pbump(static_cast<int>(b.size()));
+  }
 
-    // If the upload completed, the stream was implicitly "closed". There is
-    // no need to verify anything else.
-    if (metadata_.has_value()) {
-      committed_size_ = expected_committed_size;
-      return;
-    }
+  metadata_ = std::move(response->payload);
+  committed_size_ = response->committed_size.value_or(0);
 
-    if (committed_size_ != expected_committed_size) {
-      std::ostringstream error_message;
-      error_message << "Could not continue upload stream. GCS reports "
-                    << committed_size_ << " as committed, but we expected "
-                    << expected_committed_size;
-      last_status_ = Status(StatusCode::kAborted, error_message.str());
-    }
+  // If the upload completed, the stream was implicitly "closed". There is
+  // no need to verify anything else.
+  if (metadata_.has_value()) {
+    committed_size_ = expected_committed_size;
+    return;
+  }
+
+  if (committed_size_ != expected_committed_size) {
+    std::ostringstream error_message;
+    error_message << "Could not continue upload stream. GCS reports "
+                  << committed_size_ << " as committed, but we expected "
+                  << expected_committed_size;
+    last_status_ = Status(StatusCode::kAborted, error_message.str());
   }
 }
 

--- a/google/cloud/storage/internal/object_write_streambuf.h
+++ b/google/cloud/storage/internal/object_write_streambuf.h
@@ -116,7 +116,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   std::vector<char> current_ios_buffer_;
   std::size_t max_buffer_size_;
 
-  std::unique_ptr<HashFunction> hash_function_;
+  std::shared_ptr<HashFunction> hash_function_;
   HashValues hash_values_;
   HashValues known_hashes_;
   std::unique_ptr<HashValidator> hash_validator_;

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -369,17 +369,10 @@ StatusOr<ObjectMetadata> RestClient::InsertObjectMediaMultipart(
         request.GetOption<WithObjectMetadata>().value());
   }
 
-  if (request.HasOption<MD5HashValue>()) {
-    metadata["md5Hash"] = request.GetOption<MD5HashValue>().value();
-  } else if (!request.GetOption<DisableMD5Hash>().value_or(false)) {
-    metadata["md5Hash"] = ComputeMD5Hash(request.payload());
-  }
-
-  if (request.HasOption<Crc32cChecksumValue>()) {
-    metadata["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
-  } else if (!request.GetOption<DisableCrc32cChecksum>().value_or(false)) {
-    metadata["crc32c"] = ComputeCrc32cChecksum(request.payload());
-  }
+  request.hash_function().Update(/*offset=*/0, request.payload());
+  auto hashes = storage::internal::FinishHashes(request);
+  if (!hashes.crc32c.empty()) metadata["crc32c"] = hashes.crc32c;
+  if (!hashes.md5.empty()) metadata["md5Hash"] = hashes.md5;
 
   std::string crlf = "\r\n";
   std::string marker = "--" + boundary;
@@ -715,6 +708,12 @@ StatusOr<QueryResumableUploadResponse> RestClient::UploadChunk(
   // default (at least in this case), and that wastes bandwidth as the content
   // length is known.
   builder.AddHeader("Transfer-Encoding", {});
+  auto offset = request.offset();
+  for (auto const& b : request.payload()) {
+    request.hash_function().Update(offset,
+                                   absl::string_view{b.data(), b.size()});
+    offset += b.size();
+  }
 
   auto failure_predicate = [](rest::HttpStatusCode code) {
     return (code != rest::HttpStatusCode::kResumeIncomplete &&


### PR DESCRIPTION
Move the CRC32C and MD5 computations to the `GrpcClient` and `RestClient`. In the case of gRPC this allows us to compute the CRC32C checksum for each `Write()` message and then concatenate this checksum with the CRC32C checksum computed for the full object.  That saves one of the most expensive computations in the gRPC uploads.

Fixes #11060

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11070)
<!-- Reviewable:end -->
