### PR TITLE
impl(common): add formatter for request/response logging

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -30,11 +30,6 @@ namespace {
 
 auto const kDefaultTimepoint = std::chrono::system_clock::time_point{};
 
-std::string DebugStringSeparator(bool single_line_mode, int indent) {
-  if (single_line_mode) return " ";
-  return absl::StrCat("\n", std::string(indent * 2, ' '));
-}
-
 std::string GetJobsEndpoint(Options const& opts) {
   std::string endpoint = opts.get<EndpointOption>();
 
@@ -81,47 +76,37 @@ StateFilter StateFilter::Done() {
 }
 
 std::string GetJobRequest::DebugString(TracingOptions const& options) const {
-  auto sep = [single_line_mode = options.single_line_mode()](int indent) {
-    return DebugStringSeparator(single_line_mode, indent);
-  };
-  auto quoted = [&options](std::string const& s) {
-    return absl::StrCat("\"", internal::DebugString(s, options), "\"");
-  };
-  return absl::StrCat(
-      "google::cloud::bigquery_v2_minimal_internal::GetJobRequest {",  //
-      sep(1), "project_id: ", quoted(project_id_),                     //
-      sep(1), "job_id: ", quoted(job_id_),                             //
-      sep(1), "location: ", quoted(location_),                         //
-      sep(0), "}");
+  return internal::DebugFormatter(
+             options,
+             "google::cloud::bigquery_v2_minimal_internal::GetJobRequest")
+      .StringField("project_id", project_id_)
+      .StringField("job_id", job_id_)
+      .StringField("location", location_)
+      .Build();
 }
 
 std::string ListJobsRequest::DebugString(TracingOptions const& options) const {
-  auto sep = [single_line_mode = options.single_line_mode()](int indent) {
-    return DebugStringSeparator(single_line_mode, indent);
-  };
-  auto quoted = [&options](std::string const& s) {
-    return absl::StrCat("\"", internal::DebugString(s, options), "\"");
-  };
-  return absl::StrCat(
-      "google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {",  //
-      sep(1), "project_id: ", quoted(project_id_),                       //
-      sep(1), "all_users: ", all_users_ ? "true" : "false",              //
-      sep(1), "max_results: ", max_results_,                             //
-      sep(1), "min_creation_time {",                                     //
-      sep(2), "\"", internal::FormatRfc3339(min_creation_time_), "\"",   //
-      sep(1), "}",                                                       //
-      sep(1), "max_creation_time {",                                     //
-      sep(2), "\"", internal::FormatRfc3339(max_creation_time_), "\"",   //
-      sep(1), "}",                                                       //
-      sep(1), "page_token: ", quoted(page_token_),                       //
-      sep(1), "projection {",                                            //
-      sep(2), "value: ", quoted(projection_.value),                      //
-      sep(1), "}",                                                       //
-      sep(1), "state_filter {",                                          //
-      sep(2), "value: ", quoted(state_filter_.value),                    //
-      sep(1), "}",                                                       //
-      sep(1), "parent_job_id: ", quoted(parent_job_id_),                 //
-      sep(0), "}");
+  return internal::DebugFormatter(
+             options,
+             "google::cloud::bigquery_v2_minimal_internal::ListJobsRequest")
+      .StringField("project_id", project_id_)
+      .Field("all_users", all_users_)
+      .Field("max_results", max_results_)
+      .SubMessage("min_creation_time")
+      .QuotedField(internal::FormatRfc3339(min_creation_time_))
+      .EndMessage()
+      .SubMessage("max_creation_time")
+      .QuotedField(internal::FormatRfc3339(max_creation_time_))
+      .EndMessage()
+      .StringField("page_token", page_token_)
+      .SubMessage("projection")
+      .StringField("value", projection_.value)
+      .EndMessage()
+      .SubMessage("state_filter")
+      .StringField("value", state_filter_.value)
+      .EndMessage()
+      .StringField("parent_job_id", parent_job_id_)
+      .Build();
 }
 
 ListJobsRequest::ListJobsRequest(std::string project_id)

--- a/google/cloud/internal/debug_string.cc
+++ b/google/cloud/internal/debug_string.cc
@@ -20,6 +20,48 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
+DebugFormatter::DebugFormatter(TracingOptions options,
+                               absl::string_view message_name)
+    : options_(std::move(options)) {
+  absl::StrAppend(&str_, message_name, " {");
+  ++indent_;
+}
+
+DebugFormatter& DebugFormatter::SubMessage(absl::string_view message_name) {
+  absl::StrAppend(&str_, Sep(), message_name, " {");
+  ++indent_;
+  return *this;
+}
+
+DebugFormatter& DebugFormatter::EndMessage() {
+  --indent_;
+  absl::StrAppend(&str_, Sep(), "}");
+  return *this;
+}
+
+DebugFormatter& DebugFormatter::Field(absl::string_view field_name,
+                                      bool value) {
+  absl::StrAppend(&str_, Sep(), field_name, ": ", value ? "true" : "false");
+  return *this;
+}
+
+DebugFormatter& DebugFormatter::StringField(absl::string_view field_name,
+                                            std::string value) {
+  absl::StrAppend(&str_, Sep(), field_name, ": ", "\"",
+                  DebugString(std::move(value), options_), "\"");
+  return *this;
+}
+
+std::string DebugFormatter::Build() {
+  EndMessage();
+  return std::move(str_);
+}
+
+std::string DebugFormatter::Sep() const {
+  if (options_.single_line_mode()) return " ";
+  return absl::StrCat("\n", std::string(indent_ * 2, ' '));
+}
+
 std::string DebugString(std::string s, TracingOptions const& options) {
   auto const pos =
       static_cast<std::size_t>(options.truncate_string_field_longer_than());

--- a/google/cloud/internal/debug_string.h
+++ b/google/cloud/internal/debug_string.h
@@ -15,8 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_DEBUG_STRING_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_DEBUG_STRING_H
 
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <string>
 
 namespace google {
@@ -24,6 +26,54 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
+/**
+ * Build strings for use in request/response logging.
+ *
+ * The intent is to produce strings with a format similar to those returned
+ * by `DebugString(google::protobuf::Message const&, TracingOptions const&)`
+ * from `google/cloud/internal/debug_string_protobuf.h` for a proto message.
+ */
+class DebugFormatter {
+ public:
+  DebugFormatter(TracingOptions options, absl::string_view message_name);
+
+  DebugFormatter& SubMessage(absl::string_view message_name);
+  DebugFormatter& EndMessage();
+
+  DebugFormatter& Field(absl::string_view field_name, bool value);
+
+  template <typename T>
+  DebugFormatter& Field(absl::string_view field_name, T const& value) {
+    absl::StrAppend(&str_, Sep(), field_name, ": ", value);
+    return *this;
+  }
+
+  template <typename T>
+  DebugFormatter& QuotedField(absl::string_view field_name, T const& value) {
+    absl::StrAppend(&str_, Sep(), field_name, ": ", "\"", value, "\"");
+    return *this;
+  }
+
+  template <typename T>
+  DebugFormatter& QuotedField(T const& value) {
+    absl::StrAppend(&str_, Sep(), "\"", value, "\"");
+    return *this;
+  }
+
+  DebugFormatter& StringField(absl::string_view field_name, std::string value);
+
+  std::string Build();
+
+ private:
+  std::string Sep() const;
+
+  TracingOptions options_;
+  std::string str_;
+  int indent_ = 0;
+};
+
+// Return @p s with possible length restriction due to the application of
+// `TracingOptions::truncate_string_field_longer_than()`.
 std::string DebugString(std::string s, TracingOptions const& options);
 
 // Create a unique ID that can be used to match asynchronous requests/response

--- a/google/cloud/internal/debug_string_test.cc
+++ b/google/cloud/internal/debug_string_test.cc
@@ -21,6 +21,67 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+TEST(DebugFormatter, SingleLine) {
+  EXPECT_EQ(DebugFormatter(TracingOptions{}.SetOptions("single_line_mode=T"),
+                           "message_name")
+                .Field("field1", 42)
+                .SubMessage("sub_message")
+                .QuotedField("field2", 3.14159)
+                .EndMessage()
+                .StringField("field2", "foo")
+                .Field("field3", true)
+                .Build(),
+            R"(message_name {)"
+            R"( field1: 42)"
+            R"( sub_message {)"
+            R"( field2: "3.14159")"
+            R"( })"
+            R"( field2: "foo")"
+            R"( field3: true)"
+            R"( })");
+}
+
+TEST(DebugFormatter, MultiLine) {
+  EXPECT_EQ(DebugFormatter(TracingOptions{}.SetOptions("single_line_mode=F"),
+                           "message_name")
+                .Field("field1", 42)
+                .SubMessage("sub_message")
+                .QuotedField("field2", 3.14159)
+                .EndMessage()
+                .StringField("field2", "foo")
+                .Field("field3", true)
+                .Build(),
+            R"(message_name {
+  field1: 42
+  sub_message {
+    field2: "3.14159"
+  }
+  field2: "foo"
+  field3: true
+})");
+}
+
+TEST(DebugFormatter, Truncated) {
+  EXPECT_EQ(DebugFormatter(TracingOptions{}.SetOptions(
+                               "truncate_string_field_longer_than=2"),
+                           "message_name")
+                .Field("field1", 42)
+                .SubMessage("sub_message")
+                .QuotedField("field2", 3.14159)
+                .EndMessage()
+                .StringField("field2", "foo")
+                .Field("field3", true)
+                .Build(),
+            R"(message_name {)"
+            R"( field1: 42)"
+            R"( sub_message {)"
+            R"( field2: "3.14159")"
+            R"( })"
+            R"( field2: "fo...<truncated>...")"
+            R"( field3: true)"
+            R"( })");
+}
+
 TEST(DebugString, TruncateString) {
   TracingOptions tracing_options;
   tracing_options.SetOptions("truncate_string_field_longer_than=8");

--- a/google/cloud/internal/debug_string_test.cc
+++ b/google/cloud/internal/debug_string_test.cc
@@ -28,7 +28,7 @@ TEST(DebugFormatter, SingleLine) {
                 .SubMessage("sub_message")
                 .QuotedField("field2", 3.14159)
                 .EndMessage()
-                .StringField("field2", "foo")
+                .StringField("field2", "foobar")
                 .Field("field3", true)
                 .Build(),
             R"(message_name {)"
@@ -36,7 +36,7 @@ TEST(DebugFormatter, SingleLine) {
             R"( sub_message {)"
             R"( field2: "3.14159")"
             R"( })"
-            R"( field2: "foo")"
+            R"( field2: "foobar")"
             R"( field3: true)"
             R"( })");
 }
@@ -48,7 +48,7 @@ TEST(DebugFormatter, MultiLine) {
                 .SubMessage("sub_message")
                 .QuotedField("field2", 3.14159)
                 .EndMessage()
-                .StringField("field2", "foo")
+                .StringField("field2", "foobar")
                 .Field("field3", true)
                 .Build(),
             R"(message_name {
@@ -56,20 +56,20 @@ TEST(DebugFormatter, MultiLine) {
   sub_message {
     field2: "3.14159"
   }
-  field2: "foo"
+  field2: "foobar"
   field3: true
 })");
 }
 
 TEST(DebugFormatter, Truncated) {
   EXPECT_EQ(DebugFormatter(TracingOptions{}.SetOptions(
-                               "truncate_string_field_longer_than=2"),
+                               "truncate_string_field_longer_than=3"),
                            "message_name")
                 .Field("field1", 42)
                 .SubMessage("sub_message")
                 .QuotedField("field2", 3.14159)
                 .EndMessage()
-                .StringField("field2", "foo")
+                .StringField("field2", "foobar")
                 .Field("field3", true)
                 .Build(),
             R"(message_name {)"
@@ -77,7 +77,7 @@ TEST(DebugFormatter, Truncated) {
             R"( sub_message {)"
             R"( field2: "3.14159")"
             R"( })"
-            R"( field2: "fo...<truncated>...")"
+            R"( field2: "foo...<truncated>...")"
             R"( field3: true)"
             R"( })");
 }


### PR DESCRIPTION
Follow up on a @coryan idea from #11172 for a `DebugFormatter` to produce request/response-logging strings for non-protobuf message types.

Use `DebugFormatter` to reimplement the message formatters from #11172.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11182)
<!-- Reviewable:end -->
