### PR TITLE
impl(docfx): add tile to 'see also' sections

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -783,7 +783,10 @@ bool AppendIfSimpleSect(std::ostream& os, MarkdownContext const& ctx,
   // just repeat the text.
   if (kind == "return") return true;
 
-  if (kUseH6->count(kind) != 0) {
+  if (kind == "see") {
+    nested = ctx;
+    os << "\n\n###### See Also";
+  } else if (kUseH6->count(kind) != 0) {
     nested = ctx;
     os << "\n\n###### ";
     AppendTitle(os, nested, node);

--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -768,8 +768,8 @@ bool AppendIfSimpleSect(std::ostream& os, MarkdownContext const& ctx,
   if (std::string_view{node.name()} != "simplesect") return false;
   static auto const* const kUseH6 = [] {
     return new std::unordered_set<std::string>{
-        "see", "author", "authors",   "version",   "since", "date",
-        "pre", "post",   "copyright", "invariant", "par",   "rcs",
+        "author", "authors",   "version",   "since", "date", "pre",
+        "post",   "copyright", "invariant", "par",   "rcs",
     };
   }();
 

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -804,8 +804,8 @@ First paragraph.
 Second paragraph.)md";
 
   auto const cases = std::vector<std::string>{
-      "see", "author", "authors",   "version",   "since", "date",
-      "pre", "post",   "copyright", "invariant", "par",   "rcs",
+      "author", "authors",   "version",   "since", "date", "pre",
+      "post",   "copyright", "invariant", "par",   "rcs",
   };
 
   for (auto const& kind : cases) {
@@ -821,6 +821,33 @@ Second paragraph.)md";
     ASSERT_TRUE(AppendIfSimpleSect(os, {}, selected.node()));
     EXPECT_EQ(kExpected, os.str());
   }
+}
+
+TEST(Doxygen2Markdown, SimpleSectSeeAlso) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <simplesect id='test-node' kind="see">
+          <title>This is the title</title>
+          <para>First paragraph.</para>
+          <para>Second paragraph.</para>
+        </simplesect>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"md(
+
+###### See Also
+
+First paragraph.
+
+Second paragraph.)md";
+
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfSimpleSect(os, {}, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
 }
 
 TEST(Doxygen2Markdown, SimpleSectBlockQuote) {

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -827,7 +827,6 @@ TEST(Doxygen2Markdown, SimpleSectSeeAlso) {
   auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
     <doxygen version="1.9.1" xml:lang="en-US">
         <simplesect id='test-node' kind="see">
-          <title>This is the title</title>
           <para>First paragraph.</para>
           <para>Second paragraph.</para>
         </simplesect>


### PR DESCRIPTION
Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11218)
<!-- Reviewable:end -->
