### PR TITLE
impl(otel): use spans for HttpPayload::Read

### DIFF
--- a/google/cloud/internal/rest_opentelemetry.cc
+++ b/google/cloud/internal/rest_opentelemetry.cc
@@ -63,7 +63,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>
 MakeSpanHttpPayload(opentelemetry::trace::Span const& request_span) {
   namespace sc = opentelemetry::trace::SemanticConventions;
   opentelemetry::trace::StartSpanOptions options;
-  options.kind = opentelemetry::trace::SpanKind::kConsumer;
+  options.kind = opentelemetry::trace::SpanKind::kClient;
   return internal::GetTracer(internal::CurrentOptions())
       ->StartSpan(absl::StrCat("HTTP/Response"),
                   {{sc::kNetTransport, sc::NetTransportValues::kIpTcp}},

--- a/google/cloud/internal/rest_opentelemetry_test.cc
+++ b/google/cloud/internal/rest_opentelemetry_test.cc
@@ -32,7 +32,6 @@ using ::google::cloud::testing_util::SpanAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
-using ::google::cloud::testing_util::SpanKindIsConsumer;
 using ::google::cloud::testing_util::SpanNamed;
 using ::testing::AllOf;
 using ::testing::ElementsAre;
@@ -91,7 +90,7 @@ TEST(RestOpentelemetry, MakeSpanHttpPayload) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
       spans,
-      Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsConsumer(),
+      Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
                      SpanNamed("HTTP/Response"),
                      SpanHasAttributes(SpanAttribute<std::string>(
                          sc::kNetTransport, sc::NetTransportValues::kIpTcp)))));


### PR DESCRIPTION
The UI is not that helpful for events vs. spans.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11257)
<!-- Reviewable:end -->
