### PR TITLE
fix(storage): cache legacy credentials

### DIFF
--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/make_jwt_assertion.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/internal/oauth2_cached_credentials.h"
 #include "google/cloud/internal/oauth2_service_account_credentials.h"
 #include <nlohmann/json.hpp>
 #include <openssl/err.h>
@@ -122,12 +123,13 @@ ServiceAccountCredentials<storage::internal::CurlRequestBuilder,
                           std::chrono::system_clock>::
     ServiceAccountCredentials(ServiceAccountCredentialsInfo info,
                               ChannelOptions const& options)
-    : impl_(std::make_unique<oauth2_internal::ServiceAccountCredentials>(
-          internal::MapServiceAccountCredentialsInfo(std::move(info)),
-          Options{}.set<CARootsFilePathOption>(options.ssl_root_path()),
-          [](Options const& o) {
-            return rest_internal::MakeDefaultRestClient(std::string{}, o);
-          })) {}
+    : impl_(std::make_unique<oauth2_internal::CachedCredentials>(
+          std::make_unique<oauth2_internal::ServiceAccountCredentials>(
+              internal::MapServiceAccountCredentialsInfo(std::move(info)),
+              Options{}.set<CARootsFilePathOption>(options.ssl_root_path()),
+              [](Options const& o) {
+                return rest_internal::MakeDefaultRestClient(std::string{}, o);
+              }))) {}
 
 }  // namespace oauth2
 

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -243,7 +243,12 @@ class ServiceAccountCredentials<storage::internal::CurlRequestBuilder,
   std::string KeyId() const override { return impl_->KeyId(); }
 
  private:
-  std::unique_ptr<oauth2_internal::ServiceAccountCredentials> impl_;
+  friend struct ServiceAccountCredentialsTester;
+  StatusOr<std::string> AuthorizationHeaderForTesting(
+      std::chrono::system_clock::time_point tp) {
+    return oauth2_internal::AuthorizationHeaderJoined(*impl_, tp);
+  }
+  std::unique_ptr<oauth2_internal::Credentials> impl_;
 };
 
 /// @copydoc ServiceAccountCredentials


### PR DESCRIPTION
I think we missed the caching feature during the multiple refactorings. The test is (maybe) not ideal, but the API is not easy to test, and we do not want to change it.

Fixes #11194

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11271)
<!-- Reviewable:end -->
