### PR TITLE
impl(otel): add the Trace Exporter

### DIFF
--- a/google/cloud/opentelemetry/BUILD.bazel
+++ b/google/cloud/opentelemetry/BUILD.bazel
@@ -36,8 +36,8 @@ load(":opentelemetry_sdk_unit_tests.bzl", "opentelemetry_sdk_unit_tests")
     srcs = [test],
     deps = [
         ":google_cloud_cpp_opentelemetry_sdk",
+        "//:trace_mocks",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-        "//:trace_mocks",
     ],
 ) for test in opentelemetry_sdk_unit_tests]

--- a/google/cloud/opentelemetry/BUILD.bazel
+++ b/google/cloud/opentelemetry/BUILD.bazel
@@ -38,5 +38,6 @@ load(":opentelemetry_sdk_unit_tests.bzl", "opentelemetry_sdk_unit_tests")
         ":google_cloud_cpp_opentelemetry_sdk",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
+        "//:trace_mocks",
     ],
 ) for test in opentelemetry_sdk_unit_tests]

--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -119,7 +119,8 @@ foreach (fname ${opentelemetry_sdk_unit_tests})
     google_cloud_cpp_add_executable(target "opentelemetry" "${fname}")
     target_link_libraries(
         ${target}
-        PRIVATE google_cloud_cpp_testing google_cloud_cpp_testing_grpc
+        PRIVATE google_cloud_cpp_testing
+                google_cloud_cpp_testing_grpc
                 google-cloud-cpp::experimental-opentelemetry_sdk
                 google_cloud_cpp_trace_mocks
                 GTest::gmock_main

--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -27,8 +27,10 @@ include(GoogleCloudCppDoxygen)
 google_cloud_cpp_doxygen_targets("opentelemetry_sdk" DEPENDS cloud-docs
                                  google-cloud-cpp::trace)
 
-add_library(google_cloud_cpp_opentelemetry_sdk # cmake-format: sort
-            internal/recordable.cc internal/recordable.h trace_exporter.h)
+add_library(
+    google_cloud_cpp_opentelemetry_sdk # cmake-format: sort
+    internal/recordable.cc internal/recordable.h trace_exporter.cc
+    trace_exporter.h)
 target_link_libraries(google_cloud_cpp_opentelemetry_sdk
                       PUBLIC google-cloud-cpp::trace opentelemetry-cpp::trace)
 google_cloud_cpp_add_common_options(google_cloud_cpp_opentelemetry_sdk)
@@ -102,8 +104,9 @@ if (NOT BUILD_TESTING)
     return()
 endif ()
 
-set(opentelemetry_sdk_unit_tests # cmake-format: sort
-                                 internal/recordable_test.cc)
+set(opentelemetry_sdk_unit_tests
+    # cmake-format: sort
+    internal/recordable_test.cc trace_exporter_test.cc)
 
 export_list_to_bazel("opentelemetry_sdk_unit_tests.bzl"
                      "opentelemetry_sdk_unit_tests" YEAR "2023")
@@ -118,7 +121,10 @@ foreach (fname ${opentelemetry_sdk_unit_tests})
         ${target}
         PRIVATE google_cloud_cpp_testing google_cloud_cpp_testing_grpc
                 google-cloud-cpp::experimental-opentelemetry_sdk
-                GTest::gmock_main GTest::gmock GTest::gtest)
+                google_cloud_cpp_trace_mocks
+                GTest::gmock_main
+                GTest::gmock
+                GTest::gtest)
     google_cloud_cpp_add_common_options(${target})
 
     # With googletest it is relatively easy to exceed the default number of

