### PR TITLE
impl(otel): Recordable add links

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -222,7 +222,7 @@ void Recordable::AddLink(
   auto& proto = *link.mutable_attributes();
   attributes.ForEachKeyValue(
       [&proto](opentelemetry::nostd::string_view key,
-               opentelemetry::common::AttributeValue value) {
+               opentelemetry::common::AttributeValue const& value) {
         AddAttribute(proto, key, value, kSpanLinkAttributeLimit);
         return proto.attribute_map().size() != kSpanLinkAttributeLimit;
       });

--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -39,6 +39,12 @@ std::size_t constexpr kAttributeKeyStringLimit = 128;
 // https://github.com/googleapis/googleapis/blob/4e8d3907aec680562c9243774c67adc6d713fe50/google/devtools/cloudtrace/v2/trace.proto#L50
 std::size_t constexpr kAttributeValueStringLimit = 256;
 
+// https://github.com/googleapis/googleapis/blob/6774ccbbc3f182f6ae3a32dca29e1da489ad8a8f/google/devtools/cloudtrace/v2/trace.proto#L165-L166
+std::size_t constexpr kSpanLinkAttributeLimit = 32;
+
+// https://github.com/googleapis/googleapis/blob/52180f8ba240022dd8ce756ee69fe5a3c429ad4d/google/devtools/cloudtrace/v2/trace.proto#L266
+std::size_t constexpr kSpanLinkLimit = 128;
+
 /**
  * Helper to set [TruncatableString] fields in a [Span] proto.
  *


### PR DESCRIPTION
Part of the work for #11156 

The `opentelemetry::common::KeyValueIterable` interface is... something...

https://github.com/open-telemetry/opentelemetry-cpp/blob/7cb7654552d68936d70986bc2ee67f3cc3e0b469/api/include/opentelemetry/common/key_value_iterable.h#L13-L34

I could not find any helpers that they offer to construct one easily, so I had to extend the class myself in the test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11302)
<!-- Reviewable:end -->
