### PR TITLE
impl(otel): `StreamingReadRpcTracing`

### DIFF
--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -69,6 +69,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/setup_context.h",
     "internal/streaming_read_rpc.h",
     "internal/streaming_read_rpc_logging.h",
+    "internal/streaming_read_rpc_tracing.h",
     "internal/streaming_write_rpc.h",
     "internal/streaming_write_rpc_impl.h",
     "internal/streaming_write_rpc_logging.h",

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -90,6 +90,7 @@ add_library(
     internal/streaming_read_rpc.cc
     internal/streaming_read_rpc.h
     internal/streaming_read_rpc_logging.h
+    internal/streaming_read_rpc_tracing.h
     internal/streaming_write_rpc.h
     internal/streaming_write_rpc_impl.cc
     internal/streaming_write_rpc_impl.h
@@ -262,6 +263,7 @@ if (BUILD_TESTING)
         internal/routing_matcher_test.cc
         internal/streaming_read_rpc_logging_test.cc
         internal/streaming_read_rpc_test.cc
+        internal/streaming_read_rpc_tracing_test.cc
         internal/streaming_write_rpc_logging_test.cc
         internal/streaming_write_rpc_test.cc
         internal/time_utils_test.cc

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -53,6 +53,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/routing_matcher_test.cc",
     "internal/streaming_read_rpc_logging_test.cc",
     "internal/streaming_read_rpc_test.cc",
+    "internal/streaming_read_rpc_tracing_test.cc",
     "internal/streaming_write_rpc_logging_test.cc",
     "internal/streaming_write_rpc_test.cc",
     "internal/time_utils_test.cc",

--- a/google/cloud/internal/streaming_read_rpc_tracing.h
+++ b/google/cloud/internal/streaming_read_rpc_tracing.h
@@ -43,8 +43,8 @@ class StreamingReadRpcTracing : public StreamingReadRpc<ResponseType> {
   ~StreamingReadRpcTracing() override { (void)End(Status()); }
 
   void Cancel() override {
-    impl_->Cancel();
     span_->AddEvent("cancel");
+    impl_->Cancel();
   }
 
   absl::variant<Status, ResponseType> Read() override {

--- a/google/cloud/internal/streaming_read_rpc_tracing.h
+++ b/google/cloud/internal/streaming_read_rpc_tracing.h
@@ -1,0 +1,82 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_TRACING_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_TRACING_H
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/grpc_opentelemetry.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/streaming_read_rpc.h"
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+/**
+ * Tracing decorator for StreamingReadRpc.
+ */
+template <typename ResponseType>
+class StreamingReadRpcTracing : public StreamingReadRpc<ResponseType> {
+ public:
+  explicit StreamingReadRpcTracing(
+      std::shared_ptr<grpc::ClientContext> context,
+      std::unique_ptr<StreamingReadRpc<ResponseType>> impl,
+      opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span)
+      : context_(std::move(context)),
+        impl_(std::move(impl)),
+        span_(std::move(span)) {}
+  ~StreamingReadRpcTracing() override { (void)End(Status()); }
+
+  void Cancel() override {
+    impl_->Cancel();
+    span_->AddEvent("cancel");
+  }
+
+  absl::variant<Status, ResponseType> Read() override {
+    auto result = impl_->Read();
+    if (absl::holds_alternative<Status>(result)) {
+      return End(absl::get<Status>(result));
+    }
+    span_->AddEvent("message", {{"message.type", "RECEIVED"},
+                                {"message.id", ++read_count_}});
+    return result;
+  }
+
+  StreamingRpcMetadata GetRequestMetadata() const override {
+    return impl_->GetRequestMetadata();
+  }
+
+ private:
+  Status End(Status const& s) {
+    if (!context_) return s;
+    return EndSpan(*std::move(context_), *std::move(span_), s);
+  }
+
+  std::shared_ptr<grpc::ClientContext> context_;
+  std::unique_ptr<StreamingReadRpc<ResponseType>> impl_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span_;
+  int read_count_ = 0;
+};
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_TRACING_H

--- a/google/cloud/internal/streaming_read_rpc_tracing_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_tracing_test.cc
@@ -1,0 +1,153 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/streaming_read_rpc_tracing.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::EventNamed;
+using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::SpanEventAttributesAre;
+using ::google::cloud::testing_util::SpanHasAttributes;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Pair;
+using ::testing::Return;
+
+template <typename ResponseType>
+class MockStreamingReadRpc : public StreamingReadRpc<ResponseType> {
+ public:
+  ~MockStreamingReadRpc() override = default;
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD((absl::variant<Status, ResponseType>), Read, (), (override));
+  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+};
+
+void VerifyStream(StreamingReadRpc<int>& stream,
+                  std::vector<int> const& expected_values,
+                  Status const& expected_status) {
+  std::vector<int> values;
+  for (;;) {
+    auto v = stream.Read();
+    if (absl::holds_alternative<int>(v)) {
+      values.push_back(absl::get<int>(std::move(v)));
+      continue;
+    }
+    EXPECT_EQ(absl::get<Status>(std::move(v)), expected_status);
+    break;
+  }
+  EXPECT_EQ(values, expected_values);
+}
+
+TEST(StreamingReadRpcTracingTest, Cancel) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto mock = absl::make_unique<MockStreamingReadRpc<int>>();
+  EXPECT_CALL(*mock, Cancel).Times(1);
+  EXPECT_CALL(*mock, Read).WillOnce(Return(Status()));
+
+  auto span = MakeSpan("span");
+  StreamingReadRpcTracing<int> stream(std::make_shared<grpc::ClientContext>(),
+                                      std::move(mock), span);
+  stream.Cancel();
+  VerifyStream(stream, {}, Status());
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, ElementsAre(AllOf(SpanNamed("span"),
+                                       SpanEventsAre(EventNamed("cancel")))));
+}
+
+TEST(StreamingReadRpcTracingTest, Read) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto mock = absl::make_unique<MockStreamingReadRpc<int>>();
+  EXPECT_CALL(*mock, Read)
+      .WillOnce(Return(100))
+      .WillOnce(Return(200))
+      .WillOnce(Return(300))
+      .WillOnce(Return(Status()));
+
+  auto span = MakeSpan("span");
+  StreamingReadRpcTracing<int> stream(std::make_shared<grpc::ClientContext>(),
+                                      std::move(mock), span);
+  VerifyStream(stream, {100, 200, 300}, Status());
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanNamed("span"),
+          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)),
+          SpanEventsAre(
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "RECEIVED"),
+                        SpanAttribute<int>("message.id", 1))),
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "RECEIVED"),
+                        SpanAttribute<int>("message.id", 2))),
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "RECEIVED"),
+                        SpanAttribute<int>("message.id", 3)))))));
+}
+
+TEST(StreamingReadRpcTracingTest, GetRequestMetadata) {
+  auto mock = absl::make_unique<MockStreamingReadRpc<int>>();
+  EXPECT_CALL(*mock, GetRequestMetadata)
+      .WillOnce(Return(StreamingRpcMetadata{{"key", "value"}}));
+
+  auto span = MakeSpan("span");
+  StreamingReadRpcTracing<int> stream(std::make_shared<grpc::ClientContext>(),
+                                      std::move(mock), span);
+  auto md = stream.GetRequestMetadata();
+  EXPECT_THAT(md, ElementsAre(Pair("key", "value")));
+}
+
+TEST(StreamingReadRpcTracingTest, SpanEndsOnDestruction) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  {
+    auto mock = absl::make_unique<MockStreamingReadRpc<int>>();
+    auto span = MakeSpan("span");
+    StreamingReadRpcTracing<int> stream(std::make_shared<grpc::ClientContext>(),
+                                        std::move(mock), span);
+
+    auto spans = span_catcher->GetSpans();
+    EXPECT_THAT(spans, IsEmpty());
+  }
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, ElementsAre(SpanNamed("span")));
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -42,6 +42,12 @@ MATCHER_P(SpanAttributesImpl, matcher,
                                        result_listener);
 }
 
