### PR TITLE
impl(docfx): improve syntax for constructors

### DIFF
--- a/docfx/doxygen2syntax.cc
+++ b/docfx/doxygen2syntax.cc
@@ -129,8 +129,9 @@ std::string FunctionSyntaxContent(pugi::xml_node const& node) {
     }
     os << ">\n";
   }
-  os << LinkedTextType(node.child("type")) << "\n"
-     << node.child_value("qualifiedname") << " (";
+  auto const rettype = LinkedTextType(node.child("type"));
+  if (!rettype.empty()) os << rettype << "\n";
+  os << node.child_value("qualifiedname") << " (";
   auto sep = std::string_view();
   auto params = node.select_nodes("param");
   if (!params.empty()) {
@@ -201,11 +202,14 @@ void AppendFunctionSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //
        << FunctionSyntaxContent(node);
-  yaml << YAML::Key << "returns" << YAML::Value                //
-       << YAML::BeginMap                                       //
-       << YAML::Key << "var_type" << YAML::Value               //
-       << YAML::Literal << LinkedTextType(node.child("type"))  //
-       << YAML::EndMap;
+  auto const rettype = LinkedTextType(node.child("type"));
+  if (!rettype.empty()) {
+    yaml << YAML::Key << "returns" << YAML::Value   //
+         << YAML::BeginMap                          //
+         << YAML::Key << "var_type" << YAML::Value  //
+         << YAML::Literal << rettype                //
+         << YAML::EndMap;
+  }
   auto params = node.select_nodes("param");
   if (!params.empty()) {
     yaml << YAML::Key << "parameters" << YAML::Value  //

--- a/docfx/doxygen2syntax_test.cc
+++ b/docfx/doxygen2syntax_test.cc
@@ -382,6 +382,22 @@ google::cloud::CompletionQueue::MakeRelativeTimer (
   EXPECT_EQ(actual, kExpected);
 }
 
+TEST(Doxygen2SyntaxContent, Constructor) {
+  auto constexpr kExpected =
+      R"""(google::cloud::RuntimeStatusError::RuntimeStatusError (
+    Status status
+  ))""";
+  pugi::xml_document doc;
+  doc.load_string(kClassXml);
+  auto selected = doc.select_node(
+      "//*[@id='"
+      "classgoogle_1_1cloud_1_1RuntimeStatusError"
+      "_1aac6b78160cce6468696ce77eb1276a95']");
+  ASSERT_TRUE(selected);
+  auto const actual = FunctionSyntaxContent(selected.node());
+  EXPECT_EQ(actual, kExpected);
+}
+
 TEST(Doxygen2SyntaxContent, Struct) {
   auto constexpr kExpected =
       R"""(// Found in #include <google/cloud/async_operation.h>
@@ -545,6 +561,41 @@ TEST(Doxygen2Syntax, Function) {
       "classgoogle_1_1cloud_1_1CompletionQueue_"
       "1a760d68ec606a03ab8cc80eea8bd965b3"
       "']");
+  ASSERT_TRUE(selected);
+  YamlContext ctx;
+  ctx.parent_id = "test-only-parent-id";
+  YAML::Emitter yaml;
+  yaml << YAML::BeginMap;
+  AppendFunctionSyntax(yaml, ctx, selected.node());
+  yaml << YAML::EndMap;
+  auto const actual = std::string{yaml.c_str()};
+  EXPECT_EQ(actual, kExpected);
+}
+
+TEST(Doxygen2Syntax, Constructor) {
+  auto constexpr kExpected = R"yml(syntax:
+  contents: |
+    google::cloud::RuntimeStatusError::RuntimeStatusError (
+        Status status
+      )
+  parameters:
+    - id: status
+      var_type: |
+        Status
+  source:
+    id: RuntimeStatusError
+    path: google/cloud/status.h
+    startLine: 163
+    remote:
+      repo: https://github.com/googleapis/google-cloud-cpp/
+      branch: main
+      path: google/cloud/status.h)yml";
+  pugi::xml_document doc;
+  doc.load_string(kClassXml);
+  auto selected = doc.select_node(
+      "//*[@id='"
+      "classgoogle_1_1cloud_1_1RuntimeStatusError"
+      "_1aac6b78160cce6468696ce77eb1276a95']");
   ASSERT_TRUE(selected);
   YamlContext ctx;
   ctx.parent_id = "test-only-parent-id";


### PR DESCRIPTION
Constructors have an empty `<type>` element, clean up the output for this case.

Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11174)
<!-- Reviewable:end -->
