### PR TITLE
test(spanner): make use of the IsOkAndHolds() StatusOr<T> matcher

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -112,7 +112,7 @@ TEST_F(BackupExtraIntegrationTest, CreateBackupWithVersionTime) {
       generator_, ProjectId(),
       "(labels.restore-database-partition:generated-extra OR"
       " labels.restore-database-partition:all)");
-  ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
+  ASSERT_THAT(instance_id, IsOk());
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
 
@@ -133,7 +133,7 @@ TEST_F(BackupExtraIntegrationTest, CreateBackupWithVersionTime) {
     EXPECT_THAT(database, Not(IsOk()));
     return;
   }
-  ASSERT_THAT(database, IsOk()) << database.status();
+  ASSERT_THAT(database, IsOk());
   auto create_time =
       MakeTimestamp(database->create_time()).value().get<absl::Time>().value();
 
@@ -290,7 +290,7 @@ TEST_F(BackupExtraIntegrationTest, CreateBackupWithVersionTime) {
 TEST_F(BackupExtraIntegrationTest, CreateBackupWithExpiredVersionTime) {
   auto instance_id =
       spanner_testing::PickRandomInstance(generator_, ProjectId());
-  ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
+  ASSERT_THAT(instance_id, IsOk());
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
 
@@ -306,7 +306,7 @@ TEST_F(BackupExtraIntegrationTest, CreateBackupWithExpiredVersionTime) {
     EXPECT_THAT(database, Not(IsOk()));
     return;
   }
-  ASSERT_THAT(database, IsOk()) << database.status();
+  ASSERT_THAT(database, IsOk());
 
   auto create_time =
       MakeTimestamp(database->create_time()).value().get<absl::Time>().value();
@@ -335,7 +335,7 @@ TEST_F(BackupExtraIntegrationTest, CreateBackupWithExpiredVersionTime) {
 TEST_F(BackupExtraIntegrationTest, CreateBackupWithFutureVersionTime) {
   auto instance_id =
       spanner_testing::PickRandomInstance(generator_, ProjectId());
-  ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
+  ASSERT_THAT(instance_id, IsOk());
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
 
@@ -351,7 +351,7 @@ TEST_F(BackupExtraIntegrationTest, CreateBackupWithFutureVersionTime) {
     EXPECT_THAT(database, Not(IsOk()));
     return;
   }
-  ASSERT_THAT(database, IsOk()) << database.status();
+  ASSERT_THAT(database, IsOk());
 
   auto create_time =
       MakeTimestamp(database->create_time()).value().get<absl::Time>().value();

--- a/google/cloud/spanner/bytes_test.cc
+++ b/google/cloud/spanner/bytes_test.cc
@@ -86,7 +86,7 @@ TEST(Bytes, Conversions) {
   std::vector<std::uint8_t> const v_plain(s_plain.begin(), s_plain.end());
 
   auto bytes = spanner_internal::BytesFromBase64(s_coded);
-  EXPECT_STATUS_OK(bytes) << s_coded;
+  ASSERT_STATUS_OK(bytes) << s_coded;
   EXPECT_EQ(s_coded, spanner_internal::BytesToBase64(*bytes));
   EXPECT_EQ(s_plain, bytes->get<std::string>());
   EXPECT_EQ(d_plain, bytes->get<std::deque<char>>());

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -58,7 +58,7 @@ TEST(DatabaseAdminClientTest, CreateDatabase) {
   auto fut = client.CreateDatabase(dbase, {"-- NOT SQL for test"});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
-  EXPECT_STATUS_OK(db);
+  ASSERT_STATUS_OK(db);
 
   EXPECT_EQ(dbase.FullName(), db->name());
   EXPECT_EQ(gsad::v1::Database::CREATING, db->state());
@@ -80,7 +80,7 @@ TEST(DatabaseAdminClientTest, GetDatabase) {
 
   DatabaseAdminClient client(std::move(mock));
   auto response = client.GetDatabase(dbase);
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(gsad::v1::Database::READY, response->state());
   EXPECT_EQ(dbase.FullName(), response->name());
 }
@@ -102,9 +102,9 @@ TEST(DatabaseAdminClientTest, GetDatabaseDdl) {
 
   DatabaseAdminClient client(std::move(mock));
   auto response = client.GetDatabaseDdl(expected_name);
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   ASSERT_EQ(1, response->statements_size());
-  ASSERT_EQ("CREATE DATABASE test-database", response->statements(0));
+  EXPECT_EQ("CREATE DATABASE test-database", response->statements(0));
 }
 
 /// @test Verify DatabaseAdminClient uses UpdateDatabase() correctly.
@@ -127,7 +127,7 @@ TEST(DatabaseAdminClientTest, UpdateDatabase) {
   auto fut = client.UpdateDatabase(dbase, {"-- test only: NOT SQL"});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
-  EXPECT_STATUS_OK(db);
+  ASSERT_STATUS_OK(db);
 
   EXPECT_THAT(db->statements(), ElementsAre("-- test only: NOT SQL"));
 }
@@ -177,11 +177,11 @@ TEST(DatabaseAdminClientTest, GetIamPolicy) {
 
   DatabaseAdminClient client(std::move(mock));
   auto response = client.GetIamPolicy(expected_db);
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   ASSERT_EQ(1, response->bindings().size());
-  ASSERT_EQ(expected_role, response->bindings().Get(0).role());
+  EXPECT_EQ(expected_role, response->bindings().Get(0).role());
   ASSERT_EQ(1, response->bindings().Get(0).members().size());
-  ASSERT_EQ(expected_member, response->bindings().Get(0).members().Get(0));
+  EXPECT_EQ(expected_member, response->bindings().Get(0).members().Get(0));
 }
 
 /// @test Verify DatabaseAdminClient uses SetIamPolicy() correctly.
@@ -336,8 +336,8 @@ TEST(DatabaseAdminClientTest, TestIamPermissions) {
           });
   DatabaseAdminClient client(std::move(mock));
   auto response = client.TestIamPermissions(expected_db, {expected_permission});
-  EXPECT_STATUS_OK(response);
-  EXPECT_EQ(1, response->permissions_size());
+  ASSERT_STATUS_OK(response);
+  ASSERT_EQ(1, response->permissions_size());
   EXPECT_EQ(expected_permission, response->permissions(0));
 }
 
@@ -393,7 +393,7 @@ TEST(DatabaseAdminClientTest, CreateBackup) {
   auto fut = client.CreateBackup(dbase, backup_id, expire_time, version_time);
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto backup = fut.get();
-  EXPECT_STATUS_OK(backup);
+  ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup_name.FullName(), backup->name());
   EXPECT_EQ(gsad::v1::Backup::CREATING, backup->state());
 
@@ -403,7 +403,7 @@ TEST(DatabaseAdminClientTest, CreateBackup) {
       expire_time.get<std::chrono::system_clock::time_point>().value());
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   backup = fut.get();
-  EXPECT_STATUS_OK(backup);
+  ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup_name.FullName(), backup->name());
   EXPECT_EQ(gsad::v1::Backup::CREATING, backup->state());
 }
@@ -429,7 +429,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabase) {
   auto fut = client.RestoreDatabase(dbase, backup);
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto database = fut.get();
-  EXPECT_STATUS_OK(database);
+  ASSERT_STATUS_OK(database);
 
   EXPECT_EQ(dbase.FullName(), database->name());
   EXPECT_EQ(gsad::v1::Database::READY_OPTIMIZING, database->state());
@@ -458,7 +458,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseOverload) {
   auto fut = client.RestoreDatabase(dbase, backup);
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto database = fut.get();
-  EXPECT_STATUS_OK(database);
+  ASSERT_STATUS_OK(database);
 
   EXPECT_EQ(dbase.FullName(), database->name());
   EXPECT_EQ(gsad::v1::Database::READY_OPTIMIZING, database->state());
@@ -480,7 +480,7 @@ TEST(DatabaseAdminClientTest, GetBackup) {
 
   DatabaseAdminClient client(std::move(mock));
   auto response = client.GetBackup(backup);
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(gsad::v1::Backup::READY, response->state());
   EXPECT_EQ(backup.FullName(), response->name());
 }
@@ -584,7 +584,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTime) {
 
   DatabaseAdminClient client(std::move(mock));
   auto response = client.UpdateBackupExpireTime(backup, expire_time);
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(gsad::v1::Backup::READY, response->state());
   EXPECT_EQ(backup.FullName(), response->name());
   EXPECT_THAT(expire_time, MakeTimestamp(response->expire_time()).value());
@@ -592,7 +592,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTime) {
   // Exercise the old interface with a `time_point` expiration parameter.
   response = client.UpdateBackupExpireTime(
       backup, expire_time.get<std::chrono::system_clock::time_point>().value());
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(gsad::v1::Backup::READY, response->state());
   EXPECT_EQ(backup.FullName(), response->name());
   EXPECT_THAT(
@@ -639,7 +639,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTimeOverload) {
 
   DatabaseAdminClient client(std::move(mock));
   auto response = client.UpdateBackupExpireTime(backup, expire_time);
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(gsad::v1::Backup::READY, response->state());
   EXPECT_EQ(backup_name.FullName(), response->name());
   EXPECT_THAT(expire_time, MakeTimestamp(response->expire_time()).value());
@@ -647,7 +647,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTimeOverload) {
   // Exercise the old interface with a `time_point` expiration parameter.
   response = client.UpdateBackupExpireTime(
       backup, expire_time.get<std::chrono::system_clock::time_point>().value());
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(gsad::v1::Backup::READY, response->state());
   EXPECT_EQ(backup_name.FullName(), response->name());
   EXPECT_THAT(

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -219,8 +219,7 @@ TEST(DatabaseAdminConnectionTest, GetDatabase) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response =
       conn->GetDatabase({Database("project", "instance", "database")});
-  ASSERT_STATUS_OK(response);
-  EXPECT_THAT(*response, IsProtoEqual(expected_response));
+  EXPECT_THAT(response, IsOkAndHolds(IsProtoEqual(expected_response)));
 }
 
 /// @test Verify that permanent errors are reported immediately.
@@ -270,9 +269,9 @@ TEST(DatabaseAdminConnectionTest, GetDatabaseDdlSuccess) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->GetDatabaseDdl(
       {Database("test-project", "test-instance", "test-database")});
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   ASSERT_EQ(1, response->statements_size());
-  ASSERT_EQ("CREATE DATABASE test-database", response->statements(0));
+  EXPECT_EQ("CREATE DATABASE test-database", response->statements(0));
 }
 
 /// @test Verify that permanent errors are reported immediately.
@@ -768,9 +767,9 @@ TEST(DatabaseAdminConnectionTest, GetIamPolicySuccess) {
       {Database("test-project", "test-instance", "test-database")});
   EXPECT_STATUS_OK(response);
   ASSERT_EQ(1, response->bindings().size());
-  ASSERT_EQ(expected_role, response->bindings().Get(0).role());
+  EXPECT_EQ(expected_role, response->bindings().Get(0).role());
   ASSERT_EQ(1, response->bindings().Get(0).members().size());
-  ASSERT_EQ(expected_member, response->bindings().Get(0).members().Get(0));
+  EXPECT_EQ(expected_member, response->bindings().Get(0).members().Get(0));
 }
 
 /// @test Verify that permanent errors are reported immediately.
@@ -837,7 +836,7 @@ TEST(DatabaseAdminConnectionTest, SetIamPolicySuccess) {
   auto response = conn->SetIamPolicy(
       {Database("test-project", "test-instance", "test-database"),
        expected_policy});
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   expected_policy.set_etag("response-etag");
   EXPECT_THAT(*response, IsProtoEqual(expected_policy));
 }
@@ -911,9 +910,9 @@ TEST(DatabaseAdminConnectionTest, TestIamPermissionsSuccess) {
   auto response = conn->TestIamPermissions(
       {Database("test-project", "test-instance", "test-database"),
        {expected_permission}});
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   ASSERT_EQ(1, response->permissions_size());
-  ASSERT_EQ(expected_permission, response->permissions(0));
+  EXPECT_EQ(expected_permission, response->permissions(0));
 }
 
 /// @test Verify that permanent errors are reported immediately.
@@ -1374,7 +1373,7 @@ TEST(DatabaseAdminConnectionTest, UpdateBackupSuccess) {
       Backup(Instance("test-project", "test-instance"), "test-backup")
           .FullName());
   auto response = conn->UpdateBackup({request});
-  EXPECT_STATUS_OK(response);
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(gsad::v1::Backup::READY, response->state());
   EXPECT_EQ(expected_name, response->name());
 }

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -283,7 +283,7 @@ TEST(InstanceAdminConnectionTest, DeleteInstanceSuccess) {
 
   auto conn = MakeLimitedRetryConnection(mock);
   auto status = conn->DeleteInstance({expected_name});
-  ASSERT_STATUS_OK(status);
+  EXPECT_STATUS_OK(status);
 }
 
 TEST(InstanceAdminConnectionTest, DeleteInstancePermanentFailure) {

--- a/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
@@ -101,7 +101,7 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithVersionTime) {
       generator_, ProjectId(),
       "(labels.restore-database-partition:legacy-extra OR"
       " labels.restore-database-partition:all)");
