### PR TITLE
cleanup(GCS+gRPC): workarounds related to ctype=CORD

### DIFF
--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -327,8 +327,7 @@ TEST(GrpcObjectReadSource, HandleExtraRead) {
   EXPECT_CALL(*mock, Read)
       .WillOnce([]() {
         storage_proto::ReadObjectResponse response;
-        SetMutableContent(*response.mutable_checksummed_data(),
-                          "The quick brown fox jumps over the lazy dog");
+        SetContent(response, "The quick brown fox jumps over the lazy dog");
         return response;
       })
       .WillOnce(Return(Status{}));


### PR DESCRIPTION
One more allowance for `absl::Cord` conversion missed in #11175.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11184)
<!-- Reviewable:end -->
