### PR TITLE
impl(docfx): include groups in ToC

### DIFF
--- a/docfx/doxygen2docfx.cc
+++ b/docfx/doxygen2docfx.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "docfx/doxygen2toc.h"
+#include "docfx/doxygen_groups.h"
 #include "docfx/doxygen_pages.h"
 #include "docfx/parse_arguments.h"
 #include <fstream>
@@ -26,10 +27,16 @@ int main(int argc, char* argv[]) try {
   if (!load) throw std::runtime_error("Error loading XML input file");
 
   std::ofstream("toc.yml") << docfx::Doxygen2Toc(config, doc);
-  for (auto const& i : doc.select_nodes("//*[@kind='page']")) {
-    auto const& page = i.node();
-    auto const filename = std::string{page.attribute("id").as_string()} + ".md";
-    std::ofstream(filename) << docfx::Page2Markdown(page);
+  for (auto const& entry : docfx::PagesToc(doc)) {
+    auto const filter = std::string{"//compounddef[@id='"} + entry.name + "']";
+    auto const node = doc.select_node(filter.c_str()).node();
+    std::ofstream(entry.filename) << docfx::Page2Markdown(node);
+  }
+
+  for (auto const& entry : docfx::GroupsToc(doc)) {
+    auto const filter = std::string{"//compounddef[@id='"} + entry.name + "']";
+    auto const node = doc.select_node(filter.c_str()).node();
+    std::ofstream(entry.filename) << docfx::Group2Yaml(node);
   }
 
   return 0;

--- a/docfx/doxygen2toc.cc
+++ b/docfx/doxygen2toc.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "docfx/doxygen2toc.h"
+#include "docfx/doxygen_groups.h"
 #include "docfx/doxygen_pages.h"
 #include <yaml-cpp/yaml.h>
 #include <sstream>
@@ -20,21 +21,25 @@
 namespace docfx {
 
 std::string Doxygen2Toc(Config const& config, pugi::xml_document const& doc) {
-  auto const pages = PagesToc(doc);
   auto const uid = std::string{"cloud.google.com/cpp/"} + config.library;
   YAML::Emitter out;
-  out << YAML::BeginSeq << YAML::BeginMap           //
-      << YAML::Key << "uid" << YAML::Value << uid   //
-      << YAML::Key << "name" << YAML::Value << uid  //
-      << YAML::Key << "items" << YAML::Value        //
+  out << YAML::BeginMap                                        //
+      << YAML::Key << "name" << YAML::Value << config.library  //
+      << YAML::Key << "items" << YAML::Value                   //
       << YAML::BeginSeq;
-  for (auto const& [filename, name] : pages) {
+  for (auto const& [filename, name] : PagesToc(doc)) {
     out << YAML::BeginMap                                  //
         << YAML::Key << "name" << YAML::Value << name      //
         << YAML::Key << "href" << YAML::Value << filename  //
         << YAML::EndMap;
   }
-  out << YAML::EndSeq << YAML::EndMap << YAML::EndSeq;
+  for (auto const& [filename, name] : GroupsToc(doc)) {
+    out << YAML::BeginMap                              //
+        << YAML::Key << "uid" << YAML::Value << name   //
+        << YAML::Key << "name" << YAML::Value << name  //
+        << YAML::EndMap;
+  }
+  out << YAML::EndSeq << YAML::EndMap;
 
   std::ostringstream os;
   os << "### YamlMime:TableOfContent\n" << out.c_str() << "\n";

--- a/docfx/doxygen2toc_test.cc
+++ b/docfx/doxygen2toc_test.cc
@@ -19,8 +19,8 @@ namespace docfx {
 namespace {
 
 TEST(Doxygen2Toc, Simple) {
-  auto constexpr kXml =
-      R"xml(<?xml version="1.0" standalone="yes"?><doxygen version="1.9.1" xml:lang="en-US">
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
         <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="common-error-handling" kind="page">
           <compoundname>common-error-handling</compoundname>
           <title>Error Handling</title>
@@ -35,16 +35,30 @@ TEST(Doxygen2Toc, Simple) {
           </briefdescription>
           <detaileddescription><para>More details about the index.</para></detaileddescription>
         </compounddef>
-      </doxygen>)xml";
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle" kind="namespace" language="C++">
+        <compoundname>google</compoundname>
+        <innernamespace refid="namespacegoogle_1_1cloud">google::cloud</innernamespace>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud" kind="namespace" language="C++">
+        <compoundname>google::cloud</compoundname>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacestd" kind="namespace" language="Unknown">
+        <compoundname>std</compoundname>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="group__terminate" kind="group">
+        <compoundname>terminate</compoundname>
+      </compounddef>
+    </doxygen>)xml";
 
   auto constexpr kExpected = R"""(### YamlMime:TableOfContent
-- uid: cloud.google.com/cpp/common
-  name: cloud.google.com/cpp/common
-  items:
-    - name: common-error-handling
-      href: common-error-handling.md
-    - name: README
-      href: indexpage.md
+name: common
+items:
+  - name: common-error-handling
+    href: common-error-handling.md
+  - name: README
+    href: indexpage.md
+  - uid: group__terminate
+    name: group__terminate
 )""";
 
   pugi::xml_document doc;

--- a/docfx/doxygen_groups.cc
+++ b/docfx/doxygen_groups.cc
@@ -47,7 +47,20 @@ void AppendReferences(YAML::Emitter& yaml, pugi::xml_node const& node) {
 
 }  // namespace
 
-std::string Group2Yaml(Config const& /*config*/, pugi::xml_node const& node) {
+std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc) {
+  std::vector<TocEntry> result;
+  auto nodes = doc.select_nodes("//*[@kind='group']");
+  std::transform(nodes.begin(), nodes.end(), std::back_inserter(result),
+                 [](auto const& i) {
+                   auto const& page = i.node();
+                   auto const id =
+                       std::string{page.attribute("id").as_string()};
+                   return TocEntry{id + ".yml", id};
+                 });
+  return result;
+}
+
+std::string Group2Yaml(pugi::xml_node const& node) {
   auto const id = std::string{node.attribute("id").as_string()};
   YAML::Emitter yaml;
   yaml << YAML::BeginMap                                  // top-level
@@ -159,19 +172,6 @@ std::string Group2SummaryMarkdown(pugi::xml_node const& node) {
   }
   os << "\n";
   return std::move(os).str();
-}
-
-std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc) {
-  std::vector<TocEntry> result;
-  auto nodes = doc.select_nodes("//*[@kind='group']");
-  std::transform(nodes.begin(), nodes.end(), std::back_inserter(result),
-                 [](auto const& i) {
-                   auto const& page = i.node();
-                   auto const id =
-                       std::string_view{page.attribute("id").as_string()};
-                   return TocEntry{std::string(id) + ".yml", std::string(id)};
-                 });
-  return result;
 }
 
 }  // namespace docfx

--- a/docfx/doxygen_groups.h
+++ b/docfx/doxygen_groups.h
@@ -23,14 +23,14 @@
 
 namespace docfx {
 
+/// Get the table of contents for groups.
+std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc);
+
 /// Generates the YAML contents for a given group node.
-std::string Group2Yaml(Config const& config, pugi::xml_node const& node);
+std::string Group2Yaml(pugi::xml_node const& node);
 
 /// Generate the description of the group.
 std::string Group2SummaryMarkdown(pugi::xml_node const& node);
-
-// Get the table of contents for pages.
-std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc);
 
 }  // namespace docfx
 

--- a/docfx/doxygen_groups_test.cc
+++ b/docfx/doxygen_groups_test.cc
@@ -70,9 +70,7 @@ items:
   doc.load_string(kXml);
   auto selected = doc.select_node("//*[@id='group__terminate']");
   ASSERT_TRUE(selected);
-  auto const config =
-      Config{"test-only-filename", "test-only-library", "v42.0.0"};
-  auto const actual = Group2Yaml(config, selected.node());
+  auto const actual = Group2Yaml(selected.node());
   EXPECT_EQ(kExpected, actual);
 }
 


### PR DESCRIPTION
Add groups to the table of contents and use a more uniform structure in generating the top-level .yml files.

Part of the work for #10895 