### PR TITLE
impl(docfx): initial generator for `syntax`

### DIFF
--- a/docfx/CMakeLists.txt
+++ b/docfx/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(
     config.h
     doxygen2markdown.cc
     doxygen2markdown.h
+    doxygen2syntax.cc
+    doxygen2syntax.h
     doxygen2toc.cc
     doxygen2toc.h
     doxygen2yaml.cc
@@ -46,7 +48,10 @@ add_library(
     parse_arguments.cc
     parse_arguments.h
     toc_entry.cc
-    toc_entry.h)
+    toc_entry.h
+    yaml_context.h
+    yaml_emit.cc
+    yaml_emit.h)
 google_cloud_cpp_add_common_options(docfx)
 target_include_directories(docfx PUBLIC "${PROJECT_SOURCE_DIR}")
 target_compile_features(docfx PUBLIC cxx_std_17)
@@ -69,8 +74,13 @@ endif ()
 
 set(unit_tests
     # cmake-format: sort
-    doxygen2markdown_test.cc doxygen2toc_test.cc doxygen2yaml_test.cc
-    doxygen_pages_test.cc generate_metadata_test.cc parse_arguments_test.cc)
+    doxygen2markdown_test.cc
+    doxygen2syntax_test.cc
+    doxygen2toc_test.cc
+    doxygen2yaml_test.cc
+    doxygen_pages_test.cc
+    generate_metadata_test.cc
+    parse_arguments_test.cc)
 
 # Export the list of unit tests to a .bzl file so we do not need to maintain the
 # list in two places.

--- a/docfx/docfx.bzl
+++ b/docfx/docfx.bzl
@@ -19,6 +19,7 @@
 docfx_hdrs = [
     "config.h",
     "doxygen2markdown.h",
+    "doxygen2syntax.h",
     "doxygen2toc.h",
     "doxygen2yaml.h",
     "doxygen_errors.h",
@@ -26,10 +27,13 @@ docfx_hdrs = [
     "generate_metadata.h",
     "parse_arguments.h",
     "toc_entry.h",
+    "yaml_context.h",
+    "yaml_emit.h",
 ]
 
 docfx_srcs = [
     "doxygen2markdown.cc",
+    "doxygen2syntax.cc",
     "doxygen2toc.cc",
     "doxygen2yaml.cc",
     "doxygen_errors.cc",
@@ -37,4 +41,5 @@ docfx_srcs = [
     "generate_metadata.cc",
     "parse_arguments.cc",
     "toc_entry.cc",
+    "yaml_emit.cc",
 ]

--- a/docfx/doxygen2syntax.cc
+++ b/docfx/doxygen2syntax.cc
@@ -1,0 +1,71 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "docfx/doxygen2syntax.h"
+#include "docfx/doxygen_errors.h"
+#include "docfx/yaml_context.h"
+#include "docfx/yaml_emit.h"
+
+namespace docfx {
+namespace {
+
+void AppendLocation(YAML::Emitter& yaml, YamlContext const& ctx,
+                    pugi::xml_node const& node, char const* file_attribute,
+                    char const* line_attribute) {
+  auto const name = std::string_view{node.child("name").child_value()};
+  auto const location = node.child("location");
+  if (name.empty() || !location) return;
+  auto const line =
+      std::string_view{location.attribute(line_attribute).as_string()};
+  auto const file = std::string{location.attribute(file_attribute).as_string()};
+  if (line.empty() || file.empty()) return;
+
+  auto const repo =
+      std::string_view{"https://github.com/googleapis/google-cloud-cpp/"};
+  auto const path = ctx.library_root + file;
+  auto const branch = std::string_view{"main"};
+  yaml << YAML::Key << "source" << YAML::Value             //
+       << YAML::BeginMap                                   //
+       << YAML::Key << "id" << YAML::Value << name         //
+       << YAML::Key << "path" << YAML::Value << path       //
+       << YAML::Key << "startLine" << YAML::Value << line  //
+       << YAML::Key << "remote" << YAML::Value             //
+       << YAML::BeginMap                                   //
+       << YAML::Key << "repo" << YAML::Value << repo       //
+       << YAML::Key << "branch" << YAML::Value << branch   //
+       << YAML::Key << "path" << YAML::Value << path       //
+       << YAML::EndMap                                     // remote
+       << YAML::EndMap                                     // source
+      ;
+}
+
+}  // namespace
+
+void AppendEnumSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
+                      pugi::xml_node const& node) {
+  yaml << YAML::Key << "syntax" << YAML::Value  //
+       << YAML::BeginMap;
+  AppendLocation(yaml, ctx, node, "file", "line");
+  yaml << YAML::EndMap;
+}
+
+void AppendTypedefSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
+                         pugi::xml_node const& node) {
+  yaml << YAML::Key << "syntax" << YAML::Value  //
+       << YAML::BeginMap;
+  AppendLocation(yaml, ctx, node, "file", "line");
+  yaml << YAML::EndMap;
+}
+
+}  // namespace docfx

