### PR TITLE
impl(GCS+gRPC): alternative routing format for upload id

### DIFF
--- a/google/cloud/storage/internal/grpc_configure_client_context.cc
+++ b/google/cloud/storage/internal/grpc_configure_client_context.cc
@@ -29,10 +29,13 @@ void ApplyRoutingHeaders(
 
 void ApplyRoutingHeaders(grpc::ClientContext& context,
                          storage::internal::UploadChunkRequest const& request) {
-  static auto* bucket_regex =
+  static auto* slash_format =
       new std::regex{"(projects/[^/]+/buckets/[^/]+)/.*", std::regex::optimize};
-  std::smatch match;
-  if (std::regex_match(request.upload_session_url(), match, *bucket_regex)) {
+  static auto* colon_format =
+      new std::regex{"(projects/[^/]+/buckets/[^:]+):.*", std::regex::optimize};
+  for (auto const* re : {slash_format, colon_format}) {
+    std::smatch match;
+    if (!std::regex_match(request.upload_session_url(), match, *re)) continue;
     context.AddMetadata("x-goog-request-params", "bucket=" + match[1].str());
   }
 }

--- a/google/cloud/storage/internal/grpc_configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc_configure_client_context_test.cc
@@ -133,9 +133,22 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersInsertObjectMedia) {
                             "bucket=projects/_/buckets/test-bucket")));
 }
 
-TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatch) {
+TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchSlash) {
   storage::internal::UploadChunkRequest req(
       "projects/_/buckets/test-bucket/blah/blah", 0, {},
+      CreateNullHashFunction());
+
+  grpc::ClientContext context;
+  ApplyRoutingHeaders(context, req);
+  auto metadata = GetMetadata(context);
+  EXPECT_THAT(metadata,
+              Contains(Pair("x-goog-request-params",
+                            "bucket=projects/_/buckets/test-bucket")));
+}
+
+TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchColon) {
+  storage::internal::UploadChunkRequest req(
+      "projects/_/buckets/test-bucket:blah/blah", 0, {},
       CreateNullHashFunction());
 
   grpc::ClientContext context;


### PR DESCRIPTION
This is the analog of #11253 for one RPC that needs hand-crafted metadata decoration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11272)
<!-- Reviewable:end -->
