### PR TITLE
impl(otel): call context across async streaming read writes

### DIFF
--- a/google/cloud/internal/async_read_write_stream_impl.h
+++ b/google/cloud/internal/async_read_write_stream_impl.h
@@ -56,9 +56,9 @@ class AsyncStreamingReadWriteRpcImpl
   future<bool> Start() override {
     struct OnStart : public AsyncGrpcOperation {
       promise<bool> p;
-      Options options_ = CurrentOptions();
+      CallContext call_context;
       bool Notify(bool ok) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context);
         p.set_value(ok);
         return true;
       }
@@ -73,9 +73,9 @@ class AsyncStreamingReadWriteRpcImpl
     struct OnRead : public AsyncGrpcOperation {
       promise<absl::optional<Response>> p;
       Response response;
-      Options options_ = CurrentOptions();
+      CallContext call_context;
       bool Notify(bool ok) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context);
         if (!ok) {
           p.set_value({});
           return true;
@@ -95,9 +95,9 @@ class AsyncStreamingReadWriteRpcImpl
                      grpc::WriteOptions options) override {
     struct OnWrite : public AsyncGrpcOperation {
       promise<bool> p;
-      Options options_ = CurrentOptions();
+      CallContext call_context;
       bool Notify(bool ok) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context);
         p.set_value(ok);
         return true;
       }
@@ -113,9 +113,9 @@ class AsyncStreamingReadWriteRpcImpl
   future<bool> WritesDone() override {
     struct OnWritesDone : public AsyncGrpcOperation {
       promise<bool> p;
-      Options options_ = CurrentOptions();
+      CallContext call_context;
       bool Notify(bool ok) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context);
         p.set_value(ok);
         return true;
       }
@@ -129,10 +129,10 @@ class AsyncStreamingReadWriteRpcImpl
   future<Status> Finish() override {
     struct OnFinish : public AsyncGrpcOperation {
       promise<Status> p;
-      Options options_ = CurrentOptions();
+      CallContext call_context;
       grpc::Status status;
       bool Notify(bool /*ok*/) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context);
         p.set_value(MakeStatusFromRpcError(std::move(status)));
         return true;
       }

--- a/google/cloud/internal/async_read_write_stream_impl_test.cc
+++ b/google/cloud/internal/async_read_write_stream_impl_test.cc
@@ -15,7 +15,9 @@
 #include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
@@ -33,6 +35,7 @@ using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::testing::_;
 using ::testing::Return;
+using ::testing::SizeIs;
 
 struct FakeRequest {
   std::string key;
@@ -120,17 +123,18 @@ TEST(AsyncReadWriteStreamingRpcTest, Basic) {
       });
 
   auto start = stream->Start();
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   notify_next_op();
   EXPECT_TRUE(start.get());
 
   auto write = stream->Write(FakeRequest{"key0"},
                              grpc::WriteOptions().set_last_message());
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   notify_next_op();
+  EXPECT_TRUE(write.get());
 
   auto read0 = stream->Read();
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   notify_next_op();
   auto response0 = read0.get();
   ASSERT_TRUE(response0.has_value());
