### PR TITLE
doc(bigquery): typo in the quickstart path

### DIFF
--- a/google/cloud/bigquery/quickstart/README.md
+++ b/google/cloud/bigquery/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/bigquery/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/bigquery/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```


### PR DESCRIPTION
Should be google rather than google

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11170)
<!-- Reviewable:end -->
