### PR TITLE
impl(generator): support generating proto rpcs with empty requests

### DIFF
--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -190,7 +190,7 @@ StatusOr<std::string> DiscoveryResource::JsonToProtobufService() const {
 
     std::string request_type_name = "google.protobuf.Empty";
     DiscoveryTypeVertex const* request_type = nullptr;
-    if (method_json.contains("properties")) {
+    if (method_json.contains("parameters")) {
       request_type_name = absl::StrCat(method_name, "Request");
       auto const& request = request_types_.find(request_type_name);
       if (request == request_types_.end()) {

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -43,7 +43,7 @@ class DiscoveryResource {
   // google.api.method_signature, and google.cloud.operation_service options.
   StatusOr<std::string> FormatRpcOptions(
       nlohmann::json const& method_json,
-      DiscoveryTypeVertex const& request_type) const;
+      DiscoveryTypeVertex const* request_type) const;
 
   // Summarize all the scopes found in the resource methods for inclusion as
   // a service level google.api.oauth_scopes option.

--- a/generator/internal/discovery_resource_test.cc
+++ b/generator/internal/discovery_resource_test.cc
@@ -388,7 +388,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufService) {
         ],
         "path": "projects/{project}/regions/{region}/myResources/{foo}",
         "httpMethod": "GET",
-        "properties": {
+        "parameters": {
           "project": {
             "type": "string"
           }
@@ -405,7 +405,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufService) {
         ],
         "path": "projects/{project}/zones/{zone}/myResources/{fooId}/doFoo",
         "httpMethod": "POST",
-        "properties": {
+        "parameters": {
           "project": {
             "type": "string"
           }
@@ -506,7 +506,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingRequestType) {
         ],
         "path": "projects/{project}/zones/{zone}/myResources/{fooId}/doFoo",
         "httpMethod": "POST",
-        "properties": {
+        "parameters": {
           "project": {
             "type": "string"
           }


### PR DESCRIPTION
part of the work for #10980 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11186)
<!-- Reviewable:end -->
