### PR TITLE
impl(bigquery): Logging Decorator Cleanup: Added request and response logging to logging decorator

### DIFF
--- a/google/cloud/bigquery/BUILD.bazel
+++ b/google/cloud/bigquery/BUILD.bazel
@@ -109,6 +109,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
+        "//:grpc_utils",
         "//google/cloud:google_cloud_cpp_rest_internal",
     ],
 )

--- a/google/cloud/bigquery/bigquery_rest.cmake
+++ b/google/cloud/bigquery/bigquery_rest.cmake
@@ -52,8 +52,9 @@ target_include_directories(
            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
            $<INSTALL_INTERFACE:include>)
 target_link_libraries(
-    google_cloud_cpp_bigquery_rest PUBLIC google-cloud-cpp::rest_internal
-                                          google-cloud-cpp::common)
+    google_cloud_cpp_bigquery_rest
+    PUBLIC google-cloud-cpp::rest_internal google-cloud-cpp::grpc_utils
+           google-cloud-cpp::common)
 google_cloud_cpp_add_common_options(google_cloud_cpp_bigquery_rest)
 set_target_properties(
     google_cloud_cpp_bigquery_rest

--- a/google/cloud/bigquery/bigquery_rest.cmake
+++ b/google/cloud/bigquery/bigquery_rest.cmake
@@ -107,6 +107,7 @@ function (bigquery_rest_define_tests)
     target_sources(
         bigquery_rest_testing
         INTERFACE
+            ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/testing/mock_job_log_backend.h
             ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/testing/mock_job_rest_stub.h)
     target_link_libraries(
         bigquery_rest_testing
@@ -132,6 +133,7 @@ function (bigquery_rest_define_tests)
         v2/minimal/internal/job_client_test.cc
         v2/minimal/internal/job_connection_test.cc
         v2/minimal/internal/job_idempotency_policy_test.cc
+        v2/minimal/internal/job_logging_test.cc
         v2/minimal/internal/job_metadata_test.cc
         v2/minimal/internal/job_options_test.cc
         v2/minimal/internal/job_request_test.cc

--- a/google/cloud/bigquery/bigquery_rest_testing.bzl
+++ b/google/cloud/bigquery/bigquery_rest_testing.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for bigquery_rest_testing - DO NOT EDIT."""
 
 bigquery_rest_testing_hdrs = [
+    "v2/minimal/testing/mock_job_log_backend.h",
     "v2/minimal/testing/mock_job_rest_stub.h",
 ]
 

--- a/google/cloud/bigquery/bigquery_rest_unit_tests.bzl
+++ b/google/cloud/bigquery/bigquery_rest_unit_tests.bzl
@@ -22,6 +22,7 @@ bigquery_rest_unit_tests = [
     "v2/minimal/internal/job_client_test.cc",
     "v2/minimal/internal/job_connection_test.cc",
     "v2/minimal/internal/job_idempotency_policy_test.cc",
+    "v2/minimal/internal/job_logging_test.cc",
     "v2/minimal/internal/job_metadata_test.cc",
     "v2/minimal/internal/job_options_test.cc",
     "v2/minimal/internal/job_request_test.cc",

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h"
 #include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/rest_response.h"
 
 namespace google {
 namespace cloud {
@@ -22,6 +23,9 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace rest = ::google::cloud::rest_internal;
+
+BigQueryHttpResponse::BigQueryHttpResponse()
+    : http_status_code(static_cast<rest_internal::HttpStatusCode>(0)) {}
 
 StatusOr<BigQueryHttpResponse> BigQueryHttpResponse::BuildFromRestResponse(
     std::unique_ptr<rest::RestResponse> rest_response) {
@@ -48,6 +52,7 @@ std::string BigQueryHttpResponse::DebugString(absl::string_view name,
                                               int indent) const {
   // Payload is not logged as it might contain user sensitive data like
   // ldap/emails.
+
   return internal::DebugFormatter(name, options, indent)
       .Field("status_code", http_status_code)
       .Field("http_headers", http_headers)

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.cc
@@ -24,9 +24,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace rest = ::google::cloud::rest_internal;
 
-BigQueryHttpResponse::BigQueryHttpResponse()
-    : http_status_code(static_cast<rest_internal::HttpStatusCode>(0)) {}
-
 StatusOr<BigQueryHttpResponse> BigQueryHttpResponse::BuildFromRestResponse(
     std::unique_ptr<rest::RestResponse> rest_response) {
   BigQueryHttpResponse response;
@@ -52,7 +49,6 @@ std::string BigQueryHttpResponse::DebugString(absl::string_view name,
                                               int indent) const {
   // Payload is not logged as it might contain user sensitive data like
   // ldap/emails.
-
   return internal::DebugFormatter(name, options, indent)
       .Field("status_code", http_status_code)
       .Field("http_headers", http_headers)

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
@@ -28,7 +28,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class BigQueryHttpResponse {
  public:
-  BigQueryHttpResponse();
+  BigQueryHttpResponse() = default;
+
   // Parses the RestResponse and builds an BigQueryHttpResponse.
   static StatusOr<BigQueryHttpResponse> BuildFromRestResponse(
       std::unique_ptr<rest_internal::RestResponse> rest_response);
@@ -37,7 +38,8 @@ class BigQueryHttpResponse {
                           TracingOptions const& options = {},
                           int indent = 0) const;
 
-  rest_internal::HttpStatusCode http_status_code;
+  rest_internal::HttpStatusCode http_status_code{
+      rest_internal::HttpStatusCode::kOk};
   std::multimap<std::string, std::string> http_headers;
   std::string payload;
 };

--- a/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/bigquery_http_response.h
@@ -28,7 +28,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class BigQueryHttpResponse {
  public:
-  BigQueryHttpResponse() = default;
+  BigQueryHttpResponse();
   // Parses the RestResponse and builds an BigQueryHttpResponse.
   static StatusOr<BigQueryHttpResponse> BuildFromRestResponse(
       std::unique_ptr<rest_internal::RestResponse> rest_response);

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
@@ -37,7 +37,8 @@ Result JobLogWrapper(Functor&& functor, rest_internal::RestContext& context,
     absl::StrAppend(out, "name=", header.first, ", value={",
                     absl::StrJoin(header.second, "&"), "}");
   };
-  GCP_LOG(DEBUG) << where << "() " << request << ", Context={"
+  GCP_LOG(DEBUG) << where << "() << " << request.DebugString(options)
+                 << ", Context={"
                  << internal::DebugString(
                         absl::StrJoin(context.headers(), ", ", formatter),
                         options)

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
@@ -38,14 +38,15 @@ Result JobLogWrapper(Functor&& functor, rest_internal::RestContext& context,
                      absl::string_view response_name,
                      TracingOptions const& options) {
   auto formatter = [options](std::string* out, auto const& header) {
+    const auto* delim = options.single_line_mode() ? "&" : "\n";
     absl::StrAppend(
         out, " { name: \"", header.first, "\" value: \"",
-        internal::DebugString(absl::StrJoin(header.second, "&"), options),
-        "\" } ");
+        internal::DebugString(absl::StrJoin(header.second, delim), options),
+        "\" }");
   };
   GCP_LOG(DEBUG) << where << "() << "
                  << request.DebugString(request_name, options) << ", Context {"
-                 << absl::StrJoin(context.headers(), ", ", formatter) << " }";
+                 << absl::StrJoin(context.headers(), "", formatter) << " }";
 
   auto response = functor(context, request);
   if (!response) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
@@ -80,19 +80,23 @@ TEST_F(JobLoggingClientTest, GetJob) {
         return GetJobResponse::BuildFromHttpResponse(std::move(http_response));
       });
 
+  // Not checking all fields exhaustively. Just that request and response are
+  // being logged.
   EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
-        EXPECT_THAT(
-            lr.message,
-            HasSubstr(
-                "google::cloud::bigquery_v2_minimal_internal::GetJobRequest"));
+        EXPECT_THAT(lr.message, HasSubstr("GetJobRequest"));
         EXPECT_THAT(lr.message, HasSubstr("job_id: \"j123\""));
         EXPECT_THAT(lr.message, HasSubstr("project_id: \"p123\""));
       })
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" >> "));
-        EXPECT_THAT(lr.message, HasSubstr("status="));
+        EXPECT_THAT(lr.message, HasSubstr("status=OK"));
+      })
+      .WillOnce([](LogRecord const& lr) {
+        EXPECT_THAT(lr.message, HasSubstr("GetJobResponse"));
+        EXPECT_THAT(lr.message, HasSubstr("status: \"DONE\""));
+        EXPECT_THAT(lr.message, HasSubstr("id: \"j123\""));
       });
 
   auto client = CreateMockJobLogging(std::move(mock_stub));
@@ -138,15 +142,19 @@ TEST_F(JobLoggingClientTest, ListJobs) {
   EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
-        EXPECT_THAT(lr.message, HasSubstr("google::cloud::bigquery_v2_minimal_"
-                                          "internal::ListJobsRequest"));
+        EXPECT_THAT(lr.message, HasSubstr("ListJobsRequest"));
         EXPECT_THAT(lr.message, HasSubstr("project_id: \"p123\""));
         EXPECT_THAT(lr.message, HasSubstr("all_users: false"));
         EXPECT_THAT(lr.message, HasSubstr("max_results: 0"));
       })
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" >> "));
-        EXPECT_THAT(lr.message, HasSubstr("status="));
+        EXPECT_THAT(lr.message, HasSubstr("status=OK"));
+      })
+      .WillOnce([](LogRecord const& lr) {
+        EXPECT_THAT(lr.message, HasSubstr("ListJobsResponse"));
+        EXPECT_THAT(lr.message, HasSubstr("id: \"1\""));
+        EXPECT_THAT(lr.message, HasSubstr("state: \"DONE\""));
       });
 
   auto client = CreateMockJobLogging(std::move(mock_stub));

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
@@ -85,18 +85,14 @@ TEST_F(JobLoggingClientTest, GetJob) {
   EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
-        EXPECT_THAT(lr.message, HasSubstr("GetJobRequest"));
-        EXPECT_THAT(lr.message, HasSubstr("job_id: \"j123\""));
-        EXPECT_THAT(lr.message, HasSubstr("project_id: \"p123\""));
+        EXPECT_THAT(lr.message, HasSubstr(R"(GetJobRequest)"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(job_id: "j123")"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(project_id: "p123")"));
       })
       .WillOnce([](LogRecord const& lr) {
-        EXPECT_THAT(lr.message, HasSubstr(" >> "));
-        EXPECT_THAT(lr.message, HasSubstr("status=OK"));
-      })
-      .WillOnce([](LogRecord const& lr) {
-        EXPECT_THAT(lr.message, HasSubstr("GetJobResponse"));
-        EXPECT_THAT(lr.message, HasSubstr("status: \"DONE\""));
-        EXPECT_THAT(lr.message, HasSubstr("id: \"j123\""));
+        EXPECT_THAT(lr.message, HasSubstr(R"(GetJobResponse)"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(status: "DONE")"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(id: "j123")"));
       });
 
   auto client = CreateMockJobLogging(std::move(mock_stub));
@@ -142,19 +138,15 @@ TEST_F(JobLoggingClientTest, ListJobs) {
   EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
-        EXPECT_THAT(lr.message, HasSubstr("ListJobsRequest"));
-        EXPECT_THAT(lr.message, HasSubstr("project_id: \"p123\""));
-        EXPECT_THAT(lr.message, HasSubstr("all_users: false"));
-        EXPECT_THAT(lr.message, HasSubstr("max_results: 0"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(ListJobsRequest)"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(project_id: "p123")"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(all_users: false)"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(max_results: 0)"));
       })
       .WillOnce([](LogRecord const& lr) {
-        EXPECT_THAT(lr.message, HasSubstr(" >> "));
-        EXPECT_THAT(lr.message, HasSubstr("status=OK"));
-      })
-      .WillOnce([](LogRecord const& lr) {
-        EXPECT_THAT(lr.message, HasSubstr("ListJobsResponse"));
-        EXPECT_THAT(lr.message, HasSubstr("id: \"1\""));
-        EXPECT_THAT(lr.message, HasSubstr("state: \"DONE\""));
+        EXPECT_THAT(lr.message, HasSubstr(R"(ListJobsResponse)"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(id: "1")"));
+        EXPECT_THAT(lr.message, HasSubstr(R"(state: "DONE")"));
       });
 
   auto client = CreateMockJobLogging(std::move(mock_stub));

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
@@ -1,0 +1,162 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/v2/minimal/internal/job_logging.h"
+#include "google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h"
+#include "google/cloud/bigquery/v2/minimal/testing/mock_job_log_backend.h"
+#include "google/cloud/bigquery/v2/minimal/testing/mock_job_rest_stub.h"
+#include "google/cloud/common_options.h"
+#include "google/cloud/log.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+using ::google::cloud::bigquery_v2_minimal_testing::MockBigQueryJobRestStub;
+using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+
+std::shared_ptr<BigQueryJobLogging> CreateMockJobLogging(
+    std::shared_ptr<BigQueryJobRestStub> mock) {
+  return std::make_shared<BigQueryJobLogging>(std::move(mock), TracingOptions{},
+                                              std::set<std::string>{});
+}
+
+class JobLoggingClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    log_backend_ =
+        std::make_shared<bigquery_v2_minimal_testing::MockJobLogBackend>();
+    log_backend_id_ =
+        google::cloud::LogSink::Instance().AddBackend(log_backend_);
+  }
+  void TearDown() override {
+    google::cloud::LogSink::Instance().RemoveBackend(log_backend_id_);
+    log_backend_id_ = 0;
+    log_backend_.reset();
+  }
+
+  std::shared_ptr<bigquery_v2_minimal_testing::MockJobLogBackend> log_backend_ =
+      nullptr;
+  long log_backend_id_ = 0;  // NOLINT(google-runtime-int)
+};
+
+TEST_F(JobLoggingClientTest, GetJob) {
+  auto mock_stub = std::make_shared<MockBigQueryJobRestStub>();
+  auto constexpr kExpectedPayload =
+      R"({"kind": "jkind",
+          "etag": "jtag",
+          "id": "j123",
+          "self_link": "jselfLink",
+          "user_email": "juserEmail",
+          "status": {"state": "DONE"},
+          "reference": {"project_id": "p123", "job_id": "j123"},
+          "configuration": {
+            "job_type": "QUERY",
+            "query_config": {"query": "select 1;"}
+          }})";
+
+  EXPECT_CALL(*mock_stub, GetJob)
+      .WillOnce([&](rest_internal::RestContext&,
+                    GetJobRequest const& request) -> StatusOr<GetJobResponse> {
+        EXPECT_THAT(request.project_id(), Not(IsEmpty()));
+        EXPECT_THAT(request.job_id(), Not(IsEmpty()));
+        BigQueryHttpResponse http_response;
+        http_response.payload = kExpectedPayload;
+        return GetJobResponse::BuildFromHttpResponse(std::move(http_response));
+      });
+
+  EXPECT_CALL(*log_backend_, ProcessWithOwnership)
+      .WillOnce([](LogRecord const& lr) {
+        EXPECT_THAT(lr.message, HasSubstr(" << "));
+        EXPECT_THAT(
+            lr.message,
+            HasSubstr(
+                "google::cloud::bigquery_v2_minimal_internal::GetJobRequest"));
+        EXPECT_THAT(lr.message, HasSubstr("job_id: \"j123\""));
+        EXPECT_THAT(lr.message, HasSubstr("project_id: \"p123\""));
+      })
+      .WillOnce([](LogRecord const& lr) {
+        EXPECT_THAT(lr.message, HasSubstr(" >> "));
+        EXPECT_THAT(lr.message, HasSubstr("status="));
+      });
+
+  auto client = CreateMockJobLogging(std::move(mock_stub));
+  GetJobRequest request("p123", "j123");
+  rest_internal::RestContext context;
+
+  client->GetJob(context, request);
+}
+
+TEST_F(JobLoggingClientTest, ListJobs) {
+  auto mock_stub = std::make_shared<MockBigQueryJobRestStub>();
+  auto constexpr kExpectedPayload =
+      R"({"etag": "tag-1",
+          "kind": "kind-1",
+          "next_page_token": "npt-123",
+          "jobs": [
+              {
+                "id": "1",
+                "kind": "kind-2",
+                "reference": {"project_id": "p123", "job_id": "j123"},
+                "state": "DONE",
+                "configuration": {
+                   "job_type": "QUERY",
+                   "query_config": {"query": "select 1;"}
+                },
+                "status": {"state": "DONE"},
+                "user_email": "user-email",
+                "principal_subject": "principal-subj"
+              }
+  ]})";
+
+  EXPECT_CALL(*mock_stub, ListJobs)
+      .WillOnce(
+          [&](rest_internal::RestContext&,
+              ListJobsRequest const& request) -> StatusOr<ListJobsResponse> {
+            EXPECT_THAT(request.project_id(), Not(IsEmpty()));
+            BigQueryHttpResponse http_response;
+            http_response.payload = kExpectedPayload;
+            return ListJobsResponse::BuildFromHttpResponse(
+                std::move(http_response));
+          });
+
+  EXPECT_CALL(*log_backend_, ProcessWithOwnership)
+      .WillOnce([](LogRecord const& lr) {
+        EXPECT_THAT(lr.message, HasSubstr(" << "));
+        EXPECT_THAT(lr.message, HasSubstr("google::cloud::bigquery_v2_minimal_"
+                                          "internal::ListJobsRequest"));
+        EXPECT_THAT(lr.message, HasSubstr("project_id: \"p123\""));
+        EXPECT_THAT(lr.message, HasSubstr("all_users: false"));
+        EXPECT_THAT(lr.message, HasSubstr("max_results: 0"));
+      })
+      .WillOnce([](LogRecord const& lr) {
+        EXPECT_THAT(lr.message, HasSubstr(" >> "));
+        EXPECT_THAT(lr.message, HasSubstr("status="));
+      });
+
+  auto client = CreateMockJobLogging(std::move(mock_stub));
+  ListJobsRequest request("p123");
+  rest_internal::RestContext context;
+
+  client->ListJobs(context, request);
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigquery_v2_minimal_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/testing/mock_job_log_backend.h
+++ b/google/cloud/bigquery/v2/minimal/testing/mock_job_log_backend.h
@@ -1,0 +1,39 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_TESTING_MOCK_JOB_LOG_BACKEND_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_TESTING_MOCK_JOB_LOG_BACKEND_H
+
+#include "google/cloud/log.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+class MockJobLogBackend : public google::cloud::LogBackend {
+ public:
+  void Process(LogRecord const& lr) override { ProcessWithOwnership(lr); }
+
+  MOCK_METHOD(void, ProcessWithOwnership, (google::cloud::LogRecord),
+              (override));
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigquery_v2_minimal_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_TESTING_MOCK_JOB_LOG_BACKEND_H


### PR DESCRIPTION
This is the final PR for the logging decorator cleanup and fixes #11122

This PR integrates request and response logging with tracing options in the logging decorator and adds unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11223)
<!-- Reviewable:end -->
