### PR TITLE
impl(otel): single span for each HTTP request

### DIFF
--- a/google/cloud/internal/rest_opentelemetry.cc
+++ b/google/cloud/internal/rest_opentelemetry.cc
@@ -59,17 +59,6 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanHttp(
   return span;
 }
 
-opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>
-MakeSpanHttpPayload(opentelemetry::trace::Span const& request_span) {
-  namespace sc = opentelemetry::trace::SemanticConventions;
-  opentelemetry::trace::StartSpanOptions options;
-  options.kind = opentelemetry::trace::SpanKind::kClient;
-  return internal::GetTracer(internal::CurrentOptions())
-      ->StartSpan(absl::StrCat("HTTP/Response"),
-                  {{sc::kNetTransport, sc::NetTransportValues::kIpTcp}},
-                  {{request_span.GetContext(), {/*no attributes*/}}}, options);
-}
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal
 }  // namespace cloud

--- a/google/cloud/internal/rest_opentelemetry.h
+++ b/google/cloud/internal/rest_opentelemetry.h
@@ -35,9 +35,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanHttp(
     RestRequest const& request, opentelemetry::nostd::string_view method);
 
-opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>
-MakeSpanHttpPayload(opentelemetry::trace::Span const& request_span);
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal
 }  // namespace cloud

--- a/google/cloud/internal/rest_opentelemetry_test.cc
+++ b/google/cloud/internal/rest_opentelemetry_test.cc
@@ -76,26 +76,6 @@ TEST(RestOpentelemetry, MakeSpanHttp) {
                                          secret.substr(0, 32))))));
 }
 
-TEST(RestOpentelemetry, MakeSpanHttpPayload) {
-  namespace sc = ::opentelemetry::trace::SemanticConventions;
-  auto span_catcher = InstallSpanCatcher();
-
-  RestRequest request("https://example.com/ignored");
-  auto request_span = MakeSpanHttp(request, "GET");
-
-  auto span = MakeSpanHttpPayload(*request_span);
-  request_span->End();
-  span->End();
-
-  auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(
-      spans,
-      Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
-                     SpanNamed("HTTP/Response"),
-                     SpanHasAttributes(SpanAttribute<std::string>(
-                         sc::kNetTransport, sc::NetTransportValues::kIpTcp)))));
-}
-
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/internal/tracing_http_payload.cc
+++ b/google/cloud/internal/tracing_http_payload.cc
@@ -42,7 +42,7 @@ StatusOr<std::size_t> TracingHttpPayload::Read(absl::Span<char> buffer) {
     return internal::EndSpan(*span_, std::move(status));
   }
   span->SetAttribute("read.returned.size", static_cast<std::int64_t>(*status));
-  internal::EndSpan(*span, Status{});
+  internal::EndSpan(*span, status.status());
   if (*status != 0) return status;
   return internal::EndSpan(*span_, std::move(status));
 }

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -102,11 +102,6 @@ TEST(TracingRestClient, Delete) {
                         "http.response.header.x-test-header-1", "value1"),
                     SpanAttribute<std::string>(
                         "http.response.header.x-test-header-2", "value2"))),
-          // Response span
-          AllOf(SpanNamed("HTTP/Response"), SpanHasInstrumentationScope(),
-                SpanKindIsClient(),
-                SpanHasAttributes(SpanAttribute<std::string>(
-                    sc::kNetTransport, sc::NetTransportValues::kIpTcp))),
           // Read span on the HttpPayload
           SpanNamed("Read"), SpanNamed("Read")));
 }


### PR DESCRIPTION
Using a separate span to handle the HTTP response / payload is not a good representation of the flow. A single span that lasts (but it is not necessarily active) until the full payload is received seems like a better model of the actual code flow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11274)
<!-- Reviewable:end -->
