### PR TITLE
impl(bigquery): Logging decorator cleanup - Added DebugString member functions to …

### DIFF
--- a/google/cloud/bigquery/bigquery_rest.cmake
+++ b/google/cloud/bigquery/bigquery_rest.cmake
@@ -20,6 +20,7 @@ add_library(
     v2/minimal/internal/bigquery_http_response.h
     v2/minimal/internal/common_v2_resources.cc
     v2/minimal/internal/common_v2_resources.h
+    v2/minimal/internal/job.cc
     v2/minimal/internal/job.h
     v2/minimal/internal/job_client.cc
     v2/minimal/internal/job_client.h
@@ -135,7 +136,8 @@ function (bigquery_rest_define_tests)
         v2/minimal/internal/job_options_test.cc
         v2/minimal/internal/job_request_test.cc
         v2/minimal/internal/job_response_test.cc
-        v2/minimal/internal/job_rest_stub_test.cc)
+        v2/minimal/internal/job_rest_stub_test.cc
+        v2/minimal/internal/job_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.

--- a/google/cloud/bigquery/bigquery_rest_unit_tests.bzl
+++ b/google/cloud/bigquery/bigquery_rest_unit_tests.bzl
@@ -27,4 +27,5 @@ bigquery_rest_unit_tests = [
     "v2/minimal/internal/job_request_test.cc",
     "v2/minimal/internal/job_response_test.cc",
     "v2/minimal/internal/job_rest_stub_test.cc",
+    "v2/minimal/internal/job_test.cc",
 ]

