### PR TITLE
impl(otel): trace context across legacy async streaming reads

### DIFF
--- a/google/cloud/internal/async_read_stream_impl.h
+++ b/google/cloud/internal/async_read_stream_impl.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_READ_STREAM_IMPL_H
 
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/completion_queue_impl.h"
-#include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include <grpcpp/support/async_stream.h>
 #include <memory>
@@ -151,12 +151,12 @@ class AsyncReadStreamImpl
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
       bool Notify(bool ok) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context_);
         control_->OnStart(ok);
         return true;
       }
       std::shared_ptr<AsyncReadStreamImpl> control_;
-      Options options_ = CurrentOptions();
+      CallContext call_context_;
     };
 
     context_ = std::move(context);
@@ -198,12 +198,12 @@ class AsyncReadStreamImpl
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
       bool Notify(bool ok) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context_);
         control_->OnRead(ok, std::move(response));
         return true;
       }
       std::shared_ptr<AsyncReadStreamImpl> control_;
-      Options options_ = CurrentOptions();
+      CallContext call_context_;
     };
 
     auto callback = std::make_shared<NotifyRead>(this->shared_from_this());
@@ -248,12 +248,12 @@ class AsyncReadStreamImpl
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
       bool Notify(bool ok) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context_);
         control_->OnFinish(ok, MakeStatusFromRpcError(status));
         return true;
       }
       std::shared_ptr<AsyncReadStreamImpl> control_;
-      Options options_ = CurrentOptions();
+      CallContext call_context_;
     };
 
     auto callback = std::make_shared<NotifyFinish>(this->shared_from_this());
@@ -288,12 +288,12 @@ class AsyncReadStreamImpl
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
       bool Notify(bool ok) override {
-        OptionsSpan span(options_);
+        ScopedCallContext scope(call_context_);
         control_->OnDiscard(ok, std::move(response));
         return true;
       }
       std::shared_ptr<AsyncReadStreamImpl> control_;
-      Options options_ = CurrentOptions();
+      CallContext call_context_;
     };
 
     auto callback = std::make_shared<NotifyDiscard>(this->shared_from_this());


### PR DESCRIPTION
This is only called by legacy bigtable. Let's have it use `CallContext` > `OptionsSpan` for the sake of consistency.

No tests because this code should die.