### PR TITLE
fix(generator): routing headers handle colon

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -801,10 +801,10 @@ ExplicitRoutingInfo ParseExplicitRoutingHeader(
     // single capture group. For example:
     //
     // Input :
-    //   - path_template = "projects/*/{foo=instances/*/}/**"
+    //   - path_template = "projects/*/{foo=instances/*}:**"
     // Output:
     //   - param         = "foo"
-    //   - pattern       = "projects/[^/]+/(instances/[^/]+)/.*"
+    //   - pattern       = "projects/[^/]+/(instances/[^:]+):.*"
     static std::regex const kPatternRegex(R"((.*)\{(.*)=(.*)\}(.*))");
     std::smatch match;
     if (!std::regex_match(path_template, match, kPatternRegex)) {
@@ -814,7 +814,9 @@ ExplicitRoutingInfo ParseExplicitRoutingHeader(
     }
     auto pattern =
         absl::StrCat(match[1].str(), "(", match[3].str(), ")", match[4].str());
-    pattern = absl::StrReplaceAll(pattern, {{"**", ".*"}, {"*", "[^/]+"}});
+    pattern = absl::StrReplaceAll(
+        pattern,
+        {{"**", ".*"}, {"*):", "[^:]+):"}, {"*:", "[^:]+:"}, {"*", "[^/]+"}});
     info[match[2].str()].push_back({std::move(field_name), std::move(pattern)});
   }
   return info;

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -1185,6 +1185,10 @@ service Service0 {
         field: "foo"
         path_template: "projects/*/{routing_key=instances/*}/**"
       }
+      routing_parameters {
+        field: "foo"
+        path_template: "projects/*:{handles_colon=instances/*}:**"
+      }
     };
   }
 }
@@ -1195,9 +1199,12 @@ service Service0 {
     auto info = ParseExplicitRoutingHeader(method);
     EXPECT_THAT(
         info,
-        UnorderedElementsAre(Pair(
-            "routing_key",
-            ElementsAre(RP("foo", "projects/[^/]+/(instances/[^/]+)/.*")))));
+        UnorderedElementsAre(
+            Pair("routing_key",
+                 ElementsAre(RP("foo", "projects/[^/]+/(instances/[^/]+)/.*"))),
+            Pair("handles_colon",
+                 ElementsAre(
+                     RP("foo", "projects/[^:]+:(instances/[^:]+):.*")))));
   });
 }
 

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -380,7 +380,7 @@ StorageMetadata::CancelResumableWrite(
         {
             {[](google::storage::v2::CancelResumableWriteRequest const& request)
                  -> std::string const& { return request.upload_id(); },
-             std::regex{"(projects/[^/]+/buckets/[^/]+):.*",
+             std::regex{"(projects/[^/]+/buckets/[^:]+):.*",
                         std::regex::optimize}},
         }};
   }();
@@ -532,7 +532,7 @@ StorageMetadata::QueryWriteStatus(
         {
             {[](google::storage::v2::QueryWriteStatusRequest const& request)
                  -> std::string const& { return request.upload_id(); },
-             std::regex{"(projects/[^/]+/buckets/[^/]+):.*",
+             std::regex{"(projects/[^/]+/buckets/[^:]+):.*",
                         std::regex::optimize}},
         }};
   }();
@@ -743,7 +743,7 @@ StorageMetadata::AsyncQueryWriteStatus(
         {
             {[](google::storage::v2::QueryWriteStatusRequest const& request)
                  -> std::string const& { return request.upload_id(); },
-             std::regex{"(projects/[^/]+/buckets/[^/]+):.*",
+             std::regex{"(projects/[^/]+/buckets/[^:]+):.*",
                         std::regex::optimize}},
         }};
   }();


### PR DESCRIPTION
Bandaid for #11253 Or maybe "fixes". It buys us some time, at least.

Check to see if a `*` is followed by a `:` when turning a routing pattern into a regular expression. There is a slight complication in that we might interject a `)` to signify the capture group.

We still default to map `*` -> `[^/]+`. Several routing patterns end on a single asterisk, and that seems to be the right default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11273)
<!-- Reviewable:end -->
