### PR TITLE
ci: custom tags in GCB builds

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -44,13 +44,15 @@ substitutions:
   _TRIGGER_SOURCE: '${_PR_NUMBER:-main}'
   _TRIGGER_TYPE: 'manual'
   _LOGS_BUCKET: 'cloud-cpp-community-publiclogs'
+  _TAG1: 'team-only'
 
 timeout: 12600s
 tags: [
   '${_TRIGGER_TYPE}',
   '${_BUILD_NAME}',
   '${_DISTRO}',
-  '${_PR_NUMBER}'
+  '${_PR_NUMBER}',
+  '${_TAG1}'
 ]
 
 availableSecrets:


### PR DESCRIPTION
This will allow us to insert a custom tag in a GCB build, using the trigger configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11130)
<!-- Reviewable:end -->
