### PR TITLE
feat(common): a "lastN in thread" logger

### DIFF
--- a/google/cloud/internal/log_impl_test.cc
+++ b/google/cloud/internal/log_impl_test.cc
@@ -83,8 +83,8 @@ TEST(PerThreadCircularBufferBackend, Basic) {
 
   auto noise_generator = [&] {
     for (int i = 0; i != 10; ++i) {
-      buffer.ProcessWithOwnership(test_log_record(
-          Severity::GCP_LS_INFO, "noise " + std::to_string(i)));
+      buffer.ProcessWithOwnership(
+          test_log_record(Severity::GCP_LS_INFO, "noise " + std::to_string(i)));
     }
   };
 

--- a/google/cloud/internal/log_impl_test.cc
+++ b/google/cloud/internal/log_impl_test.cc
@@ -47,7 +47,7 @@ TEST(CircularBufferBackend, Basic) {
   buffer.ProcessWithOwnership(
       test_log_record(Severity::GCP_LS_WARNING, "msg 4"));
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 5"));
-  // The output should be empty, as no message with high enough severity have
+  // The output should be empty as no message with high enough severity has
   // been generated.
   EXPECT_THAT(be->ExtractLines(), IsEmpty());
 
@@ -56,13 +56,13 @@ TEST(CircularBufferBackend, Basic) {
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_ERROR, "msg 6"));
   EXPECT_THAT(be->ExtractLines(), ElementsAre("msg 4", "msg 5", "msg 6"));
 
-  // In this case, the buffer is not full. But a message with high enough
+  // In this case the buffer is not full, but a message with high enough
   // severity forces a flush.
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 7"));
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_ERROR, "msg 8"));
   EXPECT_THAT(be->ExtractLines(), ElementsAre("msg 7", "msg 8"));
 
-  // In this case, the buffer is not full. An explicit flush should create
+  // In this case the buffer is not full, but an explicit flush should create
   // some output.
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 9"));
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 10"));
@@ -95,7 +95,7 @@ TEST(PerThreadCircularBufferBackend, Basic) {
   buffer.ProcessWithOwnership(
       test_log_record(Severity::GCP_LS_WARNING, "msg 4"));
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 5"));
-  // The output should be empty, as no message with high enough severity have
+  // The output should be empty as no message with high enough severity has
   // been generated.
   noise.join();
   EXPECT_THAT(be->ExtractLines(), IsEmpty());
@@ -107,7 +107,7 @@ TEST(PerThreadCircularBufferBackend, Basic) {
   noise.join();
   EXPECT_THAT(be->ExtractLines(), ElementsAre("msg 4", "msg 5", "msg 6"));
 
-  // In this case, the buffer is not full. But a message with high enough
+  // In this case the buffer is not full, but a message with high enough
   // severity forces a flush.
   noise = std::thread{noise_generator};
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 7"));
@@ -115,7 +115,7 @@ TEST(PerThreadCircularBufferBackend, Basic) {
   noise.join();
   EXPECT_THAT(be->ExtractLines(), ElementsAre("msg 7", "msg 8"));
 
-  // In this case, the buffer is not full. An explicit flush should create
+  // In this case the buffer is not full, but an explicit flush should create
   // some output.
   noise = std::thread{noise_generator};
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 9"));

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -211,6 +211,15 @@ std::shared_ptr<LogBackend> DefaultLogBackend() {
             std::make_shared<StdClogBackend>(min_severity));
       }
     }
+    if (fields[0] == "thread-lastN" && fields.size() == 3) {
+      auto size = ParseSize(fields[1]);
+      auto min_flush_severity = ParseSeverity(fields[2]);
+      if (size.has_value() && min_flush_severity.has_value()) {
+        return std::make_shared<PerThreadCircularBufferBackend>(
+            *size, *min_flush_severity,
+            std::make_shared<StdClogBackend>(min_severity));
+      }
+    }
     if (fields[0] == "clog" && fields.size() == 1) {
       return std::make_shared<StdClogBackend>(min_severity);
     }


### PR DESCRIPTION
This is a variant of the "lastN" logger. It only dumps the lastN log lines *in the thread* when the library or application creates a log line over a minimum severity threshold. This is an improvement over the "lastN" logger, which dumps the last N logs from all the threads in similar circumstances.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11200)
<!-- Reviewable:end -->
