### PR TITLE
impl(docfx): a helper to filter the public API

### DIFF
--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -42,6 +42,24 @@ std::string Summary(pugi::xml_node const& node) {
 
 }  // namespace
 
+bool IncludeInPublicDocuments(pugi::xml_node const& node) {
+  // We do not generate documents for files and directories.
+  if (kind(node) == "file" || kind(node) == "dir") return false;
+  // Doxygen groups private attributes / functions in <sectiondef> elements of
+  // these kinds:
+  if (kind(node) == "private-attrib" || kind(node) == "private-func") {
+    return false;
+  }
+  // We do not generate documents for types in the C++ `std::` namespace:
+  auto const id = std::string_view{node.attribute("id").as_string()};
+  for (std::string_view prefix : {"namespacestd", "classstd", "structstd"}) {
+    if (id.substr(0, prefix.size()) == prefix) return false;
+  }
+  // We do not generate documentation for private members or sections.
+  auto const prot = std::string_view{node.attribute("prot").as_string()};
+  return prot != "private";
+}
+
 void StartDocFxYaml(YAML::Emitter& yaml) {
   yaml << YAML::BeginMap << YAML::Key << "items" << YAML::Value
        << YAML::BeginSeq;

--- a/docfx/doxygen2yaml.h
+++ b/docfx/doxygen2yaml.h
@@ -22,6 +22,14 @@
 
 namespace docfx {
 
+// Determine if a node is part of the public documentation.
+//
+// Many nodes are not part of the public documentation, for example, private
+// member variables, private functions, or any names in the `*internal*`
+// namespaces. This helper allows us to short circuit the recursion over the
+// doxygen structure when an element is not needed for the public docs.
+bool IncludeInPublicDocuments(pugi::xml_node const& node);
+
 // Initialize a YAML Emitter with the preamble elements required by DocFx.
 void StartDocFxYaml(YAML::Emitter& yaml);
 

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -78,6 +78,50 @@ be preferable to retry the operation even though it is not idempotent.</para>
     </doxygen>
 )xml";
 
+TEST(Doxygen2Yaml, IncludeInPublicDocs) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <sectiondef id="id-1" kind="private-attrib"></sectiondef>
+      <sectiondef id="id-2" kind="private-func"></sectiondef>
+      <sectiondef id="id-3" kind="public-attrib"></sectiondef>
+      <sectiondef id="id-4" kind="public-func"></sectiondef>
+      <compounddef id="id-5" kind="file" language="C++"></compounddef>
+      <compounddef id="id-6" kind="dir"></compounddef>
+      <compounddef id="namespacestd" kind="namespace"></compounddef>
+      <compounddef id="namespacestd_1_1chrono" kind="namespace"></compounddef>
+      <compounddef id="classstd_1_1array"></compounddef>
+      <compounddef id="classgoogle_1_1cloud_1_1Options" prot="public">google::cloud::Options</compounddef>
+      <compounddef id="classgoogle_1_1cloud_1_1Options_1_1DataHolder" prot="private"></compounddef>
+    </doxygen>)xml";
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+
+  struct TestCase {
+    std::string id;
+    bool expected;
+  } const cases[] = {
+      {"id-1", false},
+      {"id-2", false},
+      {"id-3", true},
+      {"id-4", true},
+      {"id-5", false},
+      {"id-6", false},
+      {"namespacestd", false},
+      {"namespacestd_1_1chrono", false},
+      {"classstd_1_1array", false},
+      {"classgoogle_1_1cloud_1_1Options", true},
+      {"classgoogle_1_1cloud_1_1Options_1_1DataHolder", false},
+  };
+
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Running with id=" + test.id);
+    auto const filter = "//*[@id='" + test.id + "']";
+    auto selected = doc.select_node(filter.c_str());
+    ASSERT_TRUE(selected);
+    EXPECT_EQ(test.expected, IncludeInPublicDocuments(selected.node()));
+  }
+}
+
 TEST(Doxygen2Yaml, StartAndEnd) {
   auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
 items:


### PR DESCRIPTION
Some things are not to be documented, e.g., the private section of a class, or the references to the C++ `std::` namespace that are created by Doxygen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11142)
<!-- Reviewable:end -->
