### PR TITLE
impl(GCS+gRPC): workarounds related to ctype=CORD

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/benchmarks/throughput_experiment.h"
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/grpc_ctype_cord_workaround.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include <google/storage/v2/storage.grpc.pb.h>
 #include <curl/curl.h>
@@ -372,7 +373,8 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
     std::string generation = "[generation-N/A]";
     while (stream->Read(&response)) {
       if (response.has_checksummed_data()) {
-        bytes_received += response.checksummed_data().content().size();
+        bytes_received +=
+            storage_internal::GetContent(response.checksummed_data()).size();
       }
       if (response.has_metadata()) {
         generation = std::to_string(response.metadata().generation());

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -30,6 +30,7 @@ google_cloud_cpp_storage_grpc_hdrs = [
     "internal/grpc_buffer_read_object_data.h",
     "internal/grpc_client.h",
     "internal/grpc_configure_client_context.h",
+    "internal/grpc_ctype_cord_workaround.h",
     "internal/grpc_hmac_key_metadata_parser.h",
     "internal/grpc_hmac_key_request_parser.h",
     "internal/grpc_notification_metadata_parser.h",

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -50,6 +50,7 @@ else ()
         internal/grpc_client.h
         internal/grpc_configure_client_context.cc
         internal/grpc_configure_client_context.h
+        internal/grpc_ctype_cord_workaround.h
         internal/grpc_hmac_key_metadata_parser.cc
         internal/grpc_hmac_key_metadata_parser.h
         internal/grpc_hmac_key_request_parser.cc

--- a/google/cloud/storage/internal/async_accumulate_read_object_test.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/async_accumulate_read_object.h"
+#include "google/cloud/storage/internal/grpc_ctype_cord_workaround.h"
 #include "google/cloud/storage/testing/mock_storage_stub.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
@@ -342,7 +343,7 @@ TEST(AsyncAccumulateReadObjectTest, FullSimple) {
   ReadObjectResponse r1;
   ASSERT_TRUE(TextFormat::ParseFromString(kText1, &r1));
 
-  auto const r0_size = r0.checksummed_data().content().size();
+  auto const r0_size = GetContent(r0.checksummed_data()).size();
   auto constexpr kReadOffset = 1024;
   auto constexpr kReadLimit = 2048;
 

--- a/google/cloud/storage/internal/grpc_ctype_cord_workaround.h
+++ b/google/cloud/storage/internal/grpc_ctype_cord_workaround.h
@@ -1,0 +1,97 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CTYPE_CORD_WORKAROUND_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CTYPE_CORD_WORKAROUND_H
+
+#include "google/cloud/internal/type_traits.h"
+#include "google/cloud/version.h"
+#include <google/storage/v2/storage.pb.h>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+// Discover the `google::storage::v2::ChecksummedData::content()` field type.
+// It is harder than usual because the member functions may be private. We
+// assume it is `std::string` when it is not queryable, and use SFINAE for
+// the other cases.
+template <typename C, typename AlwaysVoid = void>
+struct ContentTypeImpl {
+  using type = std::string;
+};
+
+template <typename C>
+struct ContentTypeImpl<
+    C, google::cloud::internal::void_t<decltype(std::declval<C>().content())>> {
+  using type = std::remove_const_t<
+      std::remove_reference_t<decltype(std::declval<C>().content())>>;
+};
+
+using ContentType =
+    typename ContentTypeImpl<google::storage::v2::ChecksummedData>::type;
+
+// Workaround for older Protobuf versions without `[ctype = CORD]` support.
+//
+// In older versions of Protobuf adding the `[ctype = CORD]` annotation moves
+// the field accessors and modifiers to the `private:` section of the generated
+// C++ class. That makes the field unusable but there is a workaround. One can
+// bypass the C++ member access control mechanism using these tricks.
+template <typename T, typename T::type M>
+struct BypassPrivateControl {
+  friend constexpr typename T::type GetMemberPointer(T) { return M; }
+};
+
+// A tag to gain access to the `mutable_content()` accessor.
+struct GetMutableContentTag {
+  using type = ContentType* (google::storage::v2::ChecksummedData::*)();
+  friend constexpr type GetMemberPointer(GetMutableContentTag);
+};
+
+extern template struct BypassPrivateControl<
+    GetMutableContentTag,
+    &google::storage::v2::ChecksummedData::mutable_content>;
+
+struct GetContentTag {
+  using type =
+      ContentType const& (google::storage::v2::ChecksummedData::*)() const;
+  friend constexpr type GetMemberPointer(GetContentTag);
+};
+
+extern template struct BypassPrivateControl<
+    GetContentTag, &google::storage::v2::ChecksummedData::content>;
+
+inline ContentType StealMutableContent(
+    google::storage::v2::ChecksummedData& d) {
+  return std::move(*(d.*GetMemberPointer(GetMutableContentTag{}))());
+}
+
+inline ContentType const& GetContent(
+    google::storage::v2::ChecksummedData const& d) {
+  return (d.*GetMemberPointer(GetContentTag{}))();
+}
+
+inline void SetMutableContent(google::storage::v2::ChecksummedData& d,
+                              ContentType value) {
+  *(d.*GetMemberPointer(GetMutableContentTag{}))() = std::move(value);
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CTYPE_CORD_WORKAROUND_H

--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/grpc_object_read_source.h"
+#include "google/cloud/storage/internal/grpc_ctype_cord_workaround.h"
 #include "google/cloud/storage/internal/grpc_object_metadata_parser.h"
+#include "google/cloud/internal/type_traits.h"
 #include "absl/strings/string_view.h"
 #include <algorithm>
 #include <limits>
@@ -83,7 +85,7 @@ void GrpcObjectReadSource::HandleResponse(
     auto const offset = result.bytes_received;
     result.bytes_received += buffer_.HandleResponse(
         buf + offset, n - offset,
-        std::move(*response.mutable_checksummed_data()->mutable_content()));
+        StealMutableContent(*response.mutable_checksummed_data()));
   }
   if (response.has_object_checksums()) {
     auto const& checksums = response.object_checksums();


### PR DESCRIPTION
With Protobuf < v23.x the effect of adding a `[ctype = CORD]` annotation is to make the accessors and modifiers for the field private. We expect that most, but not *all*, customers will use GCS+gRPC with Protobuf >= v23.x. With that version of Protobuf the field accessors and modifiers are public, and they return/consume `absl::Cord`.  To support customers using older Protobuf versions we implement a workaround to gain access to these private accessors and modifiers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11175)
<!-- Reviewable:end -->
