### PR TITLE
impl(otel): set Recordable identity and timestamps

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/opentelemetry/internal/recordable.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/time_utils.h"
 
 namespace google {
 namespace cloud {
@@ -148,8 +149,28 @@ google::devtools::cloudtrace::v2::Span&& Recordable::as_proto() && {
 }
 
 void Recordable::SetIdentity(
-    opentelemetry::trace::SpanContext const& /*span_context*/,
-    opentelemetry::trace::SpanId /*parent_span_id*/) noexcept {}
+    opentelemetry::trace::SpanContext const& span_context,
+    opentelemetry::trace::SpanId parent_span_id) noexcept {
+  std::array<char, 2 * opentelemetry::trace::TraceId::kSize> hex_trace_buf;
+  span_context.trace_id().ToLowerBase16(hex_trace_buf);
+  std::string const hex_trace(hex_trace_buf.data(),
+                              2 * opentelemetry::trace::TraceId::kSize);
+
+  std::array<char, 2 * opentelemetry::trace::SpanId::kSize> hex_span_buf;
+  span_context.span_id().ToLowerBase16(hex_span_buf);
+  std::string const hex_span(hex_span_buf.data(),
+                             2 * opentelemetry::trace::SpanId::kSize);
+
+  std::array<char, 2 * opentelemetry::trace::SpanId::kSize> hex_parent_span_buf;
+  parent_span_id.ToLowerBase16(hex_parent_span_buf);
+  std::string const hex_parent_span(hex_parent_span_buf.data(),
+                                    2 * opentelemetry::trace::SpanId::kSize);
+
+  span_.set_name(project_.FullName() + "/traces/" + hex_trace + "/spans/" +
+                 hex_span);
+  span_.set_span_id(hex_span);
+  span_.set_parent_span_id(hex_parent_span);
+}
 
 void Recordable::SetAttribute(
     opentelemetry::nostd::string_view key,
@@ -184,9 +205,15 @@ void Recordable::SetResource(
     opentelemetry::sdk::resource::Resource const& /*resource*/) noexcept {}
 
 void Recordable::SetStartTime(
-    opentelemetry::common::SystemTimestamp /*start_time*/) noexcept {}
+    opentelemetry::common::SystemTimestamp start_time) noexcept {
+  *span_.mutable_start_time() = internal::ToProtoTimestamp(start_time);
+}
 
-void Recordable::SetDuration(std::chrono::nanoseconds /*duration*/) noexcept {}
+void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept {
+  auto const end_time =
+      internal::ToChronoTimePoint(span_.start_time()) + duration;
+  *span_.mutable_end_time() = internal::ToProtoTimestamp(end_time);
+}
 
 void Recordable::SetInstrumentationScope(
     opentelemetry::sdk::instrumentationscope::InstrumentationScope const&

--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -74,7 +74,6 @@ void AddAttribute(
     opentelemetry::nostd::string_view key,
     opentelemetry::common::AttributeValue const& value, std::size_t limit);
 
-// TODO(#11156) - Implement this class.
 /**
  * Implements the OpenTelemetry Recordable specification.
  *


### PR DESCRIPTION
Part of the work for #11156 

Implement the identity and timestamp setters for a `Recordable`. This change should make the class usable with Cloud Trace.