### PR TITLE
impl(rest): require `RestContext&` for requests

### DIFF
--- a/generator/integration_tests/tests/golden_thing_admin_rest_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_stub_test.cc
@@ -88,11 +88,11 @@ TEST(GoldenThingAdminRestStubTest, ListDatabases) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Get)
-      .WillOnce([&](RestRequest const&) {
+      .WillOnce([&](RestContext&, RestRequest const&) {
         return std::unique_ptr<rest_internal::RestResponse>(
             mock_503_response.release());
       })
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(
             request.path(),
             Eq("/v1/projects/my_project/instances/my_instance/databases"));
@@ -133,8 +133,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncCreateDatabase) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(
             request.path(),
@@ -168,7 +168,7 @@ TEST(GoldenThingAdminRestStubTest, GetDatabase) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/databases/my_database"));
         return std::unique_ptr<rest_internal::RestResponse>(
@@ -201,7 +201,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncUpdateDatabaseDdl) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Patch)
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(),
                     Eq("/v1/projects/my_project/instances/"
@@ -234,7 +234,7 @@ TEST(GoldenThingAdminRestStubTest, DropDatabase) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Delete)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/databases/my_database"));
         return std::unique_ptr<rest_internal::RestResponse>(
@@ -259,7 +259,7 @@ TEST(GoldenThingAdminRestStubTest, GetDatabaseDdl) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(),
                     Eq("/v1/projects/my_project/instances/"
                        "my_instance/databases/my_database/ddl"));
@@ -316,8 +316,8 @@ TEST(GoldenThingAdminRestStubTest, SetIamPolicy) {
       CreateMockRestResponse(json_response_database);
   auto mock_200_response_backup = CreateMockRestResponse(json_response_backup);
   EXPECT_CALL(*mock_service_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(),
                     Eq("/v1/projects/my_project/instances/my_instance/"
@@ -325,7 +325,7 @@ TEST(GoldenThingAdminRestStubTest, SetIamPolicy) {
         return std::unique_ptr<rest_internal::RestResponse>(
             mock_200_response_database.release());
       })
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(),
                     Eq("/v1/projects/my_project/instances/my_instance/backups/"
@@ -361,8 +361,8 @@ TEST(GoldenThingAdminRestStubTest, GetIamPolicy) {
       CreateMockRestResponse(json_response_database);
   auto mock_200_response_backup = CreateMockRestResponse(json_response_backup);
   EXPECT_CALL(*mock_service_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(),
                     Eq("/v1/projects/my_project/instances/my_instance/"
@@ -370,7 +370,7 @@ TEST(GoldenThingAdminRestStubTest, GetIamPolicy) {
         return std::unique_ptr<rest_internal::RestResponse>(
             mock_200_response_database.release());
       })
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(),
                     Eq("/v1/projects/my_project/instances/my_instance/backups/"
@@ -408,8 +408,8 @@ TEST(GoldenThingAdminRestStubTest, TestIamPermissions) {
       CreateMockRestResponse(json_response_database);
   auto mock_200_response_backup = CreateMockRestResponse(json_response_backup);
   EXPECT_CALL(*mock_service_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(),
                     Eq("/v1/projects/my_project/instances/my_instance/"
@@ -417,7 +417,7 @@ TEST(GoldenThingAdminRestStubTest, TestIamPermissions) {
         return std::unique_ptr<rest_internal::RestResponse>(
             mock_200_response_database.release());
       })
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(),
                     Eq("/v1/projects/my_project/instances/my_instance/backups/"
@@ -453,8 +453,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncCreateBackup) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(
             request.path(),
@@ -487,7 +487,7 @@ TEST(GoldenThingAdminRestStubTest, GetBackup) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/backups/my_backup"));
         return std::unique_ptr<rest_internal::RestResponse>(
@@ -517,7 +517,7 @@ TEST(GoldenThingAdminRestStubTest, UpdateBackup) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Patch)
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/backups/my_backup"));
@@ -547,7 +547,7 @@ TEST(GoldenThingAdminRestStubTest, DeleteBackup) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Delete)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/backups/my_backup"));
         return std::unique_ptr<rest_internal::RestResponse>(
@@ -579,7 +579,7 @@ TEST(GoldenThingAdminRestStubTest, ListBackups) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(
             request.path(),
             Eq("/v1/projects/my_project/instances/my_instance/backups"));
@@ -620,8 +620,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncRestoreDatabase) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/databases:restore"));
@@ -660,7 +660,7 @@ TEST(GoldenThingAdminRestStubTest, ListDatabaseOperations) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/databaseOperations"));
         EXPECT_THAT(request.GetQueryParameter("page_size"), Contains("100"));
@@ -699,7 +699,7 @@ TEST(GoldenThingAdminRestStubTest, ListBackupOperations) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/backupOperations"));
         EXPECT_THAT(request.GetQueryParameter("page_size"), Contains("100"));
@@ -736,7 +736,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetDatabase) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/databases/my_database"));
         return std::unique_ptr<rest_internal::RestResponse>(
@@ -772,7 +772,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncDropDatabase) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_service_client, Delete)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/projects/my_project/instances/"
                                        "my_instance/databases/my_database"));
         return std::unique_ptr<rest_internal::RestResponse>(
@@ -803,7 +803,7 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetOperation) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_operations_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/my_operation"));
         return std::unique_ptr<rest_internal::RestResponse>(
             mock_200_response.release());
@@ -834,8 +834,8 @@ TEST(GoldenThingAdminRestStubTest, AsyncCancelOperation) {
 
   auto mock_200_response = CreateMockRestResponse(json_response);
   EXPECT_CALL(*mock_operations_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(), Eq("/v1/my_operation:cancel"));
         return std::unique_ptr<rest_internal::RestResponse>(

--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -43,7 +43,8 @@ google::cloud::StatusOr<std::string> GetPage(std::string const& url) {
   auto client = rest::MakeDefaultRestClient(url_pieces.first + "com", {});
   rest::RestRequest request;
   request.SetPath(url_pieces.second);
-  auto response = client->Get(request);
+  rest_internal::RestContext context;
+  auto response = client->Get(context, request);
   if (!response) {
     return std::move(response).status();
   }

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -60,8 +60,9 @@ StatusOr<GetJobResponse> DefaultBigQueryJobRestStub::GetJob(
   auto rest_request = PrepareRestRequest<GetJobRequest>(rest_context, request);
 
   // Call the rest stub and parse the RestResponse.
+  rest_internal::RestContext context;
   return ParseFromRestResponse<GetJobResponse>(
-      rest_stub_->Get(std::move(*rest_request)));
+      rest_stub_->Get(context, std::move(*rest_request)));
 }
 
 StatusOr<ListJobsResponse> DefaultBigQueryJobRestStub::ListJobs(
@@ -71,8 +72,9 @@ StatusOr<ListJobsResponse> DefaultBigQueryJobRestStub::ListJobs(
       PrepareRestRequest<ListJobsRequest>(rest_context, request);
 
   // Call the rest stub and parse the RestResponse.
+  rest_internal::RestContext context;
   return ParseFromRestResponse<ListJobsResponse>(
-      rest_stub_->Get(std::move(*rest_request)));
+      rest_stub_->Get(context, std::move(*rest_request)));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_test.cc
@@ -35,6 +35,7 @@ using ::google::cloud::testing_util::MockHttpPayload;
 using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::An;
 using ::testing::ByMove;
 using ::testing::Eq;
@@ -78,7 +79,7 @@ TEST(BigQueryJobStubTest, GetJobSuccess) {
           Return(ByMove(MakeMockHttpPayloadSuccess(job_response_payload))));
 
   auto mock_rest_client = std::make_unique<MockRestClient>();
-  EXPECT_CALL(*mock_rest_client, Get(An<rest::RestRequest const&>()))
+  EXPECT_CALL(*mock_rest_client, Get(_, An<rest::RestRequest const&>()))
       .WillOnce(Return(ByMove(
           std::unique_ptr<rest::RestResponse>(std::move(mock_response)))));
 
@@ -98,7 +99,7 @@ TEST(BigQueryJobStubTest, GetJobSuccess) {
 TEST(BigQueryJobStubTest, GetJobRestClientError) {
   // Get() fails.
   auto mock_rest_client = std::make_unique<MockRestClient>();
-  EXPECT_CALL(*mock_rest_client, Get(An<rest::RestRequest const&>()))
+  EXPECT_CALL(*mock_rest_client, Get(_, An<rest::RestRequest const&>()))
       .WillOnce(
           Return(rest::AsStatus(HttpStatusCode::kInternalServerError, "")));
 
@@ -122,7 +123,7 @@ TEST(BigQueryJobStubTest, GetJobRestResponseError) {
 
   // Get() is successful.
   auto mock_rest_client = std::make_unique<MockRestClient>();
-  EXPECT_CALL(*mock_rest_client, Get(An<rest::RestRequest const&>()))
+  EXPECT_CALL(*mock_rest_client, Get(_, An<rest::RestRequest const&>()))
       .WillOnce(Return(ByMove(
           std::unique_ptr<rest::RestResponse>(std::move(mock_response)))));
 
@@ -165,7 +166,7 @@ TEST(BigQueryJobStubTest, ListJobsSuccess) {
           Return(ByMove(MakeMockHttpPayloadSuccess(job_response_payload))));
 
   auto mock_rest_client = std::make_unique<MockRestClient>();
-  EXPECT_CALL(*mock_rest_client, Get(An<rest::RestRequest const&>()))
+  EXPECT_CALL(*mock_rest_client, Get(_, An<rest::RestRequest const&>()))
       .WillOnce(Return(ByMove(
           std::unique_ptr<rest::RestResponse>(std::move(mock_response)))));
 
@@ -181,7 +182,7 @@ TEST(BigQueryJobStubTest, ListJobsSuccess) {
 
 TEST(BigQueryJobStubTest, ListJobsRestClientError) {
   auto mock_rest_client = std::make_unique<MockRestClient>();
-  EXPECT_CALL(*mock_rest_client, Get(An<rest::RestRequest const&>()))
+  EXPECT_CALL(*mock_rest_client, Get(_, An<rest::RestRequest const&>()))
       .WillOnce(
           Return(rest::AsStatus(HttpStatusCode::kInternalServerError, "")));
 
@@ -203,7 +204,7 @@ TEST(BigQueryJobStubTest, ListJobsRestResponseError) {
       .WillOnce(Return(std::move(mock_payload)));
 
   auto mock_rest_client = std::make_unique<MockRestClient>();
-  EXPECT_CALL(*mock_rest_client, Get(An<rest::RestRequest const&>()))
+  EXPECT_CALL(*mock_rest_client, Get(_, An<rest::RestRequest const&>()))
       .WillOnce(Return(ByMove(
           std::unique_ptr<rest::RestResponse>(std::move(mock_response)))));
 

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -269,7 +269,11 @@ void CurlImpl::SetHeader(std::pair<std::string, std::string> const& header) {
   SetHeader(absl::StrCat(header.first, ": ", header.second));
 }
 
-void CurlImpl::SetHeaders(RestRequest const& request) {
+void CurlImpl::SetHeaders(RestContext const& context,
+                          RestRequest const& request) {
+  for (auto const& header : context.headers()) {
+    SetHeader(std::make_pair(header.first, absl::StrJoin(header.second, ",")));
+  }
   for (auto const& header : request.headers()) {
     SetHeader(std::make_pair(header.first, absl::StrJoin(header.second, ",")));
   }

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/curl_handle.h"
 #include "google/cloud/internal/curl_handle_factory.h"
 #include "google/cloud/internal/curl_wrappers.h"
+#include "google/cloud/internal/rest_context.h"
 #include "google/cloud/internal/rest_request.h"
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/options.h"
@@ -80,7 +81,7 @@ class CurlImpl {
 
   void SetHeader(std::string const& header);
   void SetHeader(std::pair<std::string, std::string> const& header);
-  void SetHeaders(RestRequest const& request);
+  void SetHeaders(RestContext const& context, RestRequest const& request);
 
   std::string MakeEscapedString(std::string const& s);
 

--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -52,26 +52,26 @@ class CurlRestClient : public RestClient {
   CurlRestClient& operator=(CurlRestClient&&) = default;
 
   StatusOr<std::unique_ptr<RestResponse>> Delete(
-      RestRequest const& request) override;
+      RestContext& context, RestRequest const& request) override;
   StatusOr<std::unique_ptr<RestResponse>> Get(
-      RestRequest const& request) override;
+      RestContext& context, RestRequest const& request) override;
   StatusOr<std::unique_ptr<RestResponse>> Patch(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) override;
   StatusOr<std::unique_ptr<RestResponse>> Post(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) override;
   StatusOr<std::unique_ptr<RestResponse>> Post(
-      RestRequest request,
+      RestContext& context, RestRequest const& request,
       std::vector<std::pair<std::string, std::string>> const& form_data)
       override;
   StatusOr<std::unique_ptr<RestResponse>> Put(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) override;
 
  private:
   StatusOr<std::unique_ptr<CurlImpl>> CreateCurlImpl(
-      RestRequest const& request);
+      RestContext const& context, RestRequest const& request);
 
   std::string endpoint_address_;
   std::shared_ptr<CurlHandleFactory> handle_factory_;

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -482,9 +482,9 @@ TEST_F(RestClientIntegrationTest, RestContextHeaders) {
   auto body = ReadAll(std::move(*response).ExtractPayload());
   ASSERT_STATUS_OK(body);
   auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
-  ASSERT_TRUE(parsed_response.is_object());
+  ASSERT_TRUE(parsed_response.is_object()) << "body=" << *body;
   auto sent_headers = parsed_response.find("headers");
-  ASSERT_FALSE(sent_headers == parsed_response.end());
+  ASSERT_TRUE(sent_headers != parsed_response.end()) << "body=" << *body;
   EXPECT_EQ(sent_headers->value("X-Test-Header-1", ""), "header-value-1")
       << "body=" << *body;
   EXPECT_EQ(sent_headers->value("X-Test-Header-2", ""), "header-value-2")

--- a/google/cloud/internal/external_account_integration_test.cc
+++ b/google/cloud/internal/external_account_integration_test.cc
@@ -56,7 +56,8 @@ TEST(ExternalAccountIntegrationTest, UrlSourced) {
     for (int i = 0; i != 5; ++i) {
       if (i != 0) std::this_thread::sleep_for(delay);
       now = std::chrono::system_clock::now();
-      auto response = client->Get(request);
+      rest_internal::RestContext context;
+      auto response = client->Get(context, request);
       auto payload = get_payload(std::move(response));
       if (payload) return payload;
       last_status = std::move(payload).status();

--- a/google/cloud/internal/external_account_token_source_aws.cc
+++ b/google/cloud/internal/external_account_token_source_aws.cc
@@ -69,7 +69,8 @@ StatusOr<std::string> GetMetadata(std::string path,
   if (!session_token.empty()) {
     request.AddHeader(kMetadataTokenHeader, session_token);
   }
-  auto response = client->Get(request);
+  rest_internal::RestContext context;
+  auto response = client->Get(context, request);
   if (!response) return std::move(response).status();
   if (IsHttpError(**response)) return AsStatus(std::move(**response));
   return rest_internal::ReadAll(std::move(**response).ExtractPayload());
@@ -189,7 +190,8 @@ StatusOr<std::string> FetchMetadataToken(
                      .SetPath(std::move(info.imdsv2_session_token_url))
                      .AddHeader(kMetadataTokenTtlHeader, std::to_string(ttl));
   auto client = client_factory(opts);
-  auto response = client->Put(request, {});
+  rest_internal::RestContext context;
+  auto response = client->Put(context, request, {});
   if (!response) return std::move(response).status();
   if (IsHttpError(**response)) return AsStatus(std::move(**response));
   return rest_internal::ReadAll(std::move(**response).ExtractPayload());

--- a/google/cloud/internal/external_account_token_source_aws_test.cc
+++ b/google/cloud/internal/external_account_token_source_aws_test.cc
@@ -179,7 +179,7 @@ TEST(ExternalAccountTokenSource, SourceImdsv2Failure) {
   EXPECT_CALL(client_factory, Call).WillOnce([] {
     auto mock = std::make_unique<MockRestClient>();
     auto expected_request = Property(&RestRequest::path, kTestImdsv2Url);
-    EXPECT_CALL(*mock, Put(expected_request, _))
+    EXPECT_CALL(*mock, Put(_, expected_request, _))
         .WillOnce(Return(ByMove(MakeMockResponseNotFound())));
     return mock;
   });
@@ -219,7 +219,7 @@ TEST(ExternalAccountTokenSource, SourceRegionFailure) {
   EXPECT_CALL(client_factory, Call).WillOnce([] {
     auto mock = std::make_unique<MockRestClient>();
     auto expected_request = Property(&RestRequest::path, kTestRegionUrl);
-    EXPECT_CALL(*mock, Get(expected_request))
+    EXPECT_CALL(*mock, Get(_, expected_request))
         .WillOnce(Return(ByMove(MakeMockResponseNotFound())));
     return mock;
   });
@@ -256,7 +256,7 @@ TEST(ExternalAccountTokenSource, SourceSecretsFailure) {
   EXPECT_CALL(client_factory, Call).WillOnce([] {
     auto mock = std::make_unique<MockRestClient>();
     auto expected_request = Property(&RestRequest::path, kTestMetadataUrl);
-    EXPECT_CALL(*mock, Get(expected_request))
+    EXPECT_CALL(*mock, Get(_, expected_request))
         .WillOnce(Return(ByMove(MakeMockResponseNotFound())));
     return mock;
   });
@@ -581,7 +581,7 @@ TEST(ExternalAccountTokenSource, FetchMetadataTokenV2) {
         Property(&RestRequest::path, kTestImdsv2Url),
         Property(&RestRequest::headers,
                  Contains(Pair(kMetadataTokenTtlHeader, Not(IsEmpty())))));
-    EXPECT_CALL(*mock, Put(expected_request, _))
+    EXPECT_CALL(*mock, Put(_, expected_request, _))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(kTestImdsv2SessionToken))));
     return mock;
@@ -637,7 +637,7 @@ TEST(ExternalAccountTokenSource, FetchRegionFromUrlV1) {
       .WillOnce([url = info.region_url]() {
         auto mock = std::make_unique<MockRestClient>();
         auto expected_request = Property(&RestRequest::path, url);
-        EXPECT_CALL(*mock, Get(expected_request))
+        EXPECT_CALL(*mock, Get(_, expected_request))
             .WillOnce(Return(ByMove(MakeMockResponseSuccess("test-only-1d"))));
         return mock;
       });
@@ -665,7 +665,7 @@ TEST(ExternalAccountTokenSource, FetchRegionFromUrlV2) {
                   Property(&RestRequest::headers,
                            Contains(Pair(kMetadataTokenHeader,
                                          Contains(kTestImdsv2SessionToken)))));
-        EXPECT_CALL(*mock, Get(expected_request))
+        EXPECT_CALL(*mock, Get(_, expected_request))
             .WillOnce(Return(ByMove(MakeMockResponseSuccess("test-only-1d"))));
         return mock;
       });
@@ -688,7 +688,7 @@ TEST(ExternalAccountTokenSource, FetchRegionFromUrlEmpty) {
       .WillOnce([url = info.region_url]() {
         auto mock = std::make_unique<MockRestClient>();
         auto expected_request = Property(&RestRequest::path, url);
-        EXPECT_CALL(*mock, Get(expected_request))
+        EXPECT_CALL(*mock, Get(_, expected_request))
             .WillOnce(Return(ByMove(MakeMockResponseSuccess(""))));
         return mock;
       });
@@ -755,7 +755,7 @@ TEST(ExternalAccountTokenSource, FetchSecretsFromUrlV1) {
   auto make_client = [](std::string const& url, std::string const& contents) {
     auto mock = std::make_unique<MockRestClient>();
     auto expected_request = Property(&RestRequest::path, url);
-    EXPECT_CALL(*mock, Get(expected_request))
+    EXPECT_CALL(*mock, Get(_, expected_request))
         .WillOnce(Return(ByMove(MakeMockResponseSuccess(contents))));
     return mock;
   };
@@ -798,7 +798,7 @@ TEST(ExternalAccountTokenSource, FetchSecretsFromUrlV2) {
               Property(&RestRequest::headers,
                        Contains(Pair(kMetadataTokenHeader,
                                      Contains(kTestImdsv2SessionToken)))));
-    EXPECT_CALL(*mock, Get(expected_request))
+    EXPECT_CALL(*mock, Get(_, expected_request))
         .WillOnce(Return(ByMove(MakeMockResponseSuccess(contents))));
     return mock;
   };

--- a/google/cloud/internal/external_account_token_source_url.cc
+++ b/google/cloud/internal/external_account_token_source_url.cc
@@ -46,7 +46,8 @@ StatusOr<std::string> FetchContents(HttpClientFactory const& client_factory,
   auto client = client_factory(options);
   auto request = rest_internal::RestRequest(url);
   for (auto const& h : headers) request.AddHeader(h.first, h.second);
-  auto status = client->Get(request);
+  rest_internal::RestContext context;
+  auto status = client->Get(context, request);
   if (!status) return DecorateHttpError(std::move(status).status(), ec);
   auto response = *std::move(status);
   if (IsHttpError(*response)) {

--- a/google/cloud/internal/external_account_token_source_url_test.cc
+++ b/google/cloud/internal/external_account_token_source_url_test.cc
@@ -26,6 +26,7 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using ::google::cloud::rest_internal::HttpStatusCode;
+using ::google::cloud::rest_internal::RestContext;
 using ::google::cloud::rest_internal::RestRequest;
 using ::google::cloud::rest_internal::RestResponse;
 using ::google::cloud::testing_util::MockRestClient;
@@ -99,7 +100,7 @@ TEST(ExternalAccountTokenSource, WorkingPlainResponse) {
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
     EXPECT_CALL(*mock, Get)
-        .WillOnce([test_url, token](RestRequest const& request) {
+        .WillOnce([test_url, token](RestContext&, RestRequest const& request) {
           EXPECT_EQ(request.path(), test_url);
           return MakeMockResponseSuccess(token);
         });
@@ -122,7 +123,7 @@ TEST(ExternalAccountTokenSource, WorkingPlainResponseWithHeaders) {
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
     EXPECT_CALL(*mock, Get)
-        .WillOnce([test_url, token](RestRequest const& request) {
+        .WillOnce([test_url, token](RestContext&, RestRequest const& request) {
           EXPECT_EQ(request.path(), test_url);
           EXPECT_THAT(
               request.headers(),
@@ -157,10 +158,11 @@ TEST(ExternalAccountTokenSource, WorkingJsonResponse) {
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
     EXPECT_CALL(*mock, Get)
-        .WillOnce([test_url, contents](RestRequest const& request) {
-          EXPECT_EQ(request.path(), test_url);
-          return MakeMockResponseSuccess(contents);
-        });
+        .WillOnce(
+            [test_url, contents](RestContext&, RestRequest const& request) {
+              EXPECT_EQ(request.path(), test_url);
+              return MakeMockResponseSuccess(contents);
+            });
     return mock;
   });
 
@@ -249,10 +251,11 @@ TEST(ExternalAccountTokenSource, ErrorInPlainResponse) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Get).WillOnce([test_url](RestRequest const& request) {
-      EXPECT_EQ(request.path(), test_url);
-      return MakeMockResponseError();
-    });
+    EXPECT_CALL(*mock, Get)
+        .WillOnce([test_url](RestContext&, RestRequest const& request) {
+          EXPECT_EQ(request.path(), test_url);
+          return MakeMockResponseError();
+        });
     return mock;
   });
 
@@ -280,10 +283,11 @@ TEST(ExternalAccountTokenSource, ErrorInJsonResponse) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Get).WillOnce([test_url](RestRequest const& request) {
-      EXPECT_EQ(request.path(), test_url);
-      return MakeMockResponseError();
-    });
+    EXPECT_CALL(*mock, Get)
+        .WillOnce([test_url](RestContext&, RestRequest const& request) {
+          EXPECT_EQ(request.path(), test_url);
+          return MakeMockResponseError();
+        });
     return mock;
   });
 
@@ -318,10 +322,11 @@ TEST(ExternalAccountTokenSource, JsonResponseIsNotJson) {
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
     EXPECT_CALL(*mock, Get)
-        .WillOnce([test_url, contents](RestRequest const& request) {
-          EXPECT_EQ(request.path(), test_url);
-          return MakeMockResponseSuccess(contents);
-        });
+        .WillOnce(
+            [test_url, contents](RestContext&, RestRequest const& request) {
+              EXPECT_EQ(request.path(), test_url);
+              return MakeMockResponseSuccess(contents);
+            });
     return mock;
   });
 
@@ -355,10 +360,11 @@ TEST(ExternalAccountTokenSource, JsonResponseIsNotJsonObject) {
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
     EXPECT_CALL(*mock, Get)
-        .WillOnce([test_url, contents](RestRequest const& request) {
-          EXPECT_EQ(request.path(), test_url);
-          return MakeMockResponseSuccess(contents);
-        });
+        .WillOnce(
+            [test_url, contents](RestContext&, RestRequest const& request) {
+              EXPECT_EQ(request.path(), test_url);
+              return MakeMockResponseSuccess(contents);
+            });
     return mock;
   });
 
@@ -392,10 +398,11 @@ TEST(ExternalAccountTokenSource, JsonResponseMissingField) {
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
     EXPECT_CALL(*mock, Get)
-        .WillOnce([test_url, contents](RestRequest const& request) {
-          EXPECT_EQ(request.path(), test_url);
-          return MakeMockResponseSuccess(contents);
-        });
+        .WillOnce(
+            [test_url, contents](RestContext&, RestRequest const& request) {
+              EXPECT_EQ(request.path(), test_url);
+              return MakeMockResponseSuccess(contents);
+            });
     return mock;
   });
 
@@ -429,10 +436,11 @@ TEST(ExternalAccountTokenSource, JsonResponseInvalidField) {
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
     EXPECT_CALL(*mock, Get)
-        .WillOnce([test_url, contents](RestRequest const& request) {
-          EXPECT_EQ(request.path(), test_url);
-          return MakeMockResponseSuccess(contents);
-        });
+        .WillOnce(
+            [test_url, contents](RestContext&, RestRequest const& request) {
+              EXPECT_EQ(request.path(), test_url);
+              return MakeMockResponseSuccess(contents);
+            });
     return mock;
   });
 

--- a/google/cloud/internal/oauth2_authorized_user_credentials.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.cc
@@ -100,7 +100,8 @@ StatusOr<internal::AccessToken> AuthorizedUserCredentials::GetToken(
   form_data.emplace_back("client_secret", info_.client_secret);
   form_data.emplace_back("refresh_token", info_.refresh_token);
   auto client = client_factory_(options_);
-  auto response = client->Post(request, form_data);
+  rest_internal::RestContext unused;
+  auto response = client->Post(unused, request, form_data);
   if (!response.ok()) return std::move(response).status();
   if (IsHttpError(**response)) return AsStatus(std::move(**response));
   return ParseAuthorizedUserRefreshResponse(**response, tp);

--- a/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
@@ -34,6 +34,7 @@ using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
 using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::AllOf;
 using ::testing::ByMove;
 using ::testing::HasSubstr;
@@ -82,7 +83,7 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
         Pair("client_secret", "a-123456ABCDEF"),
         Pair("refresh_token", "1/THETOKEN"),
     }));
-    EXPECT_CALL(*client, Post(expected_request, expected_form_data))
+    EXPECT_CALL(*client, Post(_, expected_request, expected_form_data))
         .WillOnce(
             Return(ByMove(std::unique_ptr<RestResponse>(std::move(response)))));
     return client;

--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -37,7 +37,8 @@ DoMetadataServerGetRequest(rest_internal::RestClient& client,
                                internal::GceMetadataHostname(), "/", path));
   request.AddHeader("metadata-flavor", "Google");
   if (recursive) request.AddQueryParameter("recursive", "true");
-  return client.Get(request);
+  rest_internal::RestContext context;
+  return client.Get(context, request);
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -151,7 +151,8 @@ StatusOr<internal::AccessToken> ExternalAccountCredentials::GetToken(
           .AddHeader("content-type", "application/x-www-form-urlencoded");
 
   auto client = client_factory_(options_);
-  auto response = client->Post(request, form_data);
+  rest_internal::RestContext unused;
+  auto response = client->Post(unused, request, form_data);
   if (!response) return std::move(response).status();
   if (IsHttpError(**response)) return AsStatus(std::move(**response));
   auto payload = rest_internal::ReadAll(std::move(**response).ExtractPayload());
@@ -212,7 +213,8 @@ ExternalAccountCredentials::GetTokenImpersonation(
       {"lifetime", std::to_string(lifetime.count()) + "s"}};
 
   auto client = client_factory_(options_);
-  auto response = client->Post(request, {request_payload.dump()});
+  rest_internal::RestContext context;
+  auto response = client->Post(context, request, {request_payload.dump()});
   if (!response) return std::move(response).status();
   return ParseGenerateAccessTokenResponse(**response, ec);
 }

--- a/google/cloud/internal/oauth2_external_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials_test.cc
@@ -614,7 +614,7 @@ TEST(ExternalAccount, Working) {
             Pair("audience", "test-audience"),
             Pair("subject_token_type", "test-subject-token-type"),
             Pair("subject_token", "test-subject-token")));
-    EXPECT_CALL(*mock, Post(expected_request, expected_payload))
+    EXPECT_CALL(*mock, Post(_, expected_request, expected_payload))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(json_response.dump()))));
     return mock;
@@ -684,7 +684,7 @@ TEST(ExternalAccount, WorkingWithImpersonation) {
             Pair("subject_token", "test-subject-token")));
     auto sts_response = MakeMockResponseSuccess(sts_payload.dump());
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(expected_sts_request, expected_form_data))
+    EXPECT_CALL(*mock, Post(_, expected_sts_request, expected_form_data))
         .WillOnce(Return(ByMove(std::move(sts_response))));
     return mock;
   }();
@@ -703,8 +703,8 @@ TEST(ExternalAccount, WorkingWithImpersonation) {
     auto impersonate_response =
         MakeMockResponseSuccess(impersonate_response_payload.dump());
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(
-        *mock, Post(expected_impersonate_request, expected_impersonate_payload))
+    EXPECT_CALL(*mock, Post(_, expected_impersonate_request,
+                            expected_impersonate_payload))
         .WillOnce(Return(ByMove(std::move(impersonate_response))));
     return mock;
   }();
@@ -754,7 +754,7 @@ TEST(ExternalAccount, HandleHttpError) {
             Pair("subject_token_type", "test-subject-token-type"),
             Pair("subject_token", "test-subject-token")));
 
-    EXPECT_CALL(*mock, Post(expected_request, expected_form_data))
+    EXPECT_CALL(*mock, Post(_, expected_request, expected_form_data))
         .WillOnce(Return(ByMove(MakeMockResponseError())));
     return mock;
   });
@@ -791,7 +791,7 @@ TEST(ExternalAccount, HandleHttpPartialError) {
             Pair("subject_token_type", "test-subject-token-type"),
             Pair("subject_token", "test-subject-token")));
 
-    EXPECT_CALL(*mock, Post(expected_request, expected_form_data))
+    EXPECT_CALL(*mock, Post(_, expected_request, expected_form_data))
         .WillOnce(Return(ByMove(MakeMockResponsePartialError(response))));
     return mock;
   });
@@ -828,7 +828,7 @@ TEST(ExternalAccount, HandleNotJson) {
             Pair("audience", "test-audience"),
             Pair("subject_token_type", "test-subject-token-type"),
             Pair("subject_token", "test-subject-token")));
-    EXPECT_CALL(*mock, Post(expected_request, expected_payload))
+    EXPECT_CALL(*mock, Post(_, expected_request, expected_payload))
         .WillOnce(Return(ByMove(MakeMockResponseSuccess(payload))));
     return mock;
   });
@@ -866,7 +866,7 @@ TEST(ExternalAccount, HandleNotJsonObject) {
             Pair("audience", "test-audience"),
             Pair("subject_token_type", "test-subject-token-type"),
             Pair("subject_token", "test-subject-token")));
