### PR TITLE
feat: consume less entropy for PRNG

### DIFF
--- a/google/cloud/internal/random.h
+++ b/google/cloud/internal/random.h
@@ -36,27 +36,20 @@ std::vector<unsigned int> FetchEntropy(std::size_t desired_bits);
 // in particular.
 using DefaultPRNG = std::mt19937_64;
 
-/**
- * Initialize any of the C++11 PRNGs in `<random>` using std::random_device.
- */
-template <typename Generator>
-Generator MakePRNG() {
-  // We need to get enough entropy to fully initialize the PRNG, that depends
-  // on the size of its state.  The size in bits is `Generator::state_size`.
-  // We convert that to the number of `unsigned int` values; as this is what
-  // std::random_device returns.
-  auto const desired_bits = Generator::state_size * Generator::word_size;
-
+/// Create a new PRNG.
+inline DefaultPRNG MakeDefaultPRNG() {
+  // Fetch a few (typically 64) bits of entropy to initialize the PRNG. We used
+  // to fetch a lot more entropy, but that is overkill for our purposes.
+  auto const desired_bits = DefaultPRNG::word_size;
   // Extract the necessary number of entropy bits.
   auto const entropy = FetchEntropy(desired_bits);
-
   // Finally, put the entropy into the form that the C++11 PRNG classes want.
+  // We need a named object because the constructor consumes a reference (and
+  // does not consume rvalue references). And `std::seed_seq` is not friendly
+  // to "Almost Always Auto" grrr..
   std::seed_seq seq(entropy.begin(), entropy.end());
-  return Generator(seq);
+  return DefaultPRNG(seq);
 }
-
-/// Create a new PRNG.
-inline DefaultPRNG MakeDefaultPRNG() { return MakePRNG<DefaultPRNG>(); }
 
 /**
  * Take @p n samples out of @p population, using the @p gen PRNG.

--- a/google/cloud/internal/random.h
+++ b/google/cloud/internal/random.h
@@ -38,8 +38,7 @@ using DefaultPRNG = std::mt19937_64;
 
 /// Create a new PRNG.
 inline DefaultPRNG MakeDefaultPRNG() {
-  // Fetch a few (typically 64) bits of entropy to initialize the PRNG. We used
-  // to fetch a lot more entropy, but that is overkill for our purposes.
+  // Fetch a few bits of entropy, which is sufficient for our purposes.
   auto const desired_bits = DefaultPRNG::word_size;
   // Extract the necessary number of entropy bits.
   auto const entropy = FetchEntropy(desired_bits);


### PR DESCRIPTION
We initialized our PRNG with a lot of entropy. This was overkill, and the entropy sources are not always an infinite resource.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11102)
<!-- Reviewable:end -->