-  ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
+  ASSERT_THAT(instance_id, IsOk());
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
 
@@ -118,7 +118,7 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithVersionTime) {
     EXPECT_THAT(database, Not(IsOk()));
     return;
   }
-  ASSERT_THAT(database, IsOk()) << database.status();
+  ASSERT_THAT(database, IsOk());
   auto create_time =
       MakeTimestamp(database->create_time()).value().get<absl::Time>().value();
 
@@ -238,7 +238,7 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithVersionTime) {
 TEST_F(BackupExtraIntegrationTest, BackupWithExpiredVersionTime) {
   auto instance_id =
       spanner_testing::PickRandomInstance(generator_, ProjectId());
-  ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
+  ASSERT_THAT(instance_id, IsOk());
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
 
@@ -251,7 +251,7 @@ TEST_F(BackupExtraIntegrationTest, BackupWithExpiredVersionTime) {
     EXPECT_THAT(database, Not(IsOk()));
     return;
   }
-  ASSERT_THAT(database, IsOk()) << database.status();
+  ASSERT_THAT(database, IsOk());
 
   auto create_time =
       MakeTimestamp(database->create_time()).value().get<absl::Time>().value();
@@ -275,7 +275,7 @@ TEST_F(BackupExtraIntegrationTest, BackupWithExpiredVersionTime) {
 TEST_F(BackupExtraIntegrationTest, BackupWithFutureVersionTime) {
   auto instance_id =
       spanner_testing::PickRandomInstance(generator_, ProjectId());
-  ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
+  ASSERT_THAT(instance_id, IsOk());
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
 
@@ -288,7 +288,7 @@ TEST_F(BackupExtraIntegrationTest, BackupWithFutureVersionTime) {
     EXPECT_THAT(database, Not(IsOk()));
     return;
   }
-  ASSERT_THAT(database, IsOk()) << database.status();
+  ASSERT_THAT(database, IsOk());
 
   auto create_time =
       MakeTimestamp(database->create_time()).value().get<absl::Time>().value();

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -30,6 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::IsOkAndHolds;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AllOf;
 using ::testing::AnyOf;
@@ -157,7 +158,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadFloat64NaN) {
   };
   auto result = WriteReadData(*client_, data, "Float64Value");
   ASSERT_STATUS_OK(result);
-  EXPECT_EQ(1, result->size());
+  ASSERT_EQ(1, result->size());
   EXPECT_TRUE(std::isnan(result->front()));
 }
 
@@ -170,8 +171,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadString) {
       std::string(1024, 'x'),
   };
   auto result = WriteReadData(*client_, data, "StringValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadBytes) {
@@ -189,8 +189,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadBytes) {
       Bytes(blob),
   };
   auto result = WriteReadData(*client_, data, "BytesValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadTimestamp) {
@@ -213,8 +212,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadTimestamp) {
       *max,
   };
   auto result = WriteReadData(*client_, data, "TimestampValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadDate) {
@@ -226,8 +224,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadDate) {
       absl::CivilDay(9999, 12, 31),  //
   };
   auto result = WriteReadData(*client_, data, "DateValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadJson) {
@@ -238,8 +235,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadJson) {
       Json("true"),               //
   };
   auto result = WriteReadData(*client_, data, "JsonValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(PgDataTypeIntegrationTest, WriteReadJson) {
@@ -252,8 +248,7 @@ TEST_F(PgDataTypeIntegrationTest, WriteReadJson) {
       JsonB("true"),               //
   };
   auto result = WriteReadData(*client_, data, "JsonValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadNumeric) {
@@ -272,8 +267,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadNumeric) {
       *max,                                //
   };
   auto result = WriteReadData(*client_, data, "NumericValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(PgDataTypeIntegrationTest, WriteReadNumeric) {
@@ -295,8 +289,7 @@ TEST_F(PgDataTypeIntegrationTest, WriteReadNumeric) {
       *max,                                  //
   };
   auto result = WriteReadData(*client_, data, "NumericValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayBool) {
@@ -308,8 +301,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayBool) {
       std::vector<bool>{false, true},
   };
   auto result = WriteReadData(*client_, data, "ArrayBoolValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayInt64) {
@@ -319,8 +311,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayInt64) {
       std::vector<std::int64_t>{-1, 0, 1},
   };
   auto result = WriteReadData(*client_, data, "ArrayInt64Value");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayFloat64) {
@@ -330,8 +321,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayFloat64) {
       std::vector<double>{-0.5, 0.5, 1.5},
   };
   auto result = WriteReadData(*client_, data, "ArrayFloat64Value");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayString) {
@@ -341,8 +331,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayString) {
       std::vector<std::string>{"", "foo", "bar"},
   };
   auto result = WriteReadData(*client_, data, "ArrayStringValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayBytes) {
@@ -352,8 +341,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayBytes) {
       std::vector<Bytes>{Bytes(""), Bytes("foo"), Bytes("bar")},
   };
   auto result = WriteReadData(*client_, data, "ArrayBytesValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayTimestamp) {
@@ -367,8 +355,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayTimestamp) {
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayTimestampValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayDate) {
@@ -382,8 +369,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayDate) {
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayDateValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayJson) {
@@ -398,8 +384,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayJson) {
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayJsonValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(PgDataTypeIntegrationTest, WriteReadArrayJson) {
@@ -416,8 +401,7 @@ TEST_F(PgDataTypeIntegrationTest, WriteReadArrayJson) {
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayJsonValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadArrayNumeric) {
@@ -431,8 +415,7 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayNumeric) {
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayNumericValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(PgDataTypeIntegrationTest, WriteReadArrayNumeric) {
@@ -448,8 +431,7 @@ TEST_F(PgDataTypeIntegrationTest, WriteReadArrayNumeric) {
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayNumericValue");
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+  EXPECT_THAT(result, IsOkAndHolds(UnorderedElementsAreArray(data)));
 }
 
 TEST_F(DataTypeIntegrationTest, JsonIndexAndPrimaryKey) {
@@ -537,7 +519,7 @@ TEST_F(PgDataTypeIntegrationTest, InsertAndQueryWithJson) {
         if (!dml_result) return dml_result.status();
         return Mutations{};
       });
-  ASSERT_STATUS_OK(commit_result);
+  EXPECT_STATUS_OK(commit_result);
 
   auto rows =
       client_->ExecuteQuery(SqlStatement("SELECT Id, JsonValue FROM DataTypes"
@@ -560,7 +542,7 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithNumericKey) {
       Mutations{InsertOrUpdateMutationBuilder("NumericKey", {"Key"})
                     .EmplaceRow(key)
                     .Build()});
-  ASSERT_STATUS_OK(commit_result);
+  EXPECT_STATUS_OK(commit_result);
 
   auto rows = client.Read("NumericKey", KeySet::All(), {"Key"});
   using RowType = std::tuple<Numeric>;
@@ -768,7 +750,7 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
         if (!dml_result) return dml_result.status();
         return Mutations{};
       });
-  ASSERT_STATUS_OK(commit_result);
+  EXPECT_STATUS_OK(commit_result);
 
   auto rows = client_->ExecuteQuery(
       SqlStatement("SELECT ARRAY(SELECT STRUCT(StringValue, ArrayInt64Value)) "
@@ -778,7 +760,7 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
   ASSERT_STATUS_OK(row);
 
   auto const& v = std::get<0>(*row);
-  EXPECT_EQ(1, v.size());
+  ASSERT_EQ(1, v.size());
   EXPECT_EQ(data, v[0]);
 }
 

--- a/google/cloud/spanner/internal/merge_chunk_test.cc
+++ b/google/cloud/spanner/internal/merge_chunk_test.cc
@@ -70,7 +70,7 @@ google::protobuf::Value MakeProtoValue(std::vector<T> v) {
 TEST(MergeChunk, ExampleStrings) {
   auto a = MakeProtoValue("foo");
   auto b = MakeProtoValue("bar");
-  ASSERT_STATUS_OK(MergeChunk(a, std::move(b)));
+  EXPECT_STATUS_OK(MergeChunk(a, std::move(b)));
 
   auto expected = MakeProtoValue("foobar");
   EXPECT_THAT(a, IsProtoEqual(expected));
@@ -83,7 +83,7 @@ TEST(MergeChunk, ExampleStrings) {
 TEST(MergeChunk, ExampleListOfInts) {
   auto a = MakeProtoValue(std::vector<double>{2, 3});
   auto b = MakeProtoValue(std::vector<double>{4});
-  ASSERT_STATUS_OK(MergeChunk(a, std::move(b)));
+  EXPECT_STATUS_OK(MergeChunk(a, std::move(b)));
 
   auto expected = MakeProtoValue(std::vector<double>{2, 3, 4});
   EXPECT_THAT(a, IsProtoEqual(expected));
@@ -96,7 +96,7 @@ TEST(MergeChunk, ExampleListOfInts) {
 TEST(MergeChunk, ExampleListOfStrings) {
   auto a = MakeProtoValue(std::vector<std::string>{"a", "b"});
   auto b = MakeProtoValue(std::vector<std::string>{"c", "d"});
-  ASSERT_STATUS_OK(MergeChunk(a, std::move(b)));
+  EXPECT_STATUS_OK(MergeChunk(a, std::move(b)));
 
   auto expected = MakeProtoValue(std::vector<std::string>{"a", "bc", "d"});
   EXPECT_THAT(a, IsProtoEqual(expected));
@@ -112,7 +112,7 @@ TEST(MergeChunk, ExampleListsOfListOfString) {
       Value("a"), Value(std::vector<std::string>{"b", "c"})});
   auto b = MakeProtoValue(
       std::vector<Value>{Value(std::vector<std::string>{"d"}), Value("e")});
-  ASSERT_STATUS_OK(MergeChunk(a, std::move(b)));
+  EXPECT_STATUS_OK(MergeChunk(a, std::move(b)));
 
   auto expected = MakeProtoValue(std::vector<Value>{
       Value("a"), Value(std::vector<std::string>{"b", "cd"}), Value("e")});
@@ -125,13 +125,13 @@ TEST(MergeChunk, ExampleListsOfListOfString) {
 
 TEST(MergeChunk, EmptyStringFirst) {
   auto empty = MakeProtoValue("");
-  ASSERT_STATUS_OK(MergeChunk(empty, MakeProtoValue("foo")));
+  EXPECT_STATUS_OK(MergeChunk(empty, MakeProtoValue("foo")));
   EXPECT_THAT(empty, IsProtoEqual(MakeProtoValue("foo")));
 }
 
 TEST(MergeChunk, EmptyStringSecond) {
   auto value = MakeProtoValue("foo");
-  ASSERT_STATUS_OK(MergeChunk(value, MakeProtoValue("")));
+  EXPECT_STATUS_OK(MergeChunk(value, MakeProtoValue("")));
   EXPECT_THAT(value, IsProtoEqual(MakeProtoValue("foo")));
 }
 
@@ -141,7 +141,7 @@ TEST(MergeChunk, EmptyListFirst) {
 
   auto b = MakeProtoValue(std::vector<std::string>{"a", "b"});
   auto const expected = b;
-  ASSERT_STATUS_OK(MergeChunk(empty_list, std::move(b)));
+  EXPECT_STATUS_OK(MergeChunk(empty_list, std::move(b)));
   EXPECT_THAT(empty_list, IsProtoEqual(expected));
 }
 
@@ -152,7 +152,7 @@ TEST(MergeChunk, EmptyListSecond) {
 
   empty_list.mutable_list_value();
 
-  ASSERT_STATUS_OK(MergeChunk(a, std::move(empty_list)));
+  EXPECT_STATUS_OK(MergeChunk(a, std::move(empty_list)));
   EXPECT_THAT(a, IsProtoEqual(expected));
 }
 

--- a/google/cloud/spanner/numeric_test.cc
+++ b/google/cloud/spanner/numeric_test.cc
@@ -27,8 +27,10 @@ namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
+using ::testing::Not;
 
 auto constexpr kNumericIntMin =  // 1 - 10^Numeric::kIntPrecision
     absl::MakeInt128(-5421010863, 10560352017195204609U);
@@ -563,9 +565,9 @@ TEST(Numeric, PostgreSQL) {
 
   // Check some limits of representation and rounding.
   auto limit = "-" + std::string(131072, '9') + "." + std::string(16383, '9');
-  EXPECT_TRUE(MakePgNumeric(limit).ok());
+  EXPECT_THAT(MakePgNumeric(limit), IsOk());
   auto too_big = "-1" + std::string(131072, '0');
-  EXPECT_FALSE(MakePgNumeric(too_big).ok());
+  EXPECT_THAT(MakePgNumeric(too_big), Not(IsOk()));
   auto round_up = "0." + std::string(16383, '9') + "5";
   EXPECT_EQ("1", MakePgNumeric(round_up).value().ToString());
 

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -215,26 +215,26 @@ TEST(RowStreamIterator, Basics) {
   auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
   EXPECT_EQ(it, it);
   EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(rows[0], **it);
 
   ++it;
   EXPECT_EQ(it, it);
   EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(rows[1], **it);
 
   it++;
   EXPECT_EQ(it, it);
   EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(rows[2], **it);
 
   // Tests op*() const and op->() const
   auto const copy = it;
   EXPECT_EQ(copy, it);
   EXPECT_NE(copy, end);
-  EXPECT_STATUS_OK(*copy);
+  ASSERT_STATUS_OK(*copy);
   EXPECT_STATUS_OK(copy->status());
 
   ++it;
@@ -254,7 +254,7 @@ TEST(RowStreamIterator, OneRow) {
   rows.emplace_back(spanner_mocks::MakeRow(1, "foo", true));
   auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
   EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(rows[0], **it);
 
   ++it;
@@ -270,13 +270,13 @@ TEST(RowStreamIterator, IterationError) {
   rows.emplace_back(spanner_mocks::MakeRow(2, "bar", true));
 
   auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
-  EXPECT_NE(it, end);
+  ASSERT_NE(it, end);
   EXPECT_STATUS_OK(*it);
   EXPECT_EQ(rows[0], *it);
 
   ++it;
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
+  ASSERT_NE(it, end);
   EXPECT_FALSE(*it);
   EXPECT_THAT(*it, StatusIs(StatusCode::kUnknown, "some error"));
 
@@ -294,9 +294,9 @@ TEST(RowStreamIterator, ForLoop) {
   auto source = MakeRowStreamIteratorSource(rows);
   std::int64_t product = 1;
   for (RowStreamIterator it(source), end; it != end; ++it) {
-    EXPECT_STATUS_OK(*it);
+    ASSERT_STATUS_OK(*it);
     auto num = (*it)->get<std::int64_t>("num");
-    EXPECT_STATUS_OK(num);
+    ASSERT_STATUS_OK(num);
     product *= *num;
   }
   EXPECT_EQ(product, 30);
@@ -311,9 +311,9 @@ TEST(RowStreamIterator, RangeForLoop) {
   RowRange range(MakeRowStreamIteratorSource(rows));
   std::int64_t product = 1;
   for (auto const& row : range) {
-    EXPECT_STATUS_OK(row);
+    ASSERT_STATUS_OK(row);
     auto num = row->get<std::int64_t>("num");
-    EXPECT_STATUS_OK(num);
+    ASSERT_STATUS_OK(num);
     product *= *num;
   }
   EXPECT_EQ(product, 30);
@@ -330,17 +330,17 @@ TEST(RowStreamIterator, MovedFromValueOk) {
 
   EXPECT_NE(it, end);
   auto row = std::move(*it);
-  EXPECT_STATUS_OK(row);
+  ASSERT_STATUS_OK(row);
   auto val = row->get("num");
-  EXPECT_STATUS_OK(val);
+  ASSERT_STATUS_OK(val);
   EXPECT_EQ(Value(1), *val);
 
   ++it;
   EXPECT_NE(it, end);
   row = std::move(*it);
-  EXPECT_STATUS_OK(row);
+  ASSERT_STATUS_OK(row);
   val = row->get("num");
-  EXPECT_STATUS_OK(val);
+  ASSERT_STATUS_OK(val);
   EXPECT_EQ(Value(2), *val);
 
   ++it;
@@ -363,27 +363,27 @@ TEST(TupleStreamIterator, Basics) {
                           RowStreamIterator());
 
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_NE(it, end);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(1, "foo", true), **it);
 
   ++it;
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_NE(it, end);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(2, "bar", true), **it);
 
   ++it;
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_NE(it, end);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(3, "baz", true), **it);
 
   // Tests op*() const and op->() const
   auto const copy = it;
   EXPECT_EQ(copy, it);
-  EXPECT_NE(copy, end);
-  EXPECT_STATUS_OK(*copy);
+  ASSERT_NE(copy, end);
+  ASSERT_STATUS_OK(*copy);
   EXPECT_STATUS_OK(copy->status());
 
   ++it;
@@ -419,14 +419,14 @@ TEST(TupleStreamIterator, Error) {
                           RowStreamIterator());
 
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_NE(it, end);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(1, "foo", true), **it);
 
   ++it;
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
-  EXPECT_FALSE(it->ok());  // Error parsing the 2nd element
+  ASSERT_NE(it, end);
+  EXPECT_THAT(*it, Not(IsOk()));  // Error parsing the 2nd element
 
   ++it;  // Due to the previous error, jumps straight to "end"
   EXPECT_EQ(it, it);
@@ -446,13 +446,13 @@ TEST(TupleStreamIterator, MovedFromValueOk) {
 
   EXPECT_NE(it, end);
   auto tup = std::move(*it);
-  EXPECT_STATUS_OK(tup);
+  ASSERT_STATUS_OK(tup);
   EXPECT_EQ(1, std::get<0>(*tup));
 
   ++it;
-  EXPECT_NE(it, end);
+  ASSERT_NE(it, end);
   tup = std::move(*it);
-  EXPECT_STATUS_OK(tup);
+  ASSERT_STATUS_OK(tup);
   EXPECT_EQ(2, std::get<0>(*tup));
 
   ++it;
@@ -473,20 +473,20 @@ TEST(TupleStream, Basics) {
   EXPECT_EQ(end, end);
 
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_NE(it, end);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(1, "foo", true), **it);
 
   ++it;
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_NE(it, end);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(2, "bar", true), **it);
 
   ++it;
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_NE(it, end);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(3, "baz", true), **it);
 
   ++it;
@@ -504,7 +504,7 @@ TEST(TupleStream, RangeForLoop) {
   RowRange range(MakeRowStreamIteratorSource(rows));
   std::int64_t product = 1;
   for (auto const& row : StreamOf<RowType>(range)) {
-    EXPECT_STATUS_OK(row);
+    ASSERT_STATUS_OK(row);
     product *= std::get<0>(*row);
   }
   EXPECT_EQ(product, 30);
@@ -523,13 +523,13 @@ TEST(TupleStream, IterationError) {
 
   auto end = stream.end();
   auto it = stream.begin();
-  EXPECT_NE(it, end);
-  EXPECT_STATUS_OK(*it);
+  ASSERT_NE(it, end);
+  ASSERT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(1, "foo", true), **it);
 
   ++it;
   EXPECT_EQ(it, it);
-  EXPECT_NE(it, end);
+  ASSERT_NE(it, end);
   EXPECT_FALSE(*it);
   EXPECT_THAT(*it, StatusIs(StatusCode::kUnknown, "some error"));
 
@@ -560,7 +560,7 @@ TEST(GetSingularRow, BasicSingleRow) {
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(range);
-  EXPECT_STATUS_OK(row);
+  ASSERT_STATUS_OK(row);
   EXPECT_EQ(1, *row->get<std::int64_t>(0));
 }
 
@@ -572,7 +572,7 @@ TEST(GetSingularRow, TupleStreamSingleRow) {
   auto tup_range = StreamOf<std::tuple<std::int64_t>>(row_range);
 
   auto row = GetSingularRow(tup_range);
-  EXPECT_STATUS_OK(row);
+  ASSERT_STATUS_OK(row);
   EXPECT_EQ(1, std::get<0>(*row));
 }
 

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -34,6 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::IsOkAndHolds;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
@@ -71,7 +72,7 @@ void TestBasicSemantics(T init) {
 
   Value const v{init};
 
-  EXPECT_STATUS_OK(v.get<T>());
+  ASSERT_STATUS_OK(v.get<T>());
   EXPECT_EQ(init, *v.get<T>());
 
   Value copy = v;
@@ -83,7 +84,7 @@ void TestBasicSemantics(T init) {
   Value const null = MakeNullValue<T>();
 
   EXPECT_THAT(null.get<T>(), Not(IsOk()));
-  EXPECT_STATUS_OK(null.get<absl::optional<T>>());
+  ASSERT_STATUS_OK(null.get<absl::optional<T>>());
   EXPECT_EQ(absl::optional<T>{}, *null.get<absl::optional<T>>());
 
   Value copy_null = null;
@@ -102,9 +103,9 @@ void TestBasicSemantics(T init) {
             google::protobuf::NullValue::NULL_VALUE);
 
   Value const not_null{absl::optional<T>(init)};
-  EXPECT_STATUS_OK(not_null.get<T>());
+  ASSERT_STATUS_OK(not_null.get<T>());
   EXPECT_EQ(init, *not_null.get<T>());
-  EXPECT_STATUS_OK(not_null.get<absl::optional<T>>());
+  ASSERT_STATUS_OK(not_null.get<absl::optional<T>>());
   EXPECT_EQ(init, **not_null.get<absl::optional<T>>());
 }
 
@@ -277,16 +278,16 @@ TEST(Value, RvalueGetString) {
   Value v(data);
 
   auto s = v.get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(data, *s);
 
   s = std::move(v).get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(data, *s);
 
   // NOLINTNEXTLINE(bugprone-use-after-move)
   s = v.get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ("", *s);
 }
 
@@ -302,16 +303,16 @@ TEST(Value, RvalueGetOptionalString) {
   Value v(data);
 
   auto s = v.get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(*data, **s);
 
   s = std::move(v).get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(*data, **s);
 
   // NOLINTNEXTLINE(bugprone-use-after-move)
   s = v.get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ("", **s);
 }
 
@@ -327,16 +328,16 @@ TEST(Value, RvalueGetVectorString) {
   Value v(data);
 
   auto s = v.get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(data, *s);
 
   s = std::move(v).get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(data, *s);
 
   // NOLINTNEXTLINE(bugprone-use-after-move)
   s = v.get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(Type(data.size(), ""), *s);
 }
 
@@ -353,16 +354,16 @@ TEST(Value, RvalueGetStructString) {
   Value v(data);
 
   auto s = v.get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(data, *s);
 
   s = std::move(v).get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(data, *s);
 
   // NOLINTNEXTLINE(bugprone-use-after-move)
   s = v.get<Type>();
-  EXPECT_STATUS_OK(s);
+  ASSERT_STATUS_OK(s);
   EXPECT_EQ(Type({"name", ""}, ""), *s);
 }
 
@@ -448,7 +449,6 @@ TEST(Value, MixingTypes) {
   Value a(A{});
   EXPECT_STATUS_OK(a.get<A>());
   EXPECT_THAT(a.get<B>(), Not(IsOk()));
-  EXPECT_THAT(a.get<B>(), Not(IsOk()));
 
   Value null_a = MakeNullValue<A>();
   EXPECT_THAT(null_a.get<A>(), Not(IsOk()));
@@ -458,7 +458,6 @@ TEST(Value, MixingTypes) {
 
   Value b(B{});
   EXPECT_STATUS_OK(b.get<B>());
-  EXPECT_THAT(b.get<A>(), Not(IsOk()));
   EXPECT_THAT(b.get<A>(), Not(IsOk()));
 
   EXPECT_NE(b, a);
@@ -480,14 +479,14 @@ TEST(Value, SpannerArray) {
   ArrayInt64 const empty = {};
   Value const ve(empty);
   EXPECT_EQ(ve, ve);
-  EXPECT_STATUS_OK(ve.get<ArrayInt64>());
+  ASSERT_STATUS_OK(ve.get<ArrayInt64>());
   EXPECT_THAT(ve.get<ArrayDouble>(), Not(IsOk()));
   EXPECT_EQ(empty, *ve.get<ArrayInt64>());
 
   ArrayInt64 const ai = {1, 2, 3};
   Value const vi(ai);
   EXPECT_EQ(vi, vi);
-  EXPECT_STATUS_OK(vi.get<ArrayInt64>());
+  ASSERT_STATUS_OK(vi.get<ArrayInt64>());
   EXPECT_THAT(vi.get<ArrayDouble>(), Not(IsOk()));
   EXPECT_EQ(ai, *vi.get<ArrayInt64>());
 
@@ -496,7 +495,7 @@ TEST(Value, SpannerArray) {
   EXPECT_EQ(vd, vd);
   EXPECT_NE(vi, vd);
   EXPECT_THAT(vd.get<ArrayInt64>(), Not(IsOk()));
-  EXPECT_STATUS_OK(vd.get<ArrayDouble>());
+  ASSERT_STATUS_OK(vd.get<ArrayDouble>());
   EXPECT_EQ(ad, *vd.get<ArrayDouble>());
 
   Value const null_vi = MakeNullValue<ArrayInt64>();
@@ -527,30 +526,29 @@ TEST(Value, SpannerStruct) {
   auto tup1 = make_tuple(false, int64_t{123});
   using T1 = decltype(tup1);
   Value v1(tup1);
-  EXPECT_STATUS_OK(v1.get<T1>());
+  ASSERT_STATUS_OK(v1.get<T1>());
   EXPECT_EQ(tup1, *v1.get<T1>());
   EXPECT_EQ(v1, v1);
 
   // Verify we can extract tuple elements even if they're wrapped in a pair.
   auto const pair0 = v1.get<tuple<pair<string, bool>, int64_t>>();
-  EXPECT_STATUS_OK(pair0);
+  ASSERT_STATUS_OK(pair0);
   EXPECT_EQ(std::get<0>(tup1), std::get<0>(*pair0).second);
   EXPECT_EQ(std::get<1>(tup1), std::get<1>(*pair0));
   auto const pair1 = v1.get<tuple<bool, pair<string, int64_t>>>();
-  EXPECT_STATUS_OK(pair1);
+  ASSERT_STATUS_OK(pair1);
   EXPECT_EQ(std::get<0>(tup1), std::get<0>(*pair1));
   EXPECT_EQ(std::get<1>(tup1), std::get<1>(*pair1).second);
   auto const pair01 =
       v1.get<tuple<pair<string, bool>, pair<string, int64_t>>>();
-  EXPECT_STATUS_OK(pair01);
+  ASSERT_STATUS_OK(pair01);
   EXPECT_EQ(std::get<0>(tup1), std::get<0>(*pair01).second);
   EXPECT_EQ(std::get<1>(tup1), std::get<1>(*pair01).second);
 
   auto tup2 = make_tuple(false, make_pair(string("f2"), int64_t{123}));
   using T2 = decltype(tup2);
   Value v2(tup2);
-  EXPECT_STATUS_OK(v2.get<T2>());
-  EXPECT_EQ(tup2, *v2.get<T2>());
+  EXPECT_THAT(v2.get<T2>(), IsOkAndHolds(tup2));
   EXPECT_EQ(v2, v2);
   EXPECT_NE(v2, v1);
 
@@ -561,8 +559,7 @@ TEST(Value, SpannerStruct) {
   auto tup3 = make_tuple(false, make_pair(string("Other"), int64_t{123}));
   using T3 = decltype(tup3);
   Value v3(tup3);
-  EXPECT_STATUS_OK(v3.get<T3>());
-  EXPECT_EQ(tup3, *v3.get<T3>());
+  EXPECT_THAT(v3.get<T3>(), IsOkAndHolds(tup3));
   EXPECT_EQ(v3, v3);
   EXPECT_NE(v3, v2);
   EXPECT_NE(v3, v1);
@@ -593,8 +590,7 @@ TEST(Value, SpannerStruct) {
   EXPECT_THAT(v4.get<T2>(), Not(IsOk()));
   EXPECT_THAT(v4.get<T1>(), Not(IsOk()));
 
-  EXPECT_STATUS_OK(v4.get<T4>());
-  EXPECT_EQ(array_struct, *v4.get<T4>());
+  EXPECT_THAT(v4.get<T4>(), IsOkAndHolds(array_struct));
 
   auto empty = tuple<>{};
   using T5 = decltype(empty);
@@ -604,8 +600,7 @@ TEST(Value, SpannerStruct) {
   EXPECT_EQ(v5, v5);
   EXPECT_NE(v5, v4);
 
-  EXPECT_STATUS_OK(v5.get<T5>());
-  EXPECT_EQ(empty, *v5.get<T5>());
+  EXPECT_THAT(v5.get<T5>(), IsOkAndHolds(empty));
 
   auto deeply_nested = tuple<tuple<std::vector<absl::optional<bool>>>>{};
   using T6 = decltype(deeply_nested);
@@ -615,8 +610,7 @@ TEST(Value, SpannerStruct) {
   EXPECT_EQ(v6, v6);
   EXPECT_NE(v6, v5);
 
-  EXPECT_STATUS_OK(v6.get<T6>());
-  EXPECT_EQ(deeply_nested, *v6.get<T6>());
+  EXPECT_THAT(v6.get<T6>(), IsOkAndHolds(deeply_nested));
 }
 
 TEST(Value, SpannerStructWithNull) {
@@ -1120,8 +1114,7 @@ TEST(Value, CommitTimestamp) {
   EXPECT_THAT(tv.second, IsProtoEqual(pv));
 
   auto good = v.get<CommitTimestamp>();
-  EXPECT_STATUS_OK(good);
-  EXPECT_EQ(CommitTimestamp{}, *good);
+  EXPECT_THAT(good, IsOkAndHolds(CommitTimestamp{}));
 
   auto bad = v.get<Timestamp>();
   EXPECT_THAT(bad, Not(IsOk()));


### PR DESCRIPTION
This started out as an exercise to use IsOkAndHolds(m) within the Spanner tests, just to make sure it was working as intended, but soon turned into a cleanup for other assert/expect mismatches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11262)
<!-- Reviewable:end -->
