### PR TITLE
fix(otel): handle non-null terminated string_views

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -74,13 +74,15 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanGrpc(
   opentelemetry::trace::StartSpanOptions options;
   options.kind = opentelemetry::trace::SpanKind::kClient;
   return GetTracer(internal::CurrentOptions())
-      ->StartSpan(absl::StrCat(service.data(), "/", method.data()),
-                  {{sc::kRpcSystem, sc::RpcSystemValues::kGrpc},
-                   {sc::kRpcService, service},
-                   {sc::kRpcMethod, method},
-                   {sc::kNetTransport, sc::NetTransportValues::kIpTcp},
-                   {"grpc.version", grpc::Version()}},
-                  options);
+      ->StartSpan(
+          absl::StrCat(absl::string_view{service.data(), service.size()}, "/",
+                       absl::string_view{method.data(), method.size()}),
+          {{sc::kRpcSystem, sc::RpcSystemValues::kGrpc},
+           {sc::kRpcService, service},
+           {sc::kRpcMethod, method},
+           {sc::kNetTransport, sc::NetTransportValues::kIpTcp},
+           {"grpc.version", grpc::Version()}},
+          options);
 }
 
 void InjectTraceContext(grpc::ClientContext& context, Options const& options) {

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -75,6 +75,19 @@ TEST(OpenTelemetry, MakeSpanGrpc) {
               SpanAttribute<std::string>("grpc.version", grpc::Version())))));
 }
 
+TEST(OpenTelemetry, MakeSpanGrpcHandlesNonNullTerminatedStringView) {
+  auto span_catcher = InstallSpanCatcher();
+
+  char service[]{'s', 'e', 'r', 'v', 'i', 'c', 'e'};
+  char method[]{'m', 'e', 't', 'h', 'o', 'd'};
+
+  auto span = MakeSpanGrpc({service, 7}, {method, 6});
+  span->End();
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, ElementsAre(SpanNamed("service/method")));
+}
+
 TEST(OpenTelemetry, InjectTraceContextGrpc) {
   auto mock_propagator = testing_util::InstallMockPropagator();
   EXPECT_CALL(*mock_propagator, Inject)


### PR DESCRIPTION
As @coryan noticed, I was assuming the string views were null terminated in `MakeSpanGrpc()`. (@devbww has also warned in the past that `sv.data()` without `sv.size()` is a red flag).

So fix it, and add a regression test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11208)
<!-- Reviewable:end -->