--- a/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry_sdk.bzl
+++ b/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry_sdk.bzl
@@ -23,4 +23,5 @@ google_cloud_cpp_opentelemetry_sdk_hdrs = [
 
 google_cloud_cpp_opentelemetry_sdk_srcs = [
     "internal/recordable.cc",
+    "trace_exporter.cc",
 ]

--- a/google/cloud/opentelemetry/opentelemetry_sdk_unit_tests.bzl
+++ b/google/cloud/opentelemetry/opentelemetry_sdk_unit_tests.bzl
@@ -18,4 +18,5 @@
 
 opentelemetry_sdk_unit_tests = [
     "internal/recordable_test.cc",
+    "trace_exporter_test.cc",
 ]

--- a/google/cloud/opentelemetry/trace_exporter.cc
+++ b/google/cloud/opentelemetry/trace_exporter.cc
@@ -1,0 +1,84 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/trace_exporter.h"
+#include "google/cloud/trace/v2/trace_client.h"
+
+namespace google {
+namespace cloud {
+namespace otel {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+class TraceExporter final : public opentelemetry::sdk::trace::SpanExporter {
+ public:
+  explicit TraceExporter(Project project,
+                         std::shared_ptr<trace_v2::TraceServiceConnection> conn)
+      : project_(std::move(project)), client_(std::move(conn)) {}
+
+  std::unique_ptr<opentelemetry::sdk::trace::Recordable>
+  MakeRecordable() noexcept override {
+    return std::make_unique<otel_internal::Recordable>(project_);
+  }
+
+  opentelemetry::sdk::common::ExportResult Export(
+      opentelemetry::nostd::span<
+          std::unique_ptr<opentelemetry::sdk::trace::Recordable>> const&
+          spans) noexcept override {
+    google::devtools::cloudtrace::v2::BatchWriteSpansRequest request;
+    request.set_name(project_.FullName());
+    for (auto& recordable : spans) {
+      auto span = std::unique_ptr<otel_internal::Recordable>(
+          static_cast<otel_internal::Recordable*>(recordable.release()));
+      *request.add_spans() = std::move(*span).as_proto();
+    }
+
+    auto status = client_.BatchWriteSpans(request);
+    return status.ok() ? opentelemetry::sdk::common::ExportResult::kSuccess
+                       : opentelemetry::sdk::common::ExportResult::kFailure;
+  }
+
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+
+ private:
+  Project project_;
+  trace_v2::TraceServiceClient client_;
+};
+
+}  // namespace
+
+std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> MakeTraceExporter(
+    Project project, Options options) {
+  // TODO(#11156) - We should filter out options that enable tracing. We should
+  // not trace requests initiated by the underlying trace_v2 client.
+  return std::make_unique<otel::TraceExporter>(
+      std::move(project),
+      trace_v2::MakeTraceServiceConnection(std::move(options)));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel
+namespace otel_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> MakeTraceExporter(
+    Project project, std::shared_ptr<trace_v2::TraceServiceConnection> conn) {
+  return std::make_unique<otel::TraceExporter>(std::move(project),
+                                               std::move(conn));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/opentelemetry/trace_exporter.cc
+++ b/google/cloud/opentelemetry/trace_exporter.cc
@@ -62,7 +62,7 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> MakeTraceExporter(
     Project project, Options options) {
   // TODO(#11156) - We should filter out options that enable tracing. We should
   // not trace requests initiated by the underlying trace_v2 client.
-  return std::make_unique<otel::TraceExporter>(
+  return std::make_unique<TraceExporter>(
       std::move(project),
       trace_v2::MakeTraceServiceConnection(std::move(options)));
 }

--- a/google/cloud/opentelemetry/trace_exporter.h
+++ b/google/cloud/opentelemetry/trace_exporter.h
@@ -18,6 +18,7 @@
 #include "google/cloud/opentelemetry/internal/recordable.h"
 #include "google/cloud/trace/v2/trace_connection.h"
 #include "google/cloud/project.h"
+#include "google/cloud/version.h"
 #include <opentelemetry/sdk/trace/exporter.h>
 #include <memory>
 

--- a/google/cloud/opentelemetry/trace_exporter.h
+++ b/google/cloud/opentelemetry/trace_exporter.h
@@ -15,17 +15,31 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_TRACE_EXPORTER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_TRACE_EXPORTER_H
 
-#include "google/cloud/version.h"
+#include "google/cloud/opentelemetry/internal/recordable.h"
+#include "google/cloud/trace/v2/trace_connection.h"
+#include "google/cloud/project.h"
+#include <opentelemetry/sdk/trace/exporter.h>
+#include <memory>
 
 namespace google {
 namespace cloud {
 namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-// TODO(#11156) - Implement this thing.
+// Make an OpenTelemetry Trace Exporter for Google Cloud Trace.
+std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> MakeTraceExporter(
+    Project project, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace otel
+namespace otel_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> MakeTraceExporter(
+    Project project, std::shared_ptr<trace_v2::TraceServiceConnection> conn);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/opentelemetry/trace_exporter_test.cc
+++ b/google/cloud/opentelemetry/trace_exporter_test.cc
@@ -1,0 +1,88 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/trace_exporter.h"
+#include "google/cloud/trace/v2/mocks/mock_trace_connection.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/version.h"
+#include <gmock/gmock.h>
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace otel {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::devtools::cloudtrace::v2::BatchWriteSpansRequest;
+using ::testing::ElementsAre;
+
+std::vector<std::string> SpanNames(BatchWriteSpansRequest const& request) {
+  auto const& spans = request.spans();
+  std::vector<std::string> names;
+  names.reserve(spans.size());
+  std::transform(spans.begin(), spans.end(), std::back_inserter(names),
+                 [](auto const& span) { return span.display_name().value(); });
+  return names;
+}
+
+TEST(TraceExporter, Success) {
+  auto mock = std::make_shared<trace_v2_mocks::MockTraceServiceConnection>();
+  EXPECT_CALL(*mock, BatchWriteSpans)
+      .WillOnce([](BatchWriteSpansRequest const& request) {
+        EXPECT_EQ(request.name(), "projects/test-project");
+        EXPECT_THAT(SpanNames(request), ElementsAre("span-1", "span-2"));
+        return Status();
+      });
+
+  auto exporter = otel_internal::MakeTraceExporter(Project("test-project"),
+                                                   std::move(mock));
+
+  std::vector<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> v;
+  v.emplace_back(exporter->MakeRecordable());
+  v.back()->SetName("span-1");
+  v.emplace_back(exporter->MakeRecordable());
+  v.back()->SetName("span-2");
+
+  auto result = exporter->Export({v.data(), v.size()});
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+TEST(TraceExporter, Failure) {
+  auto mock = std::make_shared<trace_v2_mocks::MockTraceServiceConnection>();
+  EXPECT_CALL(*mock, BatchWriteSpans)
+      .WillOnce([](BatchWriteSpansRequest const& request) {
+        EXPECT_EQ(request.name(), "projects/test-project");
+        EXPECT_THAT(SpanNames(request), ElementsAre("span"));
+        return internal::AbortedError("fail");
+      });
+
+  auto exporter = otel_internal::MakeTraceExporter(Project("test-project"),
+                                                   std::move(mock));
+
+  auto recordable = exporter->MakeRecordable();
+  recordable->SetName("span");
+
+  auto result = exporter->Export({&recordable, 1});
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Part of the work for #11156 

Implement the Trace Exporter. It is not useful until we write span IDs into the `Recordable` class though. The feature is marked as experimental, so I am ok with having a partial implementation.

The `static_cast` could use another set of eyes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11283)
<!-- Reviewable:end -->