--- a/docfx/doxygen2syntax.cc
+++ b/docfx/doxygen2syntax.cc
@@ -14,7 +14,6 @@
 
 #include "docfx/doxygen2syntax.h"
 #include "docfx/doxygen_errors.h"
-#include "docfx/yaml_context.h"
 #include "docfx/yaml_emit.h"
 
 namespace docfx {
@@ -46,8 +45,7 @@ void AppendLocation(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "branch" << YAML::Value << branch   //
        << YAML::Key << "path" << YAML::Value << path       //
        << YAML::EndMap                                     // remote
-       << YAML::EndMap                                     // source
-      ;
+       << YAML::EndMap;                                    // source
 }
 
 }  // namespace

--- a/docfx/doxygen2syntax.h
+++ b/docfx/doxygen2syntax.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2SYNTAX_H
 #define GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2SYNTAX_H
 
+#include "docfx/yaml_context.h"
 #include <pugixml.hpp>
 #include <yaml-cpp/yaml.h>
 
 namespace docfx {
-struct YamlContext;
 
 // Generate the `syntax` element in a DocFX YAML.
 //

--- a/docfx/doxygen2syntax.h
+++ b/docfx/doxygen2syntax.h
@@ -1,0 +1,45 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2SYNTAX_H
+#define GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2SYNTAX_H
+
+#include <pugixml.hpp>
+#include <yaml-cpp/yaml.h>
+
+namespace docfx {
+struct YamlContext;
+
+// Generate the `syntax` element in a DocFX YAML.
+//
+// The DocFX YAML files contain a `syntax` element which includes:
+// - Some textual representation of the element, e.g., the declaration for
+//   a function.
+// - Any template parameters for classes, structs, functions, etc.
+// - The names, types, and description of any function parameters.
+// - The return value for the function.
+// - The type aliased by a typedef or using definition.
+// - The value of enums (if applicable).
+
+// Generate the `syntax` element for an enum.
+void AppendEnumSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
+                      pugi::xml_node const& node);
+
+// Generate the `syntax` element for an typedef.
+void AppendTypedefSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
+                         pugi::xml_node const& node);
+
+}  // namespace docfx
+
+#endif  // GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2SYNTAX_H

