### PR TITLE
impl(docfx): add uid metadata to pages

### DIFF
--- a/docfx/doxygen2docfx.cc
+++ b/docfx/doxygen2docfx.cc
@@ -29,7 +29,7 @@ int main(int argc, char* argv[]) try {
   for (auto const& i : doc.select_nodes("//*[@kind='page']")) {
     auto const& page = i.node();
     auto const filename = std::string{page.attribute("id").as_string()} + ".md";
-    std::ofstream(filename) << docfx::Page2Markdown(page);
+    std::ofstream(filename) << docfx::Page2Markdown(config, page);
   }
 
   return 0;

--- a/docfx/doxygen_pages.cc
+++ b/docfx/doxygen_pages.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "docfx/doxygen_pages.h"
+#include "docfx/config.h"
 #include "docfx/doxygen2markdown.h"
 #include "docfx/doxygen_errors.h"
 #include <algorithm>
@@ -78,7 +79,8 @@ namespace docfx {
 //   <xsd:attribute name="abstract" type="DoxBool" use="optional"/>
 // </xsd:complexType>
 // clang-format on
-std::string Page2Markdown(pugi::xml_node const& node) {
+std::string Page2Markdown(Config const& /*config*/,
+                          pugi::xml_node const& node) {
   if (std::string_view{node.name()} != "compounddef" ||
       std::string_view{node.attribute("kind").as_string()} != "page") {
     std::ostringstream os;
@@ -88,8 +90,13 @@ std::string Page2Markdown(pugi::xml_node const& node) {
     throw std::runtime_error(std::move(os).str());
   }
   std::ostringstream os;
-  MarkdownContext ctx;
+  os << "---\n";
+  auto const id = std::string_view{node.attribute("id").as_string()};
+  os << "uid: " << id << "\n";
+  os << "---\n\n";
   os << "# ";
+
+  MarkdownContext ctx;
   AppendTitle(os, ctx, node);
   os << "\n";
   for (auto const& child : node) {

--- a/docfx/doxygen_pages.h
+++ b/docfx/doxygen_pages.h
@@ -28,7 +28,7 @@ namespace docfx {
  *
  * This creates the root MarkdownContext, so no need to consume it.
  */
-std::string Page2Markdown(pugi::xml_node const& node);
+std::string Page2Markdown(Config const& config, pugi::xml_node const& node);
 
 // Get the table of contents for pages.
 std::vector<TocEntry> PagesToc(pugi::xml_document const& doc);

--- a/docfx/doxygen_pages_test.cc
+++ b/docfx/doxygen_pages_test.cc
@@ -60,8 +60,11 @@ TEST(DoxygenPages, CommonPage) {
       </compounddef>
     </doxygen>)xml";
 
-  auto constexpr kExpected =
-      R"md(# Common Components for the Google Cloud C++ Client Libraries
+  auto constexpr kExpected = R"md(---
+uid: indexpage
+---
+
+# Common Components for the Google Cloud C++ Client Libraries
 
 
 ## Overview
@@ -93,7 +96,8 @@ This library contains common components shared by all the Google Cloud C++ Clien
   doc.load_string(kXml);
   auto selected = doc.select_node("//*[@id='indexpage']");
   ASSERT_TRUE(selected);
-  auto const actual = Page2Markdown(selected.node());
+  auto const actual = Page2Markdown(
+      Config{{}, /*.library=*/"common", /*version=*/"4.2"}, selected.node());
   EXPECT_EQ(kExpected, actual);
 }
 


### PR DESCRIPTION
The YAML files generated from Doxygen pages need some metadata to be linked from other YAML files.

Part of the work for #10895 