### PR TITLE
impl(common): enhance DebugFormatter support

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -75,37 +75,45 @@ StateFilter StateFilter::Done() {
   return state_filter;
 }
 
-std::string GetJobRequest::DebugString(TracingOptions const& options) const {
-  return internal::DebugFormatter(
-             options,
-             "google::cloud::bigquery_v2_minimal_internal::GetJobRequest")
+std::string GetJobRequest::DebugString(absl::string_view name,
+                                       TracingOptions const& options,
+                                       int indent) const {
+  return internal::DebugFormatter(name, options, indent)
       .StringField("project_id", project_id_)
       .StringField("job_id", job_id_)
       .StringField("location", location_)
       .Build();
 }
 
-std::string ListJobsRequest::DebugString(TracingOptions const& options) const {
-  return internal::DebugFormatter(
-             options,
-             "google::cloud::bigquery_v2_minimal_internal::ListJobsRequest")
+std::string ListJobsRequest::DebugString(absl::string_view name,
+                                         TracingOptions const& options,
+                                         int indent) const {
+  return internal::DebugFormatter(name, options, indent)
       .StringField("project_id", project_id_)
       .Field("all_users", all_users_)
       .Field("max_results", max_results_)
-      .SubMessage("min_creation_time")
-      .QuotedField(internal::FormatRfc3339(min_creation_time_))
-      .EndMessage()
-      .SubMessage("max_creation_time")
-      .QuotedField(internal::FormatRfc3339(max_creation_time_))
-      .EndMessage()
+      .Field("min_creation_time", min_creation_time_)
+      .Field("max_creation_time", max_creation_time_)
       .StringField("page_token", page_token_)
-      .SubMessage("projection")
-      .StringField("value", projection_.value)
-      .EndMessage()
-      .SubMessage("state_filter")
-      .StringField("value", state_filter_.value)
-      .EndMessage()
+      .SubMessage("projection", projection_)
+      .SubMessage("state_filter", state_filter_)
       .StringField("parent_job_id", parent_job_id_)
+      .Build();
+}
+
+std::string Projection::DebugString(absl::string_view name,
+                                    TracingOptions const& options,
+                                    int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("value", value)
+      .Build();
+}
+
+std::string StateFilter::DebugString(absl::string_view name,
+                                     TracingOptions const& options,
+                                     int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("value", value)
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -20,6 +20,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <chrono>
 #include <ostream>
 #include <string>
@@ -64,7 +65,9 @@ class GetJobRequest {
     return std::move(set_location(std::move(location)));
   }
 
-  std::string DebugString(TracingOptions const& options) const;
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 
  private:
   std::string project_id_;
@@ -77,6 +80,10 @@ struct Projection {
   static Projection Full();
 
   std::string value;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct StateFilter {
@@ -85,6 +92,10 @@ struct StateFilter {
   static StateFilter Done();
 
   std::string value;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 class ListJobsRequest {
@@ -182,7 +193,9 @@ class ListJobsRequest {
     return std::move(set_parent_job_id(std::move(parent_job_id)));
   }
 
-  std::string DebugString(TracingOptions const& options) const;
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 
   // Members
  private:

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -177,22 +177,23 @@ TEST(GetJobRequest, DebugString) {
   GetJobRequest request("test-project-id", "test-job-id");
   request.set_location("test-location");
 
-  EXPECT_EQ(request.DebugString(TracingOptions{}),
-            R"(google::cloud::bigquery_v2_minimal_internal::GetJobRequest {)"
+  EXPECT_EQ(request.DebugString("GetJobRequest", TracingOptions{}),
+            R"(GetJobRequest {)"
             R"( project_id: "test-project-id")"
             R"( job_id: "test-job-id")"
             R"( location: "test-location")"
             R"( })");
-  EXPECT_EQ(request.DebugString(TracingOptions{}.SetOptions(
-                "truncate_string_field_longer_than=7")),
-            R"(google::cloud::bigquery_v2_minimal_internal::GetJobRequest {)"
+  EXPECT_EQ(request.DebugString("GetJobRequest",
+                                TracingOptions{}.SetOptions(
+                                    "truncate_string_field_longer_than=7")),
+            R"(GetJobRequest {)"
             R"( project_id: "test-pr...<truncated>...")"
             R"( job_id: "test-jo...<truncated>...")"
             R"( location: "test-lo...<truncated>...")"
             R"( })");
-  EXPECT_EQ(
-      request.DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
-      R"(google::cloud::bigquery_v2_minimal_internal::GetJobRequest {
+  EXPECT_EQ(request.DebugString("GetJobRequest", TracingOptions{}.SetOptions(
+                                                     "single_line_mode=F")),
+            R"(GetJobRequest {
   project_id: "test-project-id"
   job_id: "test-job-id"
   location: "test-location"
@@ -214,8 +215,8 @@ TEST(ListJobsRequestTest, DebugString) {
       .set_state_filter(StateFilter::Running())
       .set_parent_job_id("test-job-id");
 
-  EXPECT_EQ(request.DebugString(TracingOptions{}),
-            R"(google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {)"
+  EXPECT_EQ(request.DebugString("ListJobsRequest", TracingOptions{}),
+            R"(ListJobsRequest {)"
             R"( project_id: "test-project-id")"
             R"( all_users: true)"
             R"( max_results: 10)"
@@ -226,9 +227,10 @@ TEST(ListJobsRequestTest, DebugString) {
             R"( state_filter { value: "RUNNING" })"
             R"( parent_job_id: "test-job-id")"
             R"( })");
-  EXPECT_EQ(request.DebugString(TracingOptions{}.SetOptions(
-                "truncate_string_field_longer_than=7")),
-            R"(google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {)"
+  EXPECT_EQ(request.DebugString("ListJobsRequest",
+                                TracingOptions{}.SetOptions(
+                                    "truncate_string_field_longer_than=7")),
+            R"(ListJobsRequest {)"
             R"( project_id: "test-pr...<truncated>...")"
             R"( all_users: true)"
             R"( max_results: 10)"
@@ -239,9 +241,9 @@ TEST(ListJobsRequestTest, DebugString) {
             R"( state_filter { value: "RUNNING" })"
             R"( parent_job_id: "test-jo...<truncated>...")"
             R"( })");
-  EXPECT_EQ(
-      request.DebugString(TracingOptions{}.SetOptions("single_line_mode=F")),
-      R"(google::cloud::bigquery_v2_minimal_internal::ListJobsRequest {
+  EXPECT_EQ(request.DebugString("ListJobsRequest", TracingOptions{}.SetOptions(
+                                                       "single_line_mode=F")),
+            R"(ListJobsRequest {
   project_id: "test-project-id"
   all_users: true
   max_results: 10

--- a/google/cloud/internal/debug_string.h
+++ b/google/cloud/internal/debug_string.h
@@ -19,6 +19,7 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
+#include <chrono>
 #include <string>
 
 namespace google {
@@ -35,12 +36,18 @@ namespace internal {
  */
 class DebugFormatter {
  public:
-  DebugFormatter(TracingOptions options, absl::string_view message_name);
+  DebugFormatter(absl::string_view name, TracingOptions options,
+                 int indent = 0);
 
-  DebugFormatter& SubMessage(absl::string_view message_name);
-  DebugFormatter& EndMessage();
+  template <typename T>
+  DebugFormatter& SubMessage(absl::string_view name, T const& message) {
+    absl::StrAppend(&str_, message.DebugString(name, options_, indent_));
+    return *this;
+  }
 
   DebugFormatter& Field(absl::string_view field_name, bool value);
+  DebugFormatter& Field(absl::string_view field_name,
+                        std::chrono::system_clock::time_point value);
 
   template <typename T>
   DebugFormatter& Field(absl::string_view field_name, T const& value) {
@@ -69,7 +76,7 @@ class DebugFormatter {
 
   TracingOptions options_;
   std::string str_;
-  int indent_ = 0;
+  int indent_;
 };
 
 // Return @p s with possible length restriction due to the application of

--- a/google/cloud/internal/debug_string_test.cc
+++ b/google/cloud/internal/debug_string_test.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/internal/debug_string.h"
+#include "absl/strings/string_view.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -21,20 +23,28 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+struct SubMessage {
+  double value;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const {
+    return DebugFormatter(name, options, indent).Field("value", value).Build();
+  }
+};
+
 TEST(DebugFormatter, SingleLine) {
-  EXPECT_EQ(DebugFormatter(TracingOptions{}.SetOptions("single_line_mode=T"),
-                           "message_name")
+  EXPECT_EQ(DebugFormatter("message_name",
+                           TracingOptions{}.SetOptions("single_line_mode=T"))
                 .Field("field1", 42)
-                .SubMessage("sub_message")
-                .QuotedField("field2", 3.14159)
-                .EndMessage()
+                .SubMessage("sub_message", SubMessage{3.14159})
                 .StringField("field2", "foobar")
                 .Field("field3", true)
                 .Build(),
             R"(message_name {)"
             R"( field1: 42)"
             R"( sub_message {)"
-            R"( field2: "3.14159")"
+            R"( value: 3.14159)"
             R"( })"
             R"( field2: "foobar")"
             R"( field3: true)"
@@ -42,19 +52,17 @@ TEST(DebugFormatter, SingleLine) {
 }
 
 TEST(DebugFormatter, MultiLine) {
-  EXPECT_EQ(DebugFormatter(TracingOptions{}.SetOptions("single_line_mode=F"),
-                           "message_name")
+  EXPECT_EQ(DebugFormatter("message_name",
+                           TracingOptions{}.SetOptions("single_line_mode=F"))
                 .Field("field1", 42)
-                .SubMessage("sub_message")
-                .QuotedField("field2", 3.14159)
-                .EndMessage()
+                .SubMessage("sub_message", SubMessage{3.14159})
                 .StringField("field2", "foobar")
                 .Field("field3", true)
                 .Build(),
             R"(message_name {
   field1: 42
   sub_message {
-    field2: "3.14159"
+    value: 3.14159
   }
   field2: "foobar"
   field3: true
@@ -62,24 +70,22 @@ TEST(DebugFormatter, MultiLine) {
 }
 
 TEST(DebugFormatter, Truncated) {
-  EXPECT_EQ(DebugFormatter(TracingOptions{}.SetOptions(
-                               "truncate_string_field_longer_than=3"),
-                           "message_name")
-                .Field("field1", 42)
-                .SubMessage("sub_message")
-                .QuotedField("field2", 3.14159)
-                .EndMessage()
-                .StringField("field2", "foobar")
-                .Field("field3", true)
-                .Build(),
-            R"(message_name {)"
-            R"( field1: 42)"
-            R"( sub_message {)"
-            R"( field2: "3.14159")"
-            R"( })"
-            R"( field2: "foo...<truncated>...")"
-            R"( field3: true)"
-            R"( })");
+  EXPECT_EQ(
+      DebugFormatter("message_name", TracingOptions{}.SetOptions(
+                                         "truncate_string_field_longer_than=3"))
+          .Field("field1", 42)
+          .SubMessage("sub_message", SubMessage{3.14159})
+          .StringField("field2", "foobar")
+          .Field("field3", true)
+          .Build(),
+      R"(message_name {)"
+      R"( field1: 42)"
+      R"( sub_message {)"
+      R"( value: 3.14159)"
+      R"( })"
+      R"( field2: "foo...<truncated>...")"
+      R"( field3: true)"
+      R"( })");
 }
 
 TEST(DebugString, TruncateString) {


### PR DESCRIPTION
- composable support for sub-messages: `SubMessage()` can now use the `DebugString()` of the sub field to build the upper `DebugString()`. This requires `DebugString()` to now take a name, which should either be the top-most class name or an inner field name.

- direct support for `time_point` fields: Match the auto formatting of `Timestamp` proto messages as human-readable strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11197)
<!-- Reviewable:end -->