--- a/docfx/doxygen2syntax_test.cc
+++ b/docfx/doxygen2syntax_test.cc
@@ -1,0 +1,133 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "docfx/doxygen2syntax.h"
+#include "docfx/yaml_context.h"
+#include <gmock/gmock.h>
+
+namespace docfx {
+namespace {
+
+TEST(Doxygen2Yaml, Enum) {
+  auto constexpr kEnumXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <memberdef kind="enum" id="namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c" prot="public" static="no" strong="yes">
+        <type/>
+        <name>Idempotency</name>
+        <qualifiedname>google::cloud::Idempotency</qualifiedname>
+        <enumvalue id="namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9caf8bb1d9c7cccc450ecd06167c7422bfa" prot="public">
+          <name>kIdempotent</name>
+          <briefdescription>
+<para>The operation is idempotent and can be retried after a transient failure.</para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9cae75d33e94f2dc4028d4d67bdaab75190" prot="public">
+          <name>kNonIdempotent</name>
+          <briefdescription>
+<para>The operation is not idempotent and should <bold>not</bold> be retried after a transient failure.</para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+            <para>Whether a [truncated].</para>
+        </briefdescription>
+        <detaileddescription>
+            <para>When a RPC fails with a retryable error [truncated]</para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="idempotency.h" line="55" column="1" bodyfile="idempotency.h" bodystart="55" bodyend="61"/>
+      </memberdef>
+    </doxygen>
+)xml";
+
+  auto constexpr kExpected = R"yml(syntax:
+  source:
+    id: Idempotency
+    path: google/cloud/idempotency.h
+    startLine: 55
+    remote:
+      repo: https://github.com/googleapis/google-cloud-cpp/
+      branch: main
+      path: google/cloud/idempotency.h)yml";
+
+  pugi::xml_document doc;
+  doc.load_string(kEnumXml);
+  auto selected = doc.select_node(
+      "//*[@id='"
+      "namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c"
+      "']");
+  ASSERT_TRUE(selected);
+  YamlContext ctx;
+  ctx.parent_id = "test-only-parent-id";
+  YAML::Emitter yaml;
+  yaml << YAML::BeginMap;
+  AppendEnumSyntax(yaml, ctx, selected.node());
+  yaml << YAML::EndMap;
+  auto const actual = std::string{yaml.c_str()};
+  EXPECT_EQ(actual, kExpected);
+}
+
+TEST(Doxygen2Yaml, Typedef) {
+  auto constexpr kXml = R"xml(xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <memberdef kind="typedef" id="namespacegoogle_1_1cloud_1a1498c1ea55d81842f37bbc42d003df1f" prot="public" static="no">
+        <type>std::function&lt; std::unique_ptr&lt; <ref refid="classgoogle_1_1cloud_1_1BackgroundThreads" kindref="compound">BackgroundThreads</ref> &gt;()&gt;</type>
+        <definition>using google::cloud::BackgroundThreadsFactory = typedef std::function&lt;std::unique_ptr&lt;BackgroundThreads&gt;()&gt;</definition>
+        <argsstring/>
+        <name>BackgroundThreadsFactory</name>
+        <qualifiedname>google::cloud::BackgroundThreadsFactory</qualifiedname>
+        <briefdescription>
+        <para>A short description of the thing.</para>
+        </briefdescription>
+        <detaileddescription>
+        <para>A longer description would go here.</para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="grpc_options.h" line="148" column="1" bodyfile="grpc_options.h" bodystart="149" bodyend="-1"/>
+      </memberdef>
+    </doxygen>)xml";
+  auto constexpr kExpected = R"yml(syntax:
+  source:
+    id: BackgroundThreadsFactory
+    path: google/cloud/grpc_options.h
+    startLine: 148
+    remote:
+      repo: https://github.com/googleapis/google-cloud-cpp/
+      branch: main
+      path: google/cloud/grpc_options.h)yml";
+
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node(
+      "//*[@id='"
+      "namespacegoogle_1_1cloud_1a1498c1ea55d81842f37bbc42d003df1f"
+      "']");
+  ASSERT_TRUE(selected);
+  YamlContext ctx;
+  ctx.parent_id = "test-only-parent-id";
+  YAML::Emitter yaml;
+  yaml << YAML::BeginMap;
+  AppendTypedefSyntax(yaml, ctx, selected.node());
+  yaml << YAML::EndMap;
+  auto const actual = std::string{yaml.c_str()};
+  EXPECT_EQ(actual, kExpected);
+}
+
+}  // namespace
+}  // namespace docfx

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -15,6 +15,8 @@
 #include "docfx/doxygen2yaml.h"
 #include "docfx/doxygen2markdown.h"
 #include "docfx/doxygen_errors.h"
+#include "docfx/yaml_context.h"
+#include "docfx/yaml_emit.h"
 #include <sstream>
 #include <string_view>
 
