### PR TITLE
cleanup(docfx): missing deps in CMake script

### DIFF
--- a/docfx/CMakeLists.txt
+++ b/docfx/CMakeLists.txt
@@ -25,6 +25,7 @@ endif ()
 
 find_package(pugixml CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
 
 include(EnableWerror)
 
@@ -57,7 +58,8 @@ add_library(
 google_cloud_cpp_add_common_options(docfx)
 target_include_directories(docfx PUBLIC "${PROJECT_SOURCE_DIR}")
 target_compile_features(docfx PUBLIC cxx_std_17)
-target_link_libraries(docfx PUBLIC pugixml::pugixml yaml-cpp)
+target_link_libraries(docfx PUBLIC pugixml::pugixml yaml-cpp
+                                   nlohmann_json::nlohmann_json)
 
 # To avoid maintaining the list of files for the library, export them to a .bzl
 # file.


### PR DESCRIPTION
CMake is too fogiving in this case. Currently using `nlohmann::json` requires no additional compiler or linker flags. However (1) that may not be the case forever, and (2) the error messages are earier to understand if one uses `find_package()` when the package is missing.

Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11128)
<!-- Reviewable:end -->
