### PR TITLE
ci: exit with a distinctive status on checkers differences

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -223,5 +223,7 @@ time {
   done
 }
 
-# Report the differences, which should break the build.
-git diff --exit-code .
+# If there are any diffs, report them and exit with a non-zero status so
+# as to break the build. Use a distinctive status so that callers have a
+# chance to distinguish formatting updates from other check failures.
+git diff --exit-code . || exit 111


### PR DESCRIPTION
If `ci/cloudbuild/builds/checkers.sh` finds any diffs, exit with a (hopefully) distinctive status (instead of 1) so that callers might distinguish formatting corrections (e.g., `clang-format`) from hard errors (e.g., `shellcheck`).

This will help me stop pushing commits with `typos` errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11193)
<!-- Reviewable:end -->
