### PR TITLE
impl(docfx): generate metadata file

### DIFF
--- a/docfx/BUILD.bazel
+++ b/docfx/BUILD.bazel
@@ -31,6 +31,7 @@ cc_library(
     }),
     deps = [
         "@com_github_jbeder_yaml_cpp//:yaml-cpp",
+        "@com_github_nlohmann_json//:nlohmann_json",
         "@com_github_zeux_pugixml//:pugixml",
     ],
 )

--- a/docfx/CMakeLists.txt
+++ b/docfx/CMakeLists.txt
@@ -37,6 +37,8 @@ add_library(
     doxygen2toc.h
     doxygen_pages.cc
     doxygen_pages.h
+    generate_metadata.cc
+    generate_metadata.h
     parse_arguments.cc
     parse_arguments.h
     toc_entry.cc
@@ -64,7 +66,7 @@ endif ()
 set(unit_tests
     # cmake-format: sort
     doxygen2markdown_test.cc doxygen2toc_test.cc doxygen_pages_test.cc
-    parse_arguments_test.cc)
+    generate_metadata_test.cc parse_arguments_test.cc)
 
 # Export the list of unit tests to a .bzl file so we do not need to maintain the
 # list in two places.

--- a/docfx/docfx.bzl
+++ b/docfx/docfx.bzl
@@ -21,6 +21,7 @@ docfx_hdrs = [
     "doxygen2markdown.h",
     "doxygen2toc.h",
     "doxygen_pages.h",
+    "generate_metadata.h",
     "parse_arguments.h",
     "toc_entry.h",
 ]
@@ -29,6 +30,7 @@ docfx_srcs = [
     "doxygen2markdown.cc",
     "doxygen2toc.cc",
     "doxygen_pages.cc",
+    "generate_metadata.cc",
     "parse_arguments.cc",
     "toc_entry.cc",
 ]

