### PR TITLE
impl(docfx): support `<ndash>` elements

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -313,6 +313,14 @@ bool AppendIfRef(std::ostream& os, MarkdownContext const& ctx,
   return true;
 }
 
+// The `ndash` element is just a convenient way to represent long dashes.
+bool AppendIfNDash(std::ostream& os, MarkdownContext const& /*ctx*/,
+                   pugi::xml_node const& node) {
+  if (std::string_view{node.name()} != "ndash") return false;
+  os << "&ndash;";
+  return true;
+}
+
 // The `docTitleCmdGroup` element type in Doxygen is defined as below.
 //
 // Only one is possible. We will ignore most of them because they do not
@@ -376,6 +384,7 @@ bool AppendIfDocTitleCmdGroup(std::ostream& os, MarkdownContext const& ctx,
   // Unexpected: linebreak
   // Unexpected: nonbreakablespace
   // Unexpected: many many symbols
+  if (AppendIfNDash(os, ctx, node)) return true;
   return false;
 }
 

--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -109,6 +109,10 @@ bool AppendIfComputerOutput(std::ostream& os, MarkdownContext const& ctx,
 bool AppendIfRef(std::ostream& os, MarkdownContext const& ctx,
                  pugi::xml_node const& node);
 
+/// Handles `ndash` elements.
+bool AppendIfNDash(std::ostream& os, MarkdownContext const& ctx,
+                   pugi::xml_node const& node);
+
 /// Part of the implementation of AppendIfParagraph().
 bool AppendIfDocTitleCmdGroup(std::ostream& os, MarkdownContext const& ctx,
                               pugi::xml_node const& node);

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -399,6 +399,18 @@ TEST(Doxygen2Markdown, RefInternal) {
   EXPECT_EQ("[Reference Text](xref:some_id)", os.str());
 }
 
+TEST(Doxygen2Markdown, NDash) {
+  pugi::xml_document doc;
+  doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <ndash id="test-node" />
+    </doxygen>)xml");
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfNDash(os, {}, selected.node()));
+  EXPECT_EQ("&ndash;", os.str());
+}
+
 TEST(Doxygen2Markdown, Paragraph) {
   pugi::xml_document doc;
   doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>
@@ -458,6 +470,7 @@ TEST(Doxygen2Markdown, ParagraphSimpleContents) {
         <para id='test-004'><computeroutput>The answer is 42.</computeroutput></para>
         <para id='test-005'><ref refid="test_id">The answer is 42.</ref></para>
         <para id='test-006'><ulink url="https://example.com/">The answer is 42.</ulink></para>
+        <para id='test-007'><ndash/></para>
     </doxygen>)xml";
 
   struct TestCase {
@@ -471,6 +484,7 @@ TEST(Doxygen2Markdown, ParagraphSimpleContents) {
       {"test-004", "\n\n`The answer is 42.`"},
       {"test-005", "\n\n[The answer is 42.](xref:test_id)"},
       {"test-006", "\n\n[The answer is 42.](https://example.com/)"},
+      {"test-007", "\n\n&ndash;"},
   };
 
   pugi::xml_document doc;


### PR DESCRIPTION
Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11149)
<!-- Reviewable:end -->
