### PR TITLE
impl(docfx): support xrefsect in markdown

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -147,6 +147,26 @@ bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
   return true;
 }
 
+// A "xrefsect" node type is defined as:
+//
+// clang-format off
+//   <xsd:complexType name="docXRefSectType">
+//     <xsd:sequence>
+//       <xsd:element name="xreftitle" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+//       <xsd:element name="xrefdescription" type="descriptionType" />
+//     </xsd:sequence>
+//     <xsd:attribute name="id" type="xsd:string" />
+//   </xsd:complexType>
+// clang-format on
+bool AppendIfXRefSect(std::ostream& os, MarkdownContext const& ctx,
+                      pugi::xml_node const& node) {
+  if (std::string_view{node.name()} != "xrefsect") return false;
+  // Add the title in bold, then some
+  os << "**" << node.child_value("xreftitle") << "**";
+  AppendDescriptionType(os, ctx, node.child("xrefdescription"));
+  return true;
+}
+
 // All "*description" nodes have this type:
 //
 // clang-format off
@@ -435,7 +455,8 @@ bool AppendIfDocCmdGroup(std::ostream& os, MarkdownContext const& ctx,
   // Unexpected: title
   if (AppendIfVariableList(os, ctx, node)) return true;
   // Unexpected: table, header, dotfile, mscfile, diafile, toclist, language
-  // Unexpected: xrefsect, copydoc, blockquote, parblock
+  if (AppendIfXRefSect(os, ctx, node)) return true;
+  // Unexpected: copydoc, blockquote, parblock
   return false;
 }
 

--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -52,6 +52,10 @@ bool AppendIfSect2(std::ostream& os, MarkdownContext const& ctx,
 bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
                    pugi::xml_node const& node);
 
+/// Handles a `<xrefsect>` node.
+bool AppendIfXRefSect(std::ostream& os, MarkdownContext const& ctx,
+                      pugi::xml_node const& node);
+
 /// Outputs a description node.
 void AppendDescriptionType(std::ostream& os, MarkdownContext const& ctx,
                            pugi::xml_node const& node);

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -633,6 +633,33 @@ for (StatusOr<int> const& v : sr) {
   EXPECT_EQ(kExpected, os.str());
 }
 
+TEST(Doxygen2Markdown, ParagraphXrefSect) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <para id='tested-node'>
+        <xrefsect id="deprecated_1_deprecated000007">
+          <xreftitle>Deprecated</xreftitle>
+          <xrefdescription>
+            <para>Use <computeroutput><ref refid="classgoogle_1_1cloud_1_1Options" kindref="compound">Options</ref></computeroutput> and <computeroutput><ref refid="structgoogle_1_1cloud_1_1EndpointOption" kindref="compound">EndpointOption</ref></computeroutput>.</para>
+          </xrefdescription>
+        </xrefsect>
+      </para>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"md(
+
+**Deprecated**
+
+Use [`Options`](xref:classgoogle_1_1cloud_1_1Options) and [`EndpointOption`](xref:structgoogle_1_1cloud_1_1EndpointOption).)md";
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//*[@id='tested-node']");
+  ASSERT_TRUE(selected);
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfParagraph(os, {}, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
+}
+
 TEST(Doxygen2Markdown, ItemizedListSimple) {
   pugi::xml_document doc;
   doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>


### PR DESCRIPTION
Part of the work for #10895 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11210)
<!-- Reviewable:end -->
