### PR TITLE
impl(generator): default operation scope to global

### DIFF
--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -112,14 +112,7 @@ StatusOr<std::string> DiscoveryResource::FormatRpcOptions(
 
   if (method_json.contains("response") &&
       method_json["response"].value("$ref", "") == "Operation") {
-    if (absl::StrContains(path, "/global/")) {
-      operation_scope = "GlobalOperations";
-    }
-    if (operation_scope.empty()) {
-      return internal::InvalidArgumentError(
-          "Method response is Operation but no scope is defined.",
-          GCP_ERROR_INFO().WithMetadata("json", method_json.dump()));
-    }
+    if (operation_scope.empty()) operation_scope = "GlobalOperations";
     rpc_options.push_back(
         absl::StrFormat("    option (google.cloud.operation_service) = \"%s\";",
                         operation_scope));


### PR DESCRIPTION
part of the work for #10980 

If an rpc returns `Operation` but does not specify zone or region, we should default to global instead of returning an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11177)
<!-- Reviewable:end -->
