### PR TITLE
cleanup(generator): remove unused substitution

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -633,8 +633,6 @@ ParameterCommentSubstitution substitutions[] = {
     {" <parent>/instanceConfigs/nam3.", " `<parent>/instanceConfigs/nam3`."},
 
     // Extra quotes in asset/v1.
-    {R"""( as "projects/my-project-id")")""",
-     R"""( as "projects/my-project-id"))"""},
     {R"""( "folders/12345")", or a )""", R"""( "folders/12345"), or a )"""},
 
     // This triggers a bug (I think it is a bug) in Doxygen:


### PR DESCRIPTION
Without this change, generating the libraries triggers this:

https://github.com/googleapis/google-cloud-cpp/blob/30872a70a880349f1c25ae9261794d6a133b6ef6/generator/standalone_main.cc#L416

I am not sure how that went unnoticed through the CI builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11230)
<!-- Reviewable:end -->
