### PR TITLE
impl(otel): create wrapped `RestClient`

### DIFF
--- a/google/cloud/internal/curl_http_payload.cc
+++ b/google/cloud/internal/curl_http_payload.cc
@@ -31,7 +31,7 @@ StatusOr<std::size_t> CurlHttpPayload::Read(absl::Span<char> buffer) {
   return impl_->Read(buffer);
 }
 
-std::multimap<std::string, std::string> CurlHttpPayload::headers() const {
+std::multimap<std::string, std::string> CurlHttpPayload::DebugHeaders() const {
   return impl_->headers();
 }
 

--- a/google/cloud/internal/curl_http_payload.h
+++ b/google/cloud/internal/curl_http_payload.h
@@ -43,7 +43,7 @@ class CurlHttpPayload : public HttpPayload {
 
   StatusOr<std::size_t> Read(absl::Span<char> buffer) override;
 
-  std::multimap<std::string, std::string> headers() const;
+  std::multimap<std::string, std::string> DebugHeaders() const override;
 
  private:
   friend class CurlRestResponse;

--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/curl_rest_response.h"
 #include "google/cloud/internal/oauth2_google_credentials.h"
+#include "google/cloud/internal/tracing_rest_client.h"
 #include "google/cloud/internal/unified_rest_credentials.h"
 #include "absl/strings/match.h"
 #include "absl/strings/strip.h"
@@ -213,7 +214,7 @@ StatusOr<std::unique_ptr<RestResponse>> CurlRestClient::Put(
 std::unique_ptr<RestClient> MakeDefaultRestClient(std::string endpoint_address,
                                                   Options options) {
   auto factory = GetDefaultCurlHandleFactory(options);
-  return std::unique_ptr<RestClient>(new CurlRestClient(
+  return MakeTracingRestClient(std::make_unique<CurlRestClient>(
       std::move(endpoint_address), std::move(factory), std::move(options)));
 }
 
@@ -226,12 +227,12 @@ std::unique_ptr<RestClient> MakePooledRestClient(std::string endpoint_address,
 
   if (pool_size > 0) {
     auto pool = std::make_shared<PooledCurlHandleFactory>(pool_size, options);
-    return std::unique_ptr<RestClient>(new CurlRestClient(
+    return MakeTracingRestClient(std::make_unique<CurlRestClient>(
         std::move(endpoint_address), std::move(pool), std::move(options)));
   }
 
   auto pool = std::make_shared<DefaultCurlHandleFactory>(options);
-  return std::unique_ptr<RestClient>(new CurlRestClient(
+  return MakeTracingRestClient(std::make_unique<CurlRestClient>(
       std::move(endpoint_address), std::move(pool), std::move(options)));
 }
 

--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -42,6 +42,8 @@ class CurlRestClient : public RestClient {
  public:
   static std::string HostHeader(Options const& options,
                                 std::string const& endpoint);
+  CurlRestClient(std::string endpoint_address,
+                 std::shared_ptr<CurlHandleFactory> factory, Options options);
   ~CurlRestClient() override = default;
 
   CurlRestClient(CurlRestClient const&) = delete;
@@ -68,14 +70,6 @@ class CurlRestClient : public RestClient {
       std::vector<absl::Span<char const>> const& payload) override;
 
  private:
-  friend std::unique_ptr<RestClient> MakeDefaultRestClient(
-      std::string endpoint_address, Options options);
-
-  friend std::unique_ptr<RestClient> MakePooledRestClient(
-      std::string endpoint_address, Options options);
-
-  CurlRestClient(std::string endpoint_address,
-                 std::shared_ptr<CurlHandleFactory> factory, Options options);
   StatusOr<std::unique_ptr<CurlImpl>> CreateCurlImpl(
       RestRequest const& request);
 

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/common_options.h"
 #include "google/cloud/credentials.h"
-#include "google/cloud/internal/curl_http_payload.h"
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/rest_client.h"
@@ -36,7 +35,6 @@ using ::testing::Contains;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Not;
-using ::testing::NotNull;
 using ::testing::Pair;
 
 class RestClientIntegrationTest : public ::testing::Test {
@@ -442,10 +440,7 @@ TEST_F(RestClientIntegrationTest, PeerPseudoHeader) {
     ASSERT_STATUS_OK(bytes);
     if (*bytes == 0) break;
   }
-  auto* payload_impl =
-      dynamic_cast<rest_internal::CurlHttpPayload*>(payload.get());
-  ASSERT_THAT(payload_impl, NotNull());
-  EXPECT_THAT(payload_impl->headers(), ContainsOnce(Pair(":curl-peer", _)));
+  EXPECT_THAT(payload->DebugHeaders(), ContainsOnce(Pair(":curl-peer", _)));
 }
 
 }  // namespace

--- a/google/cloud/internal/http_payload.h
+++ b/google/cloud/internal/http_payload.h
@@ -20,6 +20,7 @@
 #include "google/cloud/version.h"
 #include "absl/types/span.h"
 #include <map>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -40,6 +41,11 @@ class HttpPayload {
   // read the entire payload.
   // Returns number of bytes actually read into buffer from the payload.
   virtual StatusOr<std::size_t> Read(absl::Span<char> buffer) = 0;
+
+  /// Return any debug headers captured while reading.
+  virtual std::multimap<std::string, std::string> DebugHeaders() const {
+    return {};
+  }
 };
 
 // This function makes one or more HttpPayload::Read calls and writes all the

--- a/google/cloud/internal/tracing_http_payload.cc
+++ b/google/cloud/internal/tracing_http_payload.cc
@@ -47,6 +47,11 @@ StatusOr<std::size_t> TracingHttpPayload::Read(absl::Span<char> buffer) {
   return internal::EndSpan(*span_, std::move(status));
 }
 
+std::multimap<std::string, std::string> TracingHttpPayload::DebugHeaders()
+    const {
+  return impl_->DebugHeaders();
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal
 }  // namespace cloud

--- a/google/cloud/internal/tracing_http_payload.h
+++ b/google/cloud/internal/tracing_http_payload.h
@@ -36,6 +36,7 @@ class TracingHttpPayload : public HttpPayload {
 
   bool HasUnreadData() const override;
   StatusOr<std::size_t> Read(absl::Span<char> buffer) override;
+  std::multimap<std::string, std::string> DebugHeaders() const override;
 
  private:
   std::unique_ptr<HttpPayload> impl_;

--- a/google/cloud/testing_util/mock_http_payload.h
+++ b/google/cloud/testing_util/mock_http_payload.h
@@ -32,6 +32,8 @@ class MockHttpPayload : public rest_internal::HttpPayload {
   MOCK_METHOD(bool, HasUnreadData, (), (const, override));
   MOCK_METHOD(StatusOr<std::size_t>, Read, (absl::Span<char> buffer),
               (override));
+  MOCK_METHOD((std::multimap<std::string, std::string>), DebugHeaders, (),
+              (const override));
 };
 
 template <typename Collection>


### PR DESCRIPTION
I had to add a new member function to `HttpPayload` to implement tests without a `dynamic_cast<>`.  Probably a "Good Thing"[tm].

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11280)
<!-- Reviewable:end -->
