### PR TITLE
impl(docfx): support `<parblock>` elements

### DIFF
--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -137,6 +137,10 @@ bool AppendIfProgramListing(std::ostream& os, MarkdownContext const& ctx,
 bool AppendIfVerbatim(std::ostream& os, MarkdownContext const& ctx,
                       pugi::xml_node const& node);
 
+/// Handle `<parblock>` elements.
+bool AppendIfParBlock(std::ostream& os, MarkdownContext const& ctx,
+                      pugi::xml_node const& node);
+
 /// Handle `codeline` elements.
 bool AppendIfCodeline(std::ostream& os, MarkdownContext const& ctx,
                       pugi::xml_node const& node);

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -659,6 +659,33 @@ https://cloud.google.com/storage/docs/transcoding
   EXPECT_EQ(kExpected, os.str());
 }
 
+TEST(Doxygen2Markdown, ParagraphParBlock) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+        <para id='test-node'>
+          <parblock>
+            <para>First paragraph</para>
+            <para>Second paragraph</para>
+          </parblock>
+        </para>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"md(
+
+
+
+First paragraph
+
+Second paragraph)md";
+
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//*[@id='test-node']");
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfParagraph(os, {}, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
+}
+
 TEST(Doxygen2Markdown, ParagraphXrefSect) {
   auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
     <doxygen version="1.9.1" xml:lang="en-US">


### PR DESCRIPTION
Part of the work for #11245

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11300)
<!-- Reviewable:end -->
