### PR TITLE
impl(bigquery): unify bigquery request/response logging format

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -88,9 +88,11 @@ std::string GetJobRequest::DebugString(TracingOptions const& options) const {
     return absl::StrCat("\"", internal::DebugString(s, options), "\"");
   };
   return absl::StrCat(
-      "google::cloud::bigquery_v2_minimal_internal::GetJobRequest {", sep(1),
-      "project_id: ", quoted(project_id_), sep(1), "job_id: ", quoted(job_id_),
-      sep(1), "location: ", quoted(location_), sep(0), "}");
+      "google::cloud::bigquery_v2_minimal_internal::GetJobRequest {",  //
+      sep(1), "project_id: ", quoted(project_id_),                     //
+      sep(1), "job_id: ", quoted(job_id_),                             //
+      sep(1), "location: ", quoted(location_),                         //
+      sep(0), "}");
 }
 
 std::string ListJobsRequest::DebugString(TracingOptions const& options) const {
@@ -101,20 +103,25 @@ std::string ListJobsRequest::DebugString(TracingOptions const& options) const {
     return absl::StrCat("\"", internal::DebugString(s, options), "\"");
   };
   return absl::StrCat(
-      "google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {", sep(1),
-      "project_id: ", quoted(project_id_), sep(1),
-      "all_users: ", all_users_ ? "true" : "false", sep(1),
-      "max_results: ", max_results_, sep(1),  //
-      "min_creation_time {", sep(2), "\"",
-      internal::FormatRfc3339(min_creation_time_), "\"", sep(1), "}", sep(1),
-      "max_creation_time {", sep(2), "\"",
-      internal::FormatRfc3339(max_creation_time_), "\"", sep(1), "}", sep(1),
-      "page_token: ", quoted(page_token_), sep(1),  //
-      "projection {", sep(2),                       //
-      "value: ", quoted(projection_.value), sep(1), "}", sep(1),
-      "state_filter {", sep(2),  //
-      "value: ", quoted(state_filter_.value), sep(1), "}", sep(1),
-      "parent_job_id: ", quoted(parent_job_id_), sep(0), "}");
+      "google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {",  //
+      sep(1), "project_id: ", quoted(project_id_),                       //
+      sep(1), "all_users: ", all_users_ ? "true" : "false",              //
+      sep(1), "max_results: ", max_results_,                             //
+      sep(1), "min_creation_time {",                                     //
+      sep(2), "\"", internal::FormatRfc3339(min_creation_time_), "\"",   //
+      sep(1), "}",                                                       //
+      sep(1), "max_creation_time {",                                     //
+      sep(2), "\"", internal::FormatRfc3339(max_creation_time_), "\"",   //
+      sep(1), "}",                                                       //
+      sep(1), "page_token: ", quoted(page_token_),                       //
+      sep(1), "projection {",                                            //
+      sep(2), "value: ", quoted(projection_.value),                      //
+      sep(1), "}",                                                       //
+      sep(1), "state_filter {",                                          //
+      sep(2), "value: ", quoted(state_filter_.value),                    //
+      sep(1), "}",                                                       //
+      sep(1), "parent_job_id: ", quoted(parent_job_id_),                 //
+      sep(0), "}");
 }
 
 ListJobsRequest::ListJobsRequest(std::string project_id)

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -26,7 +26,14 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-static auto const kDefaultTimepoint = std::chrono::system_clock::time_point{};
+namespace {
+
+auto const kDefaultTimepoint = std::chrono::system_clock::time_point{};
+
+std::string DebugStringSeparator(bool single_line_mode, int indent) {
+  if (single_line_mode) return " ";
+  return absl::StrCat("\n", std::string(indent * 2, ' '));
+}
 
 std::string GetJobsEndpoint(Options const& opts) {
   std::string endpoint = opts.get<EndpointOption>();
@@ -40,6 +47,8 @@ std::string GetJobsEndpoint(Options const& opts) {
 
   return endpoint;
 }
+
+}  // namespace
 
 Projection Projection::Full() {
   Projection projection;
@@ -72,29 +81,40 @@ StateFilter StateFilter::Done() {
 }
 
 std::string GetJobRequest::DebugString(TracingOptions const& options) const {
-  std::string out;
-  auto const* delim = options.single_line_mode() ? " " : "\n";
-  absl::StrAppend(&out, "GetJobRequest{", delim,
-                  "project_id=", internal::DebugString(project_id_, options),
-                  delim, "job_id=", internal::DebugString(job_id_, options),
-                  delim, internal::DebugString(location_, options), delim, "}");
-  return out;
+  auto sep = [single_line_mode = options.single_line_mode()](int indent) {
+    return DebugStringSeparator(single_line_mode, indent);
+  };
+  auto quoted = [&options](std::string const& s) {
+    return absl::StrCat("\"", internal::DebugString(s, options), "\"");
+  };
+  return absl::StrCat(
+      "google::cloud::bigquery_v2_minimal_internal::GetJobRequest {", sep(1),
+      "project_id: ", quoted(project_id_), sep(1), "job_id: ", quoted(job_id_),
+      sep(1), "location: ", quoted(location_), sep(0), "}");
 }
 
 std::string ListJobsRequest::DebugString(TracingOptions const& options) const {
-  std::string out;
-  auto const* delim = options.single_line_mode() ? " " : "\n";
-  auto const* all_users = all_users_ ? "true" : "false";
-  absl::StrAppend(
-      &out, "ListJobsRequest{", delim,
-      "project_id=", internal::DebugString(project_id_, options), delim,
-      ", all_users=", all_users, delim, ", max_results=", max_results_, delim,
-      ", page_token=", internal::DebugString(page_token_, options), delim,
-      ", projection=", internal::DebugString(projection_.value, options), delim,
-      ", state_filter=", internal::DebugString(state_filter_.value, options),
-      delim, ", parent_job_id=", internal::DebugString(parent_job_id_, options),
-      delim, "}");
-  return out;
+  auto sep = [single_line_mode = options.single_line_mode()](int indent) {
+    return DebugStringSeparator(single_line_mode, indent);
+  };
+  auto quoted = [&options](std::string const& s) {
+    return absl::StrCat("\"", internal::DebugString(s, options), "\"");
+  };
+  return absl::StrCat(
+      "google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {", sep(1),
+      "project_id: ", quoted(project_id_), sep(1),
+      "all_users: ", all_users_ ? "true" : "false", sep(1),
+      "max_results: ", max_results_, sep(1),  //
+      "min_creation_time {", sep(2), "\"",
+      internal::FormatRfc3339(min_creation_time_), "\"", sep(1), "}", sep(1),
+      "max_creation_time {", sep(2), "\"",
+      internal::FormatRfc3339(max_creation_time_), "\"", sep(1), "}", sep(1),
+      "page_token: ", quoted(page_token_), sep(1),  //
+      "projection {", sep(2),                       //
+      "value: ", quoted(projection_.value), sep(1), "}", sep(1),
+      "state_filter {", sep(2),  //
+      "value: ", quoted(state_filter_.value), sep(1), "}", sep(1),
+      "parent_job_id: ", quoted(parent_job_id_), sep(0), "}");
 }
 
 ListJobsRequest::ListJobsRequest(std::string project_id)

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -164,7 +164,6 @@ TEST(ListJobsRequestTest, EmptyProjectId) {
 
 TEST(ListJobsRequestTest, OutputStream) {
   auto const request = GetListJobsRequest();
-  std::string all_users = request.all_users() ? "true" : "false";
   std::string expected =
       "ListJobsRequest{project_id=1, all_users=true, max_results=10"
       ", page_token=123, projection=FULL, state_filter=RUNNING"
@@ -177,22 +176,90 @@ TEST(ListJobsRequestTest, OutputStream) {
 TEST(GetJobRequest, DebugString) {
   GetJobRequest request("test-project-id", "test-job-id");
   request.set_location("test-location");
-  std::string expected =
-      "GetJobRequest{ project_id=test-project-id job_id=test-job-id "
-      "test-location }";
 
-  EXPECT_EQ(expected, request.DebugString(TracingOptions{}));
+  EXPECT_EQ(request.DebugString(TracingOptions{}),
+            R"(google::cloud::bigquery_v2_minimal_internal::GetJobRequest {)"
+            R"( project_id: "test-project-id")"
+            R"( job_id: "test-job-id")"
+            R"( location: "test-location")"
+            R"( })");
+  EXPECT_EQ(request.DebugString(TracingOptions{}.SetOptions(
+                "truncate_string_field_longer_than=4")),
+            R"(google::cloud::bigquery_v2_minimal_internal::GetJobRequest {)"
+            R"( project_id: "test...<truncated>...")"
+            R"( job_id: "test...<truncated>...")"
+            R"( location: "test...<truncated>...")"
+            R"( })");
+  EXPECT_EQ(
+      request.DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
+      R"(google::cloud::bigquery_v2_minimal_internal::GetJobRequest {
+  project_id: "test-project-id"
+  job_id: "test-job-id"
+  location: "test-location"
+})");
 }
 
 TEST(ListJobsRequestTest, DebugString) {
-  auto const request = GetListJobsRequest();
-  std::string all_users = request.all_users() ? "true" : "false";
-  std::string expected =
-      "ListJobsRequest{ project_id=1 , all_users=true , max_results=10 , "
-      "page_token=123 , projection=FULL , state_filter=RUNNING , "
-      "parent_job_id=1 }";
+  ListJobsRequest request("test-project-id");
+  request.set_all_users(true)
+      .set_max_results(10)
+      .set_min_creation_time(
+          std::chrono::system_clock::from_time_t(1585112316) +
+          std::chrono::microseconds(123456))
+      .set_max_creation_time(
+          std::chrono::system_clock::from_time_t(1585112892) +
+          std::chrono::microseconds(654321))
+      .set_page_token("test-page-token")
+      .set_projection(Projection::Full())
+      .set_state_filter(StateFilter::Running())
+      .set_parent_job_id("test-job-id");
 
-  EXPECT_EQ(expected, request.DebugString(TracingOptions{}));
+  EXPECT_EQ(request.DebugString(TracingOptions{}),
+            R"(google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {)"
+            R"( project_id: "test-project-id")"
+            R"( all_users: true)"
+            R"( max_results: 10)"
+            R"( min_creation_time { "2020-03-25T04:58:36.123456Z" })"
+            R"( max_creation_time { "2020-03-25T05:08:12.654321Z" })"
+            R"( page_token: "test-page-token")"
+            R"( projection { value: "FULL" })"
+            R"( state_filter { value: "RUNNING" })"
+            R"( parent_job_id: "test-job-id")"
+            R"( })");
+  EXPECT_EQ(request.DebugString(TracingOptions{}.SetOptions(
+                "truncate_string_field_longer_than=6")),
+            R"(google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {)"
+            R"( project_id: "test-p...<truncated>...")"
+            R"( all_users: true)"
+            R"( max_results: 10)"
+            R"( min_creation_time { "2020-03-25T04:58:36.123456Z" })"
+            R"( max_creation_time { "2020-03-25T05:08:12.654321Z" })"
+            R"( page_token: "test-p...<truncated>...")"
+            R"( projection { value: "FULL" })"
+            R"( state_filter { value: "RUNNIN...<truncated>..." })"
+            R"( parent_job_id: "test-j...<truncated>...")"
+            R"( })");
+  EXPECT_EQ(
+      request.DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
+      R"(google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {
+  project_id: "test-project-id"
+  all_users: true
+  max_results: 10
+  min_creation_time {
+    "2020-03-25T04:58:36.123456Z"
+  }
+  max_creation_time {
+    "2020-03-25T05:08:12.654321Z"
+  }
+  page_token: "test-page-token"
+  projection {
+    value: "FULL"
+  }
+  state_filter {
+    value: "RUNNING"
+  }
+  parent_job_id: "test-job-id"
+})");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -184,11 +184,11 @@ TEST(GetJobRequest, DebugString) {
             R"( location: "test-location")"
             R"( })");
   EXPECT_EQ(request.DebugString(TracingOptions{}.SetOptions(
-                "truncate_string_field_longer_than=4")),
+                "truncate_string_field_longer_than=7")),
             R"(google::cloud::bigquery_v2_minimal_internal::GetJobRequest {)"
-            R"( project_id: "test...<truncated>...")"
-            R"( job_id: "test...<truncated>...")"
-            R"( location: "test...<truncated>...")"
+            R"( project_id: "test-pr...<truncated>...")"
+            R"( job_id: "test-jo...<truncated>...")"
+            R"( location: "test-lo...<truncated>...")"
             R"( })");
   EXPECT_EQ(
       request.DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
@@ -227,17 +227,17 @@ TEST(ListJobsRequestTest, DebugString) {
             R"( parent_job_id: "test-job-id")"
             R"( })");
   EXPECT_EQ(request.DebugString(TracingOptions{}.SetOptions(
-                "truncate_string_field_longer_than=6")),
+                "truncate_string_field_longer_than=7")),
             R"(google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {)"
-            R"( project_id: "test-p...<truncated>...")"
+            R"( project_id: "test-pr...<truncated>...")"
             R"( all_users: true)"
             R"( max_results: 10)"
             R"( min_creation_time { "2020-03-25T04:58:36.123456Z" })"
             R"( max_creation_time { "2020-03-25T05:08:12.654321Z" })"
-            R"( page_token: "test-p...<truncated>...")"
+            R"( page_token: "test-pa...<truncated>...")"
             R"( projection { value: "FULL" })"
-            R"( state_filter { value: "RUNNIN...<truncated>..." })"
-            R"( parent_job_id: "test-j...<truncated>...")"
+            R"( state_filter { value: "RUNNING" })"
+            R"( parent_job_id: "test-jo...<truncated>...")"
             R"( })");
   EXPECT_EQ(
       request.DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),


### PR DESCRIPTION
It is a feature if request/response logging uses a common format no matter whether the message types are protoc generated or not.  So, update the `DebugString()` functions for `GetJobRequest` and `ListJobsRequest` to produce that common format, as if they had been defined as messages like ...
```
message GetJobRequest {
  string project_id = 1;
  string job_id = 2;
  string location = 3;
}

message Projection {
  string value = 1;
}

message StateFilter {
  string value = 1;
}

message ListJobsRequest {
  string project_id = 1;
  bool all_users = 2;
  int32 max_results = 3;
  google.protobuf.Timestamp min_creation_time = 4;
  google.protobuf.Timestamp max_creation_time = 5;
  string page_token = 6;
  Projection projection = 7;
  StateFilter state_filter = 8;
  string parent_job_id = 9;
}
```

In particular, `ListJobsRequest::min_creation_time` and `max_creation_time` are now logged.

Also expand the tests to cover the `TracingOptions`, move some file locals to the anonymous namespace, and remove some unused variables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11172)
<!-- Reviewable:end -->
