### PR TITLE
impl(docfx): support `briefdescription` elements

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -162,7 +162,7 @@ bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
   return true;
 }
 
-// A "detaileddescription" node type is defined as:
+// All "*description" nodes have this type:
 //
 // clang-format off
 //   <xsd:complexType name="descriptionType" mixed="true">
@@ -174,9 +174,8 @@ bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
 //     </xsd:sequence>
 //   </xsd:complexType>
 // clang-format on
-bool AppendIfDetailedDescription(std::ostream& os, MarkdownContext const& ctx,
-                                 pugi::xml_node const& node) {
-  if (std::string_view{node.name()} != "detaileddescription") return false;
+void AppendDescriptionType(std::ostream& os, MarkdownContext const& ctx,
+                           pugi::xml_node const& node) {
   for (auto const& child : node) {
     // Unexpected: title, internal -> we do not use this...
     if (AppendIfParagraph(os, ctx, child)) continue;
@@ -189,6 +188,19 @@ bool AppendIfDetailedDescription(std::ostream& os, MarkdownContext const& ctx,
     if (AppendIfSect4(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
+}
+
+bool AppendIfDetailedDescription(std::ostream& os, MarkdownContext const& ctx,
+                                 pugi::xml_node const& node) {
+  if (std::string_view{node.name()} != "detaileddescription") return false;
+  AppendDescriptionType(os, ctx, node);
+  return true;
+}
+
+bool AppendIfBriefDescription(std::ostream& os, MarkdownContext const& ctx,
+                              pugi::xml_node const& node) {
+  if (std::string_view{node.name()} != "briefdescription") return false;
+  AppendDescriptionType(os, ctx, node);
   return true;
 }
 

--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -60,9 +60,17 @@ bool AppendIfSect2(std::ostream& os, MarkdownContext const& ctx,
 bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
                    pugi::xml_node const& node);
 
+/// Outputs a description node.
+void AppendDescriptionType(std::ostream& os, MarkdownContext const& ctx,
+                           pugi::xml_node const& node);
+
 /// Handles a detailed description node.
 bool AppendIfDetailedDescription(std::ostream& os, MarkdownContext const& ctx,
                                  pugi::xml_node const& node);
+
+/// Handles a brief description node.
+bool AppendIfBriefDescription(std::ostream& os, MarkdownContext const& ctx,
+                              pugi::xml_node const& node);
 
 /**
  * Handle plain text nodes.

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -234,6 +234,26 @@ Second paragraph (4).)md";
   EXPECT_EQ(kExpected, os.str());
 }
 
+TEST(Doxygen2Markdown, BriefDescription) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <briefdescription id='tested-node'>
+          <para>This is <bold>not</bold> too detailed.</para>
+        </briefdescription>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"md(
+
+This is **not** too detailed.)md";
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//*[@id='tested-node']");
+  ASSERT_TRUE(selected);
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfBriefDescription(os, {}, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
+}
+
 TEST(Doxygen2Markdown, PlainText) {
   pugi::xml_document doc;
   doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>


### PR DESCRIPTION
Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11094)
<!-- Reviewable:end -->
