### PR TITLE
impl(generator): add alternate pagination support

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -1126,22 +1126,7 @@ std::map<std::string, VarsDictionary> CreateMethodVars(
     method_vars["response_type"] =
         ProtoNameToCppName(method.output_type()->full_name());
     SetLongrunningOperationMethodVars(method, method_vars);
-    if (IsPaginated(method)) {
-      auto pagination_info = DeterminePagination(method);
-      method_vars["range_output_field_name"] = pagination_info->first;
-      // Add exception to AIP-4233 for response types that have exactly one
-      // repeated field that is of primitive type string.
-      method_vars["range_output_type"] =
-          pagination_info->second == nullptr
-              ? "std::string"
-              : ProtoNameToCppName(pagination_info->second->full_name());
-      if (pagination_info->second) {
-        method_vars["method_paginated_return_doxygen_link"] =
-            FormatDoxygenLink(*pagination_info->second);
-      } else {
-        method_vars["method_paginated_return_doxygen_link"] = "std::string";
-      }
-    }
+    AssignPaginationMethodVars(method, method_vars);
     SetMethodSignatureMethodVars(service, method, emitted_rpcs, omitted_rpcs,
                                  method_vars);
     auto parsed_http_info = ParseHttpExtension(method);

--- a/generator/internal/pagination.cc
+++ b/generator/internal/pagination.cc
@@ -93,7 +93,7 @@ DetermineAIP4233Pagination(MethodDescriptor const& method) {
 // do not adhere to aip-4233, but the intent is there. If we can make it work,
 // add pagination for any such methods.
 google::cloud::optional<std::pair<std::string, Descriptor const*>>
-DetermineRestPagination(MethodDescriptor const& method) {
+DetermineAlternatePagination(MethodDescriptor const& method) {
   Descriptor const* request_message = method.input_type();
   Descriptor const* response_message = method.output_type();
   if (!FieldExistsAndIsType(*request_message, "max_results",
@@ -118,7 +118,7 @@ google::cloud::optional<std::pair<std::string, Descriptor const*>>
 DeterminePagination(MethodDescriptor const& method) {
   auto result = DetermineAIP4233Pagination(method);
   if (result) return result;
-  return DetermineRestPagination(method);
+  return DetermineAlternatePagination(method);
 }
 
 bool IsPaginated(MethodDescriptor const& method) {

--- a/generator/internal/pagination.h
+++ b/generator/internal/pagination.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_PAGINATION_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_PAGINATION_H
 
+#include "generator/internal/printer.h"
 #include "google/cloud/optional.h"
 #include <google/protobuf/descriptor.h>
 #include <string>
@@ -32,14 +33,28 @@ namespace generator_internal {
 bool IsPaginated(google::protobuf::MethodDescriptor const& method);
 
 /**
- * If method meets pagination criteria, provides paginated field type and field
- * name.
+ * If method meets AIP-4233 pagination criteria, provides paginated field type
+ * and field name. Failing that, attempts to apply alternate pagination
+ * scheme sometimes found in services that only support REST transport.
  *
  * https://google.aip.dev/client-libraries/4233
  */
 google::cloud::optional<
     std::pair<std::string, google::protobuf::Descriptor const*>>
 DeterminePagination(google::protobuf::MethodDescriptor const& method);
+
+/**
+ * Inspects the provided method to determine if it supports pagination and
+ * assigns values to the following variables:
+ *   range_output_field_name
+ *   range_output_type
+ *   method_paginated_return_doxygen_link
+ * @param method
+ * @param method_vars
+ */
+void AssignPaginationMethodVars(
+    google::protobuf::MethodDescriptor const& method,
+    VarsDictionary& method_vars);
 
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/pagination_test.cc
+++ b/generator/internal/pagination_test.cc
@@ -27,7 +27,7 @@ using ::google::protobuf::DescriptorPool;
 using ::google::protobuf::FileDescriptor;
 using ::google::protobuf::FileDescriptorProto;
 
-TEST(PredicateUtilsTest, PaginationAIP4233Success) {
+TEST(PaginationTest, PaginationAIP4233Success) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -72,7 +72,7 @@ TEST(PredicateUtilsTest, PaginationAIP4233Success) {
   EXPECT_EQ(result->second->full_name(), "google.protobuf.Bar");
 }
 
-TEST(PredicateUtilsTest, PaginationAIP4233NoPageSize) {
+TEST(PaginationTest, PaginationAIP4233NoPageSize) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -98,7 +98,7 @@ TEST(PredicateUtilsTest, PaginationAIP4233NoPageSize) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationAIP4233NoPageToken) {
+TEST(PaginationTest, PaginationAIP4233NoPageToken) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -127,7 +127,7 @@ TEST(PredicateUtilsTest, PaginationAIP4233NoPageToken) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationAIP4233NoNextPageToken) {
+TEST(PaginationTest, PaginationAIP4233NoNextPageToken) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -157,7 +157,7 @@ TEST(PredicateUtilsTest, PaginationAIP4233NoNextPageToken) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationAIP4233NoRepeatedMessageField) {
+TEST(PaginationTest, PaginationAIP4233NoRepeatedMessageField) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -246,7 +246,7 @@ TEST(PredicateUtilsDeathTest, PaginationAIP4233RepeatedMessageOrderMismatch) {
       "Repeated field in paginated response must be first");
 }
 
-TEST(PredicateUtilsTest, PaginationAIP4233ExactlyOneRepatedStringResponse) {
+TEST(PaginationTest, PaginationAIP4233ExactlyOneRepatedStringResponse) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -290,7 +290,7 @@ TEST(PredicateUtilsTest, PaginationAIP4233ExactlyOneRepatedStringResponse) {
   EXPECT_EQ(result->second, nullptr);
 }
 
-TEST(PredicateUtilsTest, PaginationRestSuccess) {
+TEST(PaginationTest, PaginationRestSuccess) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -335,7 +335,7 @@ TEST(PredicateUtilsTest, PaginationRestSuccess) {
   EXPECT_EQ(result->second->full_name(), "google.protobuf.Bar");
 }
 
-TEST(PredicateUtilsTest, PaginationRestNoMaxResults) {
+TEST(PaginationTest, PaginationRestNoMaxResults) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -374,7 +374,7 @@ TEST(PredicateUtilsTest, PaginationRestNoMaxResults) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationRestMaxResultsWrongType) {
+TEST(PaginationTest, PaginationRestMaxResultsWrongType) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -414,7 +414,7 @@ TEST(PredicateUtilsTest, PaginationRestMaxResultsWrongType) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationRestNoPageToken) {
+TEST(PaginationTest, PaginationRestNoPageToken) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -453,7 +453,7 @@ TEST(PredicateUtilsTest, PaginationRestNoPageToken) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationRestNoNextPageToken) {
+TEST(PaginationTest, PaginationRestNoNextPageToken) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -492,7 +492,7 @@ TEST(PredicateUtilsTest, PaginationRestNoNextPageToken) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationRestNoItems) {
+TEST(PaginationTest, PaginationRestNoItems) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -532,7 +532,7 @@ TEST(PredicateUtilsTest, PaginationRestNoItems) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationRestItemsNotRepeated) {
+TEST(PaginationTest, PaginationRestItemsNotRepeated) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(

--- a/generator/internal/pagination_test.cc
+++ b/generator/internal/pagination_test.cc
@@ -27,7 +27,7 @@ using ::google::protobuf::DescriptorPool;
 using ::google::protobuf::FileDescriptor;
 using ::google::protobuf::FileDescriptorProto;
 
-TEST(PredicateUtilsTest, PaginationSuccess) {
+TEST(PredicateUtilsTest, PaginationAIP4233Success) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -72,7 +72,7 @@ TEST(PredicateUtilsTest, PaginationSuccess) {
   EXPECT_EQ(result->second->full_name(), "google.protobuf.Bar");
 }
 
-TEST(PredicateUtilsTest, PaginationNoPageSize) {
+TEST(PredicateUtilsTest, PaginationAIP4233NoPageSize) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -98,7 +98,7 @@ TEST(PredicateUtilsTest, PaginationNoPageSize) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationNoPageToken) {
+TEST(PredicateUtilsTest, PaginationAIP4233NoPageToken) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -127,7 +127,7 @@ TEST(PredicateUtilsTest, PaginationNoPageToken) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationNoNextPageToken) {
+TEST(PredicateUtilsTest, PaginationAIP4233NoNextPageToken) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -157,7 +157,7 @@ TEST(PredicateUtilsTest, PaginationNoNextPageToken) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsTest, PaginationNoRepeatedMessageField) {
+TEST(PredicateUtilsTest, PaginationAIP4233NoRepeatedMessageField) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -196,7 +196,7 @@ TEST(PredicateUtilsTest, PaginationNoRepeatedMessageField) {
   EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
-TEST(PredicateUtilsDeathTest, PaginationRepeatedMessageOrderMismatch) {
+TEST(PredicateUtilsDeathTest, PaginationAIP4233RepeatedMessageOrderMismatch) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -246,7 +246,7 @@ TEST(PredicateUtilsDeathTest, PaginationRepeatedMessageOrderMismatch) {
       "Repeated field in paginated response must be first");
 }
 
-TEST(PredicateUtilsTest, PaginationExactlyOneRepatedStringResponse) {
+TEST(PredicateUtilsTest, PaginationAIP4233ExactlyOneRepatedStringResponse) {
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -288,6 +288,287 @@ TEST(PredicateUtilsTest, PaginationExactlyOneRepatedStringResponse) {
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result->first, "repeated_field");
   EXPECT_EQ(result->second, nullptr);
+}
+
+TEST(PredicateUtilsTest, PaginationRestSuccess) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Bar" }
+    message_type {
+      name: "Input"
+      field { name: "max_results" number: 1 type: TYPE_UINT32 }
+      field { name: "page_token" number: 2 type: TYPE_STRING }
+    }
+    message_type {
+      name: "Output"
+      field { name: "next_page_token" number: 1 type: TYPE_STRING }
+      field {
+        name: "items"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: "google.protobuf.Bar"
+      }
+    }
+    service {
+      name: "Service"
+      method {
+        name: "Paginated"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  EXPECT_TRUE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
+  auto result =
+      DeterminePagination(*service_file_descriptor->service(0)->method(0));
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result->first, "items");
+  EXPECT_EQ(result->second->full_name(), "google.protobuf.Bar");
+}
+
+TEST(PredicateUtilsTest, PaginationRestNoMaxResults) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Bar" }
+    message_type {
+      name: "Input"
+      field { name: "page_token" number: 2 type: TYPE_STRING }
+    }
+    message_type {
+      name: "Output"
+      field { name: "next_page_token" number: 1 type: TYPE_STRING }
+      field {
+        name: "items"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: "google.protobuf.Bar"
+      }
+    }
+    service {
+      name: "Service"
+      method {
+        name: "NoPageSize"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
+}
+
+TEST(PredicateUtilsTest, PaginationRestMaxResultsWrongType) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Bar" }
+    message_type {
+      name: "Input"
+      field { name: "max_results" number: 1 type: TYPE_INT32 }
+      field { name: "page_token" number: 2 type: TYPE_STRING }
+    }
+    message_type {
+      name: "Output"
+      field { name: "next_page_token" number: 1 type: TYPE_STRING }
+      field {
+        name: "items"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: "google.protobuf.Bar"
+      }
+    }
+    service {
+      name: "Service"
+      method {
+        name: "NoPageSize"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
+}
+
+TEST(PredicateUtilsTest, PaginationRestNoPageToken) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Bar" }
+    message_type {
+      name: "Input"
+      field { name: "max_results" number: 1 type: TYPE_UINT32 }
+    }
+    message_type {
+      name: "Output"
+      field { name: "next_page_token" number: 1 type: TYPE_STRING }
+      field {
+        name: "items"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: "google.protobuf.Bar"
+      }
+    }
+    service {
+      name: "Service"
+      method {
+        name: "NoPageSize"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
+}
+
+TEST(PredicateUtilsTest, PaginationRestNoNextPageToken) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Bar" }
+    message_type {
+      name: "Input"
+      field { name: "max_results" number: 1 type: TYPE_UINT32 }
+      field { name: "page_token" number: 2 type: TYPE_STRING }
+    }
+    message_type {
+      name: "Output"
+      field {
+        name: "items"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: "google.protobuf.Bar"
+      }
+    }
+    service {
+      name: "Service"
+      method {
+        name: "NoPageSize"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
+}
+
+TEST(PredicateUtilsTest, PaginationRestNoItems) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Bar" }
+    message_type {
+      name: "Input"
+      field { name: "max_results" number: 1 type: TYPE_UINT32 }
+      field { name: "page_token" number: 2 type: TYPE_STRING }
+    }
+    message_type {
+      name: "Output"
+      field { name: "next_page_token" number: 1 type: TYPE_STRING }
+      field {
+        name: "bars"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: "google.protobuf.Bar"
+      }
+    }
+    service {
+      name: "Service"
+      method {
+        name: "NoPageSize"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
+}
+
+TEST(PredicateUtilsTest, PaginationRestItemsNotRepeated) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Bar" }
+    message_type {
+      name: "Input"
+      field { name: "max_results" number: 1 type: TYPE_UINT32 }
+      field { name: "page_token" number: 2 type: TYPE_STRING }
+    }
+    message_type {
+      name: "Output"
+      field { name: "next_page_token" number: 1 type: TYPE_STRING }
+      field {
+        name: "items"
+        number: 2
+        type: TYPE_MESSAGE
+        type_name: "google.protobuf.Bar"
+      }
+    }
+    service {
+      name: "Service"
+      method {
+        name: "NoPageSize"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
+  EXPECT_FALSE(IsPaginated(*service_file_descriptor->service(0)->method(0)));
 }
 
 }  // namespace

--- a/google/cloud/sql/README.md
+++ b/google/cloud/sql/README.md
@@ -39,9 +39,10 @@ int main(int argc, char* argv[]) try {
 
   google::cloud::sql::v1::SqlInstancesListRequest request;
   request.set_project(argv[1]);
-  auto r = client.List(request);
-  if (!r) throw std::move(r).status();
-  std::cout << r->DebugString() << "\n";
+  for (auto database : client.List(request)) {
+    if (!database) throw std::move(database).status();
+    std::cout << database->DebugString() << "\n";
+  }
 
   return 0;
 } catch (google::cloud::Status const& status) {

--- a/google/cloud/sql/quickstart/quickstart.cc
+++ b/google/cloud/sql/quickstart/quickstart.cc
@@ -31,9 +31,10 @@ int main(int argc, char* argv[]) try {
 
   google::cloud::sql::v1::SqlInstancesListRequest request;
   request.set_project(argv[1]);
-  auto r = client.List(request);
-  if (!r) throw std::move(r).status();
-  std::cout << r->DebugString() << "\n";
+  for (auto database : client.List(request)) {
+    if (!database) throw std::move(database).status();
+    std::cout << database->DebugString() << "\n";
+  }
 
   return 0;
 } catch (google::cloud::Status const& status) {

--- a/google/cloud/sql/v1/internal/sql_instances_rest_connection_impl.cc
+++ b/google/cloud/sql/v1/internal/sql_instances_rest_connection_impl.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/sql/v1/internal/sql_instances_rest_stub_factory.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/credentials.h"
+#include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/internal/rest_retry_loop.h"
 #include "google/cloud/rest_options.h"
 #include <memory>
@@ -149,16 +150,35 @@ SqlInstancesServiceRestConnectionImpl::Insert(
       request, __func__);
 }
 
-StatusOr<google::cloud::sql::v1::InstancesListResponse>
+StreamRange<google::cloud::sql::v1::DatabaseInstance>
 SqlInstancesServiceRestConnectionImpl::List(
-    google::cloud::sql::v1::SqlInstancesListRequest const& request) {
-  return google::cloud::rest_internal::RestRetryLoop(
-      retry_policy(), backoff_policy(), idempotency_policy()->List(request),
-      [this](rest_internal::RestContext& rest_context,
-             google::cloud::sql::v1::SqlInstancesListRequest const& request) {
-        return stub_->List(rest_context, request);
+    google::cloud::sql::v1::SqlInstancesListRequest request) {
+  request.clear_page_token();
+  auto& stub = stub_;
+  auto retry = std::shared_ptr<sql_v1::SqlInstancesServiceRetryPolicy const>(
+      retry_policy());
+  auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+  auto idempotency = idempotency_policy()->List(request);
+  char const* function_name = __func__;
+  return google::cloud::internal::MakePaginationRange<
+      StreamRange<google::cloud::sql::v1::DatabaseInstance>>(
+      std::move(request),
+      [stub, retry, backoff, idempotency, function_name](
+          google::cloud::sql::v1::SqlInstancesListRequest const& r) {
+        return google::cloud::rest_internal::RestRetryLoop(
+            retry->clone(), backoff->clone(), idempotency,
+            [stub](rest_internal::RestContext& rest_context,
+                   google::cloud::sql::v1::SqlInstancesListRequest const&
+                       request) { return stub->List(rest_context, request); },
+            r, function_name);
       },
-      request, __func__);
+      [](google::cloud::sql::v1::InstancesListResponse r) {
+        std::vector<google::cloud::sql::v1::DatabaseInstance> result(
+            r.items().size());
+        auto& messages = *r.mutable_items();
+        std::move(messages.begin(), messages.end(), result.begin());
+        return result;
+      });
 }
 
 StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>

--- a/google/cloud/sql/v1/internal/sql_instances_rest_connection_impl.h
+++ b/google/cloud/sql/v1/internal/sql_instances_rest_connection_impl.h
@@ -28,6 +28,7 @@
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
 
@@ -82,8 +83,8 @@ class SqlInstancesServiceRestConnectionImpl
       google::cloud::sql::v1::SqlInstancesInsertRequest const& request)
       override;
 
-  StatusOr<google::cloud::sql::v1::InstancesListResponse> List(
-      google::cloud::sql::v1::SqlInstancesListRequest const& request) override;
+  StreamRange<google::cloud::sql::v1::DatabaseInstance> List(
+      google::cloud::sql::v1::SqlInstancesListRequest request) override;
 
   StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>
   ListServerCas(google::cloud::sql::v1::SqlInstancesListServerCasRequest const&

--- a/google/cloud/sql/v1/internal/sql_instances_tracing_connection.h
+++ b/google/cloud/sql/v1/internal/sql_instances_tracing_connection.h
@@ -74,8 +74,8 @@ class SqlInstancesServiceTracingConnection
       google::cloud::sql::v1::SqlInstancesInsertRequest const& request)
       override;
 
-  StatusOr<google::cloud::sql::v1::InstancesListResponse> List(
-      google::cloud::sql::v1::SqlInstancesListRequest const& request) override;
+  StreamRange<google::cloud::sql::v1::DatabaseInstance> List(
+      google::cloud::sql::v1::SqlInstancesListRequest request) override;
 
   StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>
   ListServerCas(google::cloud::sql::v1::SqlInstancesListServerCasRequest const&

--- a/google/cloud/sql/v1/internal/sql_operations_rest_connection_impl.h
+++ b/google/cloud/sql/v1/internal/sql_operations_rest_connection_impl.h
@@ -28,6 +28,7 @@
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
 
@@ -51,8 +52,8 @@ class SqlOperationsServiceRestConnectionImpl
   StatusOr<google::cloud::sql::v1::Operation> Get(
       google::cloud::sql::v1::SqlOperationsGetRequest const& request) override;
 
-  StatusOr<google::cloud::sql::v1::OperationsListResponse> List(
-      google::cloud::sql::v1::SqlOperationsListRequest const& request) override;
+  StreamRange<google::cloud::sql::v1::Operation> List(
+      google::cloud::sql::v1::SqlOperationsListRequest request) override;
 
  private:
   std::unique_ptr<sql_v1::SqlOperationsServiceRetryPolicy> retry_policy() {

--- a/google/cloud/sql/v1/internal/sql_operations_tracing_connection.h
+++ b/google/cloud/sql/v1/internal/sql_operations_tracing_connection.h
@@ -43,8 +43,8 @@ class SqlOperationsServiceTracingConnection
   StatusOr<google::cloud::sql::v1::Operation> Get(
       google::cloud::sql::v1::SqlOperationsGetRequest const& request) override;
 
-  StatusOr<google::cloud::sql::v1::OperationsListResponse> List(
-      google::cloud::sql::v1::SqlOperationsListRequest const& request) override;
+  StreamRange<google::cloud::sql::v1::Operation> List(
+      google::cloud::sql::v1::SqlOperationsListRequest request) override;
 
  private:
   std::shared_ptr<sql_v1::SqlOperationsServiceConnection> child_;

--- a/google/cloud/sql/v1/mocks/mock_sql_instances_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_instances_connection.h
@@ -90,8 +90,8 @@ class MockSqlInstancesServiceConnection
       (google::cloud::sql::v1::SqlInstancesInsertRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::InstancesListResponse>, List,
-              (google::cloud::sql::v1::SqlInstancesListRequest const& request),
+  MOCK_METHOD(StreamRange<google::cloud::sql::v1::DatabaseInstance>, List,
+              (google::cloud::sql::v1::SqlInstancesListRequest request),
               (override));
 
   MOCK_METHOD(

--- a/google/cloud/sql/v1/mocks/mock_sql_operations_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_operations_connection.h
@@ -51,8 +51,8 @@ class MockSqlOperationsServiceConnection
               (google::cloud::sql::v1::SqlOperationsGetRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::OperationsListResponse>, List,
-              (google::cloud::sql::v1::SqlOperationsListRequest const& request),
+  MOCK_METHOD(StreamRange<google::cloud::sql::v1::Operation>, List,
+              (google::cloud::sql::v1::SqlOperationsListRequest request),
               (override));
 };
 

--- a/google/cloud/sql/v1/sql_instances_client.cc
+++ b/google/cloud/sql/v1/sql_instances_client.cc
@@ -98,12 +98,11 @@ StatusOr<google::cloud::sql::v1::Operation> SqlInstancesServiceClient::Insert(
   return connection_->Insert(request);
 }
 
-StatusOr<google::cloud::sql::v1::InstancesListResponse>
+StreamRange<google::cloud::sql::v1::DatabaseInstance>
 SqlInstancesServiceClient::List(
-    google::cloud::sql::v1::SqlInstancesListRequest const& request,
-    Options opts) {
+    google::cloud::sql::v1::SqlInstancesListRequest request, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
-  return connection_->List(request);
+  return connection_->List(std::move(request));
 }
 
 StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>

--- a/google/cloud/sql/v1/sql_instances_client.h
+++ b/google/cloud/sql/v1/sql_instances_client.h
@@ -282,15 +282,15 @@ class SqlInstancesServiceClient {
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return
-  /// @googleapis_link{google::cloud::sql::v1::InstancesListResponse,google/cloud/sql/v1/cloud_sql_instances.proto#L603}
+  /// @googleapis_link{google::cloud::sql::v1::DatabaseInstance,google/cloud/sql/v1/cloud_sql_instances.proto#L693}
   ///
-  /// [google.cloud.sql.v1.InstancesListResponse]:
-  /// @googleapis_reference_link{google/cloud/sql/v1/cloud_sql_instances.proto#L603}
+  /// [google.cloud.sql.v1.DatabaseInstance]:
+  /// @googleapis_reference_link{google/cloud/sql/v1/cloud_sql_instances.proto#L693}
   /// [google.cloud.sql.v1.SqlInstancesListRequest]:
   /// @googleapis_reference_link{google/cloud/sql/v1/cloud_sql_instances.proto#L353}
   ///
-  StatusOr<google::cloud::sql::v1::InstancesListResponse> List(
-      google::cloud::sql::v1::SqlInstancesListRequest const& request,
+  StreamRange<google::cloud::sql::v1::DatabaseInstance> List(
+      google::cloud::sql::v1::SqlInstancesListRequest request,
       Options opts = {});
 
   ///

--- a/google/cloud/sql/v1/sql_instances_connection.cc
+++ b/google/cloud/sql/v1/sql_instances_connection.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/pagination_range.h"
 #include <memory>
 
 namespace google {
@@ -87,10 +88,12 @@ SqlInstancesServiceConnection::Insert(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<google::cloud::sql::v1::InstancesListResponse>
+StreamRange<google::cloud::sql::v1::DatabaseInstance>
 SqlInstancesServiceConnection::List(
-    google::cloud::sql::v1::SqlInstancesListRequest const&) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
+    google::cloud::sql::v1::
+        SqlInstancesListRequest) {  // NOLINT(performance-unnecessary-value-param)
+  return google::cloud::internal::MakeUnimplementedPaginationRange<
+      StreamRange<google::cloud::sql::v1::DatabaseInstance>>();
 }
 
 StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>

--- a/google/cloud/sql/v1/sql_instances_connection.h
+++ b/google/cloud/sql/v1/sql_instances_connection.h
@@ -25,6 +25,7 @@
 #include "google/cloud/experimental_tag.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/sql/v1/cloud_sql_instances.pb.h>
 #include <memory>
@@ -91,8 +92,8 @@ class SqlInstancesServiceConnection {
   virtual StatusOr<google::cloud::sql::v1::Operation> Insert(
       google::cloud::sql::v1::SqlInstancesInsertRequest const& request);
 
-  virtual StatusOr<google::cloud::sql::v1::InstancesListResponse> List(
-      google::cloud::sql::v1::SqlInstancesListRequest const& request);
+  virtual StreamRange<google::cloud::sql::v1::DatabaseInstance> List(
+      google::cloud::sql::v1::SqlInstancesListRequest request);
 
   virtual StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>
   ListServerCas(

--- a/google/cloud/sql/v1/sql_instances_connection_idempotency_policy.cc
+++ b/google/cloud/sql/v1/sql_instances_connection_idempotency_policy.cc
@@ -81,7 +81,7 @@ Idempotency SqlInstancesServiceConnectionIdempotencyPolicy::Insert(
 }
 
 Idempotency SqlInstancesServiceConnectionIdempotencyPolicy::List(
-    google::cloud::sql::v1::SqlInstancesListRequest const&) {
+    google::cloud::sql::v1::SqlInstancesListRequest) {  // NOLINT
   return Idempotency::kIdempotent;
 }
 

--- a/google/cloud/sql/v1/sql_instances_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_instances_connection_idempotency_policy.h
@@ -66,7 +66,7 @@ class SqlInstancesServiceConnectionIdempotencyPolicy {
       google::cloud::sql::v1::SqlInstancesInsertRequest const& request);
 
   virtual google::cloud::Idempotency List(
-      google::cloud::sql::v1::SqlInstancesListRequest const& request);
+      google::cloud::sql::v1::SqlInstancesListRequest request);
 
   virtual google::cloud::Idempotency ListServerCas(
       google::cloud::sql::v1::SqlInstancesListServerCasRequest const& request);

--- a/google/cloud/sql/v1/sql_operations_client.cc
+++ b/google/cloud/sql/v1/sql_operations_client.cc
@@ -39,12 +39,10 @@ StatusOr<google::cloud::sql::v1::Operation> SqlOperationsServiceClient::Get(
   return connection_->Get(request);
 }
 
-StatusOr<google::cloud::sql::v1::OperationsListResponse>
-SqlOperationsServiceClient::List(
-    google::cloud::sql::v1::SqlOperationsListRequest const& request,
-    Options opts) {
+StreamRange<google::cloud::sql::v1::Operation> SqlOperationsServiceClient::List(
+    google::cloud::sql::v1::SqlOperationsListRequest request, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
-  return connection_->List(request);
+  return connection_->List(std::move(request));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/sql_operations_client.h
+++ b/google/cloud/sql/v1/sql_operations_client.h
@@ -116,15 +116,15 @@ class SqlOperationsServiceClient {
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return
-  /// @googleapis_link{google::cloud::sql::v1::OperationsListResponse,google/cloud/sql/v1/cloud_sql_operations.proto#L79}
+  /// @googleapis_link{google::cloud::sql::v1::Operation,google/cloud/sql/v1/cloud_sql_resources.proto#L628}
   ///
-  /// [google.cloud.sql.v1.OperationsListResponse]:
-  /// @googleapis_reference_link{google/cloud/sql/v1/cloud_sql_operations.proto#L79}
+  /// [google.cloud.sql.v1.Operation]:
+  /// @googleapis_reference_link{google/cloud/sql/v1/cloud_sql_resources.proto#L628}
   /// [google.cloud.sql.v1.SqlOperationsListRequest]:
   /// @googleapis_reference_link{google/cloud/sql/v1/cloud_sql_operations.proto#L63}
   ///
-  StatusOr<google::cloud::sql::v1::OperationsListResponse> List(
-      google::cloud::sql::v1::SqlOperationsListRequest const& request,
+  StreamRange<google::cloud::sql::v1::Operation> List(
+      google::cloud::sql::v1::SqlOperationsListRequest request,
       Options opts = {});
 
  private:

--- a/google/cloud/sql/v1/sql_operations_connection.cc
+++ b/google/cloud/sql/v1/sql_operations_connection.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/pagination_range.h"
 #include <memory>
 
 namespace google {
@@ -38,10 +39,12 @@ StatusOr<google::cloud::sql::v1::Operation> SqlOperationsServiceConnection::Get(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<google::cloud::sql::v1::OperationsListResponse>
+StreamRange<google::cloud::sql::v1::Operation>
 SqlOperationsServiceConnection::List(
-    google::cloud::sql::v1::SqlOperationsListRequest const&) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
+    google::cloud::sql::v1::
+        SqlOperationsListRequest) {  // NOLINT(performance-unnecessary-value-param)
+  return google::cloud::internal::MakeUnimplementedPaginationRange<
+      StreamRange<google::cloud::sql::v1::Operation>>();
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/sql_operations_connection.h
+++ b/google/cloud/sql/v1/sql_operations_connection.h
@@ -25,6 +25,7 @@
 #include "google/cloud/experimental_tag.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/sql/v1/cloud_sql_operations.pb.h>
 #include <memory>
@@ -67,8 +68,8 @@ class SqlOperationsServiceConnection {
   virtual StatusOr<google::cloud::sql::v1::Operation> Get(
       google::cloud::sql::v1::SqlOperationsGetRequest const& request);
 
-  virtual StatusOr<google::cloud::sql::v1::OperationsListResponse> List(
-      google::cloud::sql::v1::SqlOperationsListRequest const& request);
+  virtual StreamRange<google::cloud::sql::v1::Operation> List(
+      google::cloud::sql::v1::SqlOperationsListRequest request);
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/sql_operations_connection_idempotency_policy.cc
+++ b/google/cloud/sql/v1/sql_operations_connection_idempotency_policy.cc
@@ -41,7 +41,7 @@ Idempotency SqlOperationsServiceConnectionIdempotencyPolicy::Get(
 }
 
 Idempotency SqlOperationsServiceConnectionIdempotencyPolicy::List(
-    google::cloud::sql::v1::SqlOperationsListRequest const&) {
+    google::cloud::sql::v1::SqlOperationsListRequest) {  // NOLINT
   return Idempotency::kIdempotent;
 }
 

--- a/google/cloud/sql/v1/sql_operations_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_operations_connection_idempotency_policy.h
@@ -42,7 +42,7 @@ class SqlOperationsServiceConnectionIdempotencyPolicy {
       google::cloud::sql::v1::SqlOperationsGetRequest const& request);
 
   virtual google::cloud::Idempotency List(
-      google::cloud::sql::v1::SqlOperationsListRequest const& request);
+      google::cloud::sql::v1::SqlOperationsListRequest request);
 };
 
 std::unique_ptr<SqlOperationsServiceConnectionIdempotencyPolicy>


### PR DESCRIPTION
PR is split into multiple commits for readability.

Modified the generator to check for the alternate pagination mechanism utilized by sql and compute in the case where AIP-4233 pagination is not detected. This cascaded into refactoring the sql quickstart which uses the List method (which is now paginated).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11318)
<!-- Reviewable:end -->
