### PR TITLE
refactor(generator): namespace printing

### DIFF
--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "generator/internal/codegen_utils.h"
+#include "generator/internal/scaffold_generator.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/absl_str_replace_quiet.h"
@@ -238,21 +239,19 @@ std::string ProtoNameToCppName(absl::string_view proto_name) {
   return absl::StrReplaceAll(proto_name, {{".", "::"}});
 }
 
-std::vector<std::string> BuildNamespaces(std::string const& product_path,
-                                         NamespaceType ns_type) {
-  std::vector<std::string> v =
-      absl::StrSplit(product_path, '/', absl::SkipEmpty());
-  std::string name =
-      absl::StrJoin(v.begin() + (v.size() > 2 ? 2 : 0), v.end(), "_");
+std::string Namespace(std::string const& product_path, NamespaceType ns_type) {
+  auto ns = absl::StrCat(LibraryName(product_path), "/",
+                         ServiceSubdirectory(product_path));
+  ns = std::string{absl::StripSuffix(ns, "/")};
+  ns = absl::StrReplaceAll(ns, {{"/", "_"}});
+
   if (ns_type == NamespaceType::kInternal) {
-    absl::StrAppend(&name, "_internal");
+    absl::StrAppend(&ns, "_internal");
   }
   if (ns_type == NamespaceType::kMocks) {
-    absl::StrAppend(&name, "_mocks");
+    absl::StrAppend(&ns, "_mocks");
   }
-
-  return std::vector<std::string>{"google", "cloud", name,
-                                  "GOOGLE_CLOUD_CPP_NS"};
+  return ns;
 }
 
 StatusOr<std::vector<std::pair<std::string, std::string>>>

--- a/generator/internal/codegen_utils.h
+++ b/generator/internal/codegen_utils.h
@@ -66,27 +66,16 @@ std::string ProtoNameToCppName(absl::string_view proto_name);
 enum class NamespaceType { kNormal, kInternal, kMocks };
 
 /**
- * Builds namespace hierarchy.
+ * Returns the namespace given a product path, and namespace type.
  *
- * Typically used with a product_path like to 'google/cloud/product/' and
- * returns {"google", "cloud", "product", "PRODUCT_CLIENT_NS"}.
+ * Typically used with a product_path like 'google/cloud/product/v1' and
+ * returns "product_v1".
  *
- * If the path contains fewer than two directories, they will be concatenated
- * to form the product value, e.g. 'unusual/product/' returns
- * {"google", "cloud", "unusual_product", "UNUSUAL_PRODUCT_CLIENT_NS"}.
- *
- * If the path contains more than three directories the third and subsequent
- * directories will be concatenated, e.g. 'google/cloud/foo/bar/baz/' returns
- * {"google", "cloud", "foo_bar_baz", "FOO_BAR_BAZ_CLIENT_NS"}.
- *
- * If ns_type is `NamespaceType::kInternal`, "_internal" is appended to the
- * product, e.g. 'google/cloud/product/' returns
- * {"google", "cloud", "product_internal", "PRODUCT_CLIENT_NS"}.
- *
+ * Depending on the NamespaceType, a suffix will be appended. e.g.
+ * "product_v1_mocks" or "product_v1_internal".
  */
-std::vector<std::string> BuildNamespaces(
-    std::string const& product_path,
-    NamespaceType ns_type = NamespaceType::kNormal);
+std::string Namespace(std::string const& product_path,
+                      NamespaceType ns_type = NamespaceType::kNormal);
 
 /**
  * Validates command line arguments passed to the microgenerator.

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -29,7 +29,6 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::AllOf;
 using ::testing::Contains;
 using ::testing::ContainsRegex;
-using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Pair;
@@ -97,69 +96,52 @@ TEST(ProtoNameToCppName, MessageType) {
             ProtoNameToCppName("google.spanner.admin.database.v1.Request"));
 }
 
-TEST(BuildNamespaces, NoDirectoryPathInternal) {
-  auto result = BuildNamespaces("/", NamespaceType::kInternal);
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "_internal",
-                                  "GOOGLE_CLOUD_CPP_NS"));
+TEST(Namespace, Normal) {
+  EXPECT_EQ("test", Namespace("google/cloud/test"));
+  EXPECT_EQ("test", Namespace("google/cloud/test/"));
+  EXPECT_EQ("test_v1", Namespace("google/cloud/test/v1"));
+  EXPECT_EQ("test_v1", Namespace("google/cloud/test/v1/"));
+  EXPECT_EQ("test_foo_v1", Namespace("google/cloud/test/foo/v1"));
+  EXPECT_EQ("golden", Namespace("blah/golden"));
+  EXPECT_EQ("golden_v1", Namespace("blah/golden/v1"));
+  EXPECT_EQ("service", Namespace("foo/bar/service"));
 }
 
-TEST(BuildNamespaces, OneDirectoryPathInternal) {
-  auto result = BuildNamespaces("one/", NamespaceType::kInternal);
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "one_internal",
-                                  "GOOGLE_CLOUD_CPP_NS"));
+TEST(Namespace, Internal) {
+  EXPECT_EQ("test_internal",
+            Namespace("google/cloud/test", NamespaceType::kInternal));
+  EXPECT_EQ("test_internal",
+            Namespace("google/cloud/test/", NamespaceType::kInternal));
+  EXPECT_EQ("test_v1_internal",
+            Namespace("google/cloud/test/v1", NamespaceType::kInternal));
+  EXPECT_EQ("test_v1_internal",
+            Namespace("google/cloud/test/v1/", NamespaceType::kInternal));
+  EXPECT_EQ("test_foo_v1_internal",
+            Namespace("google/cloud/test/foo/v1", NamespaceType::kInternal));
+  EXPECT_EQ("golden_internal",
+            Namespace("blah/golden", NamespaceType::kInternal));
+  EXPECT_EQ("golden_v1_internal",
+            Namespace("blah/golden/v1", NamespaceType::kInternal));
+  EXPECT_EQ("service_internal",
+            Namespace("foo/bar/service", NamespaceType::kInternal));
 }
 
-TEST(BuildNamespaces, TwoDirectoryPathInternal) {
-  auto result = BuildNamespaces("unusual/product/", NamespaceType::kInternal);
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "unusual_product_internal",
-                                  "GOOGLE_CLOUD_CPP_NS"));
-}
-
-TEST(BuildNamespaces, TwoDirectoryPathNotInternal) {
-  auto result = BuildNamespaces("unusual/product/");
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "unusual_product",
-                                  "GOOGLE_CLOUD_CPP_NS"));
-}
-
-TEST(BuildNamespaces, ThreeDirectoryPathInternal) {
-  auto result =
-      BuildNamespaces("google/cloud/spanner/", NamespaceType::kInternal);
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "spanner_internal",
-                                  "GOOGLE_CLOUD_CPP_NS"));
-}
-
-TEST(BuildNamespaces, ThreeDirectoryPathMocks) {
-  auto result = BuildNamespaces("google/cloud/spanner/", NamespaceType::kMocks);
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "spanner_mocks",
-                                  "GOOGLE_CLOUD_CPP_NS"));
-}
-
-TEST(BuildNamespaces, ThreeDirectoryPathNotInternal) {
-  auto result = BuildNamespaces("google/cloud/translation/");
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "translation",
-                                  "GOOGLE_CLOUD_CPP_NS"));
-}
-
-TEST(BuildNamespaces, FourDirectoryPathInternal) {
-  auto result =
-      BuildNamespaces("google/cloud/foo/bar/baz/", NamespaceType::kInternal);
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "foo_bar_baz_internal",
-                                  "GOOGLE_CLOUD_CPP_NS"));
-}
-
-TEST(BuildNamespaces, FourDirectoryPathNotInternal) {
-  auto result = BuildNamespaces("google/cloud/foo/bar/baz/");
-  ASSERT_EQ(result.size(), 4);
-  EXPECT_THAT(result, ElementsAre("google", "cloud", "foo_bar_baz",
-                                  "GOOGLE_CLOUD_CPP_NS"));
+TEST(Namespace, Mocks) {
+  EXPECT_EQ("test_mocks",
+            Namespace("google/cloud/test", NamespaceType::kMocks));
+  EXPECT_EQ("test_mocks",
+            Namespace("google/cloud/test/", NamespaceType::kMocks));
+  EXPECT_EQ("test_v1_mocks",
+            Namespace("google/cloud/test/v1", NamespaceType::kMocks));
+  EXPECT_EQ("test_v1_mocks",
+            Namespace("google/cloud/test/v1/", NamespaceType::kMocks));
+  EXPECT_EQ("test_foo_v1_mocks",
+            Namespace("google/cloud/test/foo/v1", NamespaceType::kMocks));
+  EXPECT_EQ("golden_mocks", Namespace("blah/golden", NamespaceType::kMocks));
+  EXPECT_EQ("golden_v1_mocks",
+            Namespace("blah/golden/v1", NamespaceType::kMocks));
+  EXPECT_EQ("service_mocks",
+            Namespace("foo/bar/service", NamespaceType::kMocks));
 }
 
 TEST(ProcessCommandLineArgs, NoProductPath) {

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -981,9 +981,9 @@ VarsDictionary CreateServiceVars(
   vars["options_header_path"] =
       absl::StrCat(vars["product_path"],
                    ServiceNameToFilePath(descriptor.name()), "_options.h");
-  vars["product_namespace"] = BuildNamespaces(vars["product_path"])[2];
+  vars["product_namespace"] = Namespace(vars["product_path"]);
   vars["product_internal_namespace"] =
-      BuildNamespaces(vars["product_path"], NamespaceType::kInternal)[2];
+      Namespace(vars["product_path"], NamespaceType::kInternal);
   vars["proto_file_name"] = descriptor.file()->name();
   vars["proto_grpc_header_path"] = absl::StrCat(
       absl::StripSuffix(descriptor.file()->name(), ".proto"), ".grpc.pb.h");

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -211,7 +211,7 @@ class ServiceCodeGenerator : public GeneratorInterface {
   google::protobuf::ServiceDescriptor const* service_descriptor_;
   VarsDictionary service_vars_;
   std::map<std::string, VarsDictionary> service_method_vars_;
-  std::vector<std::string> namespaces_;
+  std::string namespace_;
   bool define_backwards_compatibility_namespace_alias_ = false;
   MethodDescriptorList methods_;
   MethodDescriptorList async_methods_;


### PR DESCRIPTION
Motivated by #10782

Simplify `BuildNamespaces(...)` to only return the namespace we care about. I think we can assume the others. Also use the helpers that parse product paths.

This refactor should simplify the namespace logic and make it easier to insert documentation for a namespace.

For context, the full change is (more or less) here: https://github.com/dbolduc/google-cloud-cpp/tree/doc-generator-forwarding-namespaces

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11072)
<!-- Reviewable:end -->
