### PR TITLE
impl(otel): `rest_internal::RestClient` for tracing

### DIFF
--- a/google/cloud/google_cloud_cpp_rest_internal.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal.bzl
@@ -62,6 +62,7 @@ google_cloud_cpp_rest_internal_hdrs = [
     "internal/rest_response.h",
     "internal/rest_retry_loop.h",
     "internal/tracing_http_payload.h",
+    "internal/tracing_rest_client.h",
     "internal/tracing_rest_response.h",
     "internal/unified_rest_credentials.h",
     "rest_options.h",
@@ -105,6 +106,7 @@ google_cloud_cpp_rest_internal_srcs = [
     "internal/rest_request.cc",
     "internal/rest_response.cc",
     "internal/tracing_http_payload.cc",
+    "internal/tracing_rest_client.cc",
     "internal/tracing_rest_response.cc",
     "internal/unified_rest_credentials.cc",
 ]

--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -103,6 +103,8 @@ add_library(
     internal/rest_retry_loop.h
     internal/tracing_http_payload.cc
     internal/tracing_http_payload.h
+    internal/tracing_rest_client.cc
+    internal/tracing_rest_client.h
     internal/tracing_rest_response.cc
     internal/tracing_rest_response.h
     internal/unified_rest_credentials.cc
@@ -247,6 +249,7 @@ if (BUILD_TESTING)
         internal/rest_response_test.cc
         internal/rest_retry_loop_test.cc
         internal/tracing_http_payload_test.cc
+        internal/tracing_rest_client_test.cc
         internal/tracing_rest_response_test.cc
         internal/unified_rest_credentials_test.cc)
 

--- a/google/cloud/google_cloud_cpp_rest_internal_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal_unit_tests.bzl
@@ -57,6 +57,7 @@ google_cloud_cpp_rest_internal_unit_tests = [
     "internal/rest_response_test.cc",
     "internal/rest_retry_loop_test.cc",
     "internal/tracing_http_payload_test.cc",
+    "internal/tracing_rest_client_test.cc",
     "internal/tracing_rest_response_test.cc",
     "internal/unified_rest_credentials_test.cc",
 ]

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -1,0 +1,114 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/tracing_rest_client.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/rest_opentelemetry.h"
+#include "google/cloud/internal/tracing_http_payload.h"
+#include "google/cloud/internal/tracing_rest_response.h"
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+void ExtractAttributes(StatusOr<std::unique_ptr<RestResponse>> const& value,
+                       opentelemetry::trace::Span& span) {
+  if (!value) return;
+  auto const& response = *value;
+  if (!response) return;
+  for (auto const& kv : response->Headers()) {
+    span.SetAttribute("http.header." + kv.first, kv.second);
+  }
+}
+
+/**
+ * Extracts information from @p value, and adds it to a span.
+ *
+ * The span is ended. The original value is returned, for the sake of
+ * composition.
+ *
+ * Note that this function should be called after the RPC has finished.
+ */
+StatusOr<std::unique_ptr<RestResponse>> EndSpan(
+    opentelemetry::trace::Span& request_span,
+    StatusOr<std::unique_ptr<RestResponse>> value) {
+  if (!value) return internal::EndSpan(request_span, std::move(value));
+  auto payload_span = MakeSpanHttpPayload(request_span);
+  ExtractAttributes(value, *payload_span);
+  value = std::make_unique<TracingRestResponse>(*std::move(value),
+                                                std::move(payload_span));
+  return internal::EndSpan(request_span, std::move(value));
+}
+
+TracingRestClient::TracingRestClient(std::unique_ptr<RestClient> impl)
+    : impl_(std::move(impl)) {}
+
+StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Delete(
+    RestRequest const& request) {
+  auto span = MakeSpanHttp(request, "DELETE");
+  return EndSpan(*span, impl_->Delete(request));
+}
+
+StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Get(
+    RestRequest const& request) {
+  auto span = MakeSpanHttp(request, "GET");
+  return EndSpan(*span, impl_->Get(request));
+}
+
+StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Patch(
+    RestRequest const& request,
+    std::vector<absl::Span<char const>> const& payload) {
+  auto span = MakeSpanHttp(request, "POST");
+  return EndSpan(*span, impl_->Patch(request, payload));
+}
+
+StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Post(
+    RestRequest const& request,
+    std::vector<absl::Span<char const>> const& payload) {
+  auto span = MakeSpanHttp(request, "POST");
+  return EndSpan(*span, impl_->Post(request, payload));
+}
+
+StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Post(
+    RestRequest request,
+    std::vector<std::pair<std::string, std::string>> const& form_data) {
+  auto span = MakeSpanHttp(request, "PUT");
+  return EndSpan(*span, impl_->Post(request, form_data));
+}
+
+StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Put(
+    RestRequest const& request,
+    std::vector<absl::Span<char const>> const& payload) {
+  auto span = MakeSpanHttp(request, "PUT");
+  return EndSpan(*span, impl_->Put(request, payload));
+}
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+std::unique_ptr<RestClient> MakeTracingRestClient(
+    std::unique_ptr<RestClient> client) {
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+  return std::make_unique<TracingRestClient>(std::move(client));
+#else
+  return client;
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/tracing_rest_client.h
+++ b/google/cloud/internal/tracing_rest_client.h
@@ -1,0 +1,66 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACING_REST_CLIENT_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACING_REST_CLIENT_H
+
+#include "google/cloud/internal/rest_client.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+class TracingRestClient : public RestClient {
+ public:
+  explicit TracingRestClient(std::unique_ptr<RestClient> impl);
+  ~TracingRestClient() override = default;
+
+  StatusOr<std::unique_ptr<RestResponse>> Delete(
+      RestRequest const& request) override;
+  StatusOr<std::unique_ptr<RestResponse>> Get(
+      RestRequest const& request) override;
+  StatusOr<std::unique_ptr<RestResponse>> Patch(
+      RestRequest const& request,
+      std::vector<absl::Span<char const>> const& payload) override;
+  StatusOr<std::unique_ptr<RestResponse>> Post(
+      RestRequest const& request,
+      std::vector<absl::Span<char const>> const& payload) override;
+  StatusOr<std::unique_ptr<RestResponse>> Post(
+      RestRequest request,
+      std::vector<std::pair<std::string, std::string>> const& form_data)
+      override;
+  StatusOr<std::unique_ptr<RestResponse>> Put(
+      RestRequest const& request,
+      std::vector<absl::Span<char const>> const& payload) override;
+
+ private:
+  std::unique_ptr<RestClient> impl_;
+};
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+/// Decorate a `RestClient` with a tracing wrapper.
+std::unique_ptr<RestClient> MakeTracingRestClient(
+    std::unique_ptr<RestClient> client);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TRACING_REST_CLIENT_H

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -1,0 +1,122 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/tracing_rest_client.h"
+#include "google/cloud/testing_util/mock_http_payload.h"
+#include "google/cloud/testing_util/mock_rest_client.h"
+#include "google/cloud/testing_util/mock_rest_response.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/trace/semantic_conventions.h>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::testing_util::EventNamed;
+using ::google::cloud::testing_util::InstallSpanCatcher;
+using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
+using ::google::cloud::testing_util::MockRestClient;
+using ::google::cloud::testing_util::MockRestResponse;
+using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::SpanHasAttributes;
+using ::google::cloud::testing_util::SpanHasEvents;
+using ::google::cloud::testing_util::SpanHasInstrumentationScope;
+using ::google::cloud::testing_util::SpanKindIsClient;
+using ::google::cloud::testing_util::SpanKindIsConsumer;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::NotNull;
+using ::testing::Return;
+
+std::multimap<std::string, std::string> MockHeaders() {
+  return {{"x-test-header-1", "value1"}, {"x-test-header-2", "value2"}};
+}
+
+std::string MockContents() {
+  return "The quick brown fox jumps over the lazy dog";
+}
+
+TEST(TracingRestClient, Delete) {
+  namespace sc = ::opentelemetry::trace::SemanticConventions;
+  auto span_catcher = InstallSpanCatcher();
+
+  auto impl = std::make_unique<MockRestClient>();
+  EXPECT_CALL(*impl, Delete).WillOnce([](RestRequest const&) {
+    auto response = std::make_unique<MockRestResponse>();
+    EXPECT_CALL(*response, StatusCode)
+        .WillRepeatedly(Return(HttpStatusCode::kOk));
+    EXPECT_CALL(*response, Headers).WillRepeatedly(Return(MockHeaders()));
+    EXPECT_CALL(std::move(*response), ExtractPayload).WillOnce([] {
+      return MakeMockHttpPayloadSuccess(MockContents());
+    });
+    return std::unique_ptr<RestResponse>(std::move(response));
+  });
+
+  auto constexpr kUrl = "https://storage.googleapis.com/storage/v1/b/my-bucket";
+  RestRequest request(kUrl);
+  request.AddHeader("x-test-header-3", "value3");
+
+  auto client = MakeTracingRestClient(std::move(impl));
+  auto r = client->Delete(request);
+  ASSERT_STATUS_OK(r);
+  auto response = *std::move(r);
+  ASSERT_THAT(response, NotNull());
+  EXPECT_THAT(response->StatusCode(), HttpStatusCode::kOk);
+  EXPECT_THAT(response->Headers(), MockHeaders());
+  auto contents = ReadAll(std::move(*response).ExtractPayload());
+  ASSERT_STATUS_OK(contents);
+  EXPECT_THAT(*contents, Eq(MockContents()));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(
+          // Request span
+          AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
+                SpanNamed("HTTP/DELETE"),
+                SpanHasAttributes(
+                    SpanAttribute<std::string>(sc::kNetTransport,
+                                               sc::NetTransportValues::kIpTcp),
+                    SpanAttribute<std::string>(sc::kHttpMethod, "DELETE"),
+                    SpanAttribute<std::string>(sc::kHttpUrl, kUrl),
+                    SpanAttribute<std::string>("http.header.x-test-header-3",
+                                               "value3"))),
+          // Response span
+          AllOf(SpanHasInstrumentationScope(), SpanKindIsConsumer(),
+                SpanNamed("HTTP/Response"),
+                SpanHasAttributes(
+                    SpanAttribute<std::string>(sc::kNetTransport,
+                                               sc::NetTransportValues::kIpTcp),
+                    SpanAttribute<std::string>("http.header.x-test-header-1",
+                                               "value1"),
+                    SpanAttribute<std::string>("http.header.x-test-header-2",
+                                               "value2")),
+                SpanHasEvents(EventNamed("Read")))));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -174,6 +174,11 @@ MATCHER_P(SpanEventsAreImpl, matcher,
 }
 
 template <typename... Args>
+::testing::Matcher<SpanDataPtr> SpanHasEvents(Args const&... matchers) {
+  return SpanEventsAreImpl(::testing::IsSupersetOf({matchers...}));
+}
+
+template <typename... Args>
 ::testing::Matcher<SpanDataPtr> SpanEventsAre(Args const&... matchers) {
   return SpanEventsAreImpl(::testing::ElementsAre(matchers...));
 }


### PR DESCRIPTION
This version of `rest_internal::RestClient` wraps a separate implementation and creates opentelemetry spans for the request and payload.