### PR TITLE
impl(otel): use correct name for HTTP request headers

### DIFF
--- a/google/cloud/internal/rest_opentelemetry.cc
+++ b/google/cloud/internal/rest_opentelemetry.cc
@@ -45,16 +45,16 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanHttp(
                        {sc::kHttpUrl, request.path()}},
                       options);
   for (auto const& kv : request.headers()) {
+    auto const name = "http.request.header." + kv.first;
     if (kv.second.empty()) {
-      span->SetAttribute("http.header." + kv.first, "");
+      span->SetAttribute(name, "");
       continue;
     }
     if (absl::EqualsIgnoreCase(kv.first, "authorization")) {
-      span->SetAttribute("http.header.authorization",
-                         kv.second.front().substr(0, 32));
+      span->SetAttribute(name, kv.second.front().substr(0, 32));
       continue;
     }
-    span->SetAttribute("http.header." + kv.first, kv.second.front());
+    span->SetAttribute(name, kv.second.front());
   }
   return span;
 }

--- a/google/cloud/internal/rest_opentelemetry_test.cc
+++ b/google/cloud/internal/rest_opentelemetry_test.cc
@@ -55,16 +55,17 @@ TEST(RestOpentelemetry, MakeSpanHttp) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
-      spans, ElementsAre(AllOf(
-                 SpanHasInstrumentationScope(), SpanKindIsClient(),
-                 SpanNamed("HTTP/GET"),
-                 SpanHasAttributes(
-                     SpanAttribute<std::string>(sc::kNetTransport,
-                                                sc::NetTransportValues::kIpTcp),
-                     SpanAttribute<std::string>(sc::kHttpMethod, "GET"),
-                     SpanAttribute<std::string>(sc::kHttpUrl, kUrl),
-                     SpanAttribute<std::string>("http.header.authorization",
-                                                secret.substr(0, 32))))));
+      spans,
+      ElementsAre(AllOf(
+          SpanHasInstrumentationScope(), SpanKindIsClient(),
+          SpanNamed("HTTP/GET"),
+          SpanHasAttributes(
+              SpanAttribute<std::string>(sc::kNetTransport,
+                                         sc::NetTransportValues::kIpTcp),
+              SpanAttribute<std::string>(sc::kHttpMethod, "GET"),
+              SpanAttribute<std::string>(sc::kHttpUrl, kUrl),
+              SpanAttribute<std::string>("http.request.header.authorization",
+                                         secret.substr(0, 32))))));
 }
 
 TEST(RestOpentelemetry, MakeSpanHttpPayload) {


### PR DESCRIPTION
Addresses https://github.com/googleapis/google-cloud-cpp/pull/11249#discussion_r1164349637 