### PR TITLE
impl(otel): call context across async streaming reads

### DIFF
--- a/google/cloud/internal/async_streaming_read_rpc_impl.h
+++ b/google/cloud/internal/async_streaming_read_rpc_impl.h
@@ -18,8 +18,8 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/async_streaming_read_rpc.h"
+#include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/completion_queue_impl.h"
-#include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
 #include "absl/types/optional.h"
@@ -54,9 +54,9 @@ class AsyncStreamingReadRpcImpl : public AsyncStreamingReadRpc<Response> {
   future<bool> Start() override {
     struct OnStart : public AsyncGrpcOperation {
       promise<bool> p;
-      Options options = CurrentOptions();
+      CallContext call_context;
       bool Notify(bool ok) override {
-        OptionsSpan span(options);
+        ScopedCallContext scope(call_context);
         p.set_value(ok);
         return true;
       }
@@ -71,9 +71,9 @@ class AsyncStreamingReadRpcImpl : public AsyncStreamingReadRpc<Response> {
     struct OnRead : public AsyncGrpcOperation {
       promise<absl::optional<Response>> p;
       Response response;
-      Options options = CurrentOptions();
+      CallContext call_context;
       bool Notify(bool ok) override {
-        OptionsSpan span(options);
+        ScopedCallContext scope(call_context);
         if (!ok) {
           p.set_value({});
           return true;
@@ -92,10 +92,10 @@ class AsyncStreamingReadRpcImpl : public AsyncStreamingReadRpc<Response> {
   future<Status> Finish() override {
     struct OnFinish : public AsyncGrpcOperation {
       promise<Status> p;
-      Options options = CurrentOptions();
+      CallContext call_context;
       grpc::Status status;
       bool Notify(bool /*ok*/) override {
-        OptionsSpan span(options);
+        ScopedCallContext scope(call_context);
         p.set_value(MakeStatusFromRpcError(std::move(status)));
         return true;
       }

--- a/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
@@ -16,7 +16,9 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <deque>
@@ -32,6 +34,7 @@ namespace {
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::testing::Return;
+using ::testing::SizeIs;
 
 struct FakeRequest {
   std::string key;
@@ -123,14 +126,14 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
     EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "start");
     return f.get();
   });
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan start_clear(Options{});
   notify_next_op();
   EXPECT_TRUE(start.get());
 
   OptionsSpan read0_span(user_project("read0"));
   auto read0 = stream->Read().then(check_read_span("read0"));
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan read0_clear(Options{});
   notify_next_op();
   auto response0 = read0.get();
@@ -140,7 +143,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
 
   OptionsSpan read1_span(user_project("read1"));
   auto read1 = stream->Read().then(check_read_span("read1"));
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan read1_clear(Options{});
   notify_next_op(false);
   auto response1 = read1.get();
@@ -151,7 +154,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
     EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "finish");
     return f.get();
   });
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan finish_clear(Options{});
   notify_next_op();
   EXPECT_THAT(finish.get(), IsOk());
@@ -167,6 +170,97 @@ TEST(AsyncStreamingReadRpcTest, Error) {
   EXPECT_EQ(Status(StatusCode::kPermissionDenied, "uh-oh"),
             stream.Finish().get());
 }
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+using ::google::cloud::testing_util::IsActive;
+
+TEST(AsyncStreamingReadRpcTest, SpanActiveAcrossAsyncGrpcOperations) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  MockStub mock;
+  EXPECT_CALL(mock, FakeRpc)
+      .WillOnce([](grpc::ClientContext*, FakeRequest const&,
+                   grpc::CompletionQueue*) {
+        auto stream = absl::make_unique<MockReader>();
+        EXPECT_CALL(*stream, StartCall).Times(1);
+        EXPECT_CALL(*stream, Read).Times(1);
+        EXPECT_CALL(*stream, Finish).WillOnce([](grpc::Status* status, void*) {
+          *status = grpc::Status::OK;
+        });
+        return stream;
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(nullptr));
+
+  std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
+  auto notify_next_op = [&](bool ok = true) {
+    auto op = std::move(operations.front());
+    operations.pop_front();
+    op->Notify(ok);
+  };
+
+  EXPECT_CALL(*mock_cq, StartOperation)
+      .WillRepeatedly([&operations](std::shared_ptr<AsyncGrpcOperation> op,
+                                    absl::FunctionRef<void(void*)> call) {
+        void* tag = op.get();
+        operations.push_back(std::move(op));
+        call(tag);
+      });
+
+  google::cloud::CompletionQueue cq(mock_cq);
+
+  auto stream = [&] {
+    auto span = MakeSpan("create");
+    auto scope = opentelemetry::trace::Scope(span);
+    return MakeStreamingReadRpc<FakeRequest, FakeResponse>(
+        cq, std::make_shared<grpc::ClientContext>(), FakeRequest{},
+        [&mock, span](grpc::ClientContext* context, FakeRequest const& request,
+                      grpc::CompletionQueue* cq) {
+          EXPECT_THAT(span, IsActive());
+          return mock.FakeRpc(context, request, cq);
+        });
+  }();
+
+  auto start = [&] {
+    auto span = MakeSpan("start");
+    auto scope = opentelemetry::trace::Scope(span);
+    return stream->Start().then([span](auto f) {
+      EXPECT_THAT(span, IsActive());
+      return f.get();
+    });
+  }();
+  ASSERT_THAT(operations, SizeIs(1));
+  notify_next_op();
+  (void)start.get();
+
+  auto read = [&] {
+    auto span = MakeSpan("read");
+    auto scope = opentelemetry::trace::Scope(span);
+    return stream->Read().then([span](auto f) {
+      EXPECT_THAT(span, IsActive());
+      return f.get();
+    });
+  }();
+  ASSERT_THAT(operations, SizeIs(1));
+  notify_next_op();
+  (void)read.get();
+
+  auto finish = [&] {
+    auto span = MakeSpan("finish");
+    auto scope = opentelemetry::trace::Scope(span);
+    return stream->Finish().then([span](auto f) {
+      EXPECT_THAT(span, IsActive());
+      return f.get();
+    });
+  }();
+  ASSERT_THAT(operations, SizeIs(1));
+  notify_next_op();
+  (void)finish.get();
+}
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
Part of the work for #10619

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11076)
<!-- Reviewable:end -->