--- a/docfx/doxygen2toc_test.cc
+++ b/docfx/doxygen2toc_test.cc
@@ -49,7 +49,7 @@ TEST(Doxygen2Toc, Simple) {
 
   pugi::xml_document doc;
   ASSERT_TRUE(doc.load_string(kXml));
-  auto const config = Config{"test-only-no-input-file", "common"};
+  auto const config = Config{"test-only-no-input-file", "common", "4.2"};
   auto const actual = Doxygen2Toc(config, doc);
 
   EXPECT_EQ(kExpected, actual);

--- a/docfx/generate_metadata.cc
+++ b/docfx/generate_metadata.cc
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
-#define GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
-
-#include <string>
+#include "docfx/generate_metadata.h"
+#include <nlohmann/json.hpp>
 
 namespace docfx {
 
-struct Config {
-  std::string input_filename;
-  std::string library;
-  std::string version;
-};
+std::string GenerateMetadata(docfx::Config const& config) {
+  auto const json = nlohmann::json{
+      {"language", "cpp"},
+      {"version", config.version},
+      {"name", config.library},
+  };
+  return json.dump(4) + "\n";
+}
 
 }  // namespace docfx
-
-#endif  // GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H

--- a/docfx/generate_metadata.h
+++ b/docfx/generate_metadata.h
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
-#define GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
+#ifndef GOOGLE_CLOUD_CPP_DOCFX_GENERATE_METADATA_H
+#define GOOGLE_CLOUD_CPP_DOCFX_GENERATE_METADATA_H
 
+#include "docfx/config.h"
 #include <string>
 
 namespace docfx {
 
-struct Config {
-  std::string input_filename;
-  std::string library;
-  std::string version;
-};
+std::string GenerateMetadata(Config const& config);
 
 }  // namespace docfx
 
-#endif  // GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
+#endif  // GOOGLE_CLOUD_CPP_DOCFX_GENERATE_METADATA_H

--- a/docfx/generate_metadata_test.cc
+++ b/docfx/generate_metadata_test.cc
@@ -14,5 +14,23 @@
 
 #include "docfx/generate_metadata.h"
 #include <gmock/gmock.h>
+#include <nlohmann/json.hpp>
 
-namespace docfx {}  // namespace docfx
+namespace docfx {
+namespace {
+
+TEST(GenerateMetadata, Basic) {
+  auto const config = Config{"test-only-input-filename", "test-only-library",
+                             "test-only-version"};
+  auto const generated = GenerateMetadata(config);
+  auto const actual = nlohmann::json::parse(generated);
+  auto const expected = nlohmann::json{
+      {"language", "cpp"},
+      {"name", "test-only-library"},
+      {"version", "test-only-version"},
+  };
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace
+}  // namespace docfx

--- a/docfx/generate_metadata_test.cc
+++ b/docfx/generate_metadata_test.cc
@@ -12,19 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
-#define GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
+#include "docfx/generate_metadata.h"
+#include <gmock/gmock.h>
 
-#include <string>
-
-namespace docfx {
-
-struct Config {
-  std::string input_filename;
-  std::string library;
-  std::string version;
-};
-
-}  // namespace docfx
-
-#endif  // GOOGLE_CLOUD_CPP_DOCFX_CONFIG_H
+namespace docfx {}  // namespace docfx

--- a/docfx/parse_arguments.cc
+++ b/docfx/parse_arguments.cc
@@ -23,7 +23,7 @@ namespace {
 
 std::string Usage(std::string const& cmd) {
   std::ostringstream os;
-  os << "Usage: " << cmd << " <infile> <library>";
+  os << "Usage: " << cmd << " <infile> <library> <version>";
   return std::move(os).str();
 }
 
@@ -35,8 +35,11 @@ Config ParseArguments(std::vector<std::string> const& args) {
     std::cout << Usage(args[0]) << "\n";
     std::exit(0);
   }
-  if (args.size() != 3) throw std::runtime_error(Usage(args[0]));
-  return Config{args[1], args[2]};
+  if (args.size() != 4) throw std::runtime_error(Usage(args[0]));
+  // It is tempting to use google::cloud::version_string(), but sometimes the
+  // tool may be used to generate documentation for older versions of the
+  // library.
+  return Config{args[1], args[2], args[3]};
 }
 
 }  // namespace docfx

--- a/docfx/parse_arguments_test.cc
+++ b/docfx/parse_arguments_test.cc
@@ -19,10 +19,15 @@
 namespace docfx {
 namespace {
 
+using ::testing::StartsWith;
+
+auto constexpr kExpectedUsageCmd = "Usage: cmd <infile> <library> <version>";
+
 TEST(ParseArguments, Basic) {
-  auto const actual = ParseArguments({"cmd", "input-file", "library"});
+  auto const actual = ParseArguments({"cmd", "input-file", "library", "4.2"});
   EXPECT_EQ(actual.input_filename, "input-file");
   EXPECT_EQ(actual.library, "library");
+  EXPECT_EQ(actual.version, "4.2");
 }
 
 TEST(ParseArguments, Help) {
@@ -36,8 +41,8 @@ TEST(ParseArguments, Help) {
 TEST(ParseArguments, NoCommand) {
   EXPECT_THROW(
       try { ParseArguments({}); } catch (std::exception const& ex) {
-        EXPECT_STREQ(ex.what(),
-                     "Usage: program-name-missing <infile> <library>");
+        EXPECT_THAT(ex.what(),
+                    StartsWith("Usage: program-name-missing <infile> "));
         throw;
       },
       std::runtime_error);
@@ -46,7 +51,7 @@ TEST(ParseArguments, NoCommand) {
 TEST(ParseArguments, NoArguments) {
   EXPECT_THROW(
       try { ParseArguments({"cmd"}); } catch (std::exception const& ex) {
-        EXPECT_STREQ(ex.what(), "Usage: cmd <infile> <library>");
+        EXPECT_THAT(ex.what(), StartsWith(kExpectedUsageCmd));
         throw;
       },
       std::runtime_error);
@@ -57,7 +62,7 @@ TEST(ParseArguments, TooFewArguments) {
       try {
         ParseArguments({"cmd", "1"});
       } catch (std::exception const& ex) {
-        EXPECT_STREQ(ex.what(), "Usage: cmd <infile> <library>");
+        EXPECT_THAT(ex.what(), StartsWith(kExpectedUsageCmd));
         throw;
       },
       std::runtime_error);
@@ -66,9 +71,9 @@ TEST(ParseArguments, TooFewArguments) {
 TEST(ParseArguments, TooManyArguments) {
   EXPECT_THROW(
       try {
-        ParseArguments({"cmd", "1", "2", "3"});
+        ParseArguments({"cmd", "1", "2", "3", "4"});
       } catch (std::exception const& ex) {
-        EXPECT_STREQ(ex.what(), "Usage: cmd <infile> <library>");
+        EXPECT_THAT(ex.what(), StartsWith(kExpectedUsageCmd));
         throw;
       },
       std::runtime_error);

--- a/docfx/unit_tests.bzl
+++ b/docfx/unit_tests.bzl
@@ -20,5 +20,6 @@ unit_tests = [
     "doxygen2markdown_test.cc",
     "doxygen2toc_test.cc",
     "doxygen_pages_test.cc",
+    "generate_metadata_test.cc",
     "parse_arguments_test.cc",
 ]


### PR DESCRIPTION
The DocFX generator requires a small "docs.metadata.json" file describing the programming language, library name, and version.

Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11093)
<!-- Reviewable:end -->
