### PR TITLE
impl(common): enhance DebugFormatter support

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -86,17 +86,13 @@ std::string GetJobRequest::DebugString(absl::string_view name,
 std::string ListJobsRequest::DebugString(absl::string_view name,
                                          TracingOptions const& options,
                                          int indent) const {
-  auto formatter = internal::DebugFormatter(name, options, indent)
-                       .StringField("project_id", project_id_)
-                       .Field("all_users", all_users_)
-                       .Field("max_results", max_results_);
-  if (min_creation_time_) {
-    formatter.Field("min_creation_time", *min_creation_time_);
-  }
-  if (max_creation_time_) {
-    formatter.Field("max_creation_time", *max_creation_time_);
-  }
-  return formatter.StringField("page_token", page_token_)
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("project_id", project_id_)
+      .Field("all_users", all_users_)
+      .Field("max_results", max_results_)
+      .Field("min_creation_time", min_creation_time_)
+      .Field("max_creation_time", max_creation_time_)
+      .StringField("page_token", page_token_)
       .SubMessage("projection", projection_)
       .SubMessage("state_filter", state_filter_)
       .StringField("parent_job_id", parent_job_id_)

--- a/google/cloud/internal/debug_string.cc
+++ b/google/cloud/internal/debug_string.cc
@@ -48,6 +48,12 @@ DebugFormatter& DebugFormatter::Field(
 
 DebugFormatter& DebugFormatter::Field(
     absl::string_view field_name,
+    absl::optional<std::chrono::system_clock::time_point> value) {
+  return value ? Field(field_name, *value) : *this;
+}
+
+DebugFormatter& DebugFormatter::Field(
+    absl::string_view field_name,
     std::multimap<std::string, std::string> const& value) {
   for (auto const& e : value) {
     absl::StrAppend(&str_, Sep(), field_name, " {");

--- a/google/cloud/internal/debug_string.h
+++ b/google/cloud/internal/debug_string.h
@@ -48,9 +48,13 @@ class DebugFormatter {
     return *this;
   }
 
+  // Specialized support for types without their own DebugString().
   DebugFormatter& Field(absl::string_view field_name, bool value);
   DebugFormatter& Field(absl::string_view field_name,
                         std::chrono::system_clock::time_point value);
+  DebugFormatter& Field(
+      absl::string_view field_name,
+      absl::optional<std::chrono::system_clock::time_point> value);
   DebugFormatter& Field(absl::string_view field_name,
                         std::multimap<std::string, std::string> const& value);
 
@@ -75,18 +79,6 @@ class DebugFormatter {
     for (auto const& e : value) {
       absl::StrAppend(&str_, e.DebugString(field_name, options_, indent_));
     }
-    return *this;
-  }
-
-  template <typename T>
-  DebugFormatter& QuotedField(absl::string_view field_name, T const& value) {
-    absl::StrAppend(&str_, Sep(), field_name, ": ", "\"", value, "\"");
-    return *this;
-  }
-
-  template <typename T>
-  DebugFormatter& QuotedField(T const& value) {
-    absl::StrAppend(&str_, Sep(), "\"", value, "\"");
     return *this;
   }
 

--- a/google/cloud/internal/debug_string_test.cc
+++ b/google/cloud/internal/debug_string_test.cc
@@ -89,8 +89,17 @@ TEST(DebugFormatter, Truncated) {
 }
 
 TEST(DebugFormatter, TimePoint) {
-  auto tp = std::chrono::system_clock::from_time_t(1681165293) +
-            std::chrono::microseconds(123456);
+  absl::optional<std::chrono::system_clock::time_point> tp =
+      std::chrono::system_clock::from_time_t(1681165293) +
+      std::chrono::microseconds(123456);
+  EXPECT_EQ(DebugFormatter("message_name", TracingOptions{})
+                .Field("field1", *tp)
+                .Build(),
+            R"(message_name {)"
+            R"( field1 {)"
+            R"( "2023-04-10T22:21:33.123456Z")"
+            R"( })"
+            R"( })");
   EXPECT_EQ(DebugFormatter("message_name", TracingOptions{})
                 .Field("field1", tp)
                 .Build(),
@@ -98,6 +107,12 @@ TEST(DebugFormatter, TimePoint) {
             R"( field1 {)"
             R"( "2023-04-10T22:21:33.123456Z")"
             R"( })"
+            R"( })");
+  tp = absl::nullopt;
+  EXPECT_EQ(DebugFormatter("message_name", TracingOptions{})
+                .Field("field1", tp)
+                .Build(),
+            R"(message_name {)"
             R"( })");
 }
 


### PR DESCRIPTION
- absl::optional<std::chrono::system_clock::time_point>

Use that to simplify `DebugString()` support for `ListJobsResponse`.

Also remove `DebugFormatter::QuotedField()`, which was no longer used after the overload for `time_point` was added in #11197.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11292)
<!-- Reviewable:end -->
