### PR TITLE
impl(otel): tracing for streaming reads in generated connections

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
@@ -87,10 +87,9 @@ StreamRange<google::test::admin::database::v1::Response>
 GoldenKitchenSinkTracingConnection::StreamingRead(google::test::admin::database::v1::Request const& request) {
   auto span = internal::MakeSpan("golden_v1::GoldenKitchenSinkConnection::StreamingRead");
   auto scope = opentelemetry::trace::Scope(span);
-  auto sr = child_->StreamingRead(std::move(request));
+  auto sr = child_->StreamingRead(request);
   return internal::MakeTracedStreamRange<google::test::admin::database::v1::Response>(
         std::move(span), std::move(sr));
-  return child_->StreamingRead(request);
 }
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::test::admin::database::v1::Request,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
@@ -85,6 +85,11 @@ GoldenKitchenSinkTracingConnection::Deprecated2(google::test::admin::database::v
 
 StreamRange<google::test::admin::database::v1::Response>
 GoldenKitchenSinkTracingConnection::StreamingRead(google::test::admin::database::v1::Request const& request) {
+  auto span = internal::MakeSpan("golden_v1::GoldenKitchenSinkConnection::StreamingRead");
+  auto scope = opentelemetry::trace::Scope(span);
+  auto sr = child_->StreamingRead(std::move(request));
+  return internal::MakeTracedStreamRange<google::test::admin::database::v1::Response>(
+        std::move(span), std::move(sr));
   return child_->StreamingRead(request);
 }
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/generator/internal/tracing_connection_generator.cc
+++ b/generator/internal/tracing_connection_generator.cc
@@ -253,10 +253,9 @@ StreamRange<$response_type$>
 $tracing_connection_class_name$::$method_name$($request_type$ const& request) {
   auto span = internal::MakeSpan("$product_namespace$::$connection_class_name$::$method_name$");
   auto scope = opentelemetry::trace::Scope(span);
-  auto sr = child_->$method_name$(std::move(request));
+  auto sr = child_->$method_name$(request);
   return internal::MakeTracedStreamRange<$response_type$>(
         std::move(span), std::move(sr));
-  return child_->$method_name$(request);
 })""";
   }
 

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_tracing_connection.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_tracing_connection.cc
@@ -48,11 +48,10 @@ BigQueryReadTracingConnection::ReadRows(
   auto span = internal::MakeSpan(
       "bigquery_storage_v1::BigQueryReadConnection::ReadRows");
   auto scope = opentelemetry::trace::Scope(span);
-  auto sr = child_->ReadRows(std::move(request));
+  auto sr = child_->ReadRows(request);
   return internal::MakeTracedStreamRange<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>(std::move(span),
                                                               std::move(sr));
-  return child_->ReadRows(request);
 }
 StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
 BigQueryReadTracingConnection::SplitReadStream(

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_tracing_connection.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_tracing_connection.cc
@@ -18,6 +18,7 @@
 
 #include "google/cloud/bigquery/storage/v1/internal/bigquery_read_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/traced_stream_range.h"
 #include <memory>
 
 namespace google {
@@ -44,6 +45,13 @@ BigQueryReadTracingConnection::CreateReadSession(
 StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadTracingConnection::ReadRows(
     google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
+  auto span = internal::MakeSpan(
+      "bigquery_storage_v1::BigQueryReadConnection::ReadRows");
+  auto scope = opentelemetry::trace::Scope(span);
+  auto sr = child_->ReadRows(std::move(request));
+  return internal::MakeTracedStreamRange<
+      google::cloud::bigquery::storage::v1::ReadRowsResponse>(std::move(span),
+                                                              std::move(sr));
   return child_->ReadRows(request);
 }
 StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_tracing_connection.cc
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_tracing_connection.cc
@@ -42,11 +42,10 @@ AgentEndpointServiceTracingConnection::ReceiveTaskNotification(
       "osconfig_agentendpoint_v1::AgentEndpointServiceConnection::"
       "ReceiveTaskNotification");
   auto scope = opentelemetry::trace::Scope(span);
-  auto sr = child_->ReceiveTaskNotification(std::move(request));
+  auto sr = child_->ReceiveTaskNotification(request);
   return internal::MakeTracedStreamRange<
       google::cloud::osconfig::agentendpoint::v1::
           ReceiveTaskNotificationResponse>(std::move(span), std::move(sr));
-  return child_->ReceiveTaskNotification(request);
 }
 StatusOr<google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse>
 AgentEndpointServiceTracingConnection::StartNextTask(

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_tracing_connection.cc
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_tracing_connection.cc
@@ -18,6 +18,7 @@
 
 #include "google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/traced_stream_range.h"
 #include <memory>
 
 namespace google {
@@ -37,6 +38,14 @@ StreamRange<
 AgentEndpointServiceTracingConnection::ReceiveTaskNotification(
     google::cloud::osconfig::agentendpoint::v1::
         ReceiveTaskNotificationRequest const& request) {
+  auto span = internal::MakeSpan(
+      "osconfig_agentendpoint_v1::AgentEndpointServiceConnection::"
+      "ReceiveTaskNotification");
+  auto scope = opentelemetry::trace::Scope(span);
+  auto sr = child_->ReceiveTaskNotification(std::move(request));
+  return internal::MakeTracedStreamRange<
+      google::cloud::osconfig::agentendpoint::v1::
+          ReceiveTaskNotificationResponse>(std::move(span), std::move(sr));
   return child_->ReceiveTaskNotification(request);
 }
 StatusOr<google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse>


### PR DESCRIPTION
Part of the work for #10620 

It is basically the same code as for Paginated APIs. Only the response type differs.

Note that this change only impacts generated connections. Handwritten connections like `bigtable::DataConnection` will be instrumented later. (This explains why less files are changed in this PR than the tracing stub PR (#11104))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11106)
<!-- Reviewable:end -->