-    EXPECT_CALL(*mock, Post(expected_request, expected_payload))
+    EXPECT_CALL(*mock, Post(_, expected_request, expected_payload))
         .WillOnce(Return(ByMove(MakeMockResponseSuccess(payload))));
     return mock;
   });
@@ -899,7 +899,7 @@ TEST(ExternalAccount, MissingToken) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(_, An<FormDataType const&>()))
+    EXPECT_CALL(*mock, Post(_, _, An<FormDataType const&>()))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(json_response.dump()))));
     return mock;
@@ -932,7 +932,7 @@ TEST(ExternalAccount, MissingIssuedTokenType) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(_, An<FormDataType const&>()))
+    EXPECT_CALL(*mock, Post(_, _, An<FormDataType const&>()))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(json_response.dump()))));
     return mock;
@@ -965,7 +965,7 @@ TEST(ExternalAccount, MissingTokenType) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(_, An<FormDataType const&>()))
+    EXPECT_CALL(*mock, Post(_, _, An<FormDataType const&>()))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(json_response.dump()))));
     return mock;
@@ -998,7 +998,7 @@ TEST(ExternalAccount, InvalidIssuedTokenType) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(_, An<FormDataType const&>()))
+    EXPECT_CALL(*mock, Post(_, _, An<FormDataType const&>()))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(json_response.dump()))));
     return mock;
