### PR TITLE
ci: use default GCS timeout for Bazel cache

### DIFF
--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -48,15 +48,6 @@ if [[ -r "${TEST_KEY_FILE_JSON}" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}/macos/${BUILD_NAME:-}"
   bazel_args+=(
     "--remote_cache=${BAZEL_CACHE}/macos/${BUILD_NAME:-}"
-    # Reduce the timeout for the remote cache from the 60s default:
-    #     https://docs.bazel.build/versions/main/command-line-reference.html#flag--remote_timeout
-    # If the build machine has network problems we would rather build locally
-    # over blocking the build for 60s. When adjusting this parameter, keep in
-    # mind that:
-    # - Some of the objects in the cache in the ~60MiB range.
-    # - Without tuning uploads run in the 50 MiB/s range, and downloads in
-    #   the 150 MiB/s range.
-    "--remote_timeout=5"
   )
   bazel_args+=("--google_credentials=${TEST_KEY_FILE_JSON}")
   # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues

--- a/ci/kokoro/macos/builds/quickstart-bazel.sh
+++ b/ci/kokoro/macos/builds/quickstart-bazel.sh
@@ -48,15 +48,6 @@ if [[ -r "${CREDENTIALS_FILE}" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}/macos/${BUILD_NAME:-}"
   bazel_args+=(
     "--remote_cache=${BAZEL_CACHE}/macos/${BUILD_NAME:-}"
-    # Reduce the timeout for the remote cache from the 60s default:
-    #     https://docs.bazel.build/versions/main/command-line-reference.html#flag--remote_timeout
-    # If the build machine has network problems we would rather build locally
-    # over blocking the build for 60s. When adjusting this parameter, keep in
-    # mind that:
-    # - Some of the objects in the cache in the ~60MiB range.
-    # - Without tuning uploads run in the 50 MiB/s range, and downloads in
-    #   the 150 MiB/s range.
-    "--remote_timeout=5"
   )
   bazel_args+=("--google_credentials=${CREDENTIALS_FILE}")
   # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues

--- a/ci/kokoro/windows/lib/bazel.ps1
+++ b/ci/kokoro/windows/lib/bazel.ps1
@@ -65,15 +65,6 @@ function Get-Bazel-Build-Flags {
     $BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
     $build_flags += @(
         "--remote_cache=${BAZEL_CACHE}/windows/${BuildName}",
-        # Reduce the timeout for the remote cache from the 60s default:
-        #     https://docs.bazel.build/versions/main/command-line-reference.html#flag--remote_timeout
-        # If the build machine has network problems we would rather build
-        # locally over blocking the build for 60s. When adjusting this
-        # parameter, keep in mind that:
-        # - Some of the objects in the cache in the ~60MiB range.
-        # - Without tuning uploads run in the 50 MiB/s range, and downloads in
-        #   the 150 MiB/s range.
-        "--remote_timeout=5",
         "--google_credentials=${env:KOKORO_GFILE_DIR}/kokoro-run-key.json",
         # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues
         # and https://github.com/bazelbuild/bazel/issues/3360


### PR DESCRIPTION
I am seeing too many failures in the logs, I think my timeout is too aggressive.

I am hoping this will reduce the noise in the logs, and maybe reduce the number of crashes on macOS (#8325) simply because downloading the cache takes less memory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11129)
<!-- Reviewable:end -->
