### PR TITLE
impl(otel): add TruncatableString helper

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -27,7 +27,7 @@ bool IsTrailByte(char x) { return static_cast<signed char>(x) < -0x40; }
 void SetTruncatableString(
     google::devtools::cloudtrace::v2::TruncatableString& proto,
     opentelemetry::nostd::string_view value, std::size_t limit) {
-  if (value.size() < limit) {
+  if (value.size() <= limit) {
     proto.set_value(value.data(), value.size());
     proto.set_truncated_byte_count(0);
     return;

--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/project.h"
 #include "google/cloud/version.h"
+#include <google/devtools/cloudtrace/v2/trace.pb.h>
 #include <google/devtools/cloudtrace/v2/tracing.pb.h>
 #include <opentelemetry/common/attribute_value.h>
 #include <opentelemetry/sdk/trace/recordable.h>
@@ -25,6 +26,20 @@ namespace google {
 namespace cloud {
 namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Helper to set [TruncatableString] fields in a [Span] proto.
+ *
+ * The service defines the limit for such fields in its documentation.
+ *
+ * [Span]:
+ * https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.cloudtrace.v2#google.devtools.cloudtrace.v2.Span
+ * [TruncatableString]:
+ * https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.cloudtrace.v2#google.devtools.cloudtrace.v2.TruncatableString
+ */
+void SetTruncatableString(
+    google::devtools::cloudtrace::v2::TruncatableString& proto,
+    opentelemetry::nostd::string_view value, std::size_t limit);
 
 // TODO(#11156) - Implement this class.
 /**

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -42,7 +42,7 @@ TEST(SetTruncatableString, OverTheLimit) {
 
 TEST(SetTruncatableString, RespectsUnicodeSymbolBoundaries) {
   google::devtools::cloudtrace::v2::TruncatableString proto;
-  // A unicode that is 2 bytes wide.
+  // A UTF-8 encoded character that is 2 bytes wide.
   std::string const u2 = "\xd0\xb4";
   // The string `u2 + u2` is 4 bytes long. Truncation should respect the symbol
   // boundaries. i.e. we should not cut the symbol in half.
@@ -50,7 +50,7 @@ TEST(SetTruncatableString, RespectsUnicodeSymbolBoundaries) {
   EXPECT_EQ(proto.value(), u2);
   EXPECT_EQ(proto.truncated_byte_count(), 2);
 
-  // A unicode that is 3 bytes wide.
+  // A UTF-8 encoded character that is 3 bytes wide.
   std::string const u3 = "\xe6\x96\xad";
   SetTruncatableString(proto, u3 + u3, 5);
   EXPECT_EQ(proto.value(), u3);


### PR DESCRIPTION
Part of the work for #11156 

The `google::devtools::v2::Span` proto has several such `TruncatableString` fields. Add a helper for setting them.

I will remove the `TEST(Recordable, Compiles)` later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11221)
<!-- Reviewable:end -->
