### PR TITLE
impl(docfx): generate ToC for C++ entities

### DIFF
--- a/docfx/doxygen2docfx.cc
+++ b/docfx/doxygen2docfx.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "docfx/doxygen2toc.h"
+#include "docfx/doxygen2yaml.h"
 #include "docfx/doxygen_groups.h"
 #include "docfx/doxygen_pages.h"
 #include "docfx/parse_arguments.h"
@@ -27,16 +28,22 @@ int main(int argc, char* argv[]) try {
   if (!load) throw std::runtime_error("Error loading XML input file");
 
   std::ofstream("toc.yml") << docfx::Doxygen2Toc(config, doc);
-  for (auto const& entry : docfx::PagesToc(doc)) {
-    auto const filter = std::string{"//compounddef[@id='"} + entry.name + "']";
+  for (auto const& [filename, name] : docfx::PagesToc(doc)) {
+    auto const filter = std::string{"//compounddef[@id='"} + name + "']";
     auto const node = doc.select_node(filter.c_str()).node();
-    std::ofstream(entry.filename) << docfx::Page2Markdown(node);
+    std::ofstream(filename) << docfx::Page2Markdown(node);
   }
 
-  for (auto const& entry : docfx::GroupsToc(doc)) {
-    auto const filter = std::string{"//compounddef[@id='"} + entry.name + "']";
+  for (auto const& [filename, name] : docfx::GroupsToc(doc)) {
+    auto const filter = std::string{"//compounddef[@id='"} + name + "']";
     auto const node = doc.select_node(filter.c_str()).node();
-    std::ofstream(entry.filename) << docfx::Group2Yaml(node);
+    std::ofstream(filename) << docfx::Group2Yaml(node);
+  }
+
+  for (auto const& [filename, name] : docfx::CompoundToc(doc)) {
+    auto const filter = std::string{"//compounddef[@id='"} + name + "']";
+    auto const node = doc.select_node(filter.c_str()).node();
+    std::ofstream(filename) << docfx::Compound2Yaml(node);
   }
 
   return 0;

--- a/docfx/doxygen2toc.cc
+++ b/docfx/doxygen2toc.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "docfx/doxygen2toc.h"
+#include "docfx/doxygen2yaml.h"
 #include "docfx/doxygen_groups.h"
 #include "docfx/doxygen_pages.h"
 #include <yaml-cpp/yaml.h>
@@ -34,6 +35,12 @@ std::string Doxygen2Toc(Config const& config, pugi::xml_document const& doc) {
         << YAML::EndMap;
   }
   for (auto const& [filename, name] : GroupsToc(doc)) {
+    out << YAML::BeginMap                              //
+        << YAML::Key << "uid" << YAML::Value << name   //
+        << YAML::Key << "name" << YAML::Value << name  //
+        << YAML::EndMap;
+  }
+  for (auto const& [filename, name] : CompoundToc(doc)) {
     out << YAML::BeginMap                              //
         << YAML::Key << "uid" << YAML::Value << name   //
         << YAML::Key << "name" << YAML::Value << name  //

--- a/docfx/doxygen2toc_test.cc
+++ b/docfx/doxygen2toc_test.cc
@@ -59,6 +59,10 @@ items:
     href: indexpage.md
   - uid: group__terminate
     name: group__terminate
+  - uid: namespacegoogle
+    name: namespacegoogle
+  - uid: namespacegoogle_1_1cloud
+    name: namespacegoogle_1_1cloud
 )""";
 
   pugi::xml_document doc;

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -97,7 +97,6 @@ std::vector<TocEntry> CompoundToc(pugi::xml_document const& doc) {
 }
 
 std::string Compound2Yaml(pugi::xml_node const& node) {
-  auto const id = std::string{node.attribute("id").as_string()};
   YAML::Emitter yaml;
   StartDocFxYaml(yaml);
   YamlContext ctx;

--- a/docfx/doxygen2yaml.h
+++ b/docfx/doxygen2yaml.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2YAML_H
 #define GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2YAML_H
 
+#include "docfx/toc_entry.h"
 #include "docfx/yaml_context.h"
 #include <pugixml.hpp>
 #include <yaml-cpp/yaml.h>
@@ -29,6 +30,13 @@ namespace docfx {
 // namespaces. This helper allows us to short circuit the recursion over the
 // doxygen structure when an element is not needed for the public docs.
 bool IncludeInPublicDocuments(pugi::xml_node const& node);
+
+// Get the table of contents for `<compounddef>` nodes representing C++ types.
+std::vector<TocEntry> CompoundToc(pugi::xml_document const& doc);
+
+// Generate the YAML file contents for `<compounddef>` nodes representing C++
+// types.
+std::string Compound2Yaml(pugi::xml_node const& node);
 
 // Initialize a YAML Emitter with the preamble elements required by DocFx.
 void StartDocFxYaml(YAML::Emitter& yaml);

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -19,6 +19,8 @@
 namespace docfx {
 namespace {
 
+using ::testing::ElementsAre;
+
 auto constexpr kEnumXml = R"xml(<?xml version="1.0" standalone="yes"?>
     <doxygen version="1.9.1" xml:lang="en-US">
       <memberdef kind="enum" id="namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c" prot="public" static="no" strong="yes">
@@ -433,6 +435,31 @@ auto constexpr kClassXml = R"xml(xml(<?xml version="1.0" standalone="yes"?>
       </listofallmembers>
     </compounddef>
   </doxygen>)xml";
+
+TEST(Doxygen2Yaml, CompoundToc) {
+  auto constexpr kDocXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle" kind="namespace" language="C++">
+        <compoundname>google</compoundname>
+        <innernamespace refid="namespacegoogle_1_1cloud">google::cloud</innernamespace>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud" kind="namespace" language="C++">
+        <compoundname>google::cloud</compoundname>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacestd" kind="namespace" language="Unknown">
+        <compoundname>std</compoundname>
+      </compounddef>
+    </doxygen>)xml";
+
+  pugi::xml_document doc;
+  ASSERT_TRUE(doc.load_string(kDocXml));
+  auto const actual = CompoundToc(doc);
+
+  EXPECT_THAT(actual,
+              ElementsAre(TocEntry{"namespacegoogle.yml", "namespacegoogle"},
+                          TocEntry{"namespacegoogle_1_1cloud.yml",
+                                   "namespacegoogle_1_1cloud"}));
+}
 
 TEST(Doxygen2Yaml, IncludeInPublicDocs) {
   auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>

--- a/docfx/toc_entry.h
+++ b/docfx/toc_entry.h
@@ -26,6 +26,14 @@ struct TocEntry {
   std::string name;
 };
 
+inline bool operator==(TocEntry const& lhs, TocEntry const& rhs) {
+  return lhs.filename == rhs.filename && lhs.name == rhs.name;
+}
+
+inline bool operator!=(TocEntry const& lhs, TocEntry const& rhs) {
+  return !(lhs == rhs);
+}
+
 std::ostream& operator<<(std::ostream& os, TocEntry const& entry);
 
 }  // namespace docfx


### PR DESCRIPTION
This generates the ToC for C++ entities, starting with namespaces.

Part of the work for #10895 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11189)
<!-- Reviewable:end -->
