### PR TITLE
ci: create `grpc-at-head` build script

### DIFF
--- a/ci/cloudbuild/builds/grpc-at-head.sh
+++ b/ci/cloudbuild/builds/grpc-at-head.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+
+rm -fr /h/grpc && git -C /h clone -q --depth 1 https://github.com/grpc/grpc.git
+
+mapfile -t args < <(bazel::common_args)
+args+=("--override_repository=com_github_grpc_grpc=/h/grpc")
+bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+
+mapfile -t integration_args < <(integration::bazel_args)
+integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"


### PR DESCRIPTION
Part of the work for #10323.  I also need to create a trigger to execute this nightly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11118)
<!-- Reviewable:end -->