+MATCHER_P(EventAttributesImpl, matcher,
+          ::testing::DescribeMatcher<SpanAttributeMap>(matcher)) {
+  return ::testing::ExplainMatchResult(matcher, arg.GetAttributes(),
+                                       result_listener);
+}
+
 }  // namespace testing_util_internal
 namespace testing_util {
 
@@ -113,6 +119,31 @@ template <typename T>
     std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>>
 SpanAttribute(std::string const& key, ::testing::Matcher<T const&> matcher) {
   return ::testing::Pair(key, ::testing::VariantWith<T>(matcher));
+}
+
+MATCHER_P(EventNamed, name, "has name: " + std::string{name}) {
+  auto const& actual = arg.GetName();
+  *result_listener << "has name: " << actual;
+  return actual == name;
+}
+
+template <typename... Args>
+::testing::Matcher<opentelemetry::sdk::trace::SpanDataEvent>
+SpanEventAttributesAre(Args const&... matchers) {
+  return testing_util_internal::EventAttributesImpl(
+      ::testing::UnorderedElementsAre(matchers...));
+}
+
+MATCHER_P(SpanEventsAreImpl, matcher,
+          ::testing::DescribeMatcher<
+              std::vector<opentelemetry::sdk::trace::SpanDataEvent>>(matcher)) {
+  return ::testing::ExplainMatchResult(matcher, arg->GetEvents(),
+                                       result_listener);
+}
+
+template <typename... Args>
+::testing::Matcher<SpanDataPtr> SpanEventsAre(Args const&... matchers) {
+  return SpanEventsAreImpl(::testing::ElementsAre(matchers...));
 }
 
 /**


### PR DESCRIPTION
Part of the work for #10619 

The event names follow this convention: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/rpc/#events

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11075)
<!-- Reviewable:end -->
