### PR TITLE
impl(docfx): add content to enums and typedefs

### DIFF
--- a/docfx/doxygen2syntax.h
+++ b/docfx/doxygen2syntax.h
@@ -32,6 +32,11 @@ namespace docfx {
 // - The type aliased by a typedef or using definition.
 // - The value of enums (if applicable).
 
+// Generate the `syntax.content` element for an enum.
+std::string EnumSyntaxContent(pugi::xml_node const& node);
+
+std::string TypedefSyntaxContent(pugi::xml_node const& node);
+
 // Generate the `syntax` element for an enum.
 void AppendEnumSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
                       pugi::xml_node const& node);


### PR DESCRIPTION
The `syntax.content` attribute contains the C++ code we want to show in the reference documentation.

Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11114)
<!-- Reviewable:end -->