@@ -138,7 +142,7 @@ TEST(AsyncReadWriteStreamingRpcTest, Basic) {
   EXPECT_EQ("value0_0", response0->value);
 
   auto read1 = stream->Read();
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   notify_next_op();
   auto response1 = read1.get();
   ASSERT_TRUE(response1.has_value());
@@ -146,17 +150,18 @@ TEST(AsyncReadWriteStreamingRpcTest, Basic) {
   EXPECT_EQ("value0_1", response1->value);
 
   auto writes_done = stream->WritesDone();
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   notify_next_op();
+  EXPECT_TRUE(writes_done.get());
 
   auto read2 = stream->Read();
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   notify_next_op(false);
   auto response2 = read2.get();
   EXPECT_FALSE(response2.has_value());
 
   auto finish = stream->Finish();
-  ASSERT_EQ(1, operations.size());
+  ASSERT_THAT(operations, SizeIs(1));
   notify_next_op();
   EXPECT_THAT(finish.get(), IsOk());
 }
@@ -173,6 +178,123 @@ TEST(AsyncReadWriteStreamingRpcTest, Error) {
   EXPECT_EQ(Status(StatusCode::kPermissionDenied, "uh-oh"),
             stream.Finish().get());
 }
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+using ::google::cloud::testing_util::IsActive;
+
+TEST(AsyncReadWriteStreamingRpcTest, SpanActiveAcrossAsyncGrpcOperations) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  MockStub mock;
+  EXPECT_CALL(mock, FakeRpc)
+      .WillOnce([](grpc::ClientContext*, grpc::CompletionQueue*) {
+        auto stream = absl::make_unique<MockReaderWriter>();
+        EXPECT_CALL(*stream, StartCall).Times(1);
+        EXPECT_CALL(*stream, Write(_, _, _)).Times(1);
+        EXPECT_CALL(*stream, Read).Times(1);
+        EXPECT_CALL(*stream, WritesDone).Times(1);
+        EXPECT_CALL(*stream, Finish).WillOnce([](grpc::Status* status, void*) {
+          *status = grpc::Status::OK;
+        });
+        return stream;
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(Return(nullptr));
+
+  std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
+  auto notify_next_op = [&](bool ok = true) {
+    auto op = std::move(operations.front());
+    operations.pop_front();
+    op->Notify(ok);
+  };
+
+  EXPECT_CALL(*mock_cq, StartOperation)
+      .WillRepeatedly([&operations](std::shared_ptr<AsyncGrpcOperation> op,
+                                    absl::FunctionRef<void(void*)> call) {
+        void* tag = op.get();
+        operations.push_back(std::move(op));
+        call(tag);
+      });
+
+  google::cloud::CompletionQueue cq(mock_cq);
+
+  auto stream = [&] {
+    auto span = MakeSpan("create");
+    auto scope = opentelemetry::trace::Scope(span);
+    return MakeStreamingReadWriteRpc<FakeRequest, FakeResponse>(
+        cq, std::make_shared<grpc::ClientContext>(),
+        [&mock, span](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
+          EXPECT_THAT(span, IsActive());
+          return mock.FakeRpc(context, cq);
+        });
+  }();
+
+  auto start = [&] {
+    auto span = MakeSpan("start");
+    auto scope = opentelemetry::trace::Scope(span);
+    return stream->Start().then([span](auto f) {
+      EXPECT_THAT(span, IsActive());
+      return f.get();
+    });
+  }();
+  ASSERT_THAT(operations, SizeIs(1));
+  notify_next_op();
+  (void)start.get();
+
+  auto write = [&] {
+    auto span = MakeSpan("start");
+    auto scope = opentelemetry::trace::Scope(span);
+    return stream
+        ->Write(FakeRequest{"key0"}, grpc::WriteOptions().set_last_message())
+        .then([span](auto f) {
+          EXPECT_THAT(span, IsActive());
+          return f.get();
+        });
+  }();
+  ASSERT_THAT(operations, SizeIs(1));
+  notify_next_op();
+  (void)write.get();
+
+  auto read = [&] {
+    auto span = MakeSpan("read");
+    auto scope = opentelemetry::trace::Scope(span);
+    return stream->Read().then([span](auto f) {
+      EXPECT_THAT(span, IsActive());
+      return f.get();
+    });
+  }();
+  ASSERT_THAT(operations, SizeIs(1));
+  notify_next_op();
+  (void)read.get();
+
+  auto writes_done = [&] {
+    auto span = MakeSpan("start");
+    auto scope = opentelemetry::trace::Scope(span);
+    return stream->WritesDone().then([span](auto f) {
+      EXPECT_THAT(span, IsActive());
+      return f.get();
+    });
+  }();
+  ASSERT_THAT(operations, SizeIs(1));
+  notify_next_op();
+  (void)writes_done.get();
+
+  auto finish = [&] {
+    auto span = MakeSpan("finish");
+    auto scope = opentelemetry::trace::Scope(span);
+    return stream->Finish().then([span](auto f) {
+      EXPECT_THAT(span, IsActive());
+      return f.get();
+    });
+  }();
+  ASSERT_THAT(operations, SizeIs(1));
+  notify_next_op();
+  (void)finish.get();
+}
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
Part of the work for #10619

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11090)
<!-- Reviewable:end -->
