### PR TITLE
impl(docfx): include `<description>` in summary

### DIFF
--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -77,7 +77,7 @@ std::string Summary(pugi::xml_node const& node) {
   }
   auto description = node.child("description");
   if (!description.empty()) {
-    AppendDescriptionType(os, ctx, brief);
+    AppendDescriptionType(os, ctx, description);
     ctx = MarkdownContext{};
   }
   auto detailed = node.child("detaileddescription");

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -71,11 +71,16 @@ std::string Summary(pugi::xml_node const& node) {
   MarkdownContext ctx;
   ctx.paragraph_start = "";
   auto brief = node.child("briefdescription");
-  auto detailed = node.child("detaileddescription");
   if (!brief.empty()) {
     AppendIfBriefDescription(os, ctx, brief);
     ctx = MarkdownContext{};
   }
+  auto description = node.child("description");
+  if (!description.empty()) {
+    AppendDescriptionType(os, ctx, brief);
+    ctx = MarkdownContext{};
+  }
+  auto detailed = node.child("detaileddescription");
   if (!detailed.empty()) AppendIfDetailedDescription(os, ctx, detailed);
   return std::move(os).str();
 }

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -662,6 +662,9 @@ TEST(Doxygen2Yaml, Typedef) {
         <detaileddescription>
         <para>A longer description would go here.</para>
         </detaileddescription>
+        <description>
+          <para>The rarely used <computeroutput>&lt;description&gt;</computeroutput> would go here.</para>
+        </description>
         <inbodydescription>
         </inbodydescription>
         <location file="grpc_options.h" line="148" column="1" bodyfile="grpc_options.h" bodystart="149" bodyend="-1"/>
@@ -693,6 +696,8 @@ items:
           path: google/cloud/grpc_options.h
     summary: |
       A short description of the thing.
+
+      The rarely used `<description>` would go here.
 
       A longer description would go here.
 )yml";


### PR DESCRIPTION
Sometimes there is a `<description>` node, just make it part of the summary.

Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11216)
<!-- Reviewable:end -->
