### PR TITLE
feat(spanner): add the final pieces for the RouteToLeaderOption

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -540,7 +540,7 @@ class ReadExperiment : public BasicExperiment<Traits> {
       Status last_status;
       for (int i = 0; i != 10; ++i) {
         grpc::ClientContext context;
-        spanner_internal::RouteToLeader(context);
+        spanner_internal::RouteToLeader(context);  // always for CreateSession
         google::spanner::v1::CreateSessionRequest request{};
         request.set_database(database.FullName());
         auto response = stub->CreateSession(context, request);
@@ -680,7 +680,7 @@ class SelectExperiment : public BasicExperiment<Traits> {
       Status last_status;
       for (int i = 0; i != ExperimentImpl<Traits>::kColumnCount; ++i) {
         grpc::ClientContext context;
-        spanner_internal::RouteToLeader(context);
+        spanner_internal::RouteToLeader(context);  // always for CreateSession
         google::spanner::v1::CreateSessionRequest request{};
         request.set_database(database.FullName());
         auto response = stub->CreateSession(context, request);
@@ -840,7 +840,7 @@ class UpdateExperiment : public BasicExperiment<Traits> {
       Status last_status;
       for (int i = 0; i != 10; ++i) {
         grpc::ClientContext context;
-        spanner_internal::RouteToLeader(context);
+        spanner_internal::RouteToLeader(context);  // always for CreateSession
         google::spanner::v1::CreateSessionRequest request{};
         request.set_database(database.FullName());
         auto response = stub->CreateSession(context, request);
@@ -1026,7 +1026,7 @@ class MutationExperiment : public BasicExperiment<Traits> {
       Status last_status;
       for (int i = 0; i != 10; ++i) {
         grpc::ClientContext context;
-        spanner_internal::RouteToLeader(context);
+        spanner_internal::RouteToLeader(context);  // always for CreateSession
         google::spanner::v1::CreateSessionRequest request{};
         request.set_database(database.FullName());
         auto response = stub->CreateSession(context, request);

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/benchmarks/benchmarks_config.h"
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/internal/defaults.h"
+#include "google/cloud/spanner/internal/route_to_leader.h"
 #include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
@@ -539,6 +540,7 @@ class ReadExperiment : public BasicExperiment<Traits> {
       Status last_status;
       for (int i = 0; i != 10; ++i) {
         grpc::ClientContext context;
+        spanner_internal::RouteToLeader(context);
         google::spanner::v1::CreateSessionRequest request{};
         request.set_database(database.FullName());
         auto response = stub->CreateSession(context, request);
@@ -678,6 +680,7 @@ class SelectExperiment : public BasicExperiment<Traits> {
       Status last_status;
       for (int i = 0; i != ExperimentImpl<Traits>::kColumnCount; ++i) {
         grpc::ClientContext context;
+        spanner_internal::RouteToLeader(context);
         google::spanner::v1::CreateSessionRequest request{};
         request.set_database(database.FullName());
         auto response = stub->CreateSession(context, request);
@@ -837,6 +840,7 @@ class UpdateExperiment : public BasicExperiment<Traits> {
       Status last_status;
       for (int i = 0; i != 10; ++i) {
         grpc::ClientContext context;
+        spanner_internal::RouteToLeader(context);
         google::spanner::v1::CreateSessionRequest request{};
         request.set_database(database.FullName());
         auto response = stub->CreateSession(context, request);
@@ -1022,6 +1026,7 @@ class MutationExperiment : public BasicExperiment<Traits> {
       Status last_status;
       for (int i = 0; i != 10; ++i) {
         grpc::ClientContext context;
+        spanner_internal::RouteToLeader(context);
         google::spanner::v1::CreateSessionRequest request{};
         request.set_database(database.FullName());
         auto response = stub->CreateSession(context, request);

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -531,7 +531,7 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
         Idempotency::kIdempotent,
         [&stub](grpc::ClientContext& context,
                 google::spanner::v1::PartitionReadRequest const& request) {
-          RouteToLeader(context);
+          RouteToLeader(context);  // always for PartitionRead()
           return stub->PartitionRead(context, request);
         },
         request, __func__);
@@ -841,7 +841,7 @@ ConnectionImpl::PartitionQueryImpl(
         Idempotency::kIdempotent,
         [&stub](grpc::ClientContext& context,
                 google::spanner::v1::PartitionQueryRequest const& request) {
-          RouteToLeader(context);
+          RouteToLeader(context);  // always for PartitionQuery()
           return stub->PartitionQuery(context, request);
         },
         request, __func__);
@@ -916,7 +916,7 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
         Idempotency::kIdempotent,
         [&stub](grpc::ClientContext& context,
                 google::spanner::v1::ExecuteBatchDmlRequest const& request) {
-          RouteToLeader(context);
+          RouteToLeader(context);  // always for ExecuteBatchDml()
           return stub->ExecuteBatchDml(context, request);
         },
         request, __func__);
@@ -1040,7 +1040,7 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
       Idempotency::kIdempotent,
       [&stub](grpc::ClientContext& context,
               google::spanner::v1::CommitRequest const& request) {
-        RouteToLeader(context);
+        RouteToLeader(context);  // always for Commit()
         return stub->Commit(context, request);
       },
       request, __func__);
@@ -1104,7 +1104,7 @@ Status ConnectionImpl::RollbackImpl(
       Idempotency::kIdempotent,
       [&stub](grpc::ClientContext& context,
               google::spanner::v1::RollbackRequest const& request) {
-        RouteToLeader(context);
+        RouteToLeader(context);  // always for Rollback()
         return stub->Rollback(context, request);
       },
       request, __func__);

--- a/google/cloud/spanner/internal/defaults.cc
+++ b/google/cloud/spanner/internal/defaults.cc
@@ -105,8 +105,7 @@ Options DefaultOptions(Options opts) {
       (std::min)(min_sessions, max_sessions_per_channel * num_channels);
 
   if (!opts.has<spanner::RouteToLeaderOption>()) {
-#if 1
-    // TODO(#11111): Enable on-by-default behavior.
+    // TODO(#11111): Restore on-by-default behavior.
     opts.set<spanner::RouteToLeaderOption>(false);
     if (auto e = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER")) {
       for (auto const* enable : {"Y", "y", "T", "t", "1", "on"}) {
@@ -118,18 +117,6 @@ Options DefaultOptions(Options opts) {
         }
       }
     }
-#else
-    if (auto e = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER")) {
-      for (auto const* disable : {"N", "n", "F", "f", "0", "off"}) {
-        if (*e == disable) {
-          // Change the default from "for RW/PartitionedDml transactions"
-          // to "never".
-          opts.set<spanner::RouteToLeaderOption>(false);
-          break;
-        }
-      }
-    }
-#endif
   }
 
   return opts;

--- a/google/cloud/spanner/internal/defaults.cc
+++ b/google/cloud/spanner/internal/defaults.cc
@@ -105,6 +105,20 @@ Options DefaultOptions(Options opts) {
       (std::min)(min_sessions, max_sessions_per_channel * num_channels);
 
   if (!opts.has<spanner::RouteToLeaderOption>()) {
+#if 1
+    // TODO(#11111): Enable on-by-default behavior.
+    opts.set<spanner::RouteToLeaderOption>(false);
+    if (auto e = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER")) {
+      for (auto const* enable : {"Y", "y", "T", "t", "1", "on"}) {
+        if (*e == enable) {
+          // Change the default to "for RW/PartitionedDml transactions"
+          // from "never".
+          opts.unset<spanner::RouteToLeaderOption>();  // == true
+          break;
+        }
+      }
+    }
+#else
     if (auto e = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER")) {
       for (auto const* disable : {"N", "n", "F", "f", "0", "off"}) {
         if (*e == disable) {
@@ -115,6 +129,7 @@ Options DefaultOptions(Options opts) {
         }
       }
     }
+#endif
   }
 
   return opts;

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -85,7 +85,13 @@ TEST(Options, Defaults) {
   EXPECT_TRUE(opts.has<SpannerBackoffPolicyOption>());
   EXPECT_TRUE(opts.has<spanner_internal::SessionPoolClockOption>());
 
+#if 1
+  // TODO(#11111): Enable on-by-default behavior.
+  ASSERT_TRUE(opts.has<spanner::RouteToLeaderOption>());
+  EXPECT_FALSE(opts.get<spanner::RouteToLeaderOption>());
+#else
   EXPECT_FALSE(opts.has<spanner::RouteToLeaderOption>());
+#endif
 }
 
 TEST(Options, AdminDefaults) {
@@ -154,12 +160,19 @@ TEST(Options, SpannerEmulatorHost) {
   EXPECT_NE(opts.get<GrpcCredentialOption>(), nullptr);
 }
 
-TEST(Options, RouteToLeaderFromEnv) {
+TEST(Options, RouteToLeaderFromEnvOff) {
   testing_util::ScopedEnvironment route_to_leader_env(
       "GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER", "off");
   auto opts = spanner_internal::DefaultOptions();
   EXPECT_TRUE(opts.has<spanner::RouteToLeaderOption>());
   EXPECT_FALSE(opts.get<spanner::RouteToLeaderOption>());
+}
+
+TEST(Options, RouteToLeaderFromEnvOn) {
+  testing_util::ScopedEnvironment route_to_leader_env(
+      "GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER", "on");
+  auto opts = spanner_internal::DefaultOptions();
+  EXPECT_FALSE(opts.has<spanner::RouteToLeaderOption>());
 }
 
 TEST(Options, TracingComponentsFromEnv) {

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -85,13 +85,9 @@ TEST(Options, Defaults) {
   EXPECT_TRUE(opts.has<SpannerBackoffPolicyOption>());
   EXPECT_TRUE(opts.has<spanner_internal::SessionPoolClockOption>());
 
-#if 1
-  // TODO(#11111): Enable on-by-default behavior.
+  // TODO(#11111): Restore on-by-default behavior.
   ASSERT_TRUE(opts.has<spanner::RouteToLeaderOption>());
   EXPECT_FALSE(opts.get<spanner::RouteToLeaderOption>());
-#else
-  EXPECT_FALSE(opts.has<spanner::RouteToLeaderOption>());
-#endif
 }
 
 TEST(Options, AdminDefaults) {

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/session_pool.h"
+#include "google/cloud/spanner/internal/route_to_leader.h"
 #include "google/cloud/spanner/internal/session.h"
 #include "google/cloud/spanner/internal/status_utils.h"
 #include "google/cloud/spanner/options.h"
@@ -396,6 +397,7 @@ Status SessionPool::CreateSessionsSync(
       google::cloud::Idempotency::kIdempotent,
       [&stub](grpc::ClientContext& context,
               google::spanner::v1::BatchCreateSessionsRequest const& request) {
+        RouteToLeader(context);
         return stub->BatchCreateSessions(context, request);
       },
       request, __func__);
@@ -455,6 +457,7 @@ SessionPool::AsyncBatchCreateSessions(
       Idempotency::kIdempotent, cq,
       [stub](CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
              google::spanner::v1::BatchCreateSessionsRequest const& request) {
+        RouteToLeader(*context);
         return stub->AsyncBatchCreateSessions(cq, std::move(context), request);
       },
       std::move(request), __func__);
@@ -491,6 +494,7 @@ SessionPool::AsyncRefreshSession(CompletionQueue& cq,
       Idempotency::kIdempotent, cq,
       [stub](CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
              google::spanner::v1::ExecuteSqlRequest const& request) {
+        // Read-only transaction, so no route-to-leader.
         return stub->AsyncExecuteSql(cq, std::move(context), request);
       },
       std::move(request), __func__);

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -397,7 +397,7 @@ Status SessionPool::CreateSessionsSync(
       google::cloud::Idempotency::kIdempotent,
       [&stub](grpc::ClientContext& context,
               google::spanner::v1::BatchCreateSessionsRequest const& request) {
-        RouteToLeader(context);
+        RouteToLeader(context);  // always for BatchCreateSessions()
         return stub->BatchCreateSessions(context, request);
       },
       request, __func__);
@@ -457,7 +457,7 @@ SessionPool::AsyncBatchCreateSessions(
       Idempotency::kIdempotent, cq,
       [stub](CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
              google::spanner::v1::BatchCreateSessionsRequest const& request) {
-        RouteToLeader(*context);
+        RouteToLeader(*context);  // always for BatchCreateSessions()
         return stub->AsyncBatchCreateSessions(cq, std::move(context), request);
       },
       std::move(request), __func__);


### PR DESCRIPTION
The final glue to add a routing header to Spanner RPCs that should be served in the leader region.

For the time being, the boolean option defaults to off (set as false), but that default can be changed with a suitably-positive value for `${GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER}`.  The conditional code can be removed to restore the defaults-to-on behavior.  See #11111.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11112)
<!-- Reviewable:end -->