@@ -40,10 +42,6 @@ std::string Summary(pugi::xml_node const& node) {
 }
 
 }  // namespace
-
-YAML::Emitter& operator<<(YAML::Emitter& e, std::string_view rhs) {
-  return e.Write(std::string(rhs));
-}
 
 void StartDocFxYaml(YAML::Emitter& yaml) {
   yaml << YAML::BeginMap << YAML::Key << "items" << YAML::Value

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -15,7 +15,6 @@
 #include "docfx/doxygen2yaml.h"
 #include "docfx/doxygen2markdown.h"
 #include "docfx/doxygen_errors.h"
-#include "docfx/yaml_context.h"
 #include "docfx/yaml_emit.h"
 #include <sstream>
 #include <string_view>

--- a/docfx/doxygen2yaml.h
+++ b/docfx/doxygen2yaml.h
@@ -15,12 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2YAML_H
 #define GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2YAML_H
 
+#include "docfx/yaml_context.h"
 #include <pugixml.hpp>
 #include <yaml-cpp/yaml.h>
 #include <string>
 
 namespace docfx {
-struct YamlContext;
 
 // Initialize a YAML Emitter with the preamble elements required by DocFx.
 void StartDocFxYaml(YAML::Emitter& yaml);

--- a/docfx/doxygen2yaml.h
+++ b/docfx/doxygen2yaml.h
@@ -20,11 +20,7 @@
 #include <string>
 
 namespace docfx {
-
-struct YamlContext {
-  std::string library_root = "google/cloud/";
-  std::string parent_id;
-};
+struct YamlContext;
 
 // Initialize a YAML Emitter with the preamble elements required by DocFx.
 void StartDocFxYaml(YAML::Emitter& yaml);

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "docfx/doxygen2yaml.h"
+#include "docfx/yaml_context.h"
 #include <gmock/gmock.h>
 
 namespace docfx {

--- a/docfx/unit_tests.bzl
+++ b/docfx/unit_tests.bzl
@@ -18,6 +18,7 @@
 
 unit_tests = [
     "doxygen2markdown_test.cc",
+    "doxygen2syntax_test.cc",
     "doxygen2toc_test.cc",
     "doxygen2yaml_test.cc",
     "doxygen_pages_test.cc",

--- a/docfx/yaml_context.h
+++ b/docfx/yaml_context.h
@@ -1,0 +1,29 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_DOCFX_YAML_CONTEXT_H
+#define GOOGLE_CLOUD_CPP_DOCFX_YAML_CONTEXT_H
+
+#include <string>
+
+namespace docfx {
+
+struct YamlContext {
+  std::string library_root = "google/cloud/";
+  std::string parent_id;
+};
+
+}  // namespace docfx
+
+#endif  // GOOGLE_CLOUD_CPP_DOCFX_YAML_CONTEXT_H

--- a/docfx/yaml_emit.cc
+++ b/docfx/yaml_emit.cc
@@ -1,0 +1,23 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "docfx/yaml_emit.h"
+
+namespace docfx {
+
+YAML::Emitter& operator<<(YAML::Emitter& e, std::string_view rhs) {
+  return e.Write(std::string(rhs));
+}
+
+}  // namespace docfx

--- a/docfx/yaml_emit.h
+++ b/docfx/yaml_emit.h
@@ -1,0 +1,27 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_DOCFX_YAML_EMIT_H
+#define GOOGLE_CLOUD_CPP_DOCFX_YAML_EMIT_H
+
+#include <yaml-cpp/yaml.h>
+#include <string_view>
+
+namespace docfx {
+
+YAML::Emitter& operator<<(YAML::Emitter& e, std::string_view rhs);
+
+}  // namespace docfx
+
+#endif  // GOOGLE_CLOUD_CPP_DOCFX_YAML_EMIT_H


### PR DESCRIPTION
The YAML file the reference documentation includes a `syntax` section where one includes the source code to display (think "a function declaration"), links to the source files, the definition of the function or template parameters, etc.

Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11103)
<!-- Reviewable:end -->
