### PR TITLE
cleanup(otel): comments from 11257

### DIFF
--- a/google/cloud/internal/tracing_http_payload.cc
+++ b/google/cloud/internal/tracing_http_payload.cc
@@ -32,7 +32,7 @@ bool TracingHttpPayload::HasUnreadData() const {
 }
 
 StatusOr<std::size_t> TracingHttpPayload::Read(absl::Span<char> buffer) {
-  auto scope = internal::GetTracer(Options{})->WithActiveSpan(span_);
+  auto scope = opentelemetry::trace::Scope(span_);
   auto span = internal::MakeSpan("Read");
   span->SetAttribute("read.buffer.size",
                      static_cast<std::int64_t>(buffer.size()));

--- a/google/cloud/internal/tracing_http_payload_test.cc
+++ b/google/cloud/internal/tracing_http_payload_test.cc
@@ -59,7 +59,7 @@ TEST(TracingHttpPayload, Success) {
   for (auto s = read(); s && s.value() != 0; s = read()) continue;
 
   auto spans = span_catcher->GetSpans();
-  auto make_read_event_matcher = [](auto bs, auto rs) {
+  auto make_read_matcher = [](auto bs, auto rs) {
     return AllOf(SpanNamed("Read"), SpanHasInstrumentationScope(),
                  SpanKindIsClient(),
                  SpanHasAttributes(
@@ -68,14 +68,13 @@ TEST(TracingHttpPayload, Success) {
                      SpanAttribute<std::int64_t>("read.returned.size", rs)));
   };
   EXPECT_THAT(
-      spans,
-      UnorderedElementsAre(
-          AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
-                SpanKindIsClient(),
-                SpanHasAttributes(SpanAttribute<std::string>(
-                    sc::kNetTransport, sc::NetTransportValues::kIpTcp))),
-          make_read_event_matcher(16, 16), make_read_event_matcher(16, 16),
-          make_read_event_matcher(16, 11), make_read_event_matcher(16, 0)));
+      spans, UnorderedElementsAre(
+                 AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
+                       SpanKindIsClient(),
+                       SpanHasAttributes(SpanAttribute<std::string>(
+                           sc::kNetTransport, sc::NetTransportValues::kIpTcp))),
+                 make_read_matcher(16, 16), make_read_matcher(16, 16),
+                 make_read_matcher(16, 11), make_read_matcher(16, 0)));
 }
 
 TEST(TracingHttpPayload, Failure) {


### PR DESCRIPTION
I was late to review #11257 so I will leave my comments in the form of a PR.

- `WithActiveSpan` is a static function that just returns a `Scope` anyway. There is no need to involve `Tracer`s. https://github.com/open-telemetry/opentelemetry-cpp/blob/7887d32da60f54984a597abccbb0c883f3a51649/api/include/opentelemetry/trace/tracer.h#L147
- Reads are no longer events, so the name `make_read_event_matcher` was obsolete.