### PR TITLE
impl(otel): Recordable can set attributes

### DIFF
--- a/google/cloud/opentelemetry/BUILD.bazel
+++ b/google/cloud/opentelemetry/BUILD.bazel
@@ -36,6 +36,7 @@ load(":opentelemetry_sdk_unit_tests.bzl", "opentelemetry_sdk_unit_tests")
     srcs = [test],
     deps = [
         ":google_cloud_cpp_opentelemetry_sdk",
+        "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
 ) for test in opentelemetry_sdk_unit_tests]

--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -116,7 +116,7 @@ foreach (fname ${opentelemetry_sdk_unit_tests})
     google_cloud_cpp_add_executable(target "opentelemetry" "${fname}")
     target_link_libraries(
         ${target}
-        PRIVATE google_cloud_cpp_testing
+        PRIVATE google_cloud_cpp_testing google_cloud_cpp_testing_grpc
                 google-cloud-cpp::experimental-opentelemetry_sdk
                 GTest::gmock_main GTest::gmock GTest::gtest)
     google_cloud_cpp_add_common_options(${target})

--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -91,13 +91,11 @@ class AttributeVisitor {
     // We drop attributes whose keys are too long.
     if (key_.size() > kAttributeKeyStringLimit) return nullptr;
 
+    auto& map = *attributes_.mutable_attribute_map();
     // We do not do any sampling. We just accept the first N attributes we are
     // given, and discard the rest. We may want to consider reservoir sampling
     // in the future. See: https://en.wikipedia.org/wiki/Reservoir_sampling
-    auto& map = *attributes_.mutable_attribute_map();
-    if (attributes_.attribute_map().size() < limit_) {
-      return &map[{key_.data(), key_.size()}];
-    }
+    if (map.size() < limit_) return &map[{key_.data(), key_.size()}];
 
     // If the map is full, we can still overwrite existing keys.
     auto it = map.find({key_.data(), key_.size()});

--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -94,13 +94,12 @@ class AttributeVisitor {
     // We do not do any sampling. We just accept the first N attributes we are
     // given, and discard the rest. We may want to consider reservoir sampling
     // in the future. See: https://en.wikipedia.org/wiki/Reservoir_sampling
+    auto& map = *attributes_.mutable_attribute_map();
     if (attributes_.attribute_map().size() < limit_) {
-      auto& map = *attributes_.mutable_attribute_map();
       return &map[{key_.data(), key_.size()}];
     }
 
     // If the map is full, we can still overwrite existing keys.
-    auto& map = *attributes_.mutable_attribute_map();
     auto it = map.find({key_.data(), key_.size()});
     if (it == map.end()) return nullptr;
     return &it->second;

--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -27,8 +27,17 @@ namespace cloud {
 namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+// https://github.com/googleapis/googleapis/blob/11ddd42bcee5961c34e8529638d51e9866b65065/google/devtools/cloudtrace/v2/trace.proto#L255-L256
+std::size_t constexpr kSpanAttributeLimit = 32;
+
 // https://github.com/googleapis/googleapis/blob/a5e03049afc43ccb1217d5dd3be53006fc278643/google/devtools/cloudtrace/v2/trace.proto#L233
 std::size_t constexpr kDisplayNameStringLimit = 128;
+
+// https://github.com/googleapis/googleapis/blob/4e8d3907aec680562c9243774c67adc6d713fe50/google/devtools/cloudtrace/v2/trace.proto#L49
+std::size_t constexpr kAttributeKeyStringLimit = 128;
+
+// https://github.com/googleapis/googleapis/blob/4e8d3907aec680562c9243774c67adc6d713fe50/google/devtools/cloudtrace/v2/trace.proto#L50
+std::size_t constexpr kAttributeValueStringLimit = 256;
 
 /**
  * Helper to set [TruncatableString] fields in a [Span] proto.
@@ -43,6 +52,27 @@ std::size_t constexpr kDisplayNameStringLimit = 128;
 void SetTruncatableString(
     google::devtools::cloudtrace::v2::TruncatableString& proto,
     opentelemetry::nostd::string_view value, std::size_t limit);
+
+/**
+ * Helper to set [Attributes] fields in a [Span] proto.
+ *
+ * This function converts OpenTelemetry attributes to Cloud Trace attributes.
+ * Sadly there is not a great mapping for all attributes.
+ *
+ * Cloud Trace attributes also have limits, which are defined in the proto
+ * comments. For example, we are limited to 32 attributes per Span. We enforce
+ * the limit by accepting the first N attributes we are given, and dropping the
+ * rest.
+ *
+ * [Attributes]:
+ * https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.cloudtrace.v2#google.devtools.cloudtrace.v2.Span.Attributes
+ * [Span]:
+ * https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.cloudtrace.v2#google.devtools.cloudtrace.v2.Span
+ */
+void AddAttribute(
+    google::devtools::cloudtrace::v2::Span::Attributes& attributes,
+    opentelemetry::nostd::string_view key,
+    opentelemetry::common::AttributeValue const& value, std::size_t limit);
 
 // TODO(#11156) - Implement this class.
 /**

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/opentelemetry/internal/recordable.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
 
@@ -22,26 +23,38 @@ namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace v2 = ::google::devtools::cloudtrace::v2;
+using ::google::cloud::testing_util::IsProtoEqual;
+using ::testing::_;
+using ::testing::ElementsAre;
 using ::testing::IsEmpty;
+using ::testing::Pair;
+using ::testing::SizeIs;
 
 auto constexpr kProjectId = "test-project";
 
+template <typename T>
+opentelemetry::nostd::span<T> MakeCompositeAttribute() {
+  T v[]{T{}, T{}};
+  return opentelemetry::nostd::span<T>(v);
+}
+
 TEST(SetTruncatableString, LessThanLimit) {
-  google::devtools::cloudtrace::v2::TruncatableString proto;
+  v2::TruncatableString proto;
   SetTruncatableString(proto, "value", 1000);
   EXPECT_EQ(proto.value(), "value");
   EXPECT_EQ(proto.truncated_byte_count(), 0);
 }
 
 TEST(SetTruncatableString, OverTheLimit) {
-  google::devtools::cloudtrace::v2::TruncatableString proto;
+  v2::TruncatableString proto;
   SetTruncatableString(proto, "abcde", 3);
   EXPECT_EQ(proto.value(), "abc");
   EXPECT_EQ(proto.truncated_byte_count(), 2);
 }
 
 TEST(SetTruncatableString, RespectsUnicodeSymbolBoundaries) {
-  google::devtools::cloudtrace::v2::TruncatableString proto;
+  v2::TruncatableString proto;
   // A UTF-8 encoded character that is 2 bytes wide.
   std::string const u2 = "\xd0\xb4";
   // The string `u2 + u2` is 4 bytes long. Truncation should respect the symbol
@@ -62,6 +75,133 @@ TEST(SetTruncatableString, RespectsUnicodeSymbolBoundaries) {
   EXPECT_EQ(proto.truncated_byte_count(), 6);
 }
 
+TEST(AddAttribute, DropsNewKeyAtLimit) {
+  v2::Span::Attributes attributes;
+  AddAttribute(attributes, "accepted", "value", 1);
+  EXPECT_EQ(attributes.dropped_attributes_count(), 0);
+  EXPECT_THAT(attributes.attribute_map(), ElementsAre(Pair("accepted", _)));
+
+  AddAttribute(attributes, "rejected", "value", 1);
+  EXPECT_EQ(attributes.dropped_attributes_count(), 1);
+  EXPECT_THAT(attributes.attribute_map(), ElementsAre(Pair("accepted", _)));
+}
+
+TEST(AddAttribute, AcceptsExistingKeyAtLimit) {
+  v2::AttributeValue expected_1;
+  *expected_1.mutable_string_value()->mutable_value() = "value1";
+  v2::AttributeValue expected_2;
+  *expected_2.mutable_string_value()->mutable_value() = "value2";
+
+  v2::Span::Attributes attributes;
+  AddAttribute(attributes, "key", "value1", 1);
+  EXPECT_EQ(attributes.dropped_attributes_count(), 0);
+  EXPECT_THAT(attributes.attribute_map(),
+              ElementsAre(Pair("key", IsProtoEqual(expected_1))));
+
+  // The map is full, but we should still be able to overwrite an existing key.
+  AddAttribute(attributes, "key", "value2", 1);
+  EXPECT_EQ(attributes.dropped_attributes_count(), 0);
+  EXPECT_THAT(attributes.attribute_map(),
+              ElementsAre(Pair("key", IsProtoEqual(expected_2))));
+}
+
+TEST(AddAttribute, DropsLongKey) {
+  std::string const long_key(kAttributeKeyStringLimit + 1, 'A');
+
+  v2::Span::Attributes attributes;
+  AddAttribute(attributes, long_key, "value", 32);
+  EXPECT_EQ(attributes.dropped_attributes_count(), 1);
+  EXPECT_THAT(attributes.attribute_map(), IsEmpty());
+}
+
+TEST(AddAttribute, HandlesBoolAttribute) {
+  v2::AttributeValue expected;
+  expected.set_bool_value(true);
+
+  v2::Span::Attributes attributes;
+  AddAttribute(attributes, "key", true, 32);
+  EXPECT_EQ(attributes.dropped_attributes_count(), 0);
+  EXPECT_THAT(attributes.attribute_map(),
+              ElementsAre(Pair("key", IsProtoEqual(expected))));
+}
+
+TEST(AddAttribute, HandlesIntAttributes) {
+  v2::AttributeValue expected;
+  expected.set_int_value(42);
+
+  std::vector<opentelemetry::common::AttributeValue> values = {
+      int32_t{42}, uint32_t{42}, int64_t{42}, uint64_t{42}};
+
+  for (auto const& value : values) {
+    v2::Span::Attributes attributes;
+    AddAttribute(attributes, "key", value, 32);
+    EXPECT_EQ(attributes.dropped_attributes_count(), 0);
+    EXPECT_THAT(attributes.attribute_map(),
+                ElementsAre(Pair("key", IsProtoEqual(expected))));
+  }
+}
+
+TEST(AddAttribute, HandlesStringAttributes) {
+  v2::AttributeValue expected;
+  expected.mutable_string_value()->set_value("value");
+
+  std::vector<opentelemetry::common::AttributeValue> values = {
+      "value", opentelemetry::nostd::string_view{"value"}};
+
+  for (auto const& value : values) {
+    v2::Span::Attributes attributes;
+    AddAttribute(attributes, "key", value, 32);
+    EXPECT_EQ(attributes.dropped_attributes_count(), 0);
+    EXPECT_THAT(attributes.attribute_map(),
+                ElementsAre(Pair("key", IsProtoEqual(expected))));
+  }
+}
+
+TEST(AddAttribute, TruncatesStringValue) {
+  std::string const long_value(kAttributeValueStringLimit + 1, 'A');
+  std::string const expected_value(kAttributeValueStringLimit, 'A');
+
+  v2::AttributeValue expected;
+  expected.mutable_string_value()->set_value(expected_value);
+  expected.mutable_string_value()->set_truncated_byte_count(1);
+
+  v2::Span::Attributes attributes;
+  AddAttribute(attributes, "key", long_value, 32);
+  EXPECT_EQ(attributes.dropped_attributes_count(), 0);
+  EXPECT_THAT(attributes.attribute_map(),
+              ElementsAre(Pair("key", IsProtoEqual(expected))));
+}
+
+TEST(AddAttribute, ConvertsDoubleAttributeToString) {
+  v2::AttributeValue expected;
+  expected.mutable_string_value()->set_value("4.2");
+
+  v2::Span::Attributes attributes;
+  AddAttribute(attributes, "key", 4.2, 32);
+  EXPECT_EQ(attributes.dropped_attributes_count(), 0);
+  EXPECT_THAT(attributes.attribute_map(),
+              ElementsAre(Pair("key", IsProtoEqual(expected))));
+}
+
+TEST(AddAttribute, DropsCompositeAttributes) {
+  std::vector<opentelemetry::common::AttributeValue> values = {
+      MakeCompositeAttribute<bool>(),
+      MakeCompositeAttribute<int32_t>(),
+      MakeCompositeAttribute<int64_t>(),
+      MakeCompositeAttribute<uint32_t>(),
+      MakeCompositeAttribute<double>(),
+      MakeCompositeAttribute<opentelemetry::nostd::string_view>(),
+      MakeCompositeAttribute<uint64_t>(),
+      MakeCompositeAttribute<uint8_t>()};
+
+  for (auto const& value : values) {
+    v2::Span::Attributes attributes;
+    AddAttribute(attributes, "key", value, 32);
+    EXPECT_EQ(attributes.dropped_attributes_count(), 1);
+    EXPECT_THAT(attributes.attribute_map(), IsEmpty());
+  }
+}
+
 TEST(Recordable, SetName) {
   auto rec = Recordable(Project(kProjectId));
   rec.SetName("name");
@@ -78,6 +218,28 @@ TEST(Recordable, SetNameTruncates) {
   auto proto = std::move(rec).as_proto();
   EXPECT_EQ(proto.display_name().value(), expected);
   EXPECT_EQ(proto.display_name().truncated_byte_count(), 1);
+}
+
+TEST(Recordable, SetAttribute) {
+  v2::AttributeValue expected;
+  expected.mutable_string_value()->set_value("value");
+
+  auto rec = Recordable(Project(kProjectId));
+  rec.SetAttribute("key", "value");
+  auto proto = std::move(rec).as_proto();
+  EXPECT_THAT(proto.attributes().attribute_map(),
+              ElementsAre(Pair("key", IsProtoEqual(expected))));
+}
+
+TEST(Recordable, SetAttributeRespectsLimit) {
+  auto rec = Recordable(Project(kProjectId));
+  for (std::size_t i = 0; i != kSpanAttributeLimit + 1; ++i) {
+    rec.SetAttribute("key" + std::to_string(i), "value");
+  }
+  auto proto = std::move(rec).as_proto();
+  auto& attributes = *proto.mutable_attributes();
+  EXPECT_THAT(attributes.attribute_map(), SizeIs(kSpanAttributeLimit));
+  EXPECT_EQ(attributes.dropped_attributes_count(), 1);
 }
 
 }  // namespace

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -130,7 +130,7 @@ TEST(AddAttribute, HandlesIntAttributes) {
   expected.set_int_value(42);
 
   std::vector<opentelemetry::common::AttributeValue> values = {
-      int32_t{42}, uint32_t{42}, int64_t{42}, uint64_t{42}};
+      std::int32_t{42}, std::uint32_t{42}, std::int64_t{42}, std::uint64_t{42}};
 
   for (auto const& value : values) {
     v2::Span::Attributes attributes;
@@ -186,13 +186,13 @@ TEST(AddAttribute, ConvertsDoubleAttributeToString) {
 TEST(AddAttribute, DropsCompositeAttributes) {
   std::vector<opentelemetry::common::AttributeValue> values = {
       MakeCompositeAttribute<bool>(),
-      MakeCompositeAttribute<int32_t>(),
-      MakeCompositeAttribute<int64_t>(),
-      MakeCompositeAttribute<uint32_t>(),
+      MakeCompositeAttribute<std::int32_t>(),
+      MakeCompositeAttribute<std::int64_t>(),
+      MakeCompositeAttribute<std::uint32_t>(),
       MakeCompositeAttribute<double>(),
       MakeCompositeAttribute<opentelemetry::nostd::string_view>(),
-      MakeCompositeAttribute<uint64_t>(),
-      MakeCompositeAttribute<uint8_t>()};
+      MakeCompositeAttribute<std::uint64_t>(),
+      MakeCompositeAttribute<std::uint8_t>()};
 
   for (auto const& value : values) {
     v2::Span::Attributes attributes;


### PR DESCRIPTION
Part of the work for #11156 

Implement `Recordable::SetAttribute`. The main work is implementing a helper to set the `google::devtools::cloudtrace::v2::Attributes` field. THe helper will be used by other member functions (`AddEvent`, `AddLink`, etc.).

Is using `std::ostringstream` the best way to convert a double to a string? `to_string(x)` gave me a bunch of decimals.

Of note, the exporter spec will require us to map OpenTelemetry semantic conventions for attribute names to Cloud Trace semantic conventions. For example, "http.host" -> "/http/host". This work will come later. There is enough going on in this PR already.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11260)
<!-- Reviewable:end -->
