### PR TITLE
test(common): more logging on failures

### DIFF
--- a/google/cloud/internal/unified_rest_credentials_integration_test.cc
+++ b/google/cloud/internal/unified_rest_credentials_integration_test.cc
@@ -61,8 +61,8 @@ void MakeBigQueryRpcCall(Options options) {
   auto payload = ReadAll(std::move(response_payload));
   ASSERT_STATUS_OK(payload);
   auto parsed = nlohmann::json::parse(*payload, nullptr, false);
-  ASSERT_TRUE(parsed.is_object());
-  ASSERT_TRUE(parsed.contains("kind"));
+  ASSERT_TRUE(parsed.is_object()) << "parsed=" << parsed;
+  ASSERT_TRUE(parsed.contains("kind")) << "parsed=" << parsed;
   EXPECT_EQ(parsed.value("kind", ""), "bigquery#datasetList");
 }
 


### PR DESCRIPTION
Produce more output when the `unified_rest_credentials_integration_test` fails.

Motivated by #11109

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11113)
<!-- Reviewable:end -->
