### PR TITLE
doc: fix more google typos

### DIFF
--- a/google/cloud/internal/README.md
+++ b/google/cloud/internal/README.md
@@ -1,4 +1,4 @@
-# Implementation Details for gogle/cloud/\*.{h,cc}
+# Implementation Details for google/cloud/\*.{h,cc}
 
 This directory contains implementation details for the files in `google/cloud/`.
 All the code in this directory, is subject to change without notice.


### PR DESCRIPTION
I figured that if sometimes we put too many `o`'s in Google, sometimes we would but too few.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11173)
<!-- Reviewable:end -->
