### PR TITLE
impl(otel): docs for opentelemetry_sdk

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -31,7 +31,7 @@ doc_args=(
   "-DGOOGLE_CLOUD_CPP_ENABLE=${ENABLED_FEATURES}"
   "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON"
   "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
-  "-DDOXYGEN_CLANG_OPTIONS=-resource-dir=$(clang -print-resource-dir) -Wno-deprecated-declarations"
+  "-DGOOGLE_CLOUD_CPP_DOXYGEN_CLANG_OPTIONS=-resource-dir=$(clang -print-resource-dir)"
 )
 
 # Extract the version number if we're on a release branch.

--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -108,7 +108,13 @@ function (google_cloud_cpp_doxygen_targets_impl library)
 
     # Options controlling how to parse the C++ code
     set(DOXYGEN_CLANG_ASSISTED_PARSING YES)
-    set(DOXYGEN_CLANG_OPTIONS)
+    # We set -DHAVE_ABSEIL to generate documentation for libraries that expose
+    # OpenTelemetry types. Ideally, we would generalize this to pick up any
+    # linked library's compile definitions, but that would be hard, and we have
+    # other things to do.
+    set(DOXYGEN_CLANG_OPTIONS
+        "-Wno-deprecated-declarations -DHAVE_ABSEIL ${GOOGLE_CLOUD_CPP_DOXYGEN_CLANG_OPTIONS}"
+    )
     set(DOXYGEN_CLANG_DATABASE_PATH)
     set(DOXYGEN_SEARCH_INCLUDES YES)
     set(DOXYGEN_INCLUDE_PATH

--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -16,8 +16,19 @@
 
 find_package(opentelemetry-cpp CONFIG REQUIRED)
 
+set(DOXYGEN_PROJECT_NAME "C++ OpenTelemetry Exporters for Google Cloud")
+set(DOXYGEN_PROJECT_BRIEF
+    "Provides exporters for sending telemetry to Google Cloud services in C++.")
+set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "otel_internal")
+set(DOXYGEN_EXAMPLE_PATH "")
+
+include(GoogleCloudCppDoxygen)
+google_cloud_cpp_doxygen_targets("opentelemetry_sdk" DEPENDS cloud-docs
+                                 google-cloud-cpp::trace)
+
 add_library(google_cloud_cpp_opentelemetry_sdk # cmake-format: sort
-            internal/recordable.cc internal/recordable.h)
+            internal/recordable.cc internal/recordable.h trace_exporter.h)
 target_link_libraries(google_cloud_cpp_opentelemetry_sdk
                       PUBLIC google-cloud-cpp::trace opentelemetry-cpp::trace)
 google_cloud_cpp_add_common_options(google_cloud_cpp_opentelemetry_sdk)

--- a/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry_sdk.bzl
+++ b/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry_sdk.bzl
@@ -18,6 +18,7 @@
 
 google_cloud_cpp_opentelemetry_sdk_hdrs = [
     "internal/recordable.h",
+    "trace_exporter.h",
 ]
 
 google_cloud_cpp_opentelemetry_sdk_srcs = [

--- a/google/cloud/opentelemetry/trace_exporter.h
+++ b/google/cloud/opentelemetry/trace_exporter.h
@@ -1,0 +1,32 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_TRACE_EXPORTER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_TRACE_EXPORTER_H
+
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+namespace otel {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+// TODO(#11156) - Implement this thing.
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_TRACE_EXPORTER_H


### PR DESCRIPTION
Part of the work for #11156 

Generate documentation for `google/cloud/opentelemetry`. This is what the docs would look like if we had a public class: [otel_sdk_example.pdf](https://github.com/googleapis/google-cloud-cpp/files/11180893/otel_sdk_example.pdf). (Note that the interface will change).

Abstract Doxygen's CLANG_OPTIONS ever so slightly.

Without the `trace_exporter.h` file, Doxygen would not have any input. (It skips `internal/` directories). And if Doxygen does not have input, it throws an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11207)
<!-- Reviewable:end -->
