### PR TITLE
ci: publish-docs always run DocFX generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,10 @@ endif ()
 option(GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN "Generate Doxygen documentation" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN)
 
+# Compile the DocFX tool.
+option(GOOGLE_CLOUD_CPP_INTERNAL_DOCFX "Compile the docfx tool. Only google-cloud-cpp developers are expected to use this flag." OFF)
+mark_as_advanced(GOOGLE_CLOUD_CPP_INTERNAL_DOCFX)
+
 # Generate docs with relative URLs matching with the directory structure on
 # googleapis.dev hosting.
 option(GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV
@@ -196,6 +200,11 @@ cmake_dependent_option(
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
 
 # Add any subdirectories configured in the application.
+if (GOOGLE_CLOUD_CPP_INTERNAL_DOCFX)
+    # `docfx/` must be included before any library directories. The tool is
+    # used to generate the library documentation.
+    add_subdirectory(docfx)
+endif ()
 add_subdirectory(google/cloud)
 google_cloud_cpp_enable_features()
 

--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -29,7 +29,6 @@ read -r ENABLED_FEATURES < <(features::always_build_cmake)
 # over them.
 ENABLED_FEATURES="${ENABLED_FEATURES},experimental-storage-grpc"
 ENABLED_FEATURES="${ENABLED_FEATURES},generator"
-ENABLED_FEATURES="${ENABLED_FEATURES},internal-docfx"
 readonly ENABLED_FEATURES
 
 mapfile -t cmake_args < <(cmake::common_args)
@@ -40,7 +39,8 @@ mapfile -t cmake_args < <(cmake::common_args)
 cmake "${cmake_args[@]}" \
   -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
   -DCMAKE_CXX_STANDARD=14 \
-  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}" \
+  -DGOOGLE_CLOUD_CPP_INTERNAL_DOCFX=ON
 cmake --build cmake-out
 
 mapfile -t ctest_args < <(ctest::common_args)

--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -27,8 +27,9 @@ version=""
 doc_args=(
   "-DCMAKE_BUILD_TYPE=Debug"
   "-DGOOGLE_CLOUD_CPP_GENERATE_DOXYGEN=ON"
+  "-DGOOGLE_CLOUD_CPP_INTERNAL_DOCFX=ON"
   "-DGOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV=ON"
-  "-DGOOGLE_CLOUD_CPP_ENABLE=internal-docfx,${ENABLED_FEATURES}"
+  "-DGOOGLE_CLOUD_CPP_ENABLE=${ENABLED_FEATURES}"
   "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON"
   "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
   "-DGOOGLE_CLOUD_CPP_DOXYGEN_CLANG_OPTIONS=-resource-dir=$(clang -print-resource-dir)"
@@ -67,9 +68,7 @@ cmake -GNinja "${doc_args[@]}" -S . -B cmake-out
 # fix this by avoiding parallelism with `-j 1`, or as we do here, we'll
 # pre-generate all the proto headers, then call doxygen.
 cmake --build cmake-out --target google-cloud-cpp-protos
-cmake --build cmake-out --target doxygen-docs
-# TODO(#11245) - enable once all the libraries work
-# cmake --build cmake-out --target all-docfx
+cmake --build cmake-out --target doxygen-docs all-docfx
 
 if [[ "${PROJECT_ID:-}" != "cloud-cpp-testing-resources" ]]; then
   io::log_h2 "Skipping upload of docs," \

--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -167,7 +167,7 @@ function (google_cloud_cpp_doxygen_targets_impl library)
             ${library}-docfx
             DEPENDS ${library}-docs doxygen2docfx
             WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/docfx"
-            COMMENT "Generate DoxFX YAML for ${library}"
+            COMMENT "Generate DocFX YAML for ${library}"
             COMMAND
                 ${XSLTPROC} -o
                 "${CMAKE_CURRENT_BINARY_DIR}/xml/${library}.doxygen.xml"

--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -173,10 +173,6 @@ function (google_cloud_cpp_enable_deps)
     if (experimental-opentelemetry_sdk IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
         list(INSERT GOOGLE_CLOUD_CPP_ENABLE 0 trace)
     endif ()
-    # Building the documentation for each library depends on the docfx program.
-    if (internal-docfx IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
-        list(INSERT GOOGLE_CLOUD_CPP_ENABLE 0 internal-docfx)
-    endif ()
     set(GOOGLE_CLOUD_CPP_ENABLE
         "${GOOGLE_CLOUD_CPP_ENABLE}"
         PARENT_SCOPE)
@@ -230,10 +226,7 @@ endfunction ()
 # additional samples that are enabled if needed.
 function (google_cloud_cpp_enable_features)
     foreach (feature ${GOOGLE_CLOUD_CPP_ENABLE})
-        if ("${feature}" STREQUAL "internal-docfx")
-            add_subdirectory(docfx)
-            continue()
-        elseif ("${feature}" STREQUAL "generator")
+        if ("${feature}" STREQUAL "generator")
             add_subdirectory(generator)
         elseif ("${feature}" STREQUAL "experimental-storage-grpc")
             if (NOT ("storage" IN_LIST GOOGLE_CLOUD_CPP_ENABLE))

--- a/doc/compile-time-configuration.md
+++ b/doc/compile-time-configuration.md
@@ -34,7 +34,6 @@ A few features enable experimental functionality. We do not expect that
 customers will need to use these. If you have specific questions please start
 a [GitHub Discussion]. With that said:
 
-- `internal-docfx` enables an internal-only tool to generate documentation.
 - `generator` enables an internal-only tool to generate new libraries.
 - `experimental-storage-grpc` enables the GCS+gRPC plugin. Contact your account
   team if you want to use this feature or are interested in the GA timeline.

--- a/docfx/CMakeLists.txt
+++ b/docfx/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(pugixml CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 
-include(EnableWerror)
+include(GoogleCloudCppCommon)
 
 add_library(
     docfx # cmake-format: sort


### PR DESCRIPTION
Running the `doxygen2docfx` tool in each PR will ensure we do not regress w.r.t. supporting all the libraries in the tool. We also need to run the tool to (eventually) upload the documents to start the publication pipeline, so this is a good place to run them.

I had to change how the tool is integrated into CMake. It cannot be a "feature" (an element in the `GOOGLE_CLOUD_CPP_ENABLE` list) because CMake needs to configure the `docfx/` directory before the `google/cloud/` directory and the features always go afted `google/cloud/`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11315)
<!-- Reviewable:end -->
