### PR TITLE
impl(otel): Recordable set display name

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -45,6 +45,10 @@ void SetTruncatableString(
       static_cast<std::int32_t>(value.size() - truncation_pos));
 }
 
+google::devtools::cloudtrace::v2::Span&& Recordable::as_proto() && {
+  return std::move(span_);
+}
+
 void Recordable::SetIdentity(
     opentelemetry::trace::SpanContext const& /*span_context*/,
     opentelemetry::trace::SpanId /*parent_span_id*/) noexcept {}
@@ -66,7 +70,12 @@ void Recordable::SetStatus(
     opentelemetry::trace::StatusCode /*code*/,
     opentelemetry::nostd::string_view /*description*/) noexcept {}
 
-void Recordable::SetName(opentelemetry::nostd::string_view /*name*/) noexcept {}
+void Recordable::SetName(opentelemetry::nostd::string_view name) noexcept {
+  // Note that the `name` field in the `Span` proto refers to the GCP resource
+  // name. We want to set the `display_name` field.
+  SetTruncatableString(*span_.mutable_display_name(), name,
+                       kDisplayNameStringLimit);
+}
 
 void Recordable::SetSpanKind(
     opentelemetry::trace::SpanKind /*span_kind*/) noexcept {}

--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -27,6 +27,9 @@ namespace cloud {
 namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+// https://github.com/googleapis/googleapis/blob/a5e03049afc43ccb1217d5dd3be53006fc278643/google/devtools/cloudtrace/v2/trace.proto#L233
+std::size_t constexpr kDisplayNameStringLimit = 128;
+
 /**
  * Helper to set [TruncatableString] fields in a [Span] proto.
  *
@@ -51,6 +54,8 @@ void SetTruncatableString(
 class Recordable final : public opentelemetry::sdk::trace::Recordable {
  public:
   explicit Recordable(Project project) : project_(std::move(project)) {}
+
+  google::devtools::cloudtrace::v2::Span&& as_proto() &&;
 
   void SetIdentity(
       opentelemetry::trace::SpanContext const& span_context,

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -62,9 +62,22 @@ TEST(SetTruncatableString, RespectsUnicodeSymbolBoundaries) {
   EXPECT_EQ(proto.truncated_byte_count(), 6);
 }
 
-TEST(Recordable, Compiles) {
+TEST(Recordable, SetName) {
   auto rec = Recordable(Project(kProjectId));
-  GTEST_SUCCEED();
+  rec.SetName("name");
+  auto proto = std::move(rec).as_proto();
+  EXPECT_EQ(proto.display_name().value(), "name");
+}
+
+TEST(Recordable, SetNameTruncates) {
+  std::string const name(kDisplayNameStringLimit + 1, 'A');
+  std::string const expected(kDisplayNameStringLimit, 'A');
+
+  auto rec = Recordable(Project(kProjectId));
+  rec.SetName(name);
+  auto proto = std::move(rec).as_proto();
+  EXPECT_EQ(proto.display_name().value(), expected);
+  EXPECT_EQ(proto.display_name().truncated_byte_count(), 1);
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #11156

Implement `Recordable::SetName()`. Also add a method to extract the underlying `Span` proto from the `Recordable`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11229)
<!-- Reviewable:end -->
