### PR TITLE
doc: forwarding namespaces are deprecated

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in golden_v1 instead of the aliases defined in
+///     this namespace.
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in golden_v1 instead of the aliases defined in
+///     this namespace.
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in golden_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace golden_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in golden_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace golden_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/generator/internal/forwarding_client_generator.cc
+++ b/generator/internal/forwarding_client_generator.cc
@@ -45,7 +45,10 @@ Status ForwardingClientGenerator::GenerateHeader() {
       vars("client_header_path"),
   });
 
-  auto result = HeaderOpenForwardingNamespaces();
+  auto result = HeaderOpenForwardingNamespaces(NamespaceType::kNormal, R"""(
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in $product_namespace$ instead of the aliases defined in
+///     this namespace.)""");
   if (!result.ok()) return result;
 
   // forwards

--- a/generator/internal/forwarding_mock_connection_generator.cc
+++ b/generator/internal/forwarding_mock_connection_generator.cc
@@ -45,7 +45,10 @@ Status ForwardingMockConnectionGenerator::GenerateHeader() {
       vars("forwarding_connection_header_path"),
   });
 
-  auto result = HeaderOpenForwardingNamespaces(NamespaceType::kMocks);
+  auto result = HeaderOpenForwardingNamespaces(NamespaceType::kMocks, R"""(
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in $product_namespace$_mocks instead of the aliases
+///     defined in this namespace.)""");
   if (!result.ok()) return result;
 
   HeaderPrint(

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -274,8 +274,9 @@ Status ServiceCodeGenerator::HeaderOpenNamespaces(NamespaceType ns_type) {
 }
 
 Status ServiceCodeGenerator::HeaderOpenForwardingNamespaces(
-    NamespaceType ns_type) {
-  return OpenNamespaces(header_, ns_type, "forwarding_product_path");
+    NamespaceType ns_type, std::string const& ns_documentation) {
+  return OpenNamespaces(header_, ns_type, "forwarding_product_path",
+                        ns_documentation);
 }
 
 void ServiceCodeGenerator::HeaderCloseNamespaces() {
@@ -361,7 +362,8 @@ void ServiceCodeGenerator::GenerateSystemIncludes(
 }
 
 Status ServiceCodeGenerator::OpenNamespaces(
-    Printer& p, NamespaceType ns_type, std::string const& product_path_var) {
+    Printer& p, NamespaceType ns_type, std::string const& product_path_var,
+    std::string const& ns_documentation) {
   auto result = service_vars_.find(product_path_var);
   if (result == service_vars_.end()) {
     return Status(StatusCode::kInternal,
@@ -370,7 +372,9 @@ Status ServiceCodeGenerator::OpenNamespaces(
   namespace_ = Namespace(service_vars_[product_path_var], ns_type);
   p.Print(R"""(
 namespace google {
-namespace cloud {
+namespace cloud {)""");
+  p.Print(service_vars_, ns_documentation);
+  p.Print(R"""(
 namespace $namespace$ {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 )""",

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -76,7 +76,8 @@ class ServiceCodeGenerator : public GeneratorInterface {
 
   Status HeaderOpenNamespaces(NamespaceType ns_type = NamespaceType::kNormal);
   Status HeaderOpenForwardingNamespaces(
-      NamespaceType ns_type = NamespaceType::kNormal);
+      NamespaceType ns_type = NamespaceType::kNormal,
+      std::string const& ns_documentation = "");
   void HeaderCloseNamespaces();
   Status CcOpenNamespaces(NamespaceType ns_type = NamespaceType::kNormal);
   Status CcOpenForwardingNamespaces(
@@ -204,7 +205,8 @@ class ServiceCodeGenerator : public GeneratorInterface {
                                      std::vector<std::string> system_includes);
 
   Status OpenNamespaces(Printer& p, NamespaceType ns_type,
-                        std::string const& product_path_var);
+                        std::string const& product_path_var,
+                        std::string const& ns_documentation = "");
   void CloseNamespaces(Printer& p,
                        bool define_backwards_compatibility_namespace_alias);
 

--- a/google/cloud/accessapproval/access_approval_client.h
+++ b/google/cloud/accessapproval/access_approval_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in accessapproval_v1 instead of the aliases defined in
+///     this namespace.
 namespace accessapproval {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/accessapproval/mocks/mock_access_approval_connection.h
+++ b/google/cloud/accessapproval/mocks/mock_access_approval_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in accessapproval_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace accessapproval_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/accesscontextmanager/access_context_manager_client.h
+++ b/google/cloud/accesscontextmanager/access_context_manager_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in accesscontextmanager_v1 instead of the aliases defined
+///     in this namespace.
 namespace accesscontextmanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/accesscontextmanager/mocks/mock_access_context_manager_connection.h
+++ b/google/cloud/accesscontextmanager/mocks/mock_access_context_manager_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in accesscontextmanager_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace accesscontextmanager_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/apigateway/api_gateway_client.h
+++ b/google/cloud/apigateway/api_gateway_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in apigateway_v1 instead of the aliases defined in
+///     this namespace.
 namespace apigateway {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/apigateway/mocks/mock_api_gateway_connection.h
+++ b/google/cloud/apigateway/mocks/mock_api_gateway_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in apigateway_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace apigateway_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/apigeeconnect/connection_client.h
+++ b/google/cloud/apigeeconnect/connection_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in apigeeconnect_v1 instead of the aliases defined in
+///     this namespace.
 namespace apigeeconnect {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/apigeeconnect/mocks/mock_connection_connection.h
+++ b/google/cloud/apigeeconnect/mocks/mock_connection_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in apigeeconnect_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace apigeeconnect_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/apikeys/api_keys_client.h
+++ b/google/cloud/apikeys/api_keys_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in apikeys_v2 instead of the aliases defined in
+///     this namespace.
 namespace apikeys {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/apikeys/mocks/mock_api_keys_connection.h
+++ b/google/cloud/apikeys/mocks/mock_api_keys_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in apikeys_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace apikeys_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/applications_client.h
+++ b/google/cloud/appengine/applications_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1 instead of the aliases defined in
+///     this namespace.
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/authorized_certificates_client.h
+++ b/google/cloud/appengine/authorized_certificates_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1 instead of the aliases defined in
+///     this namespace.
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/authorized_domains_client.h
+++ b/google/cloud/appengine/authorized_domains_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1 instead of the aliases defined in
+///     this namespace.
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/domain_mappings_client.h
+++ b/google/cloud/appengine/domain_mappings_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1 instead of the aliases defined in
+///     this namespace.
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/firewall_client.h
+++ b/google/cloud/appengine/firewall_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1 instead of the aliases defined in
+///     this namespace.
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/instances_client.h
+++ b/google/cloud/appengine/instances_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1 instead of the aliases defined in
+///     this namespace.
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/mocks/mock_applications_connection.h
+++ b/google/cloud/appengine/mocks/mock_applications_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace appengine_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/mocks/mock_authorized_certificates_connection.h
+++ b/google/cloud/appengine/mocks/mock_authorized_certificates_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace appengine_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/mocks/mock_authorized_domains_connection.h
+++ b/google/cloud/appengine/mocks/mock_authorized_domains_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace appengine_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/mocks/mock_domain_mappings_connection.h
+++ b/google/cloud/appengine/mocks/mock_domain_mappings_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace appengine_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/mocks/mock_firewall_connection.h
+++ b/google/cloud/appengine/mocks/mock_firewall_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace appengine_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/mocks/mock_instances_connection.h
+++ b/google/cloud/appengine/mocks/mock_instances_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace appengine_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/mocks/mock_services_connection.h
+++ b/google/cloud/appengine/mocks/mock_services_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace appengine_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/mocks/mock_versions_connection.h
+++ b/google/cloud/appengine/mocks/mock_versions_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace appengine_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/services_client.h
+++ b/google/cloud/appengine/services_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1 instead of the aliases defined in
+///     this namespace.
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/appengine/versions_client.h
+++ b/google/cloud/appengine/versions_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in appengine_v1 instead of the aliases defined in
+///     this namespace.
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/artifactregistry/artifact_registry_client.h
+++ b/google/cloud/artifactregistry/artifact_registry_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in artifactregistry_v1 instead of the aliases defined in
+///     this namespace.
 namespace artifactregistry {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/artifactregistry/mocks/mock_artifact_registry_connection.h
+++ b/google/cloud/artifactregistry/mocks/mock_artifact_registry_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in artifactregistry_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace artifactregistry_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/asset/asset_client.h
+++ b/google/cloud/asset/asset_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in asset_v1 instead of the aliases defined in
+///     this namespace.
 namespace asset {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/asset/mocks/mock_asset_connection.h
+++ b/google/cloud/asset/mocks/mock_asset_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in asset_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace asset_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/assuredworkloads/assured_workloads_client.h
+++ b/google/cloud/assuredworkloads/assured_workloads_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in assuredworkloads_v1 instead of the aliases defined in
+///     this namespace.
 namespace assuredworkloads {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/assuredworkloads/mocks/mock_assured_workloads_connection.h
+++ b/google/cloud/assuredworkloads/mocks/mock_assured_workloads_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in assuredworkloads_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace assuredworkloads_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/automl/auto_ml_client.h
+++ b/google/cloud/automl/auto_ml_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in automl_v1 instead of the aliases defined in
+///     this namespace.
 namespace automl {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/automl/mocks/mock_auto_ml_connection.h
+++ b/google/cloud/automl/mocks/mock_auto_ml_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in automl_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace automl_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/automl/mocks/mock_prediction_connection.h
+++ b/google/cloud/automl/mocks/mock_prediction_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in automl_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace automl_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/automl/prediction_client.h
+++ b/google/cloud/automl/prediction_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in automl_v1 instead of the aliases defined in
+///     this namespace.
 namespace automl {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/baremetalsolution/bare_metal_solution_client.h
+++ b/google/cloud/baremetalsolution/bare_metal_solution_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in baremetalsolution_v2 instead of the aliases defined in
+///     this namespace.
 namespace baremetalsolution {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/baremetalsolution/mocks/mock_bare_metal_solution_connection.h
+++ b/google/cloud/baremetalsolution/mocks/mock_bare_metal_solution_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in baremetalsolution_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace baremetalsolution_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/batch/batch_client.h
+++ b/google/cloud/batch/batch_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in batch_v1 instead of the aliases defined in
+///     this namespace.
 namespace batch {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/batch/mocks/mock_batch_connection.h
+++ b/google/cloud/batch/mocks/mock_batch_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in batch_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace batch_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/app_connections_client.h
+++ b/google/cloud/beyondcorp/app_connections_client.h
@@ -25,6 +25,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_appconnections_v1 instead of the aliases
+///     defined in this namespace.
 namespace beyondcorp {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/app_connectors_client.h
+++ b/google/cloud/beyondcorp/app_connectors_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_appconnectors_v1 instead of the aliases
+///     defined in this namespace.
 namespace beyondcorp {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/app_gateways_client.h
+++ b/google/cloud/beyondcorp/app_gateways_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_appgateways_v1 instead of the aliases
+///     defined in this namespace.
 namespace beyondcorp {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/client_connector_services_client.h
+++ b/google/cloud/beyondcorp/client_connector_services_client.h
@@ -25,6 +25,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_clientconnectorservices_v1 instead of the
+///     aliases defined in this namespace.
 namespace beyondcorp {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/client_gateways_client.h
+++ b/google/cloud/beyondcorp/client_gateways_client.h
@@ -25,6 +25,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_clientgateways_v1 instead of the aliases
+///     defined in this namespace.
 namespace beyondcorp {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/mocks/mock_app_connections_connection.h
+++ b/google/cloud/beyondcorp/mocks/mock_app_connections_connection.h
@@ -25,6 +25,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_appconnections_v1_mocks instead of the
+///     aliases defined in this namespace.
 namespace beyondcorp_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/mocks/mock_app_connectors_connection.h
+++ b/google/cloud/beyondcorp/mocks/mock_app_connectors_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_appconnectors_v1_mocks instead of the
+///     aliases defined in this namespace.
 namespace beyondcorp_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/mocks/mock_app_gateways_connection.h
+++ b/google/cloud/beyondcorp/mocks/mock_app_gateways_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_appgateways_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace beyondcorp_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/mocks/mock_client_connector_services_connection.h
+++ b/google/cloud/beyondcorp/mocks/mock_client_connector_services_connection.h
@@ -25,6 +25,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_clientconnectorservices_v1_mocks instead of
+///     the aliases defined in this namespace.
 namespace beyondcorp_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/beyondcorp/mocks/mock_client_gateways_connection.h
+++ b/google/cloud/beyondcorp/mocks/mock_client_gateways_connection.h
@@ -25,6 +25,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in beyondcorp_clientgateways_v1_mocks instead of the
+///     aliases defined in this namespace.
 namespace beyondcorp_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/analytics_hub_client.h
+++ b/google/cloud/bigquery/analytics_hub_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_analyticshub_v1 instead of the aliases defined
+///     in this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_storage_v1 instead of the aliases defined in
+///     this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/bigquery_write_client.h
+++ b/google/cloud/bigquery/bigquery_write_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_storage_v1 instead of the aliases defined in
+///     this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/connection_client.h
+++ b/google/cloud/bigquery/connection_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_connection_v1 instead of the aliases defined
+///     in this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/data_policy_client.h
+++ b/google/cloud/bigquery/data_policy_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_datapolicies_v1 instead of the aliases defined
+///     in this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/data_transfer_client.h
+++ b/google/cloud/bigquery/data_transfer_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_datatransfer_v1 instead of the aliases defined
+///     in this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/migration_client.h
+++ b/google/cloud/bigquery/migration_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_migration_v2 instead of the aliases defined in
+///     this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_analytics_hub_connection.h
+++ b/google/cloud/bigquery/mocks/mock_analytics_hub_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_analyticshub_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_bigquery_read_connection.h
+++ b/google/cloud/bigquery/mocks/mock_bigquery_read_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_storage_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_bigquery_write_connection.h
+++ b/google/cloud/bigquery/mocks/mock_bigquery_write_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_storage_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_connection_connection.h
+++ b/google/cloud/bigquery/mocks/mock_connection_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_connection_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_data_policy_connection.h
+++ b/google/cloud/bigquery/mocks/mock_data_policy_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_datapolicies_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_data_transfer_connection.h
+++ b/google/cloud/bigquery/mocks/mock_data_transfer_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_datatransfer_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_migration_connection.h
+++ b/google/cloud/bigquery/mocks/mock_migration_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_migration_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_model_connection.h
+++ b/google/cloud/bigquery/mocks/mock_model_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/mocks/mock_reservation_connection.h
+++ b/google/cloud/bigquery/mocks/mock_reservation_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_reservation_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace bigquery_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/model_client.h
+++ b/google/cloud/bigquery/model_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_v2 instead of the aliases defined in
+///     this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigquery/reservation_client.h
+++ b/google/cloud/bigquery/reservation_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in bigquery_reservation_v1 instead of the aliases defined
+///     in this namespace.
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/billing/budget_client.h
+++ b/google/cloud/billing/budget_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in billing_budgets_v1 instead of the aliases defined in
+///     this namespace.
 namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/billing/cloud_billing_client.h
+++ b/google/cloud/billing/cloud_billing_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in billing_v1 instead of the aliases defined in
+///     this namespace.
 namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/billing/cloud_catalog_client.h
+++ b/google/cloud/billing/cloud_catalog_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in billing_v1 instead of the aliases defined in
+///     this namespace.
 namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/billing/mocks/mock_budget_connection.h
+++ b/google/cloud/billing/mocks/mock_budget_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in billing_budgets_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace billing_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/billing/mocks/mock_cloud_billing_connection.h
+++ b/google/cloud/billing/mocks/mock_cloud_billing_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in billing_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace billing_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/billing/mocks/mock_cloud_catalog_connection.h
+++ b/google/cloud/billing/mocks/mock_cloud_catalog_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in billing_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace billing_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/binaryauthorization/binauthz_management_service_v1_client.h
+++ b/google/cloud/binaryauthorization/binauthz_management_service_v1_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in binaryauthorization_v1 instead of the aliases defined
+///     in this namespace.
 namespace binaryauthorization {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/binaryauthorization/mocks/mock_binauthz_management_service_v1_connection.h
+++ b/google/cloud/binaryauthorization/mocks/mock_binauthz_management_service_v1_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in binaryauthorization_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace binaryauthorization_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/binaryauthorization/mocks/mock_system_policy_v1_connection.h
+++ b/google/cloud/binaryauthorization/mocks/mock_system_policy_v1_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in binaryauthorization_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace binaryauthorization_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/binaryauthorization/mocks/mock_validation_helper_v1_connection.h
+++ b/google/cloud/binaryauthorization/mocks/mock_validation_helper_v1_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in binaryauthorization_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace binaryauthorization_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/binaryauthorization/system_policy_v1_client.h
+++ b/google/cloud/binaryauthorization/system_policy_v1_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in binaryauthorization_v1 instead of the aliases defined
+///     in this namespace.
 namespace binaryauthorization {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/binaryauthorization/validation_helper_v1_client.h
+++ b/google/cloud/binaryauthorization/validation_helper_v1_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in binaryauthorization_v1 instead of the aliases defined
+///     in this namespace.
 namespace binaryauthorization {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/certificatemanager/certificate_manager_client.h
+++ b/google/cloud/certificatemanager/certificate_manager_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in certificatemanager_v1 instead of the aliases defined in
+///     this namespace.
 namespace certificatemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/certificatemanager/mocks/mock_certificate_manager_connection.h
+++ b/google/cloud/certificatemanager/mocks/mock_certificate_manager_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in certificatemanager_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace certificatemanager_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/channel/cloud_channel_client.h
+++ b/google/cloud/channel/cloud_channel_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in channel_v1 instead of the aliases defined in
+///     this namespace.
 namespace channel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/channel/mocks/mock_cloud_channel_connection.h
+++ b/google/cloud/channel/mocks/mock_cloud_channel_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in channel_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace channel_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/cloudbuild/cloud_build_client.h
+++ b/google/cloud/cloudbuild/cloud_build_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in cloudbuild_v1 instead of the aliases defined in
+///     this namespace.
 namespace cloudbuild {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/cloudbuild/mocks/mock_cloud_build_connection.h
+++ b/google/cloud/cloudbuild/mocks/mock_cloud_build_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in cloudbuild_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace cloudbuild_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/composer/environments_client.h
+++ b/google/cloud/composer/environments_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in composer_v1 instead of the aliases defined in
+///     this namespace.
 namespace composer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/composer/image_versions_client.h
+++ b/google/cloud/composer/image_versions_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in composer_v1 instead of the aliases defined in
+///     this namespace.
 namespace composer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/composer/mocks/mock_environments_connection.h
+++ b/google/cloud/composer/mocks/mock_environments_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in composer_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace composer_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/composer/mocks/mock_image_versions_connection.h
+++ b/google/cloud/composer/mocks/mock_image_versions_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in composer_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace composer_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/connectors/connectors_client.h
+++ b/google/cloud/connectors/connectors_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in connectors_v1 instead of the aliases defined in
+///     this namespace.
 namespace connectors {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/connectors/mocks/mock_connectors_connection.h
+++ b/google/cloud/connectors/mocks/mock_connectors_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in connectors_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace connectors_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/contactcenterinsights/contact_center_insights_client.h
+++ b/google/cloud/contactcenterinsights/contact_center_insights_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in contactcenterinsights_v1 instead of the aliases defined
+///     in this namespace.
 namespace contactcenterinsights {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/contactcenterinsights/mocks/mock_contact_center_insights_connection.h
+++ b/google/cloud/contactcenterinsights/mocks/mock_contact_center_insights_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in contactcenterinsights_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace contactcenterinsights_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/container/cluster_manager_client.h
+++ b/google/cloud/container/cluster_manager_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in container_v1 instead of the aliases defined in
+///     this namespace.
 namespace container {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/container/mocks/mock_cluster_manager_connection.h
+++ b/google/cloud/container/mocks/mock_cluster_manager_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in container_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace container_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/containeranalysis/container_analysis_client.h
+++ b/google/cloud/containeranalysis/container_analysis_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in containeranalysis_v1 instead of the aliases defined in
+///     this namespace.
 namespace containeranalysis {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/containeranalysis/grafeas_client.h
+++ b/google/cloud/containeranalysis/grafeas_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in containeranalysis_v1 instead of the aliases defined in
+///     this namespace.
 namespace containeranalysis {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/containeranalysis/mocks/mock_container_analysis_connection.h
+++ b/google/cloud/containeranalysis/mocks/mock_container_analysis_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in containeranalysis_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace containeranalysis_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/containeranalysis/mocks/mock_grafeas_connection.h
+++ b/google/cloud/containeranalysis/mocks/mock_grafeas_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in containeranalysis_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace containeranalysis_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datacatalog/data_catalog_client.h
+++ b/google/cloud/datacatalog/data_catalog_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datacatalog_v1 instead of the aliases defined in
+///     this namespace.
 namespace datacatalog {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datacatalog/mocks/mock_data_catalog_connection.h
+++ b/google/cloud/datacatalog/mocks/mock_data_catalog_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datacatalog_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace datacatalog_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datacatalog/mocks/mock_policy_tag_manager_connection.h
+++ b/google/cloud/datacatalog/mocks/mock_policy_tag_manager_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datacatalog_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace datacatalog_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datacatalog/mocks/mock_policy_tag_manager_serialization_connection.h
+++ b/google/cloud/datacatalog/mocks/mock_policy_tag_manager_serialization_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datacatalog_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace datacatalog_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datacatalog/policy_tag_manager_client.h
+++ b/google/cloud/datacatalog/policy_tag_manager_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datacatalog_v1 instead of the aliases defined in
+///     this namespace.
 namespace datacatalog {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datacatalog/policy_tag_manager_serialization_client.h
+++ b/google/cloud/datacatalog/policy_tag_manager_serialization_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datacatalog_v1 instead of the aliases defined in
+///     this namespace.
 namespace datacatalog {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datacatalog/v1/internal/data_catalog_tracing_connection.cc
+++ b/google/cloud/datacatalog/v1/internal/data_catalog_tracing_connection.cc
@@ -289,7 +289,10 @@ DataCatalogTracingConnection::ListTags(
 future<StatusOr<google::cloud::datacatalog::v1::ReconcileTagsResponse>>
 DataCatalogTracingConnection::ReconcileTags(
     google::cloud::datacatalog::v1::ReconcileTagsRequest const& request) {
-  return child_->ReconcileTags(request);
+  auto span = internal::MakeSpan(
+      "datacatalog_v1::DataCatalogConnection::ReconcileTags");
+  auto scope = opentelemetry::trace::Scope(span);
+  return internal::EndSpan(std::move(span), child_->ReconcileTags(request));
 }
 
 StatusOr<google::cloud::datacatalog::v1::StarEntryResponse>
@@ -338,7 +341,10 @@ DataCatalogTracingConnection::TestIamPermissions(
 future<StatusOr<google::cloud::datacatalog::v1::ImportEntriesResponse>>
 DataCatalogTracingConnection::ImportEntries(
     google::cloud::datacatalog::v1::ImportEntriesRequest const& request) {
-  return child_->ImportEntries(request);
+  auto span = internal::MakeSpan(
+      "datacatalog_v1::DataCatalogConnection::ImportEntries");
+  auto scope = opentelemetry::trace::Scope(span);
+  return internal::EndSpan(std::move(span), child_->ImportEntries(request));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/datamigration/data_migration_client.h
+++ b/google/cloud/datamigration/data_migration_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datamigration_v1 instead of the aliases defined in
+///     this namespace.
 namespace datamigration {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datamigration/mocks/mock_data_migration_connection.h
+++ b/google/cloud/datamigration/mocks/mock_data_migration_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datamigration_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace datamigration_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataplex/content_client.h
+++ b/google/cloud/dataplex/content_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataplex_v1 instead of the aliases defined in
+///     this namespace.
 namespace dataplex {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataplex/dataplex_client.h
+++ b/google/cloud/dataplex/dataplex_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataplex_v1 instead of the aliases defined in
+///     this namespace.
 namespace dataplex {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataplex/metadata_client.h
+++ b/google/cloud/dataplex/metadata_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataplex_v1 instead of the aliases defined in
+///     this namespace.
 namespace dataplex {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataplex/mocks/mock_content_connection.h
+++ b/google/cloud/dataplex/mocks/mock_content_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataplex_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace dataplex_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataplex/mocks/mock_dataplex_connection.h
+++ b/google/cloud/dataplex/mocks/mock_dataplex_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataplex_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace dataplex_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataplex/mocks/mock_metadata_connection.h
+++ b/google/cloud/dataplex/mocks/mock_metadata_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataplex_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace dataplex_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/autoscaling_policy_client.h
+++ b/google/cloud/dataproc/autoscaling_policy_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1 instead of the aliases defined in
+///     this namespace.
 namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/batch_controller_client.h
+++ b/google/cloud/dataproc/batch_controller_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1 instead of the aliases defined in
+///     this namespace.
 namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/cluster_controller_client.h
+++ b/google/cloud/dataproc/cluster_controller_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1 instead of the aliases defined in
+///     this namespace.
 namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/job_controller_client.h
+++ b/google/cloud/dataproc/job_controller_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1 instead of the aliases defined in
+///     this namespace.
 namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/mocks/mock_autoscaling_policy_connection.h
+++ b/google/cloud/dataproc/mocks/mock_autoscaling_policy_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace dataproc_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/mocks/mock_batch_controller_connection.h
+++ b/google/cloud/dataproc/mocks/mock_batch_controller_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace dataproc_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/mocks/mock_cluster_controller_connection.h
+++ b/google/cloud/dataproc/mocks/mock_cluster_controller_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace dataproc_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/mocks/mock_job_controller_connection.h
+++ b/google/cloud/dataproc/mocks/mock_job_controller_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace dataproc_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/mocks/mock_workflow_template_connection.h
+++ b/google/cloud/dataproc/mocks/mock_workflow_template_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace dataproc_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dataproc/workflow_template_client.h
+++ b/google/cloud/dataproc/workflow_template_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dataproc_v1 instead of the aliases defined in
+///     this namespace.
 namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datastream/datastream_client.h
+++ b/google/cloud/datastream/datastream_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datastream_v1 instead of the aliases defined in
+///     this namespace.
 namespace datastream {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/datastream/mocks/mock_datastream_connection.h
+++ b/google/cloud/datastream/mocks/mock_datastream_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in datastream_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace datastream_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/debugger/controller2_client.h
+++ b/google/cloud/debugger/controller2_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in debugger_v2 instead of the aliases defined in
+///     this namespace.
 namespace debugger {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/debugger/debugger2_client.h
+++ b/google/cloud/debugger/debugger2_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in debugger_v2 instead of the aliases defined in
+///     this namespace.
 namespace debugger {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/debugger/mocks/mock_controller2_connection.h
+++ b/google/cloud/debugger/mocks/mock_controller2_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in debugger_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace debugger_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/debugger/mocks/mock_debugger2_connection.h
+++ b/google/cloud/debugger/mocks/mock_debugger2_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in debugger_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace debugger_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/deploy/cloud_deploy_client.h
+++ b/google/cloud/deploy/cloud_deploy_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in deploy_v1 instead of the aliases defined in
+///     this namespace.
 namespace deploy {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/deploy/mocks/mock_cloud_deploy_connection.h
+++ b/google/cloud/deploy/mocks/mock_cloud_deploy_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in deploy_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace deploy_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dlp/dlp_client.h
+++ b/google/cloud/dlp/dlp_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dlp_v2 instead of the aliases defined in
+///     this namespace.
 namespace dlp {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/dlp/mocks/mock_dlp_connection.h
+++ b/google/cloud/dlp/mocks/mock_dlp_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in dlp_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace dlp_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/documentai/document_processor_client.h
+++ b/google/cloud/documentai/document_processor_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in documentai_v1 instead of the aliases defined in
+///     this namespace.
 namespace documentai {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/documentai/mocks/mock_document_processor_connection.h
+++ b/google/cloud/documentai/mocks/mock_document_processor_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in documentai_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace documentai_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/edgecontainer/edge_container_client.h
+++ b/google/cloud/edgecontainer/edge_container_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in edgecontainer_v1 instead of the aliases defined in
+///     this namespace.
 namespace edgecontainer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/edgecontainer/mocks/mock_edge_container_connection.h
+++ b/google/cloud/edgecontainer/mocks/mock_edge_container_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in edgecontainer_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace edgecontainer_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/eventarc/eventarc_client.h
+++ b/google/cloud/eventarc/eventarc_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in eventarc_v1 instead of the aliases defined in
+///     this namespace.
 namespace eventarc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/eventarc/mocks/mock_eventarc_connection.h
+++ b/google/cloud/eventarc/mocks/mock_eventarc_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in eventarc_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace eventarc_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/eventarc/mocks/mock_publisher_connection.h
+++ b/google/cloud/eventarc/mocks/mock_publisher_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in eventarc_publishing_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace eventarc_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/eventarc/publisher_client.h
+++ b/google/cloud/eventarc/publisher_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in eventarc_publishing_v1 instead of the aliases defined
+///     in this namespace.
 namespace eventarc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/filestore/cloud_filestore_manager_client.h
+++ b/google/cloud/filestore/cloud_filestore_manager_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in filestore_v1 instead of the aliases defined in
+///     this namespace.
 namespace filestore {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/filestore/mocks/mock_cloud_filestore_manager_connection.h
+++ b/google/cloud/filestore/mocks/mock_cloud_filestore_manager_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in filestore_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace filestore_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/functions/cloud_functions_client.h
+++ b/google/cloud/functions/cloud_functions_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in functions_v1 instead of the aliases defined in
+///     this namespace.
 namespace functions {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/functions/mocks/mock_cloud_functions_connection.h
+++ b/google/cloud/functions/mocks/mock_cloud_functions_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in functions_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace functions_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gameservices/game_server_clusters_client.h
+++ b/google/cloud/gameservices/game_server_clusters_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gameservices_v1 instead of the aliases defined in
+///     this namespace.
 namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gameservices/game_server_configs_client.h
+++ b/google/cloud/gameservices/game_server_configs_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gameservices_v1 instead of the aliases defined in
+///     this namespace.
 namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gameservices/game_server_deployments_client.h
+++ b/google/cloud/gameservices/game_server_deployments_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gameservices_v1 instead of the aliases defined in
+///     this namespace.
 namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gameservices/mocks/mock_game_server_clusters_connection.h
+++ b/google/cloud/gameservices/mocks/mock_game_server_clusters_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gameservices_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace gameservices_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gameservices/mocks/mock_game_server_configs_connection.h
+++ b/google/cloud/gameservices/mocks/mock_game_server_configs_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gameservices_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace gameservices_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gameservices/mocks/mock_game_server_deployments_connection.h
+++ b/google/cloud/gameservices/mocks/mock_game_server_deployments_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gameservices_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace gameservices_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gameservices/mocks/mock_realms_connection.h
+++ b/google/cloud/gameservices/mocks/mock_realms_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gameservices_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace gameservices_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gameservices/realms_client.h
+++ b/google/cloud/gameservices/realms_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gameservices_v1 instead of the aliases defined in
+///     this namespace.
 namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gkehub/gke_hub_client.h
+++ b/google/cloud/gkehub/gke_hub_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gkehub_v1 instead of the aliases defined in
+///     this namespace.
 namespace gkehub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/gkehub/mocks/mock_gke_hub_connection.h
+++ b/google/cloud/gkehub/mocks/mock_gke_hub_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in gkehub_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace gkehub_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iam_admin_v1 instead of the aliases defined in
+///     this namespace.
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iam_credentials_v1 instead of the aliases defined in
+///     this namespace.
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iam/iam_policy_client.h
+++ b/google/cloud/iam/iam_policy_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iam_v1 instead of the aliases defined in
+///     this namespace.
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iam/mocks/mock_iam_connection.h
+++ b/google/cloud/iam/mocks/mock_iam_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iam_admin_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace iam_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iam/mocks/mock_iam_credentials_connection.h
+++ b/google/cloud/iam/mocks/mock_iam_credentials_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iam_credentials_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace iam_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iam/mocks/mock_iam_policy_connection.h
+++ b/google/cloud/iam/mocks/mock_iam_policy_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iam_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace iam_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iap/identity_aware_proxy_admin_client.h
+++ b/google/cloud/iap/identity_aware_proxy_admin_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iap_v1 instead of the aliases defined in
+///     this namespace.
 namespace iap {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iap/identity_aware_proxy_o_auth_client.h
+++ b/google/cloud/iap/identity_aware_proxy_o_auth_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iap_v1 instead of the aliases defined in
+///     this namespace.
 namespace iap {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iap/mocks/mock_identity_aware_proxy_admin_connection.h
+++ b/google/cloud/iap/mocks/mock_identity_aware_proxy_admin_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iap_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace iap_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iap/mocks/mock_identity_aware_proxy_o_auth_connection.h
+++ b/google/cloud/iap/mocks/mock_identity_aware_proxy_o_auth_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iap_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace iap_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/ids/ids_client.h
+++ b/google/cloud/ids/ids_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in ids_v1 instead of the aliases defined in
+///     this namespace.
 namespace ids {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/ids/mocks/mock_ids_connection.h
+++ b/google/cloud/ids/mocks/mock_ids_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in ids_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace ids_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iot/device_manager_client.h
+++ b/google/cloud/iot/device_manager_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iot_v1 instead of the aliases defined in
+///     this namespace.
 namespace iot {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/iot/mocks/mock_device_manager_connection.h
+++ b/google/cloud/iot/mocks/mock_device_manager_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in iot_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace iot_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/kms/ekm_client.h
+++ b/google/cloud/kms/ekm_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in kms_v1 instead of the aliases defined in
+///     this namespace.
 namespace kms {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/kms/key_management_client.h
+++ b/google/cloud/kms/key_management_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in kms_v1 instead of the aliases defined in
+///     this namespace.
 namespace kms {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/kms/mocks/mock_ekm_connection.h
+++ b/google/cloud/kms/mocks/mock_ekm_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in kms_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace kms_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/kms/mocks/mock_key_management_connection.h
+++ b/google/cloud/kms/mocks/mock_key_management_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in kms_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace kms_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/language/language_client.h
+++ b/google/cloud/language/language_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in language_v1 instead of the aliases defined in
+///     this namespace.
 namespace language {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/language/mocks/mock_language_connection.h
+++ b/google/cloud/language/mocks/mock_language_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in language_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace language_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in logging_v2 instead of the aliases defined in
+///     this namespace.
 namespace logging {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/logging/mocks/mock_logging_service_v2_connection.h
+++ b/google/cloud/logging/mocks/mock_logging_service_v2_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in logging_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace logging_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/managedidentities/managed_identities_client.h
+++ b/google/cloud/managedidentities/managed_identities_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in managedidentities_v1 instead of the aliases defined in
+///     this namespace.
 namespace managedidentities {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/managedidentities/mocks/mock_managed_identities_connection.h
+++ b/google/cloud/managedidentities/mocks/mock_managed_identities_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in managedidentities_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace managedidentities_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/memcache/cloud_memcache_client.h
+++ b/google/cloud/memcache/cloud_memcache_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in memcache_v1 instead of the aliases defined in
+///     this namespace.
 namespace memcache {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/memcache/mocks/mock_cloud_memcache_connection.h
+++ b/google/cloud/memcache/mocks/mock_cloud_memcache_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in memcache_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace memcache_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/alert_policy_client.h
+++ b/google/cloud/monitoring/alert_policy_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3 instead of the aliases defined in
+///     this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/dashboards_client.h
+++ b/google/cloud/monitoring/dashboards_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_dashboard_v1 instead of the aliases defined
+///     in this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/group_client.h
+++ b/google/cloud/monitoring/group_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3 instead of the aliases defined in
+///     this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/metric_client.h
+++ b/google/cloud/monitoring/metric_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3 instead of the aliases defined in
+///     this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/metrics_scopes_client.h
+++ b/google/cloud/monitoring/metrics_scopes_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_metricsscope_v1 instead of the aliases
+///     defined in this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_alert_policy_connection.h
+++ b/google/cloud/monitoring/mocks/mock_alert_policy_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_dashboards_connection.h
+++ b/google/cloud/monitoring/mocks/mock_dashboards_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_dashboard_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_group_connection.h
+++ b/google/cloud/monitoring/mocks/mock_group_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_metric_connection.h
+++ b/google/cloud/monitoring/mocks/mock_metric_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_metrics_scopes_connection.h
+++ b/google/cloud/monitoring/mocks/mock_metrics_scopes_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_metricsscope_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_notification_channel_connection.h
+++ b/google/cloud/monitoring/mocks/mock_notification_channel_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_query_connection.h
+++ b/google/cloud/monitoring/mocks/mock_query_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_service_monitoring_connection.h
+++ b/google/cloud/monitoring/mocks/mock_service_monitoring_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/mocks/mock_uptime_check_connection.h
+++ b/google/cloud/monitoring/mocks/mock_uptime_check_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace monitoring_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/notification_channel_client.h
+++ b/google/cloud/monitoring/notification_channel_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3 instead of the aliases defined in
+///     this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/query_client.h
+++ b/google/cloud/monitoring/query_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3 instead of the aliases defined in
+///     this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/service_monitoring_client.h
+++ b/google/cloud/monitoring/service_monitoring_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3 instead of the aliases defined in
+///     this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/monitoring/uptime_check_client.h
+++ b/google/cloud/monitoring/uptime_check_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in monitoring_v3 instead of the aliases defined in
+///     this namespace.
 namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/networkconnectivity/hub_client.h
+++ b/google/cloud/networkconnectivity/hub_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in networkconnectivity_v1 instead of the aliases defined
+///     in this namespace.
 namespace networkconnectivity {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/networkconnectivity/mocks/mock_hub_connection.h
+++ b/google/cloud/networkconnectivity/mocks/mock_hub_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in networkconnectivity_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace networkconnectivity_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/networkmanagement/mocks/mock_reachability_connection.h
+++ b/google/cloud/networkmanagement/mocks/mock_reachability_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in networkmanagement_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace networkmanagement_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/networkmanagement/reachability_client.h
+++ b/google/cloud/networkmanagement/reachability_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in networkmanagement_v1 instead of the aliases defined in
+///     this namespace.
 namespace networkmanagement {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/notebooks/managed_notebook_client.h
+++ b/google/cloud/notebooks/managed_notebook_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in notebooks_v1 instead of the aliases defined in
+///     this namespace.
 namespace notebooks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/notebooks/mocks/mock_managed_notebook_connection.h
+++ b/google/cloud/notebooks/mocks/mock_managed_notebook_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in notebooks_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace notebooks_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/notebooks/mocks/mock_notebook_connection.h
+++ b/google/cloud/notebooks/mocks/mock_notebook_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in notebooks_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace notebooks_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/notebooks/notebook_client.h
+++ b/google/cloud/notebooks/notebook_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in notebooks_v1 instead of the aliases defined in
+///     this namespace.
 namespace notebooks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/optimization/fleet_routing_client.h
+++ b/google/cloud/optimization/fleet_routing_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in optimization_v1 instead of the aliases defined in
+///     this namespace.
 namespace optimization {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/optimization/mocks/mock_fleet_routing_connection.h
+++ b/google/cloud/optimization/mocks/mock_fleet_routing_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in optimization_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace optimization_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/orgpolicy/mocks/mock_org_policy_connection.h
+++ b/google/cloud/orgpolicy/mocks/mock_org_policy_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in orgpolicy_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace orgpolicy_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/orgpolicy/org_policy_client.h
+++ b/google/cloud/orgpolicy/org_policy_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in orgpolicy_v2 instead of the aliases defined in
+///     this namespace.
 namespace orgpolicy {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/osconfig/agent_endpoint_client.h
+++ b/google/cloud/osconfig/agent_endpoint_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in osconfig_agentendpoint_v1 instead of the aliases
+///     defined in this namespace.
 namespace osconfig {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/osconfig/mocks/mock_agent_endpoint_connection.h
+++ b/google/cloud/osconfig/mocks/mock_agent_endpoint_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in osconfig_agentendpoint_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace osconfig_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/osconfig/mocks/mock_os_config_connection.h
+++ b/google/cloud/osconfig/mocks/mock_os_config_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in osconfig_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace osconfig_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/osconfig/os_config_client.h
+++ b/google/cloud/osconfig/os_config_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in osconfig_v1 instead of the aliases defined in
+///     this namespace.
 namespace osconfig {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/oslogin/mocks/mock_os_login_connection.h
+++ b/google/cloud/oslogin/mocks/mock_os_login_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in oslogin_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace oslogin_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/oslogin/os_login_client.h
+++ b/google/cloud/oslogin/os_login_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in oslogin_v1 instead of the aliases defined in
+///     this namespace.
 namespace oslogin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/policytroubleshooter/iam_checker_client.h
+++ b/google/cloud/policytroubleshooter/iam_checker_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in policytroubleshooter_v1 instead of the aliases defined
+///     in this namespace.
 namespace policytroubleshooter {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/policytroubleshooter/mocks/mock_iam_checker_connection.h
+++ b/google/cloud/policytroubleshooter/mocks/mock_iam_checker_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in policytroubleshooter_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace policytroubleshooter_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/privateca/certificate_authority_client.h
+++ b/google/cloud/privateca/certificate_authority_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in privateca_v1 instead of the aliases defined in
+///     this namespace.
 namespace privateca {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/privateca/mocks/mock_certificate_authority_connection.h
+++ b/google/cloud/privateca/mocks/mock_certificate_authority_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in privateca_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace privateca_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/profiler/mocks/mock_profiler_connection.h
+++ b/google/cloud/profiler/mocks/mock_profiler_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in profiler_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace profiler_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/profiler/profiler_client.h
+++ b/google/cloud/profiler/profiler_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in profiler_v2 instead of the aliases defined in
+///     this namespace.
 namespace profiler {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/recommender/mocks/mock_recommender_connection.h
+++ b/google/cloud/recommender/mocks/mock_recommender_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in recommender_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace recommender_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/recommender/recommender_client.h
+++ b/google/cloud/recommender/recommender_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in recommender_v1 instead of the aliases defined in
+///     this namespace.
 namespace recommender {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/redis/cloud_redis_client.h
+++ b/google/cloud/redis/cloud_redis_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in redis_v1 instead of the aliases defined in
+///     this namespace.
 namespace redis {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/redis/mocks/mock_cloud_redis_connection.h
+++ b/google/cloud/redis/mocks/mock_cloud_redis_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in redis_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace redis_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/resourcemanager/folders_client.h
+++ b/google/cloud/resourcemanager/folders_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in resourcemanager_v3 instead of the aliases defined in
+///     this namespace.
 namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/resourcemanager/mocks/mock_folders_connection.h
+++ b/google/cloud/resourcemanager/mocks/mock_folders_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in resourcemanager_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace resourcemanager_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/resourcemanager/mocks/mock_organizations_connection.h
+++ b/google/cloud/resourcemanager/mocks/mock_organizations_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in resourcemanager_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace resourcemanager_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/resourcemanager/mocks/mock_projects_connection.h
+++ b/google/cloud/resourcemanager/mocks/mock_projects_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in resourcemanager_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace resourcemanager_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/resourcemanager/organizations_client.h
+++ b/google/cloud/resourcemanager/organizations_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in resourcemanager_v3 instead of the aliases defined in
+///     this namespace.
 namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/resourcemanager/projects_client.h
+++ b/google/cloud/resourcemanager/projects_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in resourcemanager_v3 instead of the aliases defined in
+///     this namespace.
 namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/resourcesettings/mocks/mock_resource_settings_connection.h
+++ b/google/cloud/resourcesettings/mocks/mock_resource_settings_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in resourcesettings_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace resourcesettings_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/resourcesettings/resource_settings_client.h
+++ b/google/cloud/resourcesettings/resource_settings_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in resourcesettings_v1 instead of the aliases defined in
+///     this namespace.
 namespace resourcesettings {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/catalog_client.h
+++ b/google/cloud/retail/catalog_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2 instead of the aliases defined in
+///     this namespace.
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/completion_client.h
+++ b/google/cloud/retail/completion_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2 instead of the aliases defined in
+///     this namespace.
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/mocks/mock_catalog_connection.h
+++ b/google/cloud/retail/mocks/mock_catalog_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace retail_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/mocks/mock_completion_connection.h
+++ b/google/cloud/retail/mocks/mock_completion_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace retail_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/mocks/mock_prediction_connection.h
+++ b/google/cloud/retail/mocks/mock_prediction_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace retail_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/mocks/mock_product_connection.h
+++ b/google/cloud/retail/mocks/mock_product_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace retail_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/mocks/mock_search_connection.h
+++ b/google/cloud/retail/mocks/mock_search_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace retail_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/mocks/mock_user_event_connection.h
+++ b/google/cloud/retail/mocks/mock_user_event_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace retail_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/prediction_client.h
+++ b/google/cloud/retail/prediction_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2 instead of the aliases defined in
+///     this namespace.
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/product_client.h
+++ b/google/cloud/retail/product_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2 instead of the aliases defined in
+///     this namespace.
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/search_client.h
+++ b/google/cloud/retail/search_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2 instead of the aliases defined in
+///     this namespace.
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/retail/user_event_client.h
+++ b/google/cloud/retail/user_event_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in retail_v2 instead of the aliases defined in
+///     this namespace.
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/run/mocks/mock_revisions_connection.h
+++ b/google/cloud/run/mocks/mock_revisions_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in run_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace run_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/run/mocks/mock_services_connection.h
+++ b/google/cloud/run/mocks/mock_services_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in run_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace run_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/run/revisions_client.h
+++ b/google/cloud/run/revisions_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in run_v2 instead of the aliases defined in
+///     this namespace.
 namespace run {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/run/services_client.h
+++ b/google/cloud/run/services_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in run_v2 instead of the aliases defined in
+///     this namespace.
 namespace run {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/scheduler/cloud_scheduler_client.h
+++ b/google/cloud/scheduler/cloud_scheduler_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in scheduler_v1 instead of the aliases defined in
+///     this namespace.
 namespace scheduler {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/scheduler/mocks/mock_cloud_scheduler_connection.h
+++ b/google/cloud/scheduler/mocks/mock_cloud_scheduler_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in scheduler_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace scheduler_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/secretmanager/mocks/mock_secret_manager_connection.h
+++ b/google/cloud/secretmanager/mocks/mock_secret_manager_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in secretmanager_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace secretmanager_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/secretmanager/secret_manager_client.h
+++ b/google/cloud/secretmanager/secret_manager_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in secretmanager_v1 instead of the aliases defined in
+///     this namespace.
 namespace secretmanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/securitycenter/mocks/mock_security_center_connection.h
+++ b/google/cloud/securitycenter/mocks/mock_security_center_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in securitycenter_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace securitycenter_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/securitycenter/security_center_client.h
+++ b/google/cloud/securitycenter/security_center_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in securitycenter_v1 instead of the aliases defined in
+///     this namespace.
 namespace securitycenter {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicecontrol/mocks/mock_quota_controller_connection.h
+++ b/google/cloud/servicecontrol/mocks/mock_quota_controller_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicecontrol_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace servicecontrol_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicecontrol/mocks/mock_service_controller_connection.h
+++ b/google/cloud/servicecontrol/mocks/mock_service_controller_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicecontrol_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace servicecontrol_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicecontrol/quota_controller_client.h
+++ b/google/cloud/servicecontrol/quota_controller_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicecontrol_v1 instead of the aliases defined in
+///     this namespace.
 namespace servicecontrol {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicecontrol/service_controller_client.h
+++ b/google/cloud/servicecontrol/service_controller_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicecontrol_v1 instead of the aliases defined in
+///     this namespace.
 namespace servicecontrol {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicedirectory/lookup_client.h
+++ b/google/cloud/servicedirectory/lookup_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicedirectory_v1 instead of the aliases defined in
+///     this namespace.
 namespace servicedirectory {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicedirectory/mocks/mock_lookup_connection.h
+++ b/google/cloud/servicedirectory/mocks/mock_lookup_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicedirectory_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace servicedirectory_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicedirectory/mocks/mock_registration_connection.h
+++ b/google/cloud/servicedirectory/mocks/mock_registration_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicedirectory_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace servicedirectory_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicedirectory/registration_client.h
+++ b/google/cloud/servicedirectory/registration_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicedirectory_v1 instead of the aliases defined in
+///     this namespace.
 namespace servicedirectory {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicemanagement/mocks/mock_service_manager_connection.h
+++ b/google/cloud/servicemanagement/mocks/mock_service_manager_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicemanagement_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace servicemanagement_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/servicemanagement/service_manager_client.h
+++ b/google/cloud/servicemanagement/service_manager_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in servicemanagement_v1 instead of the aliases defined in
+///     this namespace.
 namespace servicemanagement {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/serviceusage/mocks/mock_service_usage_connection.h
+++ b/google/cloud/serviceusage/mocks/mock_service_usage_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in serviceusage_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace serviceusage_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/serviceusage/service_usage_client.h
+++ b/google/cloud/serviceusage/service_usage_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in serviceusage_v1 instead of the aliases defined in
+///     this namespace.
 namespace serviceusage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/shell/cloud_shell_client.h
+++ b/google/cloud/shell/cloud_shell_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in shell_v1 instead of the aliases defined in
+///     this namespace.
 namespace shell {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/shell/mocks/mock_cloud_shell_connection.h
+++ b/google/cloud/shell/mocks/mock_cloud_shell_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in shell_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace shell_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/speech/mocks/mock_speech_connection.h
+++ b/google/cloud/speech/mocks/mock_speech_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in speech_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace speech_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/speech/speech_client.h
+++ b/google/cloud/speech/speech_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in speech_v1 instead of the aliases defined in
+///     this namespace.
 namespace speech {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/storagetransfer/mocks/mock_storage_transfer_connection.h
+++ b/google/cloud/storagetransfer/mocks/mock_storage_transfer_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in storagetransfer_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace storagetransfer_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/storagetransfer/storage_transfer_client.h
+++ b/google/cloud/storagetransfer/storage_transfer_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in storagetransfer_v1 instead of the aliases defined in
+///     this namespace.
 namespace storagetransfer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/company_client.h
+++ b/google/cloud/talent/company_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4 instead of the aliases defined in
+///     this namespace.
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/completion_client.h
+++ b/google/cloud/talent/completion_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4 instead of the aliases defined in
+///     this namespace.
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/event_client.h
+++ b/google/cloud/talent/event_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4 instead of the aliases defined in
+///     this namespace.
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/job_client.h
+++ b/google/cloud/talent/job_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4 instead of the aliases defined in
+///     this namespace.
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/mocks/mock_company_connection.h
+++ b/google/cloud/talent/mocks/mock_company_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4_mocks instead of the aliases
+///     defined in this namespace.
 namespace talent_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/mocks/mock_completion_connection.h
+++ b/google/cloud/talent/mocks/mock_completion_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4_mocks instead of the aliases
+///     defined in this namespace.
 namespace talent_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/mocks/mock_event_connection.h
+++ b/google/cloud/talent/mocks/mock_event_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4_mocks instead of the aliases
+///     defined in this namespace.
 namespace talent_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/mocks/mock_job_connection.h
+++ b/google/cloud/talent/mocks/mock_job_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4_mocks instead of the aliases
+///     defined in this namespace.
 namespace talent_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/mocks/mock_tenant_connection.h
+++ b/google/cloud/talent/mocks/mock_tenant_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4_mocks instead of the aliases
+///     defined in this namespace.
 namespace talent_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/talent/tenant_client.h
+++ b/google/cloud/talent/tenant_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in talent_v4 instead of the aliases defined in
+///     this namespace.
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in tasks_v2 instead of the aliases defined in
+///     this namespace.
 namespace tasks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/tasks/mocks/mock_cloud_tasks_connection.h
+++ b/google/cloud/tasks/mocks/mock_cloud_tasks_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in tasks_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace tasks_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/texttospeech/mocks/mock_text_to_speech_connection.h
+++ b/google/cloud/texttospeech/mocks/mock_text_to_speech_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in texttospeech_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace texttospeech_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/texttospeech/text_to_speech_client.h
+++ b/google/cloud/texttospeech/text_to_speech_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in texttospeech_v1 instead of the aliases defined in
+///     this namespace.
 namespace texttospeech {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/tpu/mocks/mock_tpu_connection.h
+++ b/google/cloud/tpu/mocks/mock_tpu_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in tpu_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace tpu_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/tpu/tpu_client.h
+++ b/google/cloud/tpu/tpu_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in tpu_v1 instead of the aliases defined in
+///     this namespace.
 namespace tpu {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/trace/mocks/mock_trace_connection.h
+++ b/google/cloud/trace/mocks/mock_trace_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in trace_v2_mocks instead of the aliases
+///     defined in this namespace.
 namespace trace_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/trace/trace_client.h
+++ b/google/cloud/trace/trace_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in trace_v2 instead of the aliases defined in
+///     this namespace.
 namespace trace {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/translate/mocks/mock_translation_connection.h
+++ b/google/cloud/translate/mocks/mock_translation_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in translate_v3_mocks instead of the aliases
+///     defined in this namespace.
 namespace translate_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/translate/translation_client.h
+++ b/google/cloud/translate/translation_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in translate_v3 instead of the aliases defined in
+///     this namespace.
 namespace translate {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/video/livestream_client.h
+++ b/google/cloud/video/livestream_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in video_livestream_v1 instead of the aliases defined in
+///     this namespace.
 namespace video {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/video/mocks/mock_livestream_connection.h
+++ b/google/cloud/video/mocks/mock_livestream_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in video_livestream_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace video_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/video/mocks/mock_transcoder_connection.h
+++ b/google/cloud/video/mocks/mock_transcoder_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in video_transcoder_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace video_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/video/mocks/mock_video_stitcher_connection.h
+++ b/google/cloud/video/mocks/mock_video_stitcher_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in video_stitcher_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace video_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/video/transcoder_client.h
+++ b/google/cloud/video/transcoder_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in video_transcoder_v1 instead of the aliases defined in
+///     this namespace.
 namespace video {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/video/video_stitcher_client.h
+++ b/google/cloud/video/video_stitcher_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in video_stitcher_v1 instead of the aliases defined in
+///     this namespace.
 namespace video {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/videointelligence/mocks/mock_video_intelligence_connection.h
+++ b/google/cloud/videointelligence/mocks/mock_video_intelligence_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in videointelligence_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace videointelligence_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/videointelligence/video_intelligence_client.h
+++ b/google/cloud/videointelligence/video_intelligence_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in videointelligence_v1 instead of the aliases defined in
+///     this namespace.
 namespace videointelligence {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/vision/image_annotator_client.h
+++ b/google/cloud/vision/image_annotator_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in vision_v1 instead of the aliases defined in
+///     this namespace.
 namespace vision {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/vision/mocks/mock_image_annotator_connection.h
+++ b/google/cloud/vision/mocks/mock_image_annotator_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in vision_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace vision_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/vision/mocks/mock_product_search_connection.h
+++ b/google/cloud/vision/mocks/mock_product_search_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in vision_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace vision_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/vision/product_search_client.h
+++ b/google/cloud/vision/product_search_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in vision_v1 instead of the aliases defined in
+///     this namespace.
 namespace vision {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/vmmigration/mocks/mock_vm_migration_connection.h
+++ b/google/cloud/vmmigration/mocks/mock_vm_migration_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in vmmigration_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace vmmigration_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/vmmigration/vm_migration_client.h
+++ b/google/cloud/vmmigration/vm_migration_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in vmmigration_v1 instead of the aliases defined in
+///     this namespace.
 namespace vmmigration {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/vpcaccess/mocks/mock_vpc_access_connection.h
+++ b/google/cloud/vpcaccess/mocks/mock_vpc_access_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in vpcaccess_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace vpcaccess_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/vpcaccess/vpc_access_client.h
+++ b/google/cloud/vpcaccess/vpc_access_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in vpcaccess_v1 instead of the aliases defined in
+///     this namespace.
 namespace vpcaccess {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/webrisk/mocks/mock_web_risk_connection.h
+++ b/google/cloud/webrisk/mocks/mock_web_risk_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in webrisk_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace webrisk_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/webrisk/web_risk_client.h
+++ b/google/cloud/webrisk/web_risk_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in webrisk_v1 instead of the aliases defined in
+///     this namespace.
 namespace webrisk {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/websecurityscanner/mocks/mock_web_security_scanner_connection.h
+++ b/google/cloud/websecurityscanner/mocks/mock_web_security_scanner_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in websecurityscanner_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace websecurityscanner_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/websecurityscanner/web_security_scanner_client.h
+++ b/google/cloud/websecurityscanner/web_security_scanner_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in websecurityscanner_v1 instead of the aliases defined in
+///     this namespace.
 namespace websecurityscanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/workflows/executions_client.h
+++ b/google/cloud/workflows/executions_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in workflows_executions_v1 instead of the aliases defined
+///     in this namespace.
 namespace workflows {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/workflows/mocks/mock_executions_connection.h
+++ b/google/cloud/workflows/mocks/mock_executions_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in workflows_executions_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace workflows_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/workflows/mocks/mock_workflows_connection.h
+++ b/google/cloud/workflows/mocks/mock_workflows_connection.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in workflows_v1_mocks instead of the aliases
+///     defined in this namespace.
 namespace workflows_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/workflows/workflows_client.h
+++ b/google/cloud/workflows/workflows_client.h
@@ -24,6 +24,9 @@
 
 namespace google {
 namespace cloud {
+/// @deprecated This namespace exists for backwards compatibility. Use the
+///     types defined in workflows_v1 instead of the aliases defined in
+///     this namespace.
 namespace workflows {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Fixes #10782 

Generates docs like [10782_kms_forwarding_ns.pdf](https://github.com/googleapis/google-cloud-cpp/files/11025581/10782_kms_forwarding_ns.pdf)

Note that doxygen concatenates the comments for these namespaces. It's unfortunate, but this is the best we can do without adding a generator flag to coordinate across `ServiceConfiguration`s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11074)
<!-- Reviewable:end -->
