### PR TITLE
impl(otel): wrap `rest_internal::RestResponse`

### DIFF
--- a/google/cloud/google_cloud_cpp_rest_internal.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal.bzl
@@ -62,6 +62,7 @@ google_cloud_cpp_rest_internal_hdrs = [
     "internal/rest_response.h",
     "internal/rest_retry_loop.h",
     "internal/tracing_http_payload.h",
+    "internal/tracing_rest_response.h",
     "internal/unified_rest_credentials.h",
     "rest_options.h",
 ]
@@ -104,5 +105,6 @@ google_cloud_cpp_rest_internal_srcs = [
     "internal/rest_request.cc",
     "internal/rest_response.cc",
     "internal/tracing_http_payload.cc",
+    "internal/tracing_rest_response.cc",
     "internal/unified_rest_credentials.cc",
 ]

--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -103,6 +103,8 @@ add_library(
     internal/rest_retry_loop.h
     internal/tracing_http_payload.cc
     internal/tracing_http_payload.h
+    internal/tracing_rest_response.cc
+    internal/tracing_rest_response.h
     internal/unified_rest_credentials.cc
     internal/unified_rest_credentials.h
     rest_options.h)
@@ -245,6 +247,7 @@ if (BUILD_TESTING)
         internal/rest_response_test.cc
         internal/rest_retry_loop_test.cc
         internal/tracing_http_payload_test.cc
+        internal/tracing_rest_response_test.cc
         internal/unified_rest_credentials_test.cc)
 
     # List the emulator integration tests, then setup the targets and

--- a/google/cloud/google_cloud_cpp_rest_internal_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal_unit_tests.bzl
@@ -57,5 +57,6 @@ google_cloud_cpp_rest_internal_unit_tests = [
     "internal/rest_response_test.cc",
     "internal/rest_retry_loop_test.cc",
     "internal/tracing_http_payload_test.cc",
+    "internal/tracing_rest_response_test.cc",
     "internal/unified_rest_credentials_test.cc",
 ]

--- a/google/cloud/internal/tracing_rest_response.cc
+++ b/google/cloud/internal/tracing_rest_response.cc
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+#include "google/cloud/internal/tracing_rest_response.h"
+#include "google/cloud/internal/tracing_http_payload.h"
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+HttpStatusCode TracingRestResponse::StatusCode() const {
+  return impl_->StatusCode();
+}
+
+std::multimap<std::string, std::string> TracingRestResponse::Headers() const {
+  return impl_->Headers();
+}
+
+std::unique_ptr<HttpPayload> TracingRestResponse::ExtractPayload() && {
+  auto payload = std::move(*impl_).ExtractPayload();
+  return std::make_unique<TracingHttpPayload>(std::move(payload),
+                                              std::move(payload_span_));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/internal/tracing_rest_response.h
+++ b/google/cloud/internal/tracing_rest_response.h
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACING_REST_RESPONSE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACING_REST_RESPONSE_H
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+#include "google/cloud/internal/rest_response.h"
+#include <opentelemetry/nostd/shared_ptr.h>
+#include <opentelemetry/trace/span.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+class TracingRestResponse : public RestResponse {
+ public:
+  TracingRestResponse(
+      std::unique_ptr<RestResponse> impl,
+      opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> payload_span)
+      : impl_(std::move(impl)), payload_span_(std::move(payload_span)) {}
+
+  ~TracingRestResponse() override = default;
+  HttpStatusCode StatusCode() const override;
+  std::multimap<std::string, std::string> Headers() const override;
+  std::unique_ptr<HttpPayload> ExtractPayload() && override;
+
+ private:
+  std::unique_ptr<RestResponse> impl_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> payload_span_;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACING_REST_RESPONSE_H

--- a/google/cloud/internal/tracing_rest_response_test.cc
+++ b/google/cloud/internal/tracing_rest_response_test.cc
@@ -1,0 +1,91 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/tracing_rest_response.h"
+#include "google/cloud/internal/rest_opentelemetry.h"
+#include "google/cloud/testing_util/mock_http_payload.h"
+#include "google/cloud/testing_util/mock_rest_response.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/trace/semantic_conventions.h>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::testing_util::EventNamed;
+using ::google::cloud::testing_util::InstallSpanCatcher;
+using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
+using ::google::cloud::testing_util::MockRestResponse;
+using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::SpanEventsAre;
+using ::google::cloud::testing_util::SpanHasAttributes;
+using ::google::cloud::testing_util::SpanHasInstrumentationScope;
+using ::google::cloud::testing_util::SpanKindIsConsumer;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::Eq;
+using ::testing::Return;
+
+std::string MockContents() {
+  return "The quick brown fox jumps over the lazy dog";
+}
+
+TEST(TracingRestResponseTest, Success) {
+  namespace sc = ::opentelemetry::trace::SemanticConventions;
+  auto span_catcher = InstallSpanCatcher();
+
+  RestRequest request("https://example.com/ignored");
+  auto request_span = MakeSpanHttp(request, "GET");
+
+  auto impl = std::make_unique<MockRestResponse>();
+  EXPECT_CALL(*impl, StatusCode).WillRepeatedly(Return(HttpStatusCode::kOk));
+  EXPECT_CALL(std::move(*impl), ExtractPayload).WillOnce([] {
+    return MakeMockHttpPayloadSuccess(MockContents());
+  });
+
+  TracingRestResponse response(std::move(impl),
+                               MakeSpanHttpPayload(*request_span));
+  auto payload = std::move(response).ExtractPayload();
+  std::vector<char> buffer(64);
+  auto status = payload->Read(absl::Span<char>(buffer.data(), buffer.size()));
+  ASSERT_STATUS_OK(status);
+  EXPECT_THAT(*status, Eq(MockContents().size()));
+  status = payload->Read(absl::Span<char>(buffer.data(), buffer.size()));
+  ASSERT_STATUS_OK(status);
+  EXPECT_THAT(*status, Eq(0));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsConsumer(),
+                     SpanNamed("HTTP/Response"),
+                     SpanHasAttributes(SpanAttribute<std::string>(
+                         sc::kNetTransport, sc::NetTransportValues::kIpTcp)),
+                     SpanEventsAre(EventNamed("Read"), EventNamed("Read")))));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY


### PR DESCRIPTION
We need to wrap the `RestResponse` object to create `TracingRestHttpPayload`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11246)
<!-- Reviewable:end -->
