### PR TITLE
impl(bigquery): Addresses remaining cleanup items for job apis

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -88,12 +88,19 @@ std::string GetJobRequest::DebugString(absl::string_view name,
 std::string ListJobsRequest::DebugString(absl::string_view name,
                                          TracingOptions const& options,
                                          int indent) const {
+  auto min_creation_time = min_creation_time_.has_value()
+                               ? min_creation_time_.value()
+                               : kDefaultTimepoint;
+  auto max_creation_time = max_creation_time_.has_value()
+                               ? max_creation_time_.value()
+                               : kDefaultTimepoint;
+
   return internal::DebugFormatter(name, options, indent)
       .StringField("project_id", project_id_)
       .Field("all_users", all_users_)
       .Field("max_results", max_results_)
-      .Field("min_creation_time", min_creation_time_.value())
-      .Field("max_creation_time", max_creation_time_.value())
+      .Field("min_creation_time", min_creation_time)
+      .Field("max_creation_time", max_creation_time)
       .StringField("page_token", page_token_)
       .SubMessage("projection", projection_)
       .SubMessage("state_filter", state_filter_)

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -92,8 +92,8 @@ std::string ListJobsRequest::DebugString(absl::string_view name,
       .StringField("project_id", project_id_)
       .Field("all_users", all_users_)
       .Field("max_results", max_results_)
-      .Field("min_creation_time", min_creation_time_)
-      .Field("max_creation_time", max_creation_time_)
+      .Field("min_creation_time", min_creation_time_.value())
+      .Field("max_creation_time", max_creation_time_.value())
       .StringField("page_token", page_token_)
       .SubMessage("projection", projection_)
       .SubMessage("state_filter", state_filter_)
@@ -172,13 +172,15 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(
   if (r.max_results() > 0) {
     request.AddQueryParameter("maxResults", std::to_string(r.max_results()));
   }
-  if (r.min_creation_time() != kDefaultTimepoint) {
-    request.AddQueryParameter("minCreationTime",
-                              internal::FormatRfc3339(r.min_creation_time()));
+  if (r.min_creation_time().has_value()) {
+    request.AddQueryParameter(
+        "minCreationTime",
+        internal::FormatRfc3339(r.min_creation_time().value()));
   }
-  if (r.max_creation_time() != kDefaultTimepoint) {
-    request.AddQueryParameter("maxCreationTime",
-                              internal::FormatRfc3339(r.max_creation_time()));
+  if (r.max_creation_time().has_value()) {
+    request.AddQueryParameter(
+        "maxCreationTime",
+        internal::FormatRfc3339(r.max_creation_time().value()));
   }
 
   auto if_not_empty_add = [&](char const* key, auto const& v) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -88,19 +88,12 @@ std::string GetJobRequest::DebugString(absl::string_view name,
 std::string ListJobsRequest::DebugString(absl::string_view name,
                                          TracingOptions const& options,
                                          int indent) const {
-  auto min_creation_time = min_creation_time_.has_value()
-                               ? min_creation_time_.value()
-                               : kDefaultTimepoint;
-  auto max_creation_time = max_creation_time_.has_value()
-                               ? max_creation_time_.value()
-                               : kDefaultTimepoint;
-
   return internal::DebugFormatter(name, options, indent)
       .StringField("project_id", project_id_)
       .Field("all_users", all_users_)
       .Field("max_results", max_results_)
-      .Field("min_creation_time", min_creation_time)
-      .Field("max_creation_time", max_creation_time)
+      .Field("min_creation_time", *min_creation_time_)
+      .Field("max_creation_time", *max_creation_time_)
       .StringField("page_token", page_token_)
       .SubMessage("projection", projection_)
       .SubMessage("state_filter", state_filter_)
@@ -179,15 +172,13 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(
   if (r.max_results() > 0) {
     request.AddQueryParameter("maxResults", std::to_string(r.max_results()));
   }
-  if (r.min_creation_time().has_value()) {
-    request.AddQueryParameter(
-        "minCreationTime",
-        internal::FormatRfc3339(r.min_creation_time().value()));
+  if (r.min_creation_time()) {
+    request.AddQueryParameter("minCreationTime",
+                              internal::FormatRfc3339(*r.min_creation_time()));
   }
-  if (r.max_creation_time().has_value()) {
-    request.AddQueryParameter(
-        "maxCreationTime",
-        internal::FormatRfc3339(r.max_creation_time().value()));
+  if (r.max_creation_time()) {
+    request.AddQueryParameter("maxCreationTime",
+                              internal::FormatRfc3339(*r.max_creation_time()));
   }
 
   auto if_not_empty_add = [&](char const* key, auto const& v) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -124,8 +124,9 @@ ListJobsRequest::ListJobsRequest(std::string project_id)
       min_creation_time_(kDefaultTimepoint),
       max_creation_time_(kDefaultTimepoint) {}
 
-StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r,
-                                                      Options const& opts) {
+StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r) {
+  auto const& opts = internal::CurrentOptions();
+
   rest_internal::RestRequest request;
   if (r.project_id().empty()) {
     return internal::InvalidArgumentError(
@@ -149,9 +150,11 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r,
   return request;
 }
 
-StatusOr<rest_internal::RestRequest> BuildRestRequest(ListJobsRequest const& r,
-                                                      Options const& opts) {
+StatusOr<rest_internal::RestRequest> BuildRestRequest(
+    ListJobsRequest const& r) {
   rest_internal::RestRequest request;
+  auto const& opts = internal::CurrentOptions();
+
   if (r.project_id().empty()) {
     return internal::InvalidArgumentError(
         "Invalid ListJobsRequest: Project Id is empty", GCP_ERROR_INFO());

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -28,8 +28,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace {
 
-auto const kDefaultTimepoint = std::chrono::system_clock::time_point{};
-
 std::string GetJobsEndpoint(Options const& opts) {
   std::string endpoint = opts.get<EndpointOption>();
 
@@ -88,13 +86,17 @@ std::string GetJobRequest::DebugString(absl::string_view name,
 std::string ListJobsRequest::DebugString(absl::string_view name,
                                          TracingOptions const& options,
                                          int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("project_id", project_id_)
-      .Field("all_users", all_users_)
-      .Field("max_results", max_results_)
-      .Field("min_creation_time", *min_creation_time_)
-      .Field("max_creation_time", *max_creation_time_)
-      .StringField("page_token", page_token_)
+  auto formatter = internal::DebugFormatter(name, options, indent)
+                       .StringField("project_id", project_id_)
+                       .Field("all_users", all_users_)
+                       .Field("max_results", max_results_);
+  if (min_creation_time_) {
+    formatter.Field("min_creation_time", *min_creation_time_);
+  }
+  if (max_creation_time_) {
+    formatter.Field("max_creation_time", *max_creation_time_);
+  }
+  return formatter.StringField("page_token", page_token_)
       .SubMessage("projection", projection_)
       .SubMessage("state_filter", state_filter_)
       .StringField("parent_job_id", parent_job_id_)
@@ -118,11 +120,7 @@ std::string StateFilter::DebugString(absl::string_view name,
 }
 
 ListJobsRequest::ListJobsRequest(std::string project_id)
-    : project_id_(std::move(project_id)),
-      all_users_(false),
-      max_results_(0),
-      min_creation_time_(kDefaultTimepoint),
-      max_creation_time_(kDefaultTimepoint) {}
+    : project_id_(std::move(project_id)), all_users_(false), max_results_(0) {}
 
 StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r) {
   auto const& opts = internal::CurrentOptions();

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REQUEST_H
 
 #include "google/cloud/internal/rest_request.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
@@ -106,10 +107,12 @@ class ListJobsRequest {
   std::string const& project_id() const { return project_id_; }
   bool const& all_users() const { return all_users_; }
   std::int32_t const& max_results() const { return max_results_; }
-  std::chrono::system_clock::time_point const& min_creation_time() const {
+  optional<std::chrono::system_clock::time_point> const& min_creation_time()
+      const {
     return min_creation_time_;
   }
-  std::chrono::system_clock::time_point const& max_creation_time() const {
+  optional<std::chrono::system_clock::time_point> const& max_creation_time()
+      const {
     return max_creation_time_;
   }
   std::string const& page_token() const { return page_token_; }
@@ -202,8 +205,8 @@ class ListJobsRequest {
   std::string project_id_;
   bool all_users_;
   std::int32_t max_results_;
-  std::chrono::system_clock::time_point min_creation_time_;
-  std::chrono::system_clock::time_point max_creation_time_;
+  optional<std::chrono::system_clock::time_point> min_creation_time_;
+  optional<std::chrono::system_clock::time_point> max_creation_time_;
   std::string page_token_;
   Projection projection_;
   StateFilter state_filter_;

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -211,11 +211,9 @@ class ListJobsRequest {
 };
 
 // Builds RestRequest from GetJobRequest.
-StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r,
-                                                      Options const& opts);
+StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r);
 // Builds RestRequest from ListJobsRequest.
-StatusOr<rest_internal::RestRequest> BuildRestRequest(ListJobsRequest const& r,
-                                                      Options const& opts);
+StatusOr<rest_internal::RestRequest> BuildRestRequest(ListJobsRequest const& r);
 
 std::ostream& operator<<(std::ostream& os, GetJobRequest const& request);
 std::ostream& operator<<(std::ostream& os, ListJobsRequest const& request);

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -22,6 +22,7 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include <chrono>
 #include <ostream>
 #include <string>
@@ -107,12 +108,12 @@ class ListJobsRequest {
   std::string const& project_id() const { return project_id_; }
   bool const& all_users() const { return all_users_; }
   std::int32_t const& max_results() const { return max_results_; }
-  optional<std::chrono::system_clock::time_point> const& min_creation_time()
-      const {
+  absl::optional<std::chrono::system_clock::time_point> const&
+  min_creation_time() const {
     return min_creation_time_;
   }
-  optional<std::chrono::system_clock::time_point> const& max_creation_time()
-      const {
+  absl::optional<std::chrono::system_clock::time_point> const&
+  max_creation_time() const {
     return max_creation_time_;
   }
   std::string const& page_token() const { return page_token_; }
@@ -205,8 +206,8 @@ class ListJobsRequest {
   std::string project_id_;
   bool all_users_;
   std::int32_t max_results_;
-  optional<std::chrono::system_clock::time_point> min_creation_time_;
-  optional<std::chrono::system_clock::time_point> max_creation_time_;
+  absl::optional<std::chrono::system_clock::time_point> min_creation_time_;
+  absl::optional<std::chrono::system_clock::time_point> max_creation_time_;
   std::string page_token_;
   Projection projection_;
   StateFilter state_filter_;

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JOB_REQUEST_H
 
 #include "google/cloud/internal/rest_request.h"
-#include "google/cloud/optional.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <sstream>
@@ -49,7 +50,9 @@ TEST(GetJobRequestTest, SuccessWithLocation) {
   request.set_location("useast");
   Options opts;
   opts.set<EndpointOption>("bigquery.googleapis.com");
-  auto actual = BuildRestRequest(request, opts);
+  internal::OptionsSpan span(opts);
+
+  auto actual = BuildRestRequest(request);
   ASSERT_STATUS_OK(actual);
 
   rest_internal::RestRequest expected;
@@ -63,7 +66,8 @@ TEST(GetJobRequestTest, SuccessWithoutLocation) {
   GetJobRequest request("1", "2");
   Options opts;
   opts.set<EndpointOption>("bigquery.googleapis.com");
-  auto actual = BuildRestRequest(request, opts);
+  internal::OptionsSpan span(opts);
+  auto actual = BuildRestRequest(request);
   ASSERT_STATUS_OK(actual);
 
   rest_internal::RestRequest expected;
@@ -94,7 +98,9 @@ TEST(GetJobRequestTest, SuccessWithEndpoint) {
                  ", expected: " + test.expected);
     Options opts;
     opts.set<EndpointOption>(test.endpoint);
-    auto actual = BuildRestRequest(request, opts);
+    internal::OptionsSpan span(opts);
+
+    auto actual = BuildRestRequest(request);
     ASSERT_STATUS_OK(actual);
     EXPECT_EQ(test.expected, actual->path());
   }
@@ -104,7 +110,9 @@ TEST(GetJobRequestTest, EmptyProjectId) {
   GetJobRequest request("", "test-job-id");
   Options opts;
   opts.set<EndpointOption>("bigquery.googleapis.com");
-  auto rest_request = BuildRestRequest(request, opts);
+  internal::OptionsSpan span(opts);
+
+  auto rest_request = BuildRestRequest(request);
   EXPECT_THAT(rest_request, StatusIs(StatusCode::kInvalidArgument,
                                      HasSubstr("Project Id is empty")));
 }
@@ -113,7 +121,9 @@ TEST(GetJobRequest, EmptyJobId) {
   GetJobRequest request("test-project-id", "");
   Options opts;
   opts.set<EndpointOption>("bigquery.googleapis.com");
-  auto rest_request = BuildRestRequest(request, opts);
+  internal::OptionsSpan span(opts);
+
+  auto rest_request = BuildRestRequest(request);
   EXPECT_THAT(rest_request, StatusIs(StatusCode::kInvalidArgument,
                                      HasSubstr("Job Id is empty")));
 }
@@ -133,7 +143,8 @@ TEST(ListJobsRequestTest, Success) {
   auto const request = GetListJobsRequest();
   Options opts;
   opts.set<EndpointOption>("bigquery.googleapis.com");
-  auto actual = BuildRestRequest(request, opts);
+  internal::OptionsSpan span(opts);
+  auto actual = BuildRestRequest(request);
   ASSERT_STATUS_OK(actual);
 
   rest_internal::RestRequest expected;
@@ -157,7 +168,9 @@ TEST(ListJobsRequestTest, EmptyProjectId) {
   ListJobsRequest request("");
   Options opts;
   opts.set<EndpointOption>("bigquery.googleapis.com");
-  auto rest_request = BuildRestRequest(request, opts);
+  internal::OptionsSpan span(opts);
+
+  auto rest_request = BuildRestRequest(request);
   EXPECT_THAT(rest_request, StatusIs(StatusCode::kInvalidArgument,
                                      HasSubstr("Project Id is empty")));
 }

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -153,9 +153,11 @@ TEST(ListJobsRequestTest, Success) {
   expected.AddQueryParameter("allUsers", "true");
   expected.AddQueryParameter("maxResults", "10");
   expected.AddQueryParameter(
-      "minCreationTime", internal::FormatRfc3339(request.min_creation_time()));
+      "minCreationTime",
+      internal::FormatRfc3339(request.min_creation_time().value()));
   expected.AddQueryParameter(
-      "maxCreationTime", internal::FormatRfc3339(request.max_creation_time()));
+      "maxCreationTime",
+      internal::FormatRfc3339(request.max_creation_time().value()));
   expected.AddQueryParameter("pageToken", "123");
   expected.AddQueryParameter("projection", "FULL");
   expected.AddQueryParameter("stateFilter", "RUNNING");

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -38,9 +38,8 @@ StatusOr<ReturnType> ParseFromRestResponse(
 
 template <typename RequestType>
 StatusOr<rest_internal::RestRequest> PrepareRestRequest(
-    rest_internal::RestContext& rest_context, RequestType const& request,
-    Options options) {
-  auto rest_request = BuildRestRequest(request, options);
+    rest_internal::RestContext& rest_context, RequestType const& request) {
+  auto rest_request = BuildRestRequest(request);
   if (!rest_request) return std::move(rest_request).status();
 
   // Copy over any headers if provided.
@@ -57,10 +56,8 @@ StatusOr<rest_internal::RestRequest> PrepareRestRequest(
 
 StatusOr<GetJobResponse> DefaultBigQueryJobRestStub::GetJob(
     rest_internal::RestContext& rest_context, GetJobRequest const& request) {
-  internal::OptionsSpan span(options_);
   // Prepare the RestRequest from GetJobRequest.
-  auto rest_request =
-      PrepareRestRequest<GetJobRequest>(rest_context, request, options_);
+  auto rest_request = PrepareRestRequest<GetJobRequest>(rest_context, request);
 
   // Call the rest stub and parse the RestResponse.
   return ParseFromRestResponse<GetJobResponse>(
@@ -69,10 +66,9 @@ StatusOr<GetJobResponse> DefaultBigQueryJobRestStub::GetJob(
 
 StatusOr<ListJobsResponse> DefaultBigQueryJobRestStub::ListJobs(
     rest_internal::RestContext& rest_context, ListJobsRequest const& request) {
-  internal::OptionsSpan span(options_);
   // Prepare the RestRequest from ListJobsRequest.
   auto rest_request =
-      PrepareRestRequest<ListJobsRequest>(rest_context, request, options_);
+      PrepareRestRequest<ListJobsRequest>(rest_context, request);
 
   // Call the rest stub and parse the RestResponse.
   return ParseFromRestResponse<ListJobsResponse>(

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -43,8 +43,8 @@ class BigQueryJobRestStub {
 class DefaultBigQueryJobRestStub : public BigQueryJobRestStub {
  public:
   explicit DefaultBigQueryJobRestStub(
-      std::unique_ptr<rest_internal::RestClient> rest_stub, Options options)
-      : rest_stub_(std::move(rest_stub)), options_(std::move(options)) {}
+      std::unique_ptr<rest_internal::RestClient> rest_stub)
+      : rest_stub_(std::move(rest_stub)) {}
 
   StatusOr<GetJobResponse> GetJob(rest_internal::RestContext& rest_context,
                                   GetJobRequest const& request) override;
@@ -53,7 +53,6 @@ class DefaultBigQueryJobRestStub : public BigQueryJobRestStub {
 
  private:
   std::unique_ptr<rest_internal::RestClient> rest_stub_;
-  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
@@ -32,12 +32,14 @@ std::shared_ptr<BigQueryJobRestStub> CreateDefaultBigQueryJobRestStub(
   if (!local_opts.has<UnifiedCredentialsOption>()) {
     local_opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());
   }
+
+  internal::OptionsSpan span(local_opts);
+
   auto curl_rest_client = rest_internal::MakePooledRestClient(
       opts.get<EndpointOption>(), local_opts);
 
   std::shared_ptr<BigQueryJobRestStub> stub =
-      std::make_shared<DefaultBigQueryJobRestStub>(std::move(curl_rest_client),
-                                                   local_opts);
+      std::make_shared<DefaultBigQueryJobRestStub>(std::move(curl_rest_client));
 
   stub = std::make_shared<BigQueryJobMetadata>(std::move(stub));
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_factory.cc
@@ -33,8 +33,6 @@ std::shared_ptr<BigQueryJobRestStub> CreateDefaultBigQueryJobRestStub(
     local_opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());
   }
 
-  internal::OptionsSpan span(local_opts);
-
   auto curl_rest_client = rest_internal::MakePooledRestClient(
       opts.get<EndpointOption>(), local_opts);
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_test.cc
@@ -83,10 +83,9 @@ TEST(BigQueryJobStubTest, GetJobSuccess) {
           std::unique_ptr<rest::RestResponse>(std::move(mock_response)))));
 
   GetJobRequest job_request("p123", "j123");
-  Options opts;
-  opts.set<EndpointOption>("bigquery.googleapis.com");
+
   rest_internal::RestContext context;
-  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client), opts);
+  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client));
 
   auto result = rest_stub.GetJob(context, std::move(job_request));
   ASSERT_STATUS_OK(result);
@@ -104,10 +103,10 @@ TEST(BigQueryJobStubTest, GetJobRestClientError) {
           Return(rest::AsStatus(HttpStatusCode::kInternalServerError, "")));
 
   GetJobRequest job_request("p123", "j123");
-  Options opts;
-  opts.set<EndpointOption>("bigquery.googleapis.com");
+
   rest_internal::RestContext context;
-  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client), opts);
+  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client));
+
   auto response = rest_stub.GetJob(context, std::move(job_request));
   EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
@@ -128,10 +127,10 @@ TEST(BigQueryJobStubTest, GetJobRestResponseError) {
           std::unique_ptr<rest::RestResponse>(std::move(mock_response)))));
 
   GetJobRequest job_request("p123", "j123");
-  Options opts;
-  opts.set<EndpointOption>("bigquery.googleapis.com");
+
   rest_internal::RestContext context;
-  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client), opts);
+  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client));
+
   auto response = rest_stub.GetJob(context, std::move(job_request));
   EXPECT_THAT(response, StatusIs(StatusCode::kInvalidArgument));
 }
@@ -172,10 +171,8 @@ TEST(BigQueryJobStubTest, ListJobsSuccess) {
 
   auto list_jobs_request = GetListJobsRequest();
 
-  Options opts;
-  opts.set<EndpointOption>("bigquery.googleapis.com");
   rest_internal::RestContext context;
-  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client), opts);
+  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client));
 
   auto result = rest_stub.ListJobs(context, std::move(list_jobs_request));
   ASSERT_STATUS_OK(result);
@@ -189,10 +186,10 @@ TEST(BigQueryJobStubTest, ListJobsRestClientError) {
           Return(rest::AsStatus(HttpStatusCode::kInternalServerError, "")));
 
   auto list_jobs_request = GetListJobsRequest();
-  Options opts;
-  opts.set<EndpointOption>("bigquery.googleapis.com");
+
   rest_internal::RestContext context;
-  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client), opts);
+  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client));
+
   auto response = rest_stub.ListJobs(context, std::move(list_jobs_request));
   EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
@@ -211,10 +208,9 @@ TEST(BigQueryJobStubTest, ListJobsRestResponseError) {
           std::unique_ptr<rest::RestResponse>(std::move(mock_response)))));
 
   auto list_jobs_request = GetListJobsRequest();
-  Options opts;
-  opts.set<EndpointOption>("bigquery.googleapis.com");
+
   rest_internal::RestContext context;
-  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client), opts);
+  DefaultBigQueryJobRestStub rest_stub(std::move(mock_rest_client));
 
   auto response = rest_stub.ListJobs(context, std::move(list_jobs_request));
 


### PR DESCRIPTION
Addressing some of the remaining cleanup items for the Job apis

This PR fixes Github issue#11123 and addresses the following changes with regards to Job Requests and stub

1) Removed passing of options to BuildRestRequest and Default job stub, to be consistent with other apis.

2) Made min_creation_time and max_creation_time optional so they can be checked and set easiy in request parameters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11224)
<!-- Reviewable:end -->