@@ -1033,7 +1033,7 @@ TEST(ExternalAccount, InvalidTokenType) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(_, An<FormDataType const&>()))
+    EXPECT_CALL(*mock, Post(_, _, An<FormDataType const&>()))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(json_response.dump()))));
     return mock;
@@ -1069,7 +1069,7 @@ TEST(ExternalAccount, MissingExpiresIn) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(_, An<FormDataType const&>()))
+    EXPECT_CALL(*mock, Post(_, _, An<FormDataType const&>()))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(json_response.dump()))));
     return mock;
@@ -1103,7 +1103,7 @@ TEST(ExternalAccount, InvalidExpiresIn) {
   MockClientFactory client_factory;
   EXPECT_CALL(client_factory, Call).WillOnce([&]() {
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(_, An<FormDataType const&>()))
+    EXPECT_CALL(*mock, Post(_, _, An<FormDataType const&>()))
         .WillOnce(
             Return(ByMove(MakeMockResponseSuccess(json_response.dump()))));
     return mock;

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -59,7 +59,8 @@ MinimalIamCredentialsRestStub::GenerateAccessToken(
   };
 
   auto client = client_factory_(options_);
-  auto response = client->Post(rest_request, {payload.dump()});
+  rest_internal::RestContext context;
+  auto response = client->Post(context, rest_request, {payload.dump()});
   if (!response) return std::move(response).status();
   return ParseGenerateAccessTokenResponse(
       **response,

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
@@ -31,6 +31,7 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::rest_internal::RestContext;
 using ::google::cloud::rest_internal::RestRequest;
 using ::google::cloud::rest_internal::RestResponse;
 using ::google::cloud::testing_util::IsOk;
@@ -216,9 +217,9 @@ TEST(MinimalIamCredentialsRestTest, GenerateAccessTokenSuccess) {
   EXPECT_CALL(mock_client_factory, Call).WillOnce([=](Options const&) {
     auto client = std::make_unique<MockRestClient>();
     EXPECT_CALL(*client,
-                Post(_, A<std::vector<absl::Span<char const>> const&>()))
+                Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
         .WillOnce([response, service_account](
-                      RestRequest const& request,
+                      RestContext&, RestRequest const& request,
                       std::vector<absl::Span<char const>> const& payload) {
           auto mock_response = std::make_unique<MockRestResponse>();
           EXPECT_CALL(*mock_response, StatusCode)

--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -355,7 +355,8 @@ StatusOr<internal::AccessToken> ServiceAccountCredentials::GetTokenOAuth(
   rest_internal::RestRequest request;
   request.SetPath(options_.get<ServiceAccountCredentialsTokenUriOption>());
   auto payload = CreateServiceAccountRefreshPayload(info_, tp);
-  auto response = client->Post(request, payload);
+  rest_internal::RestContext context;
+  auto response = client->Post(context, request, payload);
   if (!response) return std::move(response).status();
   if (IsHttpError(**response)) return AsStatus(std::move(**response));
   return ParseServiceAccountRefreshResponse(**response, tp);

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -42,6 +42,7 @@ using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::AllOf;
 using ::testing::ByMove;
 using ::testing::Contains;
@@ -142,7 +143,7 @@ void CheckInfoYieldsExpectedAssertion(ServiceAccountCredentialsInfo const& info,
     auto expected_form_data = MatcherCast<FormDataType const&>(
         AllOf(Contains(Pair("assertion", assertion)),
               Contains(Pair("grant_type", kGrantParamUnescaped))));
-    EXPECT_CALL(*mock, Post(expected_request, expected_form_data))
+    EXPECT_CALL(*mock, Post(_, expected_request, expected_form_data))
         .WillOnce([assertion, post_response]() {
           auto response = std::make_unique<MockRestResponse>();
           EXPECT_CALL(*response, StatusCode)

--- a/google/cloud/internal/rest_client.h
+++ b/google/cloud/internal/rest_client.h
@@ -56,12 +56,12 @@ std::unique_ptr<RestClient> MakePooledRestClient(std::string endpoint_address,
  * contains the HTTP status code, response headers, and an object to iterate
  * over the payload.
  *
- * Note that HTTP requests that fail with a HTTP status code, e.g. with
- * "404 - NOT FOUND" are considered a success, i.e., the returned `StatusOr<>`
- * will contain a value (and not an error). Callers can convert these HTTP
- * errors to a `Status` using @ref AsStatus(RestResponse&&). In some cases
- * (e.g. PUT requests for GCS resumable uploadS) a HTTP error is "normal", and
- * should be treated as a successful request.
+ * Note that HTTP requests that fail with an HTTP status code, e.g. with
+ * "404 - NOT FOUND", are considered a success. That is, the returned
+ * `StatusOr<>` will contain a value (and not an error). Callers can convert
+ * these HTTP errors to a `Status` using @ref AsStatus(RestResponse&&). In some
+ * cases (e.g. PUT requests for GCS resumable uploads) an HTTP error is
+ * "normal", and should be treated as a successful request.
  *
  * Each method consumes a `RestContext` parameter. Often the `request` parameter
  * is prepared once as part of a retry loop. The `RestContext` can be used to

--- a/google/cloud/internal/rest_client.h
+++ b/google/cloud/internal/rest_client.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_CLIENT_H
 
+#include "google/cloud/internal/rest_context.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/internal/rest_request.h"
 #include "google/cloud/internal/rest_response.h"
@@ -42,26 +43,50 @@ std::unique_ptr<RestClient> MakeDefaultRestClient(std::string endpoint_address,
 std::unique_ptr<RestClient> MakePooledRestClient(std::string endpoint_address,
                                                  Options options);
 
-// Provides methods corresponding to HTTP verbs to make requests to RESTful
-// services.
+/**
+ * Provides methods corresponding to HTTP verbs to make HTTP requests.
+ *
+ * Concrete versions of this class make HTTP requests. While typically used with
+ * RESTful services, the interface and implementions can be used to make any
+ * HTTP requests.
+ *
+ * The headers, payload, and query parameters for the request are passed in as
+ * a `RestRequest` parameter.  The result is a
+ * `StatusOr<std::unique_ptr<RestResponse>>`. On success, the `RestResponse`
+ * contains the HTTP status code, response headers, and an object to iterate
+ * over the payload.
+ *
+ * Note that HTTP requests that fail with a HTTP status code, e.g. with
+ * "404 - NOT FOUND" are considered a success, i.e., the returned `StatusOr<>`
+ * will contain a value (and not an error). Callers can convert these HTTP
+ * errors to a `Status` using @ref AsStatus(RestResponse&&). In some cases
+ * (e.g. PUT requests for GCS resumable uploadS) a HTTP error is "normal", and
+ * should be treated as a successful request.
+ *
+ * Each method consumes a `RestContext` parameter. Often the `request` parameter
+ * is prepared once as part of a retry loop. The `RestContext` can be used to
+ * provide or change headers in retry, tracing, or other decorators. The
+ * `RestContext` also returns request metadata, such as the local and remote
+ * IP and port. Such metadata is useful for tracing and troubleshooting.
+ */
 class RestClient {
  public:
   virtual ~RestClient() = default;
   virtual StatusOr<std::unique_ptr<RestResponse>> Delete(
-      RestRequest const& request) = 0;
+      RestContext& context, RestRequest const& request) = 0;
   virtual StatusOr<std::unique_ptr<RestResponse>> Get(
-      RestRequest const& request) = 0;
+      RestContext& context, RestRequest const& request) = 0;
   virtual StatusOr<std::unique_ptr<RestResponse>> Patch(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) = 0;
   virtual StatusOr<std::unique_ptr<RestResponse>> Post(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) = 0;
   virtual StatusOr<std::unique_ptr<RestResponse>> Post(
-      RestRequest request,
+      RestContext& context, RestRequest const& request,
       std::vector<std::pair<std::string, std::string>> const& form_data) = 0;
   virtual StatusOr<std::unique_ptr<RestResponse>> Put(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) = 0;
 };
 

--- a/google/cloud/internal/rest_stub_helpers.h
+++ b/google/cloud/internal/rest_stub_helpers.h
@@ -48,9 +48,9 @@ template <typename Request>
 Status Delete(rest_internal::RestClient& client,
               rest_internal::RestContext& rest_context, Request const&,
               std::string path) {
-  rest_internal::RestRequest rest_request(rest_context);
+  rest_internal::RestRequest rest_request;
   rest_request.SetPath(std::move(path));
-  auto response = client.Delete(rest_request);
+  auto response = client.Delete(rest_context, rest_request);
   if (!response.ok()) return response.status();
   return AsStatus(std::move(**response));
 }
@@ -59,9 +59,9 @@ template <typename Response, typename Request>
 StatusOr<Response> Delete(rest_internal::RestClient& client,
                           rest_internal::RestContext& rest_context,
                           Request const&, std::string path) {
-  rest_internal::RestRequest rest_request(rest_context);
+  rest_internal::RestRequest rest_request;
   rest_request.SetPath(std::move(path));
-  auto response = client.Delete(rest_request);
+  auto response = client.Delete(rest_context, rest_request);
   if (!response.ok()) return response.status();
   return RestResponseToProto<Response>(std::move(**response));
 }
@@ -71,12 +71,12 @@ StatusOr<Response> Get(
     rest_internal::RestClient& client, rest_internal::RestContext& rest_context,
     Request const&, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
-  rest_internal::RestRequest rest_request(rest_context);
+  rest_internal::RestRequest rest_request;
   for (auto& p : query_params) {
     rest_request.AddQueryParameter(std::move(p));
   }
   rest_request.SetPath(std::move(path));
-  auto response = client.Get(rest_request);
+  auto response = client.Get(rest_context, rest_request);
   if (!response.ok()) return response.status();
   return RestResponseToProto<Response>(std::move(**response));
 }
@@ -88,11 +88,11 @@ StatusOr<Response> Patch(rest_internal::RestClient& client,
   std::string json_payload;
   auto status = ProtoRequestToJsonPayload(request, json_payload);
   if (!status.ok()) return status;
-  rest_internal::RestRequest rest_request(rest_context);
+  rest_internal::RestRequest rest_request;
   rest_request.SetPath(std::move(path));
   rest_request.AddHeader("content-type", "application/json");
-  auto response =
-      client.Patch(rest_request, {absl::MakeConstSpan(json_payload)});
+  auto response = client.Patch(rest_context, rest_request,
+                               {absl::MakeConstSpan(json_payload)});
   if (!response.ok()) return response.status();
   return RestResponseToProto<Response>(std::move(**response));
 }
@@ -105,14 +105,14 @@ StatusOr<Response> Post(
   std::string json_payload;
   auto status = ProtoRequestToJsonPayload(request, json_payload);
   if (!status.ok()) return status;
-  rest_internal::RestRequest rest_request(rest_context);
+  rest_internal::RestRequest rest_request;
   rest_request.SetPath(std::move(path));
   for (auto& p : query_params) {
     rest_request.AddQueryParameter(std::move(p));
   }
   rest_request.AddHeader("content-type", "application/json");
-  auto response =
-      client.Post(rest_request, {absl::MakeConstSpan(json_payload)});
+  auto response = client.Post(rest_context, rest_request,
+                              {absl::MakeConstSpan(json_payload)});
   if (!response.ok()) return response.status();
   return RestResponseToProto<Response>(std::move(**response));
 }
@@ -125,14 +125,14 @@ Status Post(
   std::string json_payload;
   auto status = ProtoRequestToJsonPayload(request, json_payload);
   if (!status.ok()) return status;
-  rest_internal::RestRequest rest_request(rest_context);
+  rest_internal::RestRequest rest_request;
   rest_request.SetPath(std::move(path));
   for (auto& p : query_params) {
     rest_request.AddQueryParameter(std::move(p));
   }
   rest_request.AddHeader("content-type", "application/json");
-  auto response =
-      client.Post(rest_request, {absl::MakeConstSpan(json_payload)});
+  auto response = client.Post(rest_context, rest_request,
+                              {absl::MakeConstSpan(json_payload)});
   if (!response.ok()) return response.status();
   return AsStatus(std::move(**response));
 }
@@ -144,10 +144,11 @@ StatusOr<Response> Put(rest_internal::RestClient& client,
   std::string json_payload;
   auto status = ProtoRequestToJsonPayload(request, json_payload);
   if (!status.ok()) return status;
-  rest_internal::RestRequest rest_request(rest_context);
+  rest_internal::RestRequest rest_request;
   rest_request.SetPath(std::move(path));
   rest_request.AddHeader("content-type", "application/json");
-  auto response = client.Put(rest_request, {absl::MakeConstSpan(json_payload)});
+  auto response = client.Put(rest_context, rest_request,
+                             {absl::MakeConstSpan(json_payload)});
   if (!response.ok()) return response.status();
   return RestResponseToProto<Response>(std::move(**response));
 }

--- a/google/cloud/internal/rest_stub_helpers_test.cc
+++ b/google/cloud/internal/rest_stub_helpers_test.cc
@@ -136,15 +136,15 @@ TEST(RestStubHelpers, DeleteWithEmptyResponse) {
 
   auto mock_client = std::make_unique<MockRestClient>();
   EXPECT_CALL(*mock_client, Delete)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/delete/"));
         return std::unique_ptr<rest_internal::RestResponse>(mock_200_response);
       })
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/delete/"));
         return Status(StatusCode::kInternal, "Internal Error");
       })
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/delete/"));
         return std::unique_ptr<rest_internal::RestResponse>(mock_403_response);
       });
@@ -186,11 +186,11 @@ TEST(RestStubHelpers, DeleteWithNonEmptyResponse) {
 
   auto mock_client = std::make_unique<MockRestClient>();
   EXPECT_CALL(*mock_client, Delete)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/delete/"));
         return Status(StatusCode::kInternal, "Internal Error");
       })
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/delete/"));
         return std::unique_ptr<rest_internal::RestResponse>(mock_200_response);
       });
@@ -223,13 +223,13 @@ TEST(RestStubHelpers, Get) {
 
   auto mock_client = std::make_unique<MockRestClient>();
   EXPECT_CALL(*mock_client, Get)
-      .WillOnce([&](RestRequest const& request) {
+      .WillOnce([&](RestContext&, RestRequest const& request) {
         EXPECT_THAT(request.path(), Eq("/v1/"));
         EXPECT_THAT(request.GetQueryParameter("name"),
                     Contains(proto_request.name()));
         return Status(StatusCode::kInternal, "Internal Error");
       })
-      .WillOnce([&](RestRequest const& request)
+      .WillOnce([&](RestContext&, RestRequest const& request)
                     -> google::cloud::StatusOr<
                         std::unique_ptr<rest_internal::RestResponse>> {
         EXPECT_THAT(request.path(), Eq("/v1/"));
@@ -299,17 +299,17 @@ TEST(RestStubHelpers, Patch) {
 
   auto mock_client = std::make_unique<MockRestClient>();
   EXPECT_CALL(*mock_client, Patch)
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(), Eq("/v1/"));
         return Status(StatusCode::kInternal, "Internal Error");
       })
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext& context, RestRequest const& request,
                     std::vector<absl::Span<char const>> const& payload) {
         EXPECT_THAT(request.path(), Eq("/v1/"));
         EXPECT_THAT(request.GetHeader("content-type"),
                     Contains("application/json"));
-        EXPECT_THAT(request.GetHeader("custom"), Contains("header"));
+        EXPECT_THAT(context.GetHeader("custom"), Contains("header"));
         std::string payload_str(payload[0].begin(), payload[0].end());
         EXPECT_THAT(payload_str, Eq(json_request));
         return std::unique_ptr<rest_internal::RestResponse>(mock_200_response);
@@ -349,15 +349,15 @@ TEST(RestStubHelpers, PostWithNonEmptyResponse) {
 
   auto mock_client = std::make_unique<MockRestClient>();
   EXPECT_CALL(*mock_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(), Eq("/v1/"));
         EXPECT_THAT(request.GetQueryParameter("name"),
                     Contains(proto_request.name()));
         return Status(StatusCode::kInternal, "Internal Error");
       })
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const& payload)
                     -> google::cloud::StatusOr<
                         std::unique_ptr<rest_internal::RestResponse>> {
@@ -406,15 +406,15 @@ TEST(RestStubHelpers, PostWithEmptyResponse) {
 
   auto mock_client = std::make_unique<MockRestClient>();
   EXPECT_CALL(*mock_client,
-              Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](RestRequest const& request,
+              Post(_, _, A<std::vector<absl::Span<char const>> const&>()))
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(), Eq("/v1/"));
         EXPECT_THAT(request.GetQueryParameter("name"),
                     Contains(proto_request.name()));
         return Status(StatusCode::kInternal, "Internal Error");
       })
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const& payload) {
         EXPECT_THAT(request.path(), Eq("/v1/"));
         EXPECT_THAT(request.GetQueryParameter("name"),
@@ -458,14 +458,14 @@ TEST(RestStubHelpers, Put) {
 
   auto mock_client = std::make_unique<MockRestClient>();
   EXPECT_CALL(*mock_client, Put)
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const&) {
         EXPECT_THAT(request.path(), Eq("/v1/"));
         EXPECT_THAT(request.GetHeader("content-type"),
                     Contains("application/json"));
         return Status(StatusCode::kInternal, "Internal Error");
       })
-      .WillOnce([&](RestRequest const& request,
+      .WillOnce([&](RestContext&, RestRequest const& request,
                     std::vector<absl::Span<char const>> const& payload) {
         EXPECT_THAT(request.path(), Eq("/v1/"));
         EXPECT_THAT(request.GetHeader("content-type"),

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -56,43 +56,47 @@ TracingRestClient::TracingRestClient(std::unique_ptr<RestClient> impl)
     : impl_(std::move(impl)) {}
 
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Delete(
-    RestRequest const& request) {
+    RestContext& context, RestRequest const& request) {
   auto span = MakeSpanHttp(request, "DELETE");
-  return EndResponseSpan(std::move(span), impl_->Delete(request));
+  return EndResponseSpan(std::move(span), impl_->Delete(context, request));
 }
 
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Get(
-    RestRequest const& request) {
+    RestContext& context, RestRequest const& request) {
   auto span = MakeSpanHttp(request, "GET");
-  return EndResponseSpan(std::move(span), impl_->Get(request));
+  return EndResponseSpan(std::move(span), impl_->Get(context, request));
 }
 
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Patch(
-    RestRequest const& request,
+    RestContext& context, RestRequest const& request,
     std::vector<absl::Span<char const>> const& payload) {
   auto span = MakeSpanHttp(request, "POST");
-  return EndResponseSpan(std::move(span), impl_->Patch(request, payload));
+  return EndResponseSpan(std::move(span),
+                         impl_->Patch(context, request, payload));
 }
 
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Post(
-    RestRequest const& request,
+    RestContext& context, RestRequest const& request,
     std::vector<absl::Span<char const>> const& payload) {
   auto span = MakeSpanHttp(request, "POST");
-  return EndResponseSpan(std::move(span), impl_->Post(request, payload));
+  return EndResponseSpan(std::move(span),
+                         impl_->Post(context, request, payload));
 }
 
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Post(
-    RestRequest request,
+    RestContext& context, RestRequest const& request,
     std::vector<std::pair<std::string, std::string>> const& form_data) {
   auto span = MakeSpanHttp(request, "PUT");
-  return EndResponseSpan(std::move(span), impl_->Post(request, form_data));
+  return EndResponseSpan(std::move(span),
+                         impl_->Post(context, request, form_data));
 }
 
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Put(
-    RestRequest const& request,
+    RestContext& context, RestRequest const& request,
     std::vector<absl::Span<char const>> const& payload) {
   auto span = MakeSpanHttp(request, "PUT");
-  return EndResponseSpan(std::move(span), impl_->Put(request, payload));
+  return EndResponseSpan(std::move(span),
+                         impl_->Put(context, request, payload));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/internal/tracing_rest_client.h
+++ b/google/cloud/internal/tracing_rest_client.h
@@ -31,21 +31,21 @@ class TracingRestClient : public RestClient {
   ~TracingRestClient() override = default;
 
   StatusOr<std::unique_ptr<RestResponse>> Delete(
-      RestRequest const& request) override;
+      RestContext& context, RestRequest const& request) override;
   StatusOr<std::unique_ptr<RestResponse>> Get(
-      RestRequest const& request) override;
+      RestContext& context, RestRequest const& request) override;
   StatusOr<std::unique_ptr<RestResponse>> Patch(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) override;
   StatusOr<std::unique_ptr<RestResponse>> Post(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) override;
   StatusOr<std::unique_ptr<RestResponse>> Post(
-      RestRequest request,
+      RestContext& context, RestRequest const& request,
       std::vector<std::pair<std::string, std::string>> const& form_data)
       override;
   StatusOr<std::unique_ptr<RestResponse>> Put(
-      RestRequest const& request,
+      RestContext& context, RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) override;
 
  private:

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -59,7 +59,7 @@ TEST(TracingRestClient, Delete) {
   auto span_catcher = InstallSpanCatcher();
 
   auto impl = std::make_unique<MockRestClient>();
-  EXPECT_CALL(*impl, Delete).WillOnce([](RestRequest const&) {
+  EXPECT_CALL(*impl, Delete).WillOnce([](RestContext&, RestRequest const&) {
     auto response = std::make_unique<MockRestResponse>();
     EXPECT_CALL(*response, StatusCode)
         .WillRepeatedly(Return(HttpStatusCode::kOk));
@@ -75,7 +75,8 @@ TEST(TracingRestClient, Delete) {
   request.AddHeader("x-test-header-3", "value3");
 
   auto client = MakeTracingRestClient(std::move(impl));
-  auto r = client->Delete(request);
+  rest_internal::RestContext context;
+  auto r = client->Delete(context, request);
   ASSERT_STATUS_OK(r);
   auto response = *std::move(r);
   ASSERT_THAT(response, NotNull());

--- a/google/cloud/internal/unified_rest_credentials_integration_test.cc
+++ b/google/cloud/internal/unified_rest_credentials_integration_test.cc
@@ -54,7 +54,10 @@ void MakeBigQueryRpcCall(Options options) {
   RestRequest request;
   request.SetPath("bigquery/v2/projects/bigquery-public-data/datasets");
   request.AddQueryParameter({"maxResults", "10"});
-  auto response = RetryRestRequest([&] { return client->Get(request); });
+  auto response = RetryRestRequest([&] {
+    rest_internal::RestContext context;
+    return client->Get(context, request);
+  });
   ASSERT_STATUS_OK(response);
 
   auto response_payload = std::move(**response).ExtractPayload();
@@ -73,7 +76,10 @@ void MakeStorageRpcCall(Options options) {
   auto client = MakePooledRestClient(endpoint, std::move(options));
   RestRequest request;
   request.SetPath("storage/v1/b/gcp-public-data-landsat");
-  auto response = RetryRestRequest([&] { return client->Get(request); });
+  auto response = RetryRestRequest([&] {
+    rest_internal::RestContext context;
+    return client->Get(context, request);
+  });
   ASSERT_STATUS_OK(response);
 
   auto response_payload = std::move(**response).ExtractPayload();

--- a/google/cloud/internal/unified_rest_credentials_test.cc
+++ b/google/cloud/internal/unified_rest_credentials_test.cc
@@ -46,6 +46,7 @@ using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::A;
 using ::testing::AtMost;
 using ::testing::ByMove;
@@ -207,7 +208,7 @@ TEST(UnifiedRestCredentialsTest, AdcIsAuthorizedUser) {
         Pair("client_secret", "a-123456ABCDEF"),
         Pair("refresh_token", "1/THETOKEN"),
     }));
-    EXPECT_CALL(*client, Post(expected_request, expected_form_data))
+    EXPECT_CALL(*client, Post(_, expected_request, expected_form_data))
         .WillOnce(Return(
             Status{StatusCode::kPermissionDenied, "uh-oh - user refresh"}));
     return client;
@@ -242,7 +243,7 @@ TEST(UnifiedRestCredentialsTest, AdcIsComputeEngine) {
                               "default/")),
         Property(&RestRequest::headers,
                  Contains(Pair("metadata-flavor", Contains("Google")))));
-    EXPECT_CALL(*client, Get(expected_request))
+    EXPECT_CALL(*client, Get(_, expected_request))
         .WillOnce(Return(
             Status{StatusCode::kPermissionDenied, "uh-oh - GCE metadata"}));
     return client;
@@ -256,7 +257,7 @@ TEST(UnifiedRestCredentialsTest, AdcIsComputeEngine) {
                               "default/", "token")),
         Property(&RestRequest::headers,
                  Contains(Pair("metadata-flavor", Contains("Google")))));
-    EXPECT_CALL(*client, Get(expected_request))
+    EXPECT_CALL(*client, Get(_, expected_request))
         .WillOnce(
             Return(Status{StatusCode::kPermissionDenied, "uh-oh - GCE token"}));
     return client;
@@ -283,7 +284,7 @@ TEST(UnifiedRestCredentialsTest, AdcIsExternalAccount) {
   auto subject_token_client = [subject_url, subject_token] {
     auto expected_sts_request = Property(&RestRequest::path, subject_url);
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Get(expected_sts_request))
+    EXPECT_CALL(*mock, Get(_, expected_sts_request))
         .WillOnce(Return(ByMove(MakeMockResponse(subject_token))));
     return mock;
   }();
@@ -297,7 +298,7 @@ TEST(UnifiedRestCredentialsTest, AdcIsExternalAccount) {
     auto expected_form_data = MatcherCast<FormDataType const&>(
         Contains(Pair("subject_token", subject_token)));
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(expected_sts_request, expected_form_data))
+    EXPECT_CALL(*mock, Post(_, expected_sts_request, expected_form_data))
         .WillOnce(Return(
             Status{StatusCode::kPermissionDenied, "uh-oh - STS exchange"}));
     return mock;
@@ -364,7 +365,7 @@ TEST(UnifiedRestCredentialsTest, ImpersonateServiceAccount) {
                  Contains(Pair("authorization",
                                Contains("Bearer base-access-token")))));
     using PayloadType = std::vector<absl::Span<char const>>;
-    EXPECT_CALL(*client, Post(expected_request, A<PayloadType const&>()))
+    EXPECT_CALL(*client, Post(_, expected_request, A<PayloadType const&>()))
         .WillOnce(Return(Status{StatusCode::kPermissionDenied,
                                 "uh-oh - cannot impersonate"}));
     return client;
@@ -410,7 +411,7 @@ TEST(UnifiedRestCredentialsTest, ExternalAccount) {
   auto subject_token_client = [subject_url, subject_token] {
     auto expected_sts_request = Property(&RestRequest::path, subject_url);
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Get(expected_sts_request))
+    EXPECT_CALL(*mock, Get(_, expected_sts_request))
         .WillOnce(Return(ByMove(MakeMockResponse(subject_token))));
     return mock;
   }();
@@ -424,7 +425,7 @@ TEST(UnifiedRestCredentialsTest, ExternalAccount) {
     auto expected_form_data = MatcherCast<FormDataType const&>(
         Contains(Pair("subject_token", subject_token)));
     auto mock = std::make_unique<MockRestClient>();
-    EXPECT_CALL(*mock, Post(expected_sts_request, expected_form_data))
+    EXPECT_CALL(*mock, Post(_, expected_sts_request, expected_form_data))
         .WillOnce(Return(
             Status{StatusCode::kPermissionDenied, "uh-oh - STS exchange"}));
     return mock;

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -254,7 +254,8 @@ absl::optional<std::string> GetMetadata(RestClient& metadata_server,
                                         std::string const& path) {
   RestRequest request(path);
   request.AddHeader("Metadata-Flavor", "Google");
-  auto response_status = metadata_server.Get(request);
+  rest_internal::RestContext context;
+  auto response_status = metadata_server.Get(context, request);
   if (!response_status) return absl::nullopt;
   auto response = *std::move(response_status);
   auto const status_code = response->StatusCode();

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -271,8 +271,9 @@ StorageIntegrationTest::InsertRetryTest(RetryTestRequest const& request) {
   };
 
   while (keep_trying()) {
-    auto http_response =
-        retry_client->Post(http_request, {absl::Span<char const>{payload}});
+    rest_internal::RestContext context;
+    auto http_response = retry_client->Post(context, http_request,
+                                            {absl::Span<char const>{payload}});
     if (!http_response) continue;
     if ((*http_response)->StatusCode() != rest::HttpStatusCode::kOk) continue;
     auto response_payload =

--- a/google/cloud/testing_util/mock_rest_client.h
+++ b/google/cloud/testing_util/mock_rest_client.h
@@ -27,25 +27,27 @@ namespace testing_util {
 class MockRestClient : public rest_internal::RestClient {
  public:
   MOCK_METHOD(StatusOr<std::unique_ptr<rest_internal::RestResponse>>, Delete,
-              (rest_internal::RestRequest const& request), (override));
+              (rest_internal::RestContext&, rest_internal::RestRequest const&),
+              (override));
   MOCK_METHOD(StatusOr<std::unique_ptr<rest_internal::RestResponse>>, Get,
-              (rest_internal::RestRequest const& request), (override));
+              (rest_internal::RestContext&, rest_internal::RestRequest const&),
+              (override));
   MOCK_METHOD(StatusOr<std::unique_ptr<rest_internal::RestResponse>>, Patch,
-              (rest_internal::RestRequest const& request,
-               std::vector<absl::Span<char const>> const& payload),
+              (rest_internal::RestContext&, rest_internal::RestRequest const&,
+               std::vector<absl::Span<char const>> const&),
               (override));
   MOCK_METHOD(StatusOr<std::unique_ptr<rest_internal::RestResponse>>, Post,
-              (rest_internal::RestRequest const& request,
-               std::vector<absl::Span<char const>> const& payload),
+              (rest_internal::RestContext&, rest_internal::RestRequest const&,
+               std::vector<absl::Span<char const>> const&),
               (override));
-  MOCK_METHOD(
-      StatusOr<std::unique_ptr<rest_internal::RestResponse>>, Post,
-      (rest_internal::RestRequest request,
-       (std::vector<std::pair<std::string, std::string>> const& form_data)),
-      (override));
+  MOCK_METHOD(StatusOr<std::unique_ptr<rest_internal::RestResponse>>, Post,
+              (rest_internal::RestContext&,
+               rest_internal::RestRequest const& request,
+               (std::vector<std::pair<std::string, std::string>> const&)),
+              (override));
   MOCK_METHOD(StatusOr<std::unique_ptr<rest_internal::RestResponse>>, Put,
-              (rest_internal::RestRequest const& request,
-               std::vector<absl::Span<char const>> const& payload),
+              (rest_internal::RestContext&, rest_internal::RestRequest const&,
+               std::vector<absl::Span<char const>> const&),
               (override));
 };
 


### PR DESCRIPTION
This will be use to inject per-call annotations (e.g. span ids, and retry ids) for each request. It also provides an output parameter to return metadata specific to a call, such as the IP addresses involved.

Part of the work for #11264

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11322)
<!-- Reviewable:end -->
