### PR TITLE
impl(otel): pass-by-value in `EndSpan()`

### DIFF
--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -109,8 +109,7 @@ Status EndSpan(opentelemetry::trace::Span& span, Status const& status);
  * composition.
  */
 template <typename T>
-StatusOr<T> EndSpan(opentelemetry::trace::Span& span,
-                    StatusOr<T> const& value) {
+StatusOr<T> EndSpan(opentelemetry::trace::Span& span, StatusOr<T> value) {
   EndSpanImpl(span, value.status());
   return value;
 }


### PR DESCRIPTION
The `EndSpan()` function consumes (and returns) a `StatusOr<T>`. That should be captured by value. There are the usual performance reasons, but also `T` may not satisfy the `std::copyable<>` concept.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11220)
<!-- Reviewable:end -->