--- a/google/cloud/bigquery/google_cloud_cpp_bigquery_rest.bzl
+++ b/google/cloud/bigquery/google_cloud_cpp_bigquery_rest.bzl
@@ -38,6 +38,7 @@ google_cloud_cpp_bigquery_rest_hdrs = [
 google_cloud_cpp_bigquery_rest_srcs = [
     "v2/minimal/internal/bigquery_http_response.cc",
     "v2/minimal/internal/common_v2_resources.cc",
+    "v2/minimal/internal/job.cc",
     "v2/minimal/internal/job_client.cc",
     "v2/minimal/internal/job_connection.cc",
     "v2/minimal/internal/job_idempotency_policy.cc",

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
@@ -44,13 +44,12 @@ StatusOr<BigQueryHttpResponse> BigQueryHttpResponse::BuildFromRestResponse(
   return response;
 }
 
-std::string BigQueryHttpResponse::DebugString(
-    TracingOptions const& options) const {
+std::string BigQueryHttpResponse::DebugString(absl::string_view name,
+                                              TracingOptions const& options,
+                                              int indent) const {
   // Payload is not logged as it might contain user sensitive data like
   // ldap/emails.
-  return internal::DebugFormatter(options,
-                                  "google::cloud::bigquery_v2_minimal_internal:"
-                                  ":BigQueryHttpResponse")
+  return internal::DebugFormatter(name, options, indent)
       .Field("status_code", http_status_code)
       .StringField("headers",
                    absl::StrJoin(http_headers, ", ", absl::PairFormatter(": ")))

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/make_status.h"
 #include <iostream>
 
@@ -44,15 +45,16 @@ StatusOr<BigQueryHttpResponse> BigQueryHttpResponse::BuildFromRestResponse(
   return response;
 }
 
-std::ostream& operator<<(std::ostream& os,
-                         BigQueryHttpResponse const& response) {
-  // Payload is not being printed as it may contain user sensitive PII data like
-  // email etc.
-  os << "BigQueryHttpResponse{Status_Code=" << response.http_status_code
-     << ", headers={"
-     << absl::StrJoin(response.http_headers, ", ", absl::PairFormatter(": "))
-     << "}";
-  return os << "}";
+std::string BigQueryHttpResponse::DebugString(
+    TracingOptions const& options) const {
+  // Payload is not being printed as it may contain user sensitive data like
+  // email, ldap etc.
+  std::string out;
+  absl::StrAppend(&out, "BigQueryHttpResponse{Status_Code=", http_status_code,
+                  ", headers={",
+                  absl::StrJoin(http_headers, ", ", absl::PairFormatter(": ")),
+                  "}}");
+  return internal::DebugString(out, options);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/make_status.h"
+#include <iostream>
 
 namespace google {
 namespace cloud {
@@ -40,6 +42,17 @@ StatusOr<BigQueryHttpResponse> BigQueryHttpResponse::BuildFromRestResponse(
 
   response.payload = std::move(*payload);
   return response;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         BigQueryHttpResponse const& response) {
+  // Payload is not being printed as it may contain user sensitive PII data like
+  // email etc.
+  os << "BigQueryHttpResponse{Status_Code=" << response.http_status_code
+     << ", headers={"
+     << absl::StrJoin(response.http_headers, ", ", absl::PairFormatter(": "))
+     << "}";
+  return os << "}";
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
@@ -50,11 +50,12 @@ std::string BigQueryHttpResponse::DebugString(
   // Payload is not being printed as it may contain user sensitive data like
   // email, ldap etc.
   std::string out;
-  absl::StrAppend(&out, "BigQueryHttpResponse{Status_Code=", http_status_code,
-                  ", headers={",
+  auto const* delim = options.single_line_mode() ? " " : "\n";
+  absl::StrAppend(&out, "BigQueryHttpResponse{", delim,
+                  "Status_Code=", http_status_code, delim, ", headers={", delim,
                   absl::StrJoin(http_headers, ", ", absl::PairFormatter(": ")),
-                  "}}");
-  return internal::DebugString(out, options);
+                  delim, "}}");
+  return out;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/make_status.h"
-#include <iostream>
 
 namespace google {
 namespace cloud {
@@ -47,15 +46,15 @@ StatusOr<BigQueryHttpResponse> BigQueryHttpResponse::BuildFromRestResponse(
 
 std::string BigQueryHttpResponse::DebugString(
     TracingOptions const& options) const {
-  // Payload is not being printed as it may contain user sensitive data like
-  // email, ldap etc.
-  std::string out;
-  auto const* delim = options.single_line_mode() ? " " : "\n";
-  absl::StrAppend(&out, "BigQueryHttpResponse{", delim,
-                  "Status_Code=", http_status_code, delim, ", headers={", delim,
-                  absl::StrJoin(http_headers, ", ", absl::PairFormatter(": ")),
-                  delim, "}}");
-  return out;
+  // Payload is not logged as it might contain user sensitive data like
+  // ldap/emails.
+  return internal::DebugFormatter(options,
+                                  "google::cloud::bigquery_v2_minimal_internal:"
+                                  ":BigQueryHttpResponse")
+      .Field("status_code", http_status_code)
+      .StringField("headers",
+                   absl::StrJoin(http_headers, ", ", absl::PairFormatter(": ")))
+      .Build();
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <iosfwd>
 
 namespace google {
 namespace cloud {
@@ -35,6 +36,9 @@ class BigQueryHttpResponse {
   std::multimap<std::string, std::string> http_headers;
   std::string payload;
 };
+
+std::ostream& operator<<(std::ostream& os,
+                         BigQueryHttpResponse const& response);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
@@ -19,7 +19,6 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
-#include <iosfwd>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include <iosfwd>
 
@@ -32,13 +33,12 @@ class BigQueryHttpResponse {
   static StatusOr<BigQueryHttpResponse> BuildFromRestResponse(
       std::unique_ptr<rest_internal::RestResponse> rest_response);
 
+  std::string DebugString(TracingOptions const& options) const;
+
   rest_internal::HttpStatusCode http_status_code;
   std::multimap<std::string, std::string> http_headers;
   std::string payload;
 };
-
-std::ostream& operator<<(std::ostream& os,
-                         BigQueryHttpResponse const& response);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
@@ -19,6 +19,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ class BigQueryHttpResponse {
   static StatusOr<BigQueryHttpResponse> BuildFromRestResponse(
       std::unique_ptr<rest_internal::RestResponse> rest_response);
 
-  std::string DebugString(TracingOptions const& options) const;
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 
   rest_internal::HttpStatusCode http_status_code;
   std::multimap<std::string, std::string> http_headers;

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
@@ -101,12 +101,11 @@ TEST(BigQueryHttpResponseTest, DebugString) {
   response.http_headers.insert({{"header1", "value1"}});
   response.payload = payload;
 
-  EXPECT_EQ(
-      response.DebugString(TracingOptions{}),
-      R"(google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
-      R"( status_code: 200)"
-      R"( headers: "header1: value1")"
-      R"( })");
+  EXPECT_EQ(response.DebugString("BigQueryHttpResponse", TracingOptions{}),
+            R"(BigQueryHttpResponse {)"
+            R"( status_code: 200)"
+            R"( headers: "header1: value1")"
+            R"( })");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
@@ -94,7 +94,7 @@ TEST(BigQueryHttpResponseTest, NullPtr) {
                        HasSubstr("RestResponse argument passed in is null")));
 }
 
-TEST(BigQueryHttpResponseTest, OutputStream) {
+TEST(BigQueryHttpResponseTest, DebugString) {
   std::string payload = "some-payload";
   BigQueryHttpResponse response;
   response.http_status_code = HttpStatusCode::kOk;
@@ -103,8 +103,7 @@ TEST(BigQueryHttpResponseTest, OutputStream) {
   std::ostringstream os;
   std::string expected =
       R"(BigQueryHttpResponse{Status_Code=200, headers={header1: value1}})";
-  os << response;
-  EXPECT_EQ(expected, os.str());
+  EXPECT_EQ(expected, response.DebugString(TracingOptions{}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
@@ -100,10 +100,13 @@ TEST(BigQueryHttpResponseTest, DebugString) {
   response.http_status_code = HttpStatusCode::kOk;
   response.http_headers.insert({{"header1", "value1"}});
   response.payload = payload;
-  std::ostringstream os;
-  std::string expected =
-      "BigQueryHttpResponse{ Status_Code=200 , headers={ header1: value1 }}";
-  EXPECT_EQ(expected, response.DebugString(TracingOptions{}));
+
+  EXPECT_EQ(
+      response.DebugString(TracingOptions{}),
+      R"(google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
+      R"( status_code: 200)"
+      R"( headers: "header1: value1")"
+      R"( })");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
@@ -102,7 +102,7 @@ TEST(BigQueryHttpResponseTest, DebugString) {
   response.payload = payload;
   std::ostringstream os;
   std::string expected =
-      R"(BigQueryHttpResponse{Status_Code=200, headers={header1: value1}})";
+      "BigQueryHttpResponse{ Status_Code=200 , headers={ header1: value1 }}";
   EXPECT_EQ(expected, response.DebugString(TracingOptions{}));
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/testing_util/mock_rest_response.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <sstream>
 
 namespace google {
 namespace cloud {
@@ -91,6 +92,19 @@ TEST(BigQueryHttpResponseTest, NullPtr) {
   EXPECT_THAT(http_response,
               StatusIs(StatusCode::kInvalidArgument,
                        HasSubstr("RestResponse argument passed in is null")));
+}
+
+TEST(BigQueryHttpResponseTest, OutputStream) {
+  std::string payload = "some-payload";
+  BigQueryHttpResponse response;
+  response.http_status_code = HttpStatusCode::kOk;
+  response.http_headers.insert({{"header1", "value1"}});
+  response.payload = payload;
+  std::ostringstream os;
+  std::string expected =
+      R"(BigQueryHttpResponse{Status_Code=200, headers={header1: value1}})";
+  os << response;
+  EXPECT_EQ(expected, os.str());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job.cc
@@ -23,26 +23,34 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::string Job::DebugString(TracingOptions const& options) const {
   std::string out;
-  absl::StrAppend(
-      &out, "Job{etag=", etag, ", kind=", kind, ", id=", id,
-      ", job_configuration={job_type=", configuration.job_type,
-      ", query=", configuration.query_config.query, "}", ", job_reference={",
-      "job_id=", reference.job_id, ", location=", reference.location,
-      ", project_id=", reference.project_id, "}", ", job_status=", status.state,
-      ", error_result=", status.error_result.message, "}");
-  return internal::DebugString(out, options);
+  auto const* delim = options.single_line_mode() ? " " : "\n";
+  absl::StrAppend(&out, "Job{", delim, "etag=", etag, delim, ", kind=", kind,
+                  delim, ", id=", id, delim, ", job_configuration={", delim,
+                  "job_type=", configuration.job_type, delim,
+                  ", query=", configuration.query_config.query, delim, "}",
+                  delim, ", job_reference={", delim,
+                  "job_id=", reference.job_id, delim,
+                  ", location=", reference.location, delim,
+                  ", project_id=", reference.project_id, delim, "}", delim,
+                  ", job_status=", status.state, delim,
+                  ", error_result=", status.error_result.message, delim, "}");
+  return out;
 }
 
 std::string ListFormatJob::DebugString(TracingOptions const& options) const {
   std::string out;
+  auto const* delim = options.single_line_mode() ? " " : "\n";
   absl::StrAppend(
-      &out, "ListFormatJob{id=", id, ", kind=", kind, ", state=", state,
-      ", job_configuration={job_type=", configuration.job_type,
-      ", query=", configuration.query_config.query, "}", ", job_reference={",
-      "job_id=", reference.job_id, ", location=", reference.location,
-      ", project_id=", reference.project_id, "}", ", job_status=", status.state,
-      ", error_result=", error_result.message, "}");
-  return internal::DebugString(out, options);
+      &out, "ListFormatJob{", delim, "id=", id, delim, ", kind=", kind, delim,
+      ", state=", state, delim, ", job_configuration={", delim,
+      "job_type=", configuration.job_type, delim,
+      ", query=", configuration.query_config.query, delim, "}", delim,
+      ", job_reference={", delim, "job_id=", reference.job_id, delim,
+      ", location=", reference.location, delim,
+      ", project_id=", reference.project_id, delim, "}",
+      ", job_status=", status.state, delim,
+      ", error_result=", error_result.message, delim, "}");
+  return out;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job.cc
@@ -1,0 +1,51 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/v2/minimal/internal/job.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/internal/debug_string.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::string Job::DebugString(TracingOptions const& options) const {
+  std::string out;
+  absl::StrAppend(
+      &out, "Job{etag=", etag, ", kind=", kind, ", id=", id,
+      ", job_configuration={job_type=", configuration.job_type,
+      ", query=", configuration.query_config.query, "}", ", job_reference={",
+      "job_id=", reference.job_id, ", location=", reference.location,
+      ", project_id=", reference.project_id, "}", ", job_status=", status.state,
+      ", error_result=", status.error_result.message, "}");
+  return internal::DebugString(out, options);
+}
+
+std::string ListFormatJob::DebugString(TracingOptions const& options) const {
+  std::string out;
+  absl::StrAppend(
+      &out, "ListFormatJob{id=", id, ", kind=", kind, ", state=", state,
+      ", job_configuration={job_type=", configuration.job_type,
+      ", query=", configuration.query_config.query, "}", ", job_reference={",
+      "job_id=", reference.job_id, ", location=", reference.location,
+      ", project_id=", reference.project_id, "}", ", job_status=", status.state,
+      ", error_result=", error_result.message, "}");
+  return internal::DebugString(out, options);
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigquery_v2_minimal_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job.cc
@@ -22,22 +22,20 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace {
-std::string MakeJobConfiguration(TracingOptions const& options,
+std::string MakeJobConfiguration(absl::string_view name,
+                                 TracingOptions const& options,
                                  std::string job_type, std::string query) {
-  return internal::DebugFormatter(
-             options,
-             "google::cloud::bigquery_v2_minimal_internal::JobConfiguration")
+  return internal::DebugFormatter(name, options)
       .StringField("job_type", std::move(job_type))
       .StringField("query", std::move(query))
       .Build();
 }
 
-std::string MakeJobReference(TracingOptions const& options,
+std::string MakeJobReference(absl::string_view name,
+                             TracingOptions const& options,
                              std::string project_id, std::string job_id,
                              std::string location) {
-  return internal::DebugFormatter(
-             options,
-             "google::cloud::bigquery_v2_minimal_internal::JobReference")
+  return internal::DebugFormatter(name, options)
       .StringField("project_id", std::move(project_id))
       .StringField("job_id", std::move(job_id))
       .StringField("location", std::move(location))
@@ -46,13 +44,16 @@ std::string MakeJobReference(TracingOptions const& options,
 
 }  // namespace
 
-std::string Job::DebugString(TracingOptions const& options) const {
-  auto job_configuration = MakeJobConfiguration(
-      options, configuration.job_type, configuration.query_config.query);
-  auto job_reference = MakeJobReference(options, reference.project_id,
-                                        reference.job_id, reference.location);
-  return internal::DebugFormatter(
-             options, "google::cloud::bigquery_v2_minimal_internal::Job")
+std::string Job::DebugString(absl::string_view name,
+                             TracingOptions const& options, int indent) const {
+  auto job_configuration =
+      MakeJobConfiguration("JobConfiguration", options, configuration.job_type,
+                           configuration.query_config.query);
+  auto job_reference =
+      MakeJobReference("JobReference", options, reference.project_id,
+                       reference.job_id, reference.location);
+
+  return internal::DebugFormatter(name, options, indent)
       .StringField("etag", etag)
       .StringField("kind", kind)
       .StringField("id", id)
@@ -63,14 +64,17 @@ std::string Job::DebugString(TracingOptions const& options) const {
       .Build();
 }
 
-std::string ListFormatJob::DebugString(TracingOptions const& options) const {
-  auto job_configuration = MakeJobConfiguration(
-      options, configuration.job_type, configuration.query_config.query);
-  auto job_reference = MakeJobReference(options, reference.project_id,
-                                        reference.job_id, reference.location);
-  return internal::DebugFormatter(
-             options,
-             "google::cloud::bigquery_v2_minimal_internal::ListFormatJob")
+std::string ListFormatJob::DebugString(absl::string_view name,
+                                       TracingOptions const& options,
+                                       int indent) const {
+  auto job_configuration =
+      MakeJobConfiguration("JobConfiguration", options, configuration.job_type,
+                           configuration.query_config.query);
+  auto job_reference =
+      MakeJobReference("JobReference", options, reference.project_id,
+                       reference.job_id, reference.location);
+
+  return internal::DebugFormatter(name, options, indent)
       .StringField("id", id)
       .StringField("kind", kind)
       .StringField("state", state)

--- a/google/cloud/bigquery/v2/minimal/internal/job.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job.cc
@@ -21,44 +21,33 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace {
-std::string MakeJobConfiguration(absl::string_view name,
-                                 TracingOptions const& options,
-                                 std::string job_type, std::string query) {
-  return internal::DebugFormatter(name, options)
-      .StringField("job_type", std::move(job_type))
-      .StringField("query", std::move(query))
+std::string JobConfiguration::DebugString(absl::string_view name,
+                                          TracingOptions const& options,
+                                          int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("job_type", job_type)
+      .StringField("query", query_config.query)
       .Build();
 }
 
-std::string MakeJobReference(absl::string_view name,
-                             TracingOptions const& options,
-                             std::string project_id, std::string job_id,
-                             std::string location) {
-  return internal::DebugFormatter(name, options)
-      .StringField("project_id", std::move(project_id))
-      .StringField("job_id", std::move(job_id))
-      .StringField("location", std::move(location))
+std::string JobReference::DebugString(absl::string_view name,
+                                      TracingOptions const& options,
+                                      int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("project_id", project_id)
+      .StringField("job_id", job_id)
+      .StringField("location", location)
       .Build();
 }
-
-}  // namespace
 
 std::string Job::DebugString(absl::string_view name,
                              TracingOptions const& options, int indent) const {
-  auto job_configuration =
-      MakeJobConfiguration("JobConfiguration", options, configuration.job_type,
-                           configuration.query_config.query);
-  auto job_reference =
-      MakeJobReference("JobReference", options, reference.project_id,
-                       reference.job_id, reference.location);
-
   return internal::DebugFormatter(name, options, indent)
       .StringField("etag", etag)
       .StringField("kind", kind)
       .StringField("id", id)
-      .StringField("job_configuration", job_configuration)
-      .StringField("job_reference", job_reference)
+      .SubMessage("job_configuration", configuration)
+      .SubMessage("job_reference", reference)
       .StringField("job_status", status.state)
       .StringField("error_result", status.error_result.message)
       .Build();
@@ -67,19 +56,12 @@ std::string Job::DebugString(absl::string_view name,
 std::string ListFormatJob::DebugString(absl::string_view name,
                                        TracingOptions const& options,
                                        int indent) const {
-  auto job_configuration =
-      MakeJobConfiguration("JobConfiguration", options, configuration.job_type,
-                           configuration.query_config.query);
-  auto job_reference =
-      MakeJobReference("JobReference", options, reference.project_id,
-                       reference.job_id, reference.location);
-
   return internal::DebugFormatter(name, options, indent)
       .StringField("id", id)
       .StringField("kind", kind)
       .StringField("state", state)
-      .StringField("job_configuration", job_configuration)
-      .StringField("job_reference", job_reference)
+      .SubMessage("job_configuration", configuration)
+      .SubMessage("job_reference", reference)
       .StringField("job_status", status.state)
       .StringField("error_result", status.error_result.message)
       .Build();

--- a/google/cloud/bigquery/v2/minimal/internal/job.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job.cc
@@ -21,36 +21,64 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+namespace {
+std::string MakeJobConfiguration(TracingOptions const& options,
+                                 std::string job_type, std::string query) {
+  return internal::DebugFormatter(
+             options,
+             "google::cloud::bigquery_v2_minimal_internal::JobConfiguration")
+      .StringField("job_type", std::move(job_type))
+      .StringField("query", std::move(query))
+      .Build();
+}
+
+std::string MakeJobReference(TracingOptions const& options,
+                             std::string project_id, std::string job_id,
+                             std::string location) {
+  return internal::DebugFormatter(
+             options,
+             "google::cloud::bigquery_v2_minimal_internal::JobReference")
+      .StringField("project_id", std::move(project_id))
+      .StringField("job_id", std::move(job_id))
+      .StringField("location", std::move(location))
+      .Build();
+}
+
+}  // namespace
+
 std::string Job::DebugString(TracingOptions const& options) const {
-  std::string out;
-  auto const* delim = options.single_line_mode() ? " " : "\n";
-  absl::StrAppend(&out, "Job{", delim, "etag=", etag, delim, ", kind=", kind,
-                  delim, ", id=", id, delim, ", job_configuration={", delim,
-                  "job_type=", configuration.job_type, delim,
-                  ", query=", configuration.query_config.query, delim, "}",
-                  delim, ", job_reference={", delim,
-                  "job_id=", reference.job_id, delim,
-                  ", location=", reference.location, delim,
-                  ", project_id=", reference.project_id, delim, "}", delim,
-                  ", job_status=", status.state, delim,
-                  ", error_result=", status.error_result.message, delim, "}");
-  return out;
+  auto job_configuration = MakeJobConfiguration(
+      options, configuration.job_type, configuration.query_config.query);
+  auto job_reference = MakeJobReference(options, reference.project_id,
+                                        reference.job_id, reference.location);
+  return internal::DebugFormatter(
+             options, "google::cloud::bigquery_v2_minimal_internal::Job")
+      .StringField("etag", etag)
+      .StringField("kind", kind)
+      .StringField("id", id)
+      .StringField("job_configuration", job_configuration)
+      .StringField("job_reference", job_reference)
+      .StringField("job_status", status.state)
+      .StringField("error_result", status.error_result.message)
+      .Build();
 }
 
 std::string ListFormatJob::DebugString(TracingOptions const& options) const {
-  std::string out;
-  auto const* delim = options.single_line_mode() ? " " : "\n";
-  absl::StrAppend(
-      &out, "ListFormatJob{", delim, "id=", id, delim, ", kind=", kind, delim,
-      ", state=", state, delim, ", job_configuration={", delim,
-      "job_type=", configuration.job_type, delim,
-      ", query=", configuration.query_config.query, delim, "}", delim,
-      ", job_reference={", delim, "job_id=", reference.job_id, delim,
-      ", location=", reference.location, delim,
-      ", project_id=", reference.project_id, delim, "}",
-      ", job_status=", status.state, delim,
-      ", error_result=", error_result.message, delim, "}");
-  return out;
+  auto job_configuration = MakeJobConfiguration(
+      options, configuration.job_type, configuration.query_config.query);
+  auto job_reference = MakeJobReference(options, reference.project_id,
+                                        reference.job_id, reference.location);
+  return internal::DebugFormatter(
+             options,
+             "google::cloud::bigquery_v2_minimal_internal::ListFormatJob")
+      .StringField("id", id)
+      .StringField("kind", kind)
+      .StringField("state", state)
+      .StringField("job_configuration", job_configuration)
+      .StringField("job_reference", job_reference)
+      .StringField("job_status", status.state)
+      .StringField("error_result", status.error_result.message)
+      .Build();
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigquery/v2/minimal/internal/job_configuration.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <string>
@@ -54,7 +55,9 @@ struct Job {
   JobReference reference;
   JobConfiguration configuration;
 
-  std::string DebugString(TracingOptions const& options) const;
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct ListFormatJob {
@@ -70,7 +73,9 @@ struct ListFormatJob {
 
   ErrorProto error_result;
 
-  std::string DebugString(TracingOptions const& options) const;
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(JobStatus, error_result, errors,

--- a/google/cloud/bigquery/v2/minimal/internal/job.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job.h
@@ -42,6 +42,10 @@ struct JobReference {
   std::string project_id;
   std::string job_id;
   std::string location;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct Job {

--- a/google/cloud/bigquery/v2/minimal/internal/job.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_H
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_configuration.h"
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
@@ -52,6 +53,8 @@ struct Job {
   JobStatus status;
   JobReference reference;
   JobConfiguration configuration;
+
+  std::string DebugString(TracingOptions const& options) const;
 };
 
 struct ListFormatJob {
@@ -66,6 +69,8 @@ struct ListFormatJob {
   JobStatus status;
 
   ErrorProto error_result;
+
+  std::string DebugString(TracingOptions const& options) const;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(JobStatus, error_result, errors,

--- a/google/cloud/bigquery/v2/minimal/internal/job_configuration.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_configuration.h
@@ -16,7 +16,9 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_CONFIGURATION_H
 
 #include "google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h"
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <nlohmann/json.hpp>
 #include <string>
 
@@ -57,6 +59,10 @@ struct JobConfiguration {
   std::map<std::string, std::string> labels;
 
   JobConfigurationQuery query_config;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -16,13 +16,13 @@
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/make_status.h"
-#include <iostream>
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+namespace {
 bool valid_job(nlohmann::json const& j) {
   return (j.contains("kind") && j.contains("etag") && j.contains("id") &&
           j.contains("status") && j.contains("reference") &&
@@ -57,13 +57,13 @@ StatusOr<nlohmann::json> parse_json(std::string const& payload) {
 std::string DebugJobsString(std::vector<ListFormatJob> const& jobs,
                             TracingOptions const& options) {
   std::string out;
-  auto const* delim = options.single_line_mode() ? " " : "\n";
   for (auto const& j : jobs) {
     std::string jout;
-    absl::StrAppend(&out, j.DebugString(options), delim);
+    absl::StrAppend(&out, j.DebugString(options));
   }
   return out;
 }
+}  // namespace
 
 StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
     BigQueryHttpResponse const& http_response) {
@@ -83,12 +83,12 @@ StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
 }
 
 std::string GetJobResponse::DebugString(TracingOptions const& options) const {
-  std::string out;
-  auto const* delim = options.single_line_mode() ? " " : "\n";
-  absl::StrAppend(&out, "GetJobResponse{", delim, "http_response={", delim,
-                  http_response.DebugString(options), delim, "}", delim,
-                  ", job={", delim, job.DebugString(options), delim, "}");
-  return out;
+  return internal::DebugFormatter(
+             options,
+             "google::cloud::bigquery_v2_minimal_internal::GetJobResponse")
+      .StringField("http_response", http_response.DebugString(options))
+      .StringField("job", job.DebugString(options))
+      .Build();
 }
 
 StatusOr<ListJobsResponse> ListJobsResponse::BuildFromHttpResponse(
@@ -122,13 +122,12 @@ StatusOr<ListJobsResponse> ListJobsResponse::BuildFromHttpResponse(
 }
 
 std::string ListJobsResponse::DebugString(TracingOptions const& options) const {
-  std::string out;
-  auto const* delim = options.single_line_mode() ? " " : "\n";
-  absl::StrAppend(&out, "ListJobsResponse{", delim, "http_response={", delim,
-                  http_response.DebugString(options), delim, "}", delim,
-                  ", jobs={", delim, DebugJobsString(jobs, options), delim,
-                  "}");
-  return internal::DebugString(out, options);
+  return internal::DebugFormatter(
+             options,
+             "google::cloud::bigquery_v2_minimal_internal::ListJobsResponse")
+      .StringField("http_response", http_response.DebugString(options))
+      .StringField("jobs", DebugJobsString(jobs, options))
+      .Build();
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -87,9 +87,8 @@ std::string GetJobResponse::DebugString(absl::string_view name,
                                         TracingOptions const& options,
                                         int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .StringField("http_response",
-                   http_response.DebugString("BigQueryHttpResponse", options))
-      .StringField("job", job.DebugString("Job", options, indent))
+      .SubMessage("http_response", http_response)
+      .SubMessage("job", job)
       .Build();
 }
 
@@ -127,8 +126,7 @@ std::string ListJobsResponse::DebugString(absl::string_view name,
                                           TracingOptions const& options,
                                           int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .StringField("http_response",
-                   http_response.DebugString("BigQueryHttpResponse", options))
+      .SubMessage("http_response", http_response)
       .StringField("jobs",
                    DebugJobsString(jobs, "ListFormatJob", options, indent))
       .Build();

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_response.h"
 #include "google/cloud/internal/make_status.h"
+#include <iostream>
 
 namespace google {
 namespace cloud {
@@ -96,6 +97,54 @@ StatusOr<ListJobsResponse> ListJobsResponse::BuildFromHttpResponse(
   }
 
   return result;
+}
+
+std::ostream& operator<<(std::ostream& os, Job const& job) {
+  os << "Job{etag=" << job.etag << ", kind=" << job.kind << ", id=" << job.id
+     << ", job_configuration={job_type=" << job.configuration.job_type
+     << ", query=" << job.configuration.query_config.query << "}"
+     << ", job_reference={"
+     << "job_id=" << job.reference.job_id
+     << ", location=" << job.reference.location
+     << ", project_id=" << job.reference.project_id << "}";
+  os << ", job_status=" << job.status.state
+     << ", error_result=" << job.status.error_result.message << "}";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         ListFormatJob const& list_format_job) {
+  os << "Job{id=" << list_format_job.id << ", kind=" << list_format_job.kind
+     << ", state=" << list_format_job.state << ", job_configuration={job_type="
+     << list_format_job.configuration.job_type
+     << ", query=" << list_format_job.configuration.query_config.query << "}"
+     << ", job_reference={"
+     << "job_id=" << list_format_job.reference.job_id
+     << ", location=" << list_format_job.reference.location
+     << ", project_id=" << list_format_job.reference.project_id << "}";
+  os << ", job_status=" << list_format_job.status.state
+     << ", error_result=" << list_format_job.error_result.message << "}";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         std::vector<ListFormatJob> const& jobs) {
+  for (auto const& j : jobs) {
+    os << j << ",";
+  }
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, GetJobResponse const& response) {
+  os << "GetJobResponse{http_response={" << response.http_response << "}";
+  os << ", job={" << response.job << "}";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, ListJobsResponse const& response) {
+  os << "ListJobsResponse{http_response={" << response.http_response << "}";
+  os << ", jobs={" << response.jobs << "}";
+  return os;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_response.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/make_status.h"
 #include <iostream>
 
@@ -52,6 +54,16 @@ StatusOr<nlohmann::json> parse_json(std::string const& payload) {
   return json;
 }
 
+std::string DebugJobsString(std::vector<ListFormatJob> const& jobs,
+                            TracingOptions const& options) {
+  std::string out;
+  for (auto const& j : jobs) {
+    std::string jout;
+    absl::StrAppend(&out, j.DebugString(options), ",");
+  }
+  return internal::DebugString(out, options);
+}
+
 StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
     BigQueryHttpResponse const& http_response) {
   auto json = parse_json(http_response.payload);
@@ -67,6 +79,14 @@ StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
   result.http_response = http_response;
 
   return result;
+}
+
+std::string GetJobResponse::DebugString(TracingOptions const& options) const {
+  std::string out;
+  absl::StrAppend(&out, "GetJobResponse{http_response={",
+                  http_response.DebugString(options), "}, job={",
+                  job.DebugString(options), "}");
+  return internal::DebugString(out, options);
 }
 
 StatusOr<ListJobsResponse> ListJobsResponse::BuildFromHttpResponse(
@@ -99,52 +119,12 @@ StatusOr<ListJobsResponse> ListJobsResponse::BuildFromHttpResponse(
   return result;
 }
 
-std::ostream& operator<<(std::ostream& os, Job const& job) {
-  os << "Job{etag=" << job.etag << ", kind=" << job.kind << ", id=" << job.id
-     << ", job_configuration={job_type=" << job.configuration.job_type
-     << ", query=" << job.configuration.query_config.query << "}"
-     << ", job_reference={"
-     << "job_id=" << job.reference.job_id
-     << ", location=" << job.reference.location
-     << ", project_id=" << job.reference.project_id << "}";
-  os << ", job_status=" << job.status.state
-     << ", error_result=" << job.status.error_result.message << "}";
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os,
-                         ListFormatJob const& list_format_job) {
-  os << "Job{id=" << list_format_job.id << ", kind=" << list_format_job.kind
-     << ", state=" << list_format_job.state << ", job_configuration={job_type="
-     << list_format_job.configuration.job_type
-     << ", query=" << list_format_job.configuration.query_config.query << "}"
-     << ", job_reference={"
-     << "job_id=" << list_format_job.reference.job_id
-     << ", location=" << list_format_job.reference.location
-     << ", project_id=" << list_format_job.reference.project_id << "}";
-  os << ", job_status=" << list_format_job.status.state
-     << ", error_result=" << list_format_job.error_result.message << "}";
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os,
-                         std::vector<ListFormatJob> const& jobs) {
-  for (auto const& j : jobs) {
-    os << j << ",";
-  }
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os, GetJobResponse const& response) {
-  os << "GetJobResponse{http_response={" << response.http_response << "}";
-  os << ", job={" << response.job << "}";
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os, ListJobsResponse const& response) {
-  os << "ListJobsResponse{http_response={" << response.http_response << "}";
-  os << ", jobs={" << response.jobs << "}";
-  return os;
+std::string ListJobsResponse::DebugString(TracingOptions const& options) const {
+  std::string out;
+  absl::StrAppend(&out, "ListJobsResponse{http_response={",
+                  http_response.DebugString(options), "}, jobs={",
+                  DebugJobsString(jobs, options), "}");
+  return internal::DebugString(out, options);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -57,11 +57,12 @@ StatusOr<nlohmann::json> parse_json(std::string const& payload) {
 std::string DebugJobsString(std::vector<ListFormatJob> const& jobs,
                             TracingOptions const& options) {
   std::string out;
+  auto const* delim = options.single_line_mode() ? " " : "\n";
   for (auto const& j : jobs) {
     std::string jout;
-    absl::StrAppend(&out, j.DebugString(options), ",");
+    absl::StrAppend(&out, j.DebugString(options), delim);
   }
-  return internal::DebugString(out, options);
+  return out;
 }
 
 StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
@@ -83,10 +84,11 @@ StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
 
 std::string GetJobResponse::DebugString(TracingOptions const& options) const {
   std::string out;
-  absl::StrAppend(&out, "GetJobResponse{http_response={",
-                  http_response.DebugString(options), "}, job={",
-                  job.DebugString(options), "}");
-  return internal::DebugString(out, options);
+  auto const* delim = options.single_line_mode() ? " " : "\n";
+  absl::StrAppend(&out, "GetJobResponse{", delim, "http_response={", delim,
+                  http_response.DebugString(options), delim, "}", delim,
+                  ", job={", delim, job.DebugString(options), delim, "}");
+  return out;
 }
 
 StatusOr<ListJobsResponse> ListJobsResponse::BuildFromHttpResponse(
@@ -121,9 +123,11 @@ StatusOr<ListJobsResponse> ListJobsResponse::BuildFromHttpResponse(
 
 std::string ListJobsResponse::DebugString(TracingOptions const& options) const {
   std::string out;
-  absl::StrAppend(&out, "ListJobsResponse{http_response={",
-                  http_response.DebugString(options), "}, jobs={",
-                  DebugJobsString(jobs, options), "}");
+  auto const* delim = options.single_line_mode() ? " " : "\n";
+  absl::StrAppend(&out, "ListJobsResponse{", delim, "http_response={", delim,
+                  http_response.DebugString(options), delim, "}", delim,
+                  ", jobs={", delim, DebugJobsString(jobs, options), delim,
+                  "}");
   return internal::DebugString(out, options);
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -55,11 +55,12 @@ StatusOr<nlohmann::json> parse_json(std::string const& payload) {
 }
 
 std::string DebugJobsString(std::vector<ListFormatJob> const& jobs,
-                            TracingOptions const& options) {
+                            absl::string_view name,
+                            TracingOptions const& options, int indent) {
   std::string out;
   for (auto const& j : jobs) {
     std::string jout;
-    absl::StrAppend(&out, j.DebugString(options));
+    absl::StrAppend(&out, j.DebugString(name, options, indent));
   }
   return out;
 }
@@ -82,12 +83,13 @@ StatusOr<GetJobResponse> GetJobResponse::BuildFromHttpResponse(
   return result;
 }
 
-std::string GetJobResponse::DebugString(TracingOptions const& options) const {
-  return internal::DebugFormatter(
-             options,
-             "google::cloud::bigquery_v2_minimal_internal::GetJobResponse")
-      .StringField("http_response", http_response.DebugString(options))
-      .StringField("job", job.DebugString(options))
+std::string GetJobResponse::DebugString(absl::string_view name,
+                                        TracingOptions const& options,
+                                        int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("http_response",
+                   http_response.DebugString("BigQueryHttpResponse", options))
+      .StringField("job", job.DebugString("Job", options, indent))
       .Build();
 }
 
@@ -121,12 +123,14 @@ StatusOr<ListJobsResponse> ListJobsResponse::BuildFromHttpResponse(
   return result;
 }
 
-std::string ListJobsResponse::DebugString(TracingOptions const& options) const {
-  return internal::DebugFormatter(
-             options,
-             "google::cloud::bigquery_v2_minimal_internal::ListJobsResponse")
-      .StringField("http_response", http_response.DebugString(options))
-      .StringField("jobs", DebugJobsString(jobs, options))
+std::string ListJobsResponse::DebugString(absl::string_view name,
+                                          TracingOptions const& options,
+                                          int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("http_response",
+                   http_response.DebugString("BigQueryHttpResponse", options))
+      .StringField("jobs",
+                   DebugJobsString(jobs, "ListFormatJob", options, indent))
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -20,6 +20,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,9 @@ class GetJobResponse {
   static StatusOr<GetJobResponse> BuildFromHttpResponse(
       BigQueryHttpResponse const& http_response);
 
-  std::string DebugString(TracingOptions const& options) const;
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 
   Job job;
   BigQueryHttpResponse http_response;
@@ -48,7 +51,9 @@ class ListJobsResponse {
   static StatusOr<ListJobsResponse> BuildFromHttpResponse(
       BigQueryHttpResponse const& http_response);
 
-  std::string DebugString(TracingOptions const& options) const;
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 
   std::vector<ListFormatJob> jobs;
   std::string next_page_token;

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigquery/v2/minimal/internal/job.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <iosfwd>
 
 namespace google {
 namespace cloud {
@@ -52,6 +53,14 @@ class ListJobsResponse {
 
   BigQueryHttpResponse http_response;
 };
+
+std::ostream& operator<<(std::ostream& os, Job const& job);
+std::ostream& operator<<(std::ostream& os,
+                         ListFormatJob const& list_format_job);
+std::ostream& operator<<(std::ostream& os,
+                         std::vector<ListFormatJob> const& jobs);
+std::ostream& operator<<(std::ostream& os, GetJobResponse const& response);
+std::ostream& operator<<(std::ostream& os, ListJobsResponse const& response);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -20,7 +20,6 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
-#include <iosfwd>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h"
 #include "google/cloud/bigquery/v2/minimal/internal/job.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include <iosfwd>
 
@@ -34,6 +35,8 @@ class GetJobResponse {
   static StatusOr<GetJobResponse> BuildFromHttpResponse(
       BigQueryHttpResponse const& http_response);
 
+  std::string DebugString(TracingOptions const& options) const;
+
   Job job;
   BigQueryHttpResponse http_response;
 };
@@ -46,6 +49,8 @@ class ListJobsResponse {
   static StatusOr<ListJobsResponse> BuildFromHttpResponse(
       BigQueryHttpResponse const& http_response);
 
+  std::string DebugString(TracingOptions const& options) const;
+
   std::vector<ListFormatJob> jobs;
   std::string next_page_token;
   std::string kind;
@@ -53,14 +58,6 @@ class ListJobsResponse {
 
   BigQueryHttpResponse http_response;
 };
-
-std::ostream& operator<<(std::ostream& os, Job const& job);
-std::ostream& operator<<(std::ostream& os,
-                         ListFormatJob const& list_format_job);
-std::ostream& operator<<(std::ostream& os,
-                         std::vector<ListFormatJob> const& jobs);
-std::ostream& operator<<(std::ostream& os, GetJobResponse const& response);
-std::ostream& operator<<(std::ostream& os, ListJobsResponse const& response);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -223,18 +223,61 @@ TEST(GetJobResponseTest, DebugString) {
   auto response = GetJobResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
 
-  std::string expected =
-      "GetJobResponse{ http_response={ BigQueryHttpResponse{ "
-      "Status_Code=200 , headers={ header1: value1 }} } , job={ Job{ "
-      "etag=jtag , kind=jkind , id=j123 , job_configuration={ job_type=QUERY , "
-      "query=select 1; } , job_reference={ job_id=j123 , location= , "
-      "project_id=p123 } , "
-      "job_status=DONE , error_result= } }";
+  EXPECT_EQ(
+      response->DebugString(TracingOptions{}),
+      R"(google::cloud::bigquery_v2_minimal_internal::GetJobResponse {)"
+      R"( http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
+      R"( status_code: 200 headers: "header1: value1")"
+      R"( }")"
+      R"( job: "google::cloud::bigquery_v2_minimal_internal::Job {)"
+      R"( etag: "jtag")"
+      R"( kind: "jkind")"
+      R"( id: "j123")"
+      R"( job_configuration: "google::cloud::bigq...<truncated>...")"
+      R"( })");
 
-  EXPECT_EQ(expected, response->DebugString(TracingOptions{}));
+  EXPECT_EQ(
+      response->DebugString(TracingOptions{}.SetOptions(
+          "truncate_string_field_longer_than=1024")),
+      R"(google::cloud::bigquery_v2_minimal_internal::GetJobResponse {)"
+      R"( http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
+      R"( status_code: 200)"
+      R"( headers: "header1: value1")"
+      R"( }")"
+      R"( job: "google::cloud::bigquery_v2_minimal_internal::Job {)"
+      R"( etag: "jtag")"
+      R"( kind: "jkind")"
+      R"( id: "j123")"
+      R"( job_configuration: "google::cloud::bigquery_v2_minimal_internal::JobConfiguration {)"
+      R"( job_type: "QUERY")"
+      R"( query: "select 1;")"
+      R"( }")"
+      R"( job_reference: "google::cloud::bigquery_v2_minimal_internal::JobReference {)"
+      R"( project_id: "p123")"
+      R"( job_id: "j123")"
+      R"( location: "")"
+      R"( }")"
+      R"( job_status: "DONE")"
+      R"( error_result: "")"
+      R"( }")"
+      R"( })");
+
+  EXPECT_EQ(
+      response->DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
+      R"(google::cloud::bigquery_v2_minimal_internal::GetJobResponse {
+  http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {
+  status_code: 200
+  headers: "header1: value1"
+}"
+  job: "google::cloud::bigquery_v2_minimal_internal::Job {
+  etag: "jtag"
+  kind: "jkind"
+  id: "j123"
+  job_configuration: "google::clo...<truncated>..."
+})");
 }
 
-TEST(ListJobsResponseTest, OutputStream) {
+TEST(ListJobsResponseTest, DebugString) {
   BigQueryHttpResponse http_response;
   http_response.http_status_code = HttpStatusCode::kOk;
   http_response.http_headers.insert({{"header1", "value1"}});
@@ -260,12 +303,59 @@ TEST(ListJobsResponseTest, OutputStream) {
   auto response = ListJobsResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
 
-  std::string expected =
-      "ListJobsResponse{ http_response={ BigQueryHttpResponse{ Status_Code=200 "
-      ", "
-      "headers={ header1: value1 }} } , jobs={ ListFormatJob{...<truncated>...";
+  EXPECT_EQ(
+      response->DebugString(TracingOptions{}),
+      R"(google::cloud::bigquery_v2_minimal_internal::ListJobsResponse {)"
+      R"( http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
+      R"( status_code: 200)"
+      R"( headers: "header1: value1")"
+      R"( }")"
+      R"( jobs: "google::cloud::bigquery_v2_minimal_internal::ListFormatJob {)"
+      R"( id: "1")"
+      R"( kind: "kind-2")"
+      R"( state: "DONE")"
+      R"( job_configuration: "google::cl...<truncated>...")"
+      R"( })");
 
-  EXPECT_EQ(expected, response->DebugString(TracingOptions{}));
+  EXPECT_EQ(
+      response->DebugString(TracingOptions{}.SetOptions(
+          "truncate_string_field_longer_than=1024")),
+      R"(google::cloud::bigquery_v2_minimal_internal::ListJobsResponse {)"
+      R"( http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
+      R"( status_code: 200)"
+      R"( headers: "header1: value1")"
+      R"( }")"
+      R"( jobs: "google::cloud::bigquery_v2_minimal_internal::ListFormatJob {)"
+      R"( id: "1")"
+      R"( kind: "kind-2")"
+      R"( state: "DONE")"
+      R"( job_configuration: "google::cloud::bigquery_v2_minimal_internal::JobConfiguration {)"
+      R"( job_type: "QUERY")"
+      R"( query: "select 1;")"
+      R"( }")"
+      R"( job_reference: "google::cloud::bigquery_v2_minimal_internal::JobReference {)"
+      R"( project_id: "p123")"
+      R"( job_id: "j123")"
+      R"( location: "")"
+      R"( }")"
+      R"( job_status: "DONE")"
+      R"( error_result: "")"
+      R"( }")"
+      R"( })");
+
+  EXPECT_EQ(
+      response->DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
+      R"(google::cloud::bigquery_v2_minimal_internal::ListJobsResponse {
+  http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {
+  status_code: 200
+  headers: "header1: value1"
+}"
+  jobs: "google::cloud::bigquery_v2_minimal_internal::ListFormatJob {
+  id: "1"
+  kind: "kind-2"
+  state: "DONE"
+  job_configuration: "go...<truncated>..."
+})");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -223,36 +223,41 @@ TEST(GetJobResponseTest, DebugString) {
   auto response = GetJobResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
 
-  EXPECT_EQ(
-      response->DebugString(TracingOptions{}),
-      R"(google::cloud::bigquery_v2_minimal_internal::GetJobResponse {)"
-      R"( http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
-      R"( status_code: 200 headers: "header1: value1")"
-      R"( }")"
-      R"( job: "google::cloud::bigquery_v2_minimal_internal::Job {)"
-      R"( etag: "jtag")"
-      R"( kind: "jkind")"
-      R"( id: "j123")"
-      R"( job_configuration: "google::cloud::bigq...<truncated>...")"
-      R"( })");
+  EXPECT_EQ(response->DebugString("GetJobResponse", TracingOptions{}),
+            R"(GetJobResponse {)"
+            R"( http_response: "BigQueryHttpResponse {)"
+            R"( status_code: 200)"
+            R"( headers: "header1: value1")"
+            R"( }")"
+            R"( job: "Job {)"
+            R"( etag: "jtag")"
+            R"( kind: "jkind")"
+            R"( id: "j123")"
+            R"( job_configuration: "JobConfiguration {)"
+            R"( job_type: "QUERY")"
+            R"( query: "select 1;")"
+            R"( }")"
+            R"( job_r...<truncated>...")"
+            R"( })");
 
   EXPECT_EQ(
-      response->DebugString(TracingOptions{}.SetOptions(
-          "truncate_string_field_longer_than=1024")),
-      R"(google::cloud::bigquery_v2_minimal_internal::GetJobResponse {)"
-      R"( http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
+      response->DebugString("GetJobResponse",
+                            TracingOptions{}.SetOptions(
+                                "truncate_string_field_longer_than=1024")),
+      R"(GetJobResponse {)"
+      R"( http_response: "BigQueryHttpResponse {)"
       R"( status_code: 200)"
       R"( headers: "header1: value1")"
       R"( }")"
-      R"( job: "google::cloud::bigquery_v2_minimal_internal::Job {)"
+      R"( job: "Job {)"
       R"( etag: "jtag")"
       R"( kind: "jkind")"
       R"( id: "j123")"
-      R"( job_configuration: "google::cloud::bigquery_v2_minimal_internal::JobConfiguration {)"
+      R"( job_configuration: "JobConfiguration {)"
       R"( job_type: "QUERY")"
       R"( query: "select 1;")"
       R"( }")"
-      R"( job_reference: "google::cloud::bigquery_v2_minimal_internal::JobReference {)"
+      R"( job_reference: "JobReference {)"
       R"( project_id: "p123")"
       R"( job_id: "j123")"
       R"( location: "")"
@@ -262,18 +267,20 @@ TEST(GetJobResponseTest, DebugString) {
       R"( }")"
       R"( })");
 
-  EXPECT_EQ(
-      response->DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
-      R"(google::cloud::bigquery_v2_minimal_internal::GetJobResponse {
-  http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {
+  EXPECT_EQ(response->DebugString("GetJobResponse", TracingOptions{}.SetOptions(
+                                                        "single_line_mode=F")),
+            R"(GetJobResponse {
+  http_response: "BigQueryHttpResponse {
   status_code: 200
   headers: "header1: value1"
 }"
-  job: "google::cloud::bigquery_v2_minimal_internal::Job {
+  job: "Job {
   etag: "jtag"
   kind: "jkind"
   id: "j123"
-  job_configuration: "google::clo...<truncated>..."
+  job_configuration: "JobConfiguration {
+  job_type: "QUERY"
+  query: "select ...<truncated>..."
 })");
 }
 
@@ -303,37 +310,39 @@ TEST(ListJobsResponseTest, DebugString) {
   auto response = ListJobsResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
 
-  EXPECT_EQ(
-      response->DebugString(TracingOptions{}),
-      R"(google::cloud::bigquery_v2_minimal_internal::ListJobsResponse {)"
-      R"( http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
-      R"( status_code: 200)"
-      R"( headers: "header1: value1")"
-      R"( }")"
-      R"( jobs: "google::cloud::bigquery_v2_minimal_internal::ListFormatJob {)"
-      R"( id: "1")"
-      R"( kind: "kind-2")"
-      R"( state: "DONE")"
-      R"( job_configuration: "google::cl...<truncated>...")"
-      R"( })");
+  EXPECT_EQ(response->DebugString("ListJobsResponse", TracingOptions{}),
+            R"(ListJobsResponse {)"
+            R"( http_response: "BigQueryHttpResponse {)"
+            R"( status_code: 200)"
+            R"( headers: "header1: value1")"
+            R"( }")"
+            R"( jobs: "ListFormatJob {)"
+            R"( id: "1")"
+            R"( kind: "kind-2")"
+            R"( state: "DONE")"
+            R"( job_configuration: "JobConfiguration {)"
+            R"( job_type: "QUERY")"
+            R"( query: "select 1;"...<truncated>...")"
+            R"( })");
 
   EXPECT_EQ(
-      response->DebugString(TracingOptions{}.SetOptions(
-          "truncate_string_field_longer_than=1024")),
-      R"(google::cloud::bigquery_v2_minimal_internal::ListJobsResponse {)"
-      R"( http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {)"
+      response->DebugString("ListJobsResponse",
+                            TracingOptions{}.SetOptions(
+                                "truncate_string_field_longer_than=1024")),
+      R"(ListJobsResponse {)"
+      R"( http_response: "BigQueryHttpResponse {)"
       R"( status_code: 200)"
       R"( headers: "header1: value1")"
       R"( }")"
-      R"( jobs: "google::cloud::bigquery_v2_minimal_internal::ListFormatJob {)"
+      R"( jobs: "ListFormatJob {)"
       R"( id: "1")"
       R"( kind: "kind-2")"
       R"( state: "DONE")"
-      R"( job_configuration: "google::cloud::bigquery_v2_minimal_internal::JobConfiguration {)"
+      R"( job_configuration: "JobConfiguration {)"
       R"( job_type: "QUERY")"
       R"( query: "select 1;")"
       R"( }")"
-      R"( job_reference: "google::cloud::bigquery_v2_minimal_internal::JobReference {)"
+      R"( job_reference: "JobReference {)"
       R"( project_id: "p123")"
       R"( job_id: "j123")"
       R"( location: "")"
@@ -344,17 +353,20 @@ TEST(ListJobsResponseTest, DebugString) {
       R"( })");
 
   EXPECT_EQ(
-      response->DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
-      R"(google::cloud::bigquery_v2_minimal_internal::ListJobsResponse {
-  http_response: "google::cloud::bigquery_v2_minimal_internal::BigQueryHttpResponse {
+      response->DebugString("ListJobsResponse",
+                            TracingOptions{}.SetOptions("single_line_mode=F")),
+      R"(ListJobsResponse {
+  http_response: "BigQueryHttpResponse {
   status_code: 200
   headers: "header1: value1"
 }"
-  jobs: "google::cloud::bigquery_v2_minimal_internal::ListFormatJob {
+  jobs: "ListFormatJob {
   id: "1"
   kind: "kind-2"
   state: "DONE"
-  job_configuration: "go...<truncated>..."
+  job_configuration: "JobConfiguration {
+  job_type: "QUERY"
+  query:...<truncated>..."
 })");
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -225,62 +225,51 @@ TEST(GetJobResponseTest, DebugString) {
 
   EXPECT_EQ(response->DebugString("GetJobResponse", TracingOptions{}),
             R"(GetJobResponse {)"
-            R"( http_response: "BigQueryHttpResponse {)"
+            R"( http_response {)"
             R"( status_code: 200)"
             R"( headers: "header1: value1")"
-            R"( }")"
-            R"( job: "Job {)"
+            R"( })"
+            R"( job {)"
             R"( etag: "jtag")"
             R"( kind: "jkind")"
             R"( id: "j123")"
-            R"( job_configuration: "JobConfiguration {)"
+            R"( job_configuration {)"
             R"( job_type: "QUERY")"
             R"( query: "select 1;")"
-            R"( }")"
-            R"( job_r...<truncated>...")"
+            R"( })"
+            R"( job_reference {)"
+            R"( project_id: "p123")"
+            R"( job_id: "j123")"
+            R"( location: "")"
+            R"( })"
+            R"( job_status: "DONE")"
+            R"( error_result: "")"
+            R"( })"
             R"( })");
-
-  EXPECT_EQ(
-      response->DebugString("GetJobResponse",
-                            TracingOptions{}.SetOptions(
-                                "truncate_string_field_longer_than=1024")),
-      R"(GetJobResponse {)"
-      R"( http_response: "BigQueryHttpResponse {)"
-      R"( status_code: 200)"
-      R"( headers: "header1: value1")"
-      R"( }")"
-      R"( job: "Job {)"
-      R"( etag: "jtag")"
-      R"( kind: "jkind")"
-      R"( id: "j123")"
-      R"( job_configuration: "JobConfiguration {)"
-      R"( job_type: "QUERY")"
-      R"( query: "select 1;")"
-      R"( }")"
-      R"( job_reference: "JobReference {)"
-      R"( project_id: "p123")"
-      R"( job_id: "j123")"
-      R"( location: "")"
-      R"( }")"
-      R"( job_status: "DONE")"
-      R"( error_result: "")"
-      R"( }")"
-      R"( })");
 
   EXPECT_EQ(response->DebugString("GetJobResponse", TracingOptions{}.SetOptions(
                                                         "single_line_mode=F")),
             R"(GetJobResponse {
-  http_response: "BigQueryHttpResponse {
-  status_code: 200
-  headers: "header1: value1"
-}"
-  job: "Job {
-  etag: "jtag"
-  kind: "jkind"
-  id: "j123"
-  job_configuration: "JobConfiguration {
-  job_type: "QUERY"
-  query: "select ...<truncated>..."
+  http_response {
+    status_code: 200
+    headers: "header1: value1"
+  }
+  job {
+    etag: "jtag"
+    kind: "jkind"
+    id: "j123"
+    job_configuration {
+      job_type: "QUERY"
+      query: "select 1;"
+    }
+    job_reference {
+      project_id: "p123"
+      job_id: "j123"
+      location: ""
+    }
+    job_status: "DONE"
+    error_result: ""
+  }
 })");
 }
 
@@ -312,17 +301,19 @@ TEST(ListJobsResponseTest, DebugString) {
 
   EXPECT_EQ(response->DebugString("ListJobsResponse", TracingOptions{}),
             R"(ListJobsResponse {)"
-            R"( http_response: "BigQueryHttpResponse {)"
+            R"( http_response {)"
             R"( status_code: 200)"
             R"( headers: "header1: value1")"
-            R"( }")"
+            R"( })"
             R"( jobs: "ListFormatJob {)"
             R"( id: "1")"
             R"( kind: "kind-2")"
             R"( state: "DONE")"
-            R"( job_configuration: "JobConfiguration {)"
+            R"( job_configuration {)"
             R"( job_type: "QUERY")"
-            R"( query: "select 1;"...<truncated>...")"
+            R"( query: "select 1;")"
+            R"( })"
+            R"( job_reference { ...<truncated>...")"
             R"( })");
 
   EXPECT_EQ(
@@ -330,23 +321,23 @@ TEST(ListJobsResponseTest, DebugString) {
                             TracingOptions{}.SetOptions(
                                 "truncate_string_field_longer_than=1024")),
       R"(ListJobsResponse {)"
-      R"( http_response: "BigQueryHttpResponse {)"
+      R"( http_response {)"
       R"( status_code: 200)"
       R"( headers: "header1: value1")"
-      R"( }")"
+      R"( })"
       R"( jobs: "ListFormatJob {)"
       R"( id: "1")"
       R"( kind: "kind-2")"
       R"( state: "DONE")"
-      R"( job_configuration: "JobConfiguration {)"
+      R"( job_configuration {)"
       R"( job_type: "QUERY")"
       R"( query: "select 1;")"
-      R"( }")"
-      R"( job_reference: "JobReference {)"
+      R"( })"
+      R"( job_reference {)"
       R"( project_id: "p123")"
       R"( job_id: "j123")"
       R"( location: "")"
-      R"( }")"
+      R"( })"
       R"( job_status: "DONE")"
       R"( error_result: "")"
       R"( }")"
@@ -356,17 +347,18 @@ TEST(ListJobsResponseTest, DebugString) {
       response->DebugString("ListJobsResponse",
                             TracingOptions{}.SetOptions("single_line_mode=F")),
       R"(ListJobsResponse {
-  http_response: "BigQueryHttpResponse {
-  status_code: 200
-  headers: "header1: value1"
-}"
+  http_response {
+    status_code: 200
+    headers: "header1: value1"
+  }
   jobs: "ListFormatJob {
   id: "1"
   kind: "kind-2"
   state: "DONE"
-  job_configuration: "JobConfiguration {
-  job_type: "QUERY"
-  query:...<truncated>..."
+  job_configuration {
+    job_type: "QUERY"
+    query: "select 1;"
+  ...<truncated>..."
 })");
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -224,16 +224,14 @@ TEST(GetJobResponseTest, DebugString) {
   ASSERT_STATUS_OK(response);
 
   std::string expected =
-      "GetJobResponse{"
-      "http_response={BigQueryHttpResponse{"
-      "Status_Code=200, headers={header1: value1}}}, "
-      "job={Job{etag=jtag, kind=jkind, id=j123, "
-      "job_configuration={job_type=QUERY, query=select 1;}, "
-      "job_reference={job_id=j123, location=, project_id=p123}, "
-      "job_status=DONE, error_result=}}";
+      "GetJobResponse{ http_response={ BigQueryHttpResponse{ "
+      "Status_Code=200 , headers={ header1: value1 }} } , job={ Job{ "
+      "etag=jtag , kind=jkind , id=j123 , job_configuration={ job_type=QUERY , "
+      "query=select 1; } , job_reference={ job_id=j123 , location= , "
+      "project_id=p123 } , "
+      "job_status=DONE , error_result= } }";
 
-  EXPECT_EQ(expected, response->DebugString(TracingOptions{}.SetOptions(
-                          "truncate_string_field_longer_than=1024")));
+  EXPECT_EQ(expected, response->DebugString(TracingOptions{}));
 }
 
 TEST(ListJobsResponseTest, OutputStream) {
@@ -263,16 +261,11 @@ TEST(ListJobsResponseTest, OutputStream) {
   ASSERT_STATUS_OK(response);
 
   std::string expected =
-      "ListJobsResponse{"
-      "http_response={BigQueryHttpResponse{"
-      "Status_Code=200, headers={header1: value1}}}, "
-      "jobs={ListFormatJob{id=1, kind=kind-2, state=DONE, "
-      "job_configuration={job_type=QUERY, query=select 1;}, "
-      "job_reference={job_id=j123, location=, project_id=p123}, "
-      "job_status=DONE, error_result=},}";
+      "ListJobsResponse{ http_response={ BigQueryHttpResponse{ Status_Code=200 "
+      ", "
+      "headers={ header1: value1 }} } , jobs={ ListFormatJob{...<truncated>...";
 
-  EXPECT_EQ(expected, response->DebugString(TracingOptions{}.SetOptions(
-                          "truncate_string_field_longer_than=1024")));
+  EXPECT_EQ(expected, response->DebugString(TracingOptions{}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -204,7 +204,7 @@ TEST(ListJobsResponseTest, InvalidListFormatJob) {
                        HasSubstr("Not a valid Json ListFormatJob object")));
 }
 
-TEST(GetJobResponseTest, OutputStream) {
+TEST(GetJobResponseTest, DebugString) {
   BigQueryHttpResponse http_response;
   http_response.http_status_code = HttpStatusCode::kOk;
   http_response.http_headers.insert({{"header1", "value1"}});
@@ -220,7 +220,7 @@ TEST(GetJobResponseTest, OutputStream) {
             "job_type": "QUERY",
             "query_config": {"query": "select 1;"}
           }})";
-  auto const response = GetJobResponse::BuildFromHttpResponse(http_response);
+  auto response = GetJobResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
 
   std::string expected =
@@ -231,9 +231,9 @@ TEST(GetJobResponseTest, OutputStream) {
       "job_configuration={job_type=QUERY, query=select 1;}, "
       "job_reference={job_id=j123, location=, project_id=p123}, "
       "job_status=DONE, error_result=}}";
-  std::ostringstream os;
-  os << *response;
-  EXPECT_EQ(expected, os.str());
+
+  EXPECT_EQ(expected, response->DebugString(TracingOptions{}.SetOptions(
+                          "truncate_string_field_longer_than=1024")));
 }
 
 TEST(ListJobsResponseTest, OutputStream) {
@@ -259,20 +259,20 @@ TEST(ListJobsResponseTest, OutputStream) {
                 "principal_subject": "principal-subj"
               }
   ]})";
-  auto const response = ListJobsResponse::BuildFromHttpResponse(http_response);
+  auto response = ListJobsResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
 
   std::string expected =
       "ListJobsResponse{"
       "http_response={BigQueryHttpResponse{"
       "Status_Code=200, headers={header1: value1}}}, "
-      "jobs={Job{id=1, kind=kind-2, state=DONE, "
+      "jobs={ListFormatJob{id=1, kind=kind-2, state=DONE, "
       "job_configuration={job_type=QUERY, query=select 1;}, "
       "job_reference={job_id=j123, location=, project_id=p123}, "
       "job_status=DONE, error_result=},}";
-  std::ostringstream os;
-  os << *response;
-  EXPECT_EQ(expected, os.str());
+
+  EXPECT_EQ(expected, response->DebugString(TracingOptions{}.SetOptions(
+                          "truncate_string_field_longer_than=1024")));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_test.cc
@@ -33,13 +33,24 @@ TEST(JobTest, JobDebugString) {
   job.configuration.job_type = "QUERY";
   job.configuration.query_config.query = "select 1;";
 
-  std::string expected =
-      "Job{ etag=etag , kind=Job , id=1 , "
-      "job_configuration={ job_type=QUERY , query=select 1; } , "
-      "job_reference={ job_id=2 , location= , project_id=1 } , "
-      "job_status=DONE , error_result= }";
-
-  EXPECT_EQ(expected, job.DebugString(TracingOptions{}));
+  EXPECT_EQ(
+      job.DebugString(TracingOptions{}),
+      R"(google::cloud::bigquery_v2_minimal_internal::Job {)"
+      R"( etag: "etag")"
+      R"( kind: "Job")"
+      R"( id: "1")"
+      R"( job_configuration: "google::cloud::bigquery_v2_minimal_internal::JobConfiguration {)"
+      R"( job_type: "QUERY")"
+      R"( query: "select 1;")"
+      R"( }")"
+      R"( job_reference: "google::cloud::bigquery_v2_minimal_internal::JobReference {)"
+      R"( project_id: "1")"
+      R"( job_id: "2")"
+      R"( location: "")"
+      R"( }")"
+      R"( job_status: "DONE")"
+      R"( error_result: "")"
+      R"( })");
 }
 
 TEST(JobTest, ListFormatJobDebugString) {
@@ -53,13 +64,24 @@ TEST(JobTest, ListFormatJobDebugString) {
   job.configuration.job_type = "QUERY";
   job.configuration.query_config.query = "select 1;";
 
-  std::string expected =
-      "ListFormatJob{ id=1 , kind=Job , "
-      "state=DONE , job_configuration={ job_type=QUERY , "
-      "query=select 1; } , job_reference={ job_id=2 , "
-      "location= , project_id=1 }, job_status=DONE , error_result= }";
-
-  EXPECT_EQ(expected, job.DebugString(TracingOptions{}));
+  EXPECT_EQ(
+      job.DebugString(TracingOptions{}),
+      R"(google::cloud::bigquery_v2_minimal_internal::ListFormatJob {)"
+      R"( id: "1")"
+      R"( kind: "Job")"
+      R"( state: "DONE")"
+      R"( job_configuration: "google::cloud::bigquery_v2_minimal_internal::JobConfiguration {)"
+      R"( job_type: "QUERY")"
+      R"( query: "select 1;")"
+      R"( }")"
+      R"( job_reference: "google::cloud::bigquery_v2_minimal_internal::JobReference {)"
+      R"( project_id: "1")"
+      R"( job_id: "2")"
+      R"( location: "")"
+      R"( }")"
+      R"( job_status: "DONE")"
+      R"( error_result: "")"
+      R"( })");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_test.cc
@@ -33,24 +33,23 @@ TEST(JobTest, JobDebugString) {
   job.configuration.job_type = "QUERY";
   job.configuration.query_config.query = "select 1;";
 
-  EXPECT_EQ(
-      job.DebugString(TracingOptions{}),
-      R"(google::cloud::bigquery_v2_minimal_internal::Job {)"
-      R"( etag: "etag")"
-      R"( kind: "Job")"
-      R"( id: "1")"
-      R"( job_configuration: "google::cloud::bigquery_v2_minimal_internal::JobConfiguration {)"
-      R"( job_type: "QUERY")"
-      R"( query: "select 1;")"
-      R"( }")"
-      R"( job_reference: "google::cloud::bigquery_v2_minimal_internal::JobReference {)"
-      R"( project_id: "1")"
-      R"( job_id: "2")"
-      R"( location: "")"
-      R"( }")"
-      R"( job_status: "DONE")"
-      R"( error_result: "")"
-      R"( })");
+  EXPECT_EQ(job.DebugString("Job", TracingOptions{}),
+            R"(Job {)"
+            R"( etag: "etag")"
+            R"( kind: "Job")"
+            R"( id: "1")"
+            R"( job_configuration: "JobConfiguration {)"
+            R"( job_type: "QUERY")"
+            R"( query: "select 1;")"
+            R"( }")"
+            R"( job_reference: "JobReference {)"
+            R"( project_id: "1")"
+            R"( job_id: "2")"
+            R"( location: "")"
+            R"( }")"
+            R"( job_status: "DONE")"
+            R"( error_result: "")"
+            R"( })");
 }
 
 TEST(JobTest, ListFormatJobDebugString) {
@@ -64,24 +63,23 @@ TEST(JobTest, ListFormatJobDebugString) {
   job.configuration.job_type = "QUERY";
   job.configuration.query_config.query = "select 1;";
 
-  EXPECT_EQ(
-      job.DebugString(TracingOptions{}),
-      R"(google::cloud::bigquery_v2_minimal_internal::ListFormatJob {)"
-      R"( id: "1")"
-      R"( kind: "Job")"
-      R"( state: "DONE")"
-      R"( job_configuration: "google::cloud::bigquery_v2_minimal_internal::JobConfiguration {)"
-      R"( job_type: "QUERY")"
-      R"( query: "select 1;")"
-      R"( }")"
-      R"( job_reference: "google::cloud::bigquery_v2_minimal_internal::JobReference {)"
-      R"( project_id: "1")"
-      R"( job_id: "2")"
-      R"( location: "")"
-      R"( }")"
-      R"( job_status: "DONE")"
-      R"( error_result: "")"
-      R"( })");
+  EXPECT_EQ(job.DebugString("ListFormatJob", TracingOptions{}),
+            R"(ListFormatJob {)"
+            R"( id: "1")"
+            R"( kind: "Job")"
+            R"( state: "DONE")"
+            R"( job_configuration: "JobConfiguration {)"
+            R"( job_type: "QUERY")"
+            R"( query: "select 1;")"
+            R"( }")"
+            R"( job_reference: "JobReference {)"
+            R"( project_id: "1")"
+            R"( job_id: "2")"
+            R"( location: "")"
+            R"( }")"
+            R"( job_status: "DONE")"
+            R"( error_result: "")"
+            R"( })");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_test.cc
@@ -33,23 +33,22 @@ TEST(JobTest, JobDebugString) {
   job.configuration.job_type = "QUERY";
   job.configuration.query_config.query = "select 1;";
 
-  EXPECT_EQ(job.DebugString("Job", TracingOptions{}),
-            R"(Job {)"
-            R"( etag: "etag")"
-            R"( kind: "Job")"
-            R"( id: "1")"
-            R"( job_configuration: "JobConfiguration {)"
-            R"( job_type: "QUERY")"
-            R"( query: "select 1;")"
-            R"( }")"
-            R"( job_reference: "JobReference {)"
-            R"( project_id: "1")"
-            R"( job_id: "2")"
-            R"( location: "")"
-            R"( }")"
-            R"( job_status: "DONE")"
-            R"( error_result: "")"
-            R"( })");
+  EXPECT_EQ(job.DebugString("Job", TracingOptions{}), R"(Job {)"
+                                                      R"( etag: "etag")"
+                                                      R"( kind: "Job")"
+                                                      R"( id: "1")"
+                                                      R"( job_configuration {)"
+                                                      R"( job_type: "QUERY")"
+                                                      R"( query: "select 1;")"
+                                                      R"( })"
+                                                      R"( job_reference {)"
+                                                      R"( project_id: "1")"
+                                                      R"( job_id: "2")"
+                                                      R"( location: "")"
+                                                      R"( })"
+                                                      R"( job_status: "DONE")"
+                                                      R"( error_result: "")"
+                                                      R"( })");
 }
 
 TEST(JobTest, ListFormatJobDebugString) {
@@ -68,15 +67,15 @@ TEST(JobTest, ListFormatJobDebugString) {
             R"( id: "1")"
             R"( kind: "Job")"
             R"( state: "DONE")"
-            R"( job_configuration: "JobConfiguration {)"
+            R"( job_configuration {)"
             R"( job_type: "QUERY")"
             R"( query: "select 1;")"
-            R"( }")"
-            R"( job_reference: "JobReference {)"
+            R"( })"
+            R"( job_reference {)"
             R"( project_id: "1")"
             R"( job_id: "2")"
             R"( location: "")"
-            R"( }")"
+            R"( })"
             R"( job_status: "DONE")"
             R"( error_result: "")"
             R"( })");

--- a/google/cloud/bigquery/v2/minimal/internal/job_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_test.cc
@@ -1,0 +1,82 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/v2/minimal/internal/job.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+TEST(JobTest, JobDebugString) {
+  Job job;
+  job.etag = "etag";
+  job.id = "1";
+  job.kind = "Job";
+  job.reference.project_id = "1";
+  job.reference.job_id = "2";
+  job.status.state = "DONE";
+  job.configuration.job_type = "QUERY";
+  job.configuration.query_config.query = "select 1;";
+
+  std::string expected =
+      "Job{etag=etag, kind=Job, id=1, "
+      "job_configuration={job_type=QUERY, query=select 1;}, "
+      "job_reference={job_id=2, location=, project_id=1}, job_status=DONE, "
+      "error_result=}";
+  std::string truncated =
+      "Job{etag=etag, kind=Job, id=1, "
+      "job_configuration={job_type=QUERY, "
+      "query=select 1;}, job_reference={job_id=2, location=, "
+      "project_...<truncated>...";
+
+  EXPECT_EQ(expected, job.DebugString(TracingOptions{}.SetOptions(
+                          "truncate_string_field_longer_than=1024")));
+  EXPECT_EQ(truncated, job.DebugString(TracingOptions{}));
+}
+
+TEST(JobTest, ListFormatJobDebugString) {
+  ListFormatJob job;
+  job.id = "1";
+  job.kind = "Job";
+  job.reference.project_id = "1";
+  job.reference.job_id = "2";
+  job.state = "DONE";
+  job.status.state = "DONE";
+  job.configuration.job_type = "QUERY";
+  job.configuration.query_config.query = "select 1;";
+
+  std::string expected =
+      "ListFormatJob{id=1, kind=Job, state=DONE, "
+      "job_configuration={job_type=QUERY, query=select 1;}, "
+      "job_reference={job_id=2, location=, project_id=1}, job_status=DONE, "
+      "error_result=}";
+
+  std::string truncated =
+      "ListFormatJob{id=1, kind=Job, state=DONE, "
+      "job_configuration={job_type=QUERY, query=select 1;}, "
+      "job_reference={job_id=2, location...<truncated>...";
+
+  EXPECT_EQ(expected, job.DebugString(TracingOptions{}.SetOptions(
+                          "truncate_string_field_longer_than=1024")));
+  EXPECT_EQ(truncated, job.DebugString(TracingOptions{}));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigquery_v2_minimal_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/job_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_test.cc
@@ -34,19 +34,12 @@ TEST(JobTest, JobDebugString) {
   job.configuration.query_config.query = "select 1;";
 
   std::string expected =
-      "Job{etag=etag, kind=Job, id=1, "
-      "job_configuration={job_type=QUERY, query=select 1;}, "
-      "job_reference={job_id=2, location=, project_id=1}, job_status=DONE, "
-      "error_result=}";
-  std::string truncated =
-      "Job{etag=etag, kind=Job, id=1, "
-      "job_configuration={job_type=QUERY, "
-      "query=select 1;}, job_reference={job_id=2, location=, "
-      "project_...<truncated>...";
+      "Job{ etag=etag , kind=Job , id=1 , "
+      "job_configuration={ job_type=QUERY , query=select 1; } , "
+      "job_reference={ job_id=2 , location= , project_id=1 } , "
+      "job_status=DONE , error_result= }";
 
-  EXPECT_EQ(expected, job.DebugString(TracingOptions{}.SetOptions(
-                          "truncate_string_field_longer_than=1024")));
-  EXPECT_EQ(truncated, job.DebugString(TracingOptions{}));
+  EXPECT_EQ(expected, job.DebugString(TracingOptions{}));
 }
 
 TEST(JobTest, ListFormatJobDebugString) {
@@ -61,19 +54,12 @@ TEST(JobTest, ListFormatJobDebugString) {
   job.configuration.query_config.query = "select 1;";
 
   std::string expected =
-      "ListFormatJob{id=1, kind=Job, state=DONE, "
-      "job_configuration={job_type=QUERY, query=select 1;}, "
-      "job_reference={job_id=2, location=, project_id=1}, job_status=DONE, "
-      "error_result=}";
+      "ListFormatJob{ id=1 , kind=Job , "
+      "state=DONE , job_configuration={ job_type=QUERY , "
+      "query=select 1; } , job_reference={ job_id=2 , "
+      "location= , project_id=1 }, job_status=DONE , error_result= }";
 
-  std::string truncated =
-      "ListFormatJob{id=1, kind=Job, state=DONE, "
-      "job_configuration={job_type=QUERY, query=select 1;}, "
-      "job_reference={job_id=2, location...<truncated>...";
-
-  EXPECT_EQ(expected, job.DebugString(TracingOptions{}.SetOptions(
-                          "truncate_string_field_longer_than=1024")));
-  EXPECT_EQ(truncated, job.DebugString(TracingOptions{}));
+  EXPECT_EQ(expected, job.DebugString(TracingOptions{}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
…GetJobResponse and ListJobResponse so it can be used in the logging decorator.

Subsequent PR will contain the logging decorator changes that will use the logging from this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11131)
<!-- Reviewable:end -->
