### PR TITLE
doc: typo in quickstart paths

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -803,7 +803,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $$HOME/gooogle-cloud-cpp/google/cloud/$library$/quickstart
+   cd $$HOME/google-cloud-cpp/google/cloud/$library$/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/accessapproval/quickstart/README.md
+++ b/google/cloud/accessapproval/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/accessapproval/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/accessapproval/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/accesscontextmanager/quickstart/README.md
+++ b/google/cloud/accesscontextmanager/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/accesscontextmanager/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/accesscontextmanager/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/advisorynotifications/quickstart/README.md
+++ b/google/cloud/advisorynotifications/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/advisorynotifications/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/advisorynotifications/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/alloydb/quickstart/README.md
+++ b/google/cloud/alloydb/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/alloydb/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/alloydb/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/apigateway/quickstart/README.md
+++ b/google/cloud/apigateway/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/apigateway/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/apigateway/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/apigeeconnect/quickstart/README.md
+++ b/google/cloud/apigeeconnect/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/apigeeconnect/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/apigeeconnect/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/apikeys/quickstart/README.md
+++ b/google/cloud/apikeys/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/apikeys/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/apikeys/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/appengine/quickstart/README.md
+++ b/google/cloud/appengine/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/appengine/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/appengine/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/artifactregistry/quickstart/README.md
+++ b/google/cloud/artifactregistry/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/artifactregistry/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/artifactregistry/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/asset/quickstart/README.md
+++ b/google/cloud/asset/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/asset/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/asset/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/assuredworkloads/quickstart/README.md
+++ b/google/cloud/assuredworkloads/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/assuredworkloads/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/assuredworkloads/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/automl/quickstart/README.md
+++ b/google/cloud/automl/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/automl/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/automl/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/baremetalsolution/quickstart/README.md
+++ b/google/cloud/baremetalsolution/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/baremetalsolution/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/baremetalsolution/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/batch/quickstart/README.md
+++ b/google/cloud/batch/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/batch/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/batch/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/beyondcorp/quickstart/README.md
+++ b/google/cloud/beyondcorp/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/beyondcorp/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/beyondcorp/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/bigtable/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/bigtable/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/billing/quickstart/README.md
+++ b/google/cloud/billing/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/billing/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/billing/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/binaryauthorization/quickstart/README.md
+++ b/google/cloud/binaryauthorization/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/binaryauthorization/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/binaryauthorization/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/certificatemanager/quickstart/README.md
+++ b/google/cloud/certificatemanager/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/certificatemanager/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/certificatemanager/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/channel/quickstart/README.md
+++ b/google/cloud/channel/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/channel/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/channel/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/cloudbuild/quickstart/README.md
+++ b/google/cloud/cloudbuild/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/cloudbuild/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/cloudbuild/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/composer/quickstart/README.md
+++ b/google/cloud/composer/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/composer/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/composer/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/connectors/quickstart/README.md
+++ b/google/cloud/connectors/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/connectors/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/connectors/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/contactcenterinsights/quickstart/README.md
+++ b/google/cloud/contactcenterinsights/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/contactcenterinsights/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/contactcenterinsights/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/container/quickstart/README.md
+++ b/google/cloud/container/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/container/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/container/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/containeranalysis/quickstart/README.md
+++ b/google/cloud/containeranalysis/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/containeranalysis/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/containeranalysis/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/datacatalog/quickstart/README.md
+++ b/google/cloud/datacatalog/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/datacatalog/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/datacatalog/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/datamigration/quickstart/README.md
+++ b/google/cloud/datamigration/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/datamigration/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/datamigration/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/dataplex/quickstart/README.md
+++ b/google/cloud/dataplex/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/dataplex/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/dataplex/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/dataproc/quickstart/README.md
+++ b/google/cloud/dataproc/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/dataproc/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/dataproc/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/datastream/quickstart/README.md
+++ b/google/cloud/datastream/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/datastream/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/datastream/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/debugger/quickstart/README.md
+++ b/google/cloud/debugger/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/debugger/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/debugger/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/deploy/quickstart/README.md
+++ b/google/cloud/deploy/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/deploy/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/deploy/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/dialogflow_cx/quickstart/README.md
+++ b/google/cloud/dialogflow_cx/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/dialogflow_cx/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/dialogflow_cx/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/dialogflow_es/quickstart/README.md
+++ b/google/cloud/dialogflow_es/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/dialogflow_es/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/dialogflow_es/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/dlp/quickstart/README.md
+++ b/google/cloud/dlp/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/dlp/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/dlp/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/documentai/quickstart/README.md
+++ b/google/cloud/documentai/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/documentai/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/documentai/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/edgecontainer/quickstart/README.md
+++ b/google/cloud/edgecontainer/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/edgecontainer/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/edgecontainer/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/eventarc/quickstart/README.md
+++ b/google/cloud/eventarc/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/eventarc/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/eventarc/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/filestore/quickstart/README.md
+++ b/google/cloud/filestore/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/filestore/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/filestore/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/functions/quickstart/README.md
+++ b/google/cloud/functions/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/functions/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/functions/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/gameservices/quickstart/README.md
+++ b/google/cloud/gameservices/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/gameservices/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/gameservices/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/gkehub/quickstart/README.md
+++ b/google/cloud/gkehub/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/gkehub/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/gkehub/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/gkemulticloud/quickstart/README.md
+++ b/google/cloud/gkemulticloud/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/gkemulticloud/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/gkemulticloud/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/iam/quickstart/README.md
+++ b/google/cloud/iam/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/iam/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/iam/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/iap/quickstart/README.md
+++ b/google/cloud/iap/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/iap/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/iap/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/ids/quickstart/README.md
+++ b/google/cloud/ids/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/ids/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/ids/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/iot/quickstart/README.md
+++ b/google/cloud/iot/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/iot/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/iot/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/kms/quickstart/README.md
+++ b/google/cloud/kms/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/kms/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/kms/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/language/quickstart/README.md
+++ b/google/cloud/language/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/language/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/language/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/logging/quickstart/README.md
+++ b/google/cloud/logging/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/logging/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/logging/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/managedidentities/quickstart/README.md
+++ b/google/cloud/managedidentities/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/managedidentities/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/managedidentities/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/memcache/quickstart/README.md
+++ b/google/cloud/memcache/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/memcache/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/memcache/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/monitoring/quickstart/README.md
+++ b/google/cloud/monitoring/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/monitoring/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/monitoring/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/networkconnectivity/quickstart/README.md
+++ b/google/cloud/networkconnectivity/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/networkconnectivity/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/networkconnectivity/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/networkmanagement/quickstart/README.md
+++ b/google/cloud/networkmanagement/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/networkmanagement/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/networkmanagement/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/notebooks/quickstart/README.md
+++ b/google/cloud/notebooks/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/notebooks/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/notebooks/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/optimization/quickstart/README.md
+++ b/google/cloud/optimization/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/optimization/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/optimization/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/orgpolicy/quickstart/README.md
+++ b/google/cloud/orgpolicy/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/orgpolicy/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/orgpolicy/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/osconfig/quickstart/README.md
+++ b/google/cloud/osconfig/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/osconfig/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/osconfig/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/oslogin/quickstart/README.md
+++ b/google/cloud/oslogin/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/oslogin/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/oslogin/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/policytroubleshooter/quickstart/README.md
+++ b/google/cloud/policytroubleshooter/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/policytroubleshooter/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/policytroubleshooter/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/privateca/quickstart/README.md
+++ b/google/cloud/privateca/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/privateca/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/privateca/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/profiler/quickstart/README.md
+++ b/google/cloud/profiler/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/profiler/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/profiler/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/pubsub/quickstart/README.md
+++ b/google/cloud/pubsub/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/pubsub/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/pubsub/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/pubsublite/quickstart/README.md
+++ b/google/cloud/pubsublite/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/pubsublite/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/pubsublite/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/recommender/quickstart/README.md
+++ b/google/cloud/recommender/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/recommender/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/recommender/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/redis/quickstart/README.md
+++ b/google/cloud/redis/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/redis/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/redis/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/resourcemanager/quickstart/README.md
+++ b/google/cloud/resourcemanager/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/resourcemanager/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/resourcemanager/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/resourcesettings/quickstart/README.md
+++ b/google/cloud/resourcesettings/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/resourcesettings/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/resourcesettings/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/retail/quickstart/README.md
+++ b/google/cloud/retail/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/retail/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/retail/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/run/quickstart/README.md
+++ b/google/cloud/run/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/run/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/run/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/scheduler/quickstart/README.md
+++ b/google/cloud/scheduler/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/scheduler/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/scheduler/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/secretmanager/quickstart/README.md
+++ b/google/cloud/secretmanager/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/secretmanager/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/secretmanager/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/securitycenter/quickstart/README.md
+++ b/google/cloud/securitycenter/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/securitycenter/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/securitycenter/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/servicecontrol/quickstart/README.md
+++ b/google/cloud/servicecontrol/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/servicecontrol/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/servicecontrol/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/servicedirectory/quickstart/README.md
+++ b/google/cloud/servicedirectory/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/servicedirectory/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/servicedirectory/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/servicemanagement/quickstart/README.md
+++ b/google/cloud/servicemanagement/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/servicemanagement/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/servicemanagement/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/serviceusage/quickstart/README.md
+++ b/google/cloud/serviceusage/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/serviceusage/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/serviceusage/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/shell/quickstart/README.md
+++ b/google/cloud/shell/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/shell/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/shell/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/spanner/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/spanner/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/speech/quickstart/README.md
+++ b/google/cloud/speech/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/speech/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/speech/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/storage/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/storage/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
@@ -141,7 +141,7 @@ feature. To enable the feature add `-DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON`
 to your CMake configuration step. Using the previous example:
 
 ```sh
-cd $HOME/gooogle-cloud-cpp/google/cloud/storage/quickstart
+cd $HOME/google-cloud-cpp/google/cloud/storage/quickstart
 cmake -H. -B.build -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON \
     -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
 cmake --build .build --target quickstart_grpc

--- a/google/cloud/storagetransfer/quickstart/README.md
+++ b/google/cloud/storagetransfer/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/storagetransfer/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/storagetransfer/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/talent/quickstart/README.md
+++ b/google/cloud/talent/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/talent/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/talent/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/tasks/quickstart/README.md
+++ b/google/cloud/tasks/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/tasks/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/tasks/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/texttospeech/quickstart/README.md
+++ b/google/cloud/texttospeech/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/texttospeech/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/texttospeech/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/tpu/quickstart/README.md
+++ b/google/cloud/tpu/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/tpu/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/tpu/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/trace/quickstart/README.md
+++ b/google/cloud/trace/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/trace/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/trace/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/translate/quickstart/README.md
+++ b/google/cloud/translate/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/translate/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/translate/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/video/quickstart/README.md
+++ b/google/cloud/video/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/video/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/video/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/videointelligence/quickstart/README.md
+++ b/google/cloud/videointelligence/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/videointelligence/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/videointelligence/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/vision/quickstart/README.md
+++ b/google/cloud/vision/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/vision/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/vision/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/vmmigration/quickstart/README.md
+++ b/google/cloud/vmmigration/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/vmmigration/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/vmmigration/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/vmwareengine/quickstart/README.md
+++ b/google/cloud/vmwareengine/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/vmwareengine/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/vmwareengine/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/vpcaccess/quickstart/README.md
+++ b/google/cloud/vpcaccess/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/vpcaccess/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/vpcaccess/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/webrisk/quickstart/README.md
+++ b/google/cloud/webrisk/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/webrisk/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/webrisk/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/websecurityscanner/quickstart/README.md
+++ b/google/cloud/websecurityscanner/quickstart/README.md
@@ -99,7 +99,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/websecurityscanner/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/websecurityscanner/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```

--- a/google/cloud/workflows/quickstart/README.md
+++ b/google/cloud/workflows/quickstart/README.md
@@ -102,7 +102,7 @@ https://cloud.google.com/docs/authentication/production
    the dependencies:
 
    ```bash
-   cd $HOME/gooogle-cloud-cpp/google/cloud/workflows/quickstart
+   cd $HOME/google-cloud-cpp/google/cloud/workflows/quickstart
    cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```


### PR DESCRIPTION
Inspired by #11170 

I left `google/cloud/bigquery/...` alone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11171)
<!-- Reviewable:end -->
