### PR TITLE
impl(docfx): generate files for every compounddef

### DIFF
--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -449,6 +449,16 @@ TEST(Doxygen2Yaml, CompoundToc) {
       <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacestd" kind="namespace" language="Unknown">
         <compoundname>std</compoundname>
       </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classgoogle_1_1cloud_1_1future" kind="class" language="C++" prot="public" final="yes">
+        <compoundname>google::cloud::future</compoundname>
+        <basecompoundref prot="private" virt="non-virtual">internal::future_base&lt; T &gt;</basecompoundref>
+        <includes refid="future__generic_8h" local="no">google/cloud/future_generic.h</includes>
+        <templateparamlist>
+          <param>
+            <type>typename T</type>
+          </param>
+        </templateparamlist>
+      </compounddef>
     </doxygen>)xml";
 
   pugi::xml_document doc;


### PR DESCRIPTION
My plan to use the ToC entries in driving the file generation does not work. We need all compounddef generated so the cross-references work.

Part of the work for #10895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11219)
<!-- Reviewable:end -->
