### PR TITLE
impl(docfx): iterate on TOC

### DIFF
--- a/docfx/doxygen2docfx.cc
+++ b/docfx/doxygen2docfx.cc
@@ -38,7 +38,8 @@ int main(int argc, char* argv[]) try {
     auto const kind = std::string_view{node.attribute("kind").as_string()};
     auto const id = std::string{node.attribute("id").as_string()};
     if (kind == "page") {
-      std::ofstream(id + ".md") << docfx::Page2Markdown(node);
+      auto filename = (id == "indexpage" ? "index.md" : id) + ".md";
+      std::ofstream(filename) << docfx::Page2Markdown(node);
       continue;
     }
     if (kind == "group") {

--- a/docfx/doxygen2docfx.cc
+++ b/docfx/doxygen2docfx.cc
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) try {
     auto const kind = std::string_view{node.attribute("kind").as_string()};
     auto const id = std::string{node.attribute("id").as_string()};
     if (kind == "page") {
-      auto filename = (id == "indexpage" ? "index.md" : id) + ".md";
+      auto filename = (id == "indexpage" ? "index" : id) + ".md";
       std::ofstream(filename) << docfx::Page2Markdown(node);
       continue;
     }

--- a/docfx/doxygen2toc.cc
+++ b/docfx/doxygen2toc.cc
@@ -28,22 +28,31 @@ std::string Doxygen2Toc(Config const& config, pugi::xml_document const& doc) {
       << YAML::Key << "name" << YAML::Value << config.library  //
       << YAML::Key << "items" << YAML::Value                   //
       << YAML::BeginSeq;
-  for (auto const& [filename, name] : PagesToc(doc)) {
-    out << YAML::BeginMap                                  //
-        << YAML::Key << "name" << YAML::Value << name      //
-        << YAML::Key << "href" << YAML::Value << filename  //
+  auto pages = PagesToc(doc);
+  if (!pages.empty()) {
+    auto const& e = pages.front();
+    out << YAML::BeginMap                                    //
+        << YAML::Key << "name" << YAML::Value << e.name      //
+        << YAML::Key << "href" << YAML::Value << e.filename  //
+        << YAML::EndMap;
+    pages.erase(pages.begin());
+  }
+  for (auto const& e : CompoundToc(doc)) {
+    out << YAML::BeginMap                                //
+        << YAML::Key << "uid" << YAML::Value << e.uid    //
+        << YAML::Key << "name" << YAML::Value << e.name  //
         << YAML::EndMap;
   }
-  for (auto const& [filename, name] : GroupsToc(doc)) {
-    out << YAML::BeginMap                              //
-        << YAML::Key << "uid" << YAML::Value << name   //
-        << YAML::Key << "name" << YAML::Value << name  //
+  for (auto const& e : pages) {
+    out << YAML::BeginMap                                    //
+        << YAML::Key << "name" << YAML::Value << e.name      //
+        << YAML::Key << "href" << YAML::Value << e.filename  //
         << YAML::EndMap;
   }
-  for (auto const& [filename, name] : CompoundToc(doc)) {
-    out << YAML::BeginMap                              //
-        << YAML::Key << "uid" << YAML::Value << name   //
-        << YAML::Key << "name" << YAML::Value << name  //
+  for (auto const& e : GroupsToc(doc)) {
+    out << YAML::BeginMap                                //
+        << YAML::Key << "uid" << YAML::Value << e.uid    //
+        << YAML::Key << "name" << YAML::Value << e.name  //
         << YAML::EndMap;
   }
   out << YAML::EndSeq << YAML::EndMap;

--- a/docfx/doxygen2toc_test.cc
+++ b/docfx/doxygen2toc_test.cc
@@ -30,7 +30,7 @@ TEST(Doxygen2Toc, Simple) {
         </compounddef>
         <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="indexpage" kind="page">
           <compoundname>index</compoundname>
-          <title>The Page Title: unused in this test</title>
+          <title>The Page Title</title>
           <briefdescription><para>Some brief description.</para>
           </briefdescription>
           <detaileddescription><para>More details about the index.</para></detaileddescription>
@@ -47,22 +47,23 @@ TEST(Doxygen2Toc, Simple) {
       </compounddef>
       <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="group__terminate" kind="group">
         <compoundname>terminate</compoundname>
+        <title>Terminate Group Title</title>
       </compounddef>
     </doxygen>)xml";
 
   auto constexpr kExpected = R"""(### YamlMime:TableOfContent
 name: common
 items:
-  - name: common-error-handling
-    href: common-error-handling.md
-  - name: README
-    href: indexpage.md
-  - uid: group__terminate
-    name: group__terminate
+  - name: The Page Title
+    href: index.md
   - uid: namespacegoogle
-    name: namespacegoogle
+    name: google
   - uid: namespacegoogle_1_1cloud
-    name: namespacegoogle_1_1cloud
+    name: google::cloud
+  - name: Error Handling
+    href: common-error-handling.md
+  - uid: group__terminate
+    name: Terminate Group Title
 )""";
 
   pugi::xml_document doc;

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -17,6 +17,7 @@
 #include "docfx/doxygen2syntax.h"
 #include "docfx/doxygen_errors.h"
 #include "docfx/yaml_emit.h"
+#include <algorithm>
 #include <sstream>
 #include <string_view>
 
@@ -115,8 +116,12 @@ std::vector<TocEntry> CompoundToc(pugi::xml_document const& doc) {
     auto const& node = i.node();
     if (!IncludeInPublicDocuments(node)) continue;
     auto const id = std::string{node.attribute("id").as_string()};
-    result.push_back(TocEntry{id + ".yml", id});
+    auto const name =
+        std::string_view{node.child("compoundname").child_value()};
+    result.push_back(TocEntry{id, std::string(name), id + ".yml"});
   }
+  std::sort(result.begin(), result.end(),
+            [](auto const& a, auto const& b) { return a.name < b.name; });
   return result;
 }
 

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -465,10 +465,11 @@ TEST(Doxygen2Yaml, CompoundToc) {
   ASSERT_TRUE(doc.load_string(kDocXml));
   auto const actual = CompoundToc(doc);
 
-  EXPECT_THAT(actual,
-              ElementsAre(TocEntry{"namespacegoogle.yml", "namespacegoogle"},
-                          TocEntry{"namespacegoogle_1_1cloud.yml",
-                                   "namespacegoogle_1_1cloud"}));
+  EXPECT_THAT(
+      actual,
+      ElementsAre(TocEntry{"namespacegoogle", "google", "namespacegoogle.yml"},
+                  TocEntry{"namespacegoogle_1_1cloud", "google::cloud",
+                           "namespacegoogle_1_1cloud.yml"}));
 }
 
 TEST(Doxygen2Yaml, IncludeInPublicDocs) {

--- a/docfx/doxygen_groups.cc
+++ b/docfx/doxygen_groups.cc
@@ -52,11 +52,15 @@ std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc) {
   auto nodes = doc.select_nodes("//*[@kind='group']");
   std::transform(nodes.begin(), nodes.end(), std::back_inserter(result),
                  [](auto const& i) {
-                   auto const& page = i.node();
+                   auto const& group = i.node();
                    auto const id =
-                       std::string{page.attribute("id").as_string()};
-                   return TocEntry{id + ".yml", id};
+                       std::string{group.attribute("id").as_string()};
+                   std::ostringstream title;
+                   AppendTitle(title, MarkdownContext{}, group);
+                   return TocEntry{id, title.str(), id + ".yml"};
                  });
+  std::sort(result.begin(), result.end(),
+            [](auto const& a, auto const& b) { return a.name < b.name; });
   return result;
 }
 

--- a/docfx/doxygen_groups_test.cc
+++ b/docfx/doxygen_groups_test.cc
@@ -97,8 +97,9 @@ TEST(DoxygenGroups, GroupsToc) {
   ASSERT_TRUE(doc.load_string(kXml));
   auto const actual = GroupsToc(doc);
 
-  EXPECT_THAT(actual, ElementsAre(FieldsAre("group__g1.yml", "group__g1"),
-                                  FieldsAre("group__g2.yml", "group__g2")));
+  EXPECT_THAT(actual,
+              ElementsAre(FieldsAre("group__g1", "Group 1", "group__g1.yml"),
+                          FieldsAre("group__g2", "Group 2", "group__g2.yml")));
 }
 
 }  // namespace

--- a/docfx/doxygen_pages.cc
+++ b/docfx/doxygen_pages.cc
@@ -129,9 +129,10 @@ std::vector<TocEntry> PagesToc(pugi::xml_document const& doc) {
     return TocEntry{std::string{id}, title.str(), std::move(filename)};
   });
   std::sort(result.begin(), result.end(), [](auto const& a, auto const& b) {
-    // Make `index.md` (if present) the first entry.
-    if (a.uid == "indexpage") return true;
+    // If there is an `indexpage` element (aka `index.md`) it should be the
+    // first entry.
     if (b.uid == "indexpage") return false;
+    if (a.uid == "indexpage") return true;
     return a.uid < b.uid;
   });
   return result;

--- a/docfx/doxygen_pages.cc
+++ b/docfx/doxygen_pages.cc
@@ -122,8 +122,17 @@ std::vector<TocEntry> PagesToc(pugi::xml_document const& doc) {
   std::transform(nodes.begin(), nodes.end(), result.begin(), [](auto const& i) {
     auto const& page = i.node();
     auto const id = std::string_view{page.attribute("id").as_string()};
-    if (id == "indexpage") return TocEntry{"indexpage.md", "README"};
-    return TocEntry{std::string(id) + ".md", std::string(id)};
+    std::ostringstream title;
+    AppendTitle(title, MarkdownContext{}, page);
+    auto filename =
+        std::string(id == "indexpage" ? std::string_view{"index"} : id) + ".md";
+    return TocEntry{std::string{id}, title.str(), std::move(filename)};
+  });
+  std::sort(result.begin(), result.end(), [](auto const& a, auto const& b) {
+    // Make `index.md` (if present) the first entry.
+    if (a.uid == "indexpage") return true;
+    if (b.uid == "indexpage") return false;
+    return a.uid < b.uid;
   });
   return result;
 }

--- a/docfx/doxygen_pages_test.cc
+++ b/docfx/doxygen_pages_test.cc
@@ -112,7 +112,7 @@ TEST(DoxygenPages, PagesToc) {
         </compounddef>
         <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="indexpage" kind="page">
           <compoundname>index</compoundname>
-          <title>The Page Title: unused in this test</title>
+          <title>The Page Title</title>
           <briefdescription><para>Some brief description.</para>
           </briefdescription>
           <detaileddescription><para>More details about the index.</para></detaileddescription>
@@ -123,9 +123,11 @@ TEST(DoxygenPages, PagesToc) {
   ASSERT_TRUE(doc.load_string(kXml));
   auto const actual = PagesToc(doc);
 
-  EXPECT_THAT(actual, ElementsAre(FieldsAre("common-error-handling.md",
-                                            "common-error-handling"),
-                                  FieldsAre("indexpage.md", "README")));
+  // The order matters, we want `indexpage` to be the first page.
+  EXPECT_THAT(actual,
+              ElementsAre(FieldsAre("indexpage", "The Page Title", "index.md"),
+                          FieldsAre("common-error-handling", "Error Handling",
+                                    "common-error-handling.md")));
 }
 
 }  // namespace

--- a/docfx/toc_entry.h
+++ b/docfx/toc_entry.h
@@ -22,8 +22,9 @@ namespace docfx {
 
 /// An entry in table of contents
 struct TocEntry {
-  std::string filename;
+  std::string uid;
   std::string name;
+  std::string filename;
 };
 
 inline bool operator==(TocEntry const& lhs, TocEntry const& rhs) {


### PR DESCRIPTION
Start the table of contents (TOC) with the `indexpage` and use
`index.md` as the output file for that page. Doxygen uses `indexpage`
for the landing page, the cloud site uses `index.md`.

Move the namespaces up in the TOC, and use the C++ name (instead of the
Doxygen uid) as the name of the TOC entry.

Move the groups down in the TOC, and use the group title as the name of
the TOC entry.

Keep the TOC entries sorted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11319)
<!-- Reviewable:end -->
