### PR TITLE
impl(otel): implement `Recordable` status, kind, scope

### DIFF
--- a/google/cloud/opentelemetry/BUILD.bazel
+++ b/google/cloud/opentelemetry/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         "//:trace",
+        "@com_google_googleapis//google/rpc:code_cc_proto",
         "@io_opentelemetry_cpp//sdk/src/trace",
     ],
 )


### PR DESCRIPTION
Part of the work for #11156 

Implements `SetStatus`, `SetSpanKind`, `SetInstrumentationScope`.

The remaining member functions are busy enough to warrant their own PRs.
- `AddLink`
- `AddEvent`
- `SetResource`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11299)
<!-- Reviewable:end -->
