### PR TITLE
fix(rest): normalize headers in `RestRequest`

### DIFF
--- a/google/cloud/internal/rest_request_test.cc
+++ b/google/cloud/internal/rest_request_test.cc
@@ -27,7 +27,7 @@ using ::testing::Eq;
 class RestRequestTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    headers_["header1"] = {"value1"};
+    headers_["Header1"] = {"value1"};
     headers_["header2"] = {"value2a", "value2b"};
     parameters_.emplace_back("param1", "value1");
   }


### PR DESCRIPTION
The constructors consumed headers but did not normalize them to lowercase. These are internal-only APIs and rarely used, so I think it is harmless.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11258)
<!-- Reviewable:end -->
