### PR TITLE
cleanup(iam): versioned clients in samples

### DIFF
--- a/google/cloud/iam/doc/iam-credentials-mock.dox
+++ b/google/cloud/iam/doc/iam-credentials-mock.dox
@@ -17,7 +17,8 @@ The example uses a number of aliases to save typing and improve readability:
 
 @snippet mock_iam_credentials.cc helper-aliases
 
-Create a mocking object for `google::cloud::iam::IAMCredentialsConnection`:
+Create a mocking object for
+`google::cloud::iam_credentials_v1::IAMCredentialsConnection`:
 
 @snippet mock_iam_credentials.cc create-mock
 
@@ -27,7 +28,7 @@ write the rest of the code:
 @snippet mock_iam_credentials.cc setup-expectations
 
 With the expectations in place, create a
-`google::cloud::iam::IAMCredentialsClient` object:
+`google::cloud::iam_credentials_v1::IAMCredentialsClient` object:
 
 @snippet mock_iam_credentials.cc create-client
 

--- a/google/cloud/iam/doc/iam-mock.dox
+++ b/google/cloud/iam/doc/iam-mock.dox
@@ -17,7 +17,7 @@ The example uses a number of aliases to save typing and improve readability:
 
 @snippet mock_iam.cc helper-aliases
 
-Create a mocking object for `google::cloud::iam::IAMConnection`:
+Create a mocking object for `google::cloud::iam_admin_v1::IAMConnection`:
 
 @snippet mock_iam.cc create-mock
 
@@ -27,7 +27,7 @@ write the rest of the code:
 @snippet mock_iam.cc setup-expectations
 
 With the expectations in place, create a
-`google::cloud::iam::IAMClient` object:
+`google::cloud::iam_admin_v1::IAMClient` object:
 
 @snippet mock_iam.cc create-client
 

--- a/google/cloud/iam/samples/iam_credentials_samples.cc
+++ b/google/cloud/iam/samples/iam_credentials_samples.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/iam/iam_credentials_client.h"
+#include "google/cloud/iam/credentials/v1/iam_credentials_client.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
@@ -27,7 +27,7 @@ void GenerateAccessToken(std::vector<std::string> const& argv) {
   }
   //! [START iamcredentials_generate_access_token]
   //! [iamcredentials-generate-access-token]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_credentials_v1;
   [](std::string const& name, std::string const& lifetime_seconds,
      std::vector<std::string> const& scope) {
     iam::IAMCredentialsClient client(iam::MakeIAMCredentialsConnection());
@@ -51,7 +51,7 @@ void GenerateIdToken(std::vector<std::string> const& argv) {
   }
   //! [START iamcredentials_generate_id_token]
   //! [iamcredentials-generate-id-token]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_credentials_v1;
   [](std::string const& name, std::string const& audience,
      std::string const& include_email,
      std::vector<std::string> const& delegates) {
@@ -72,7 +72,7 @@ void SignBlob(std::vector<std::string> const& argv) {
         "sign-blob <service-account-name> <payload> [<delegates>]*");
   }
   //! [START iamcredentials_sign_blob] [iamcredentials-sign-blob]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_credentials_v1;
   [](std::string const& name, std::string const& payload,
      std::vector<std::string> const& delegates) {
     iam::IAMCredentialsClient client(iam::MakeIAMCredentialsConnection());
@@ -91,7 +91,7 @@ void SignJwt(std::vector<std::string> const& argv) {
         "sign-jwt <service-account-name> <payload> [<delegates>]*");
   }
   //! [START iamcredentials_sign_jwt] [iamcredentials-sign-jwt]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_credentials_v1;
   [](std::string const& name, std::string const& payload,
      std::vector<std::string> const& delegates) {
     iam::IAMCredentialsClient client(iam::MakeIAMCredentialsConnection());

--- a/google/cloud/iam/samples/iam_samples.cc
+++ b/google/cloud/iam/samples/iam_samples.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/iam/iam_client.h"
+#include "google/cloud/iam/admin/v1/iam_client.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
@@ -30,7 +30,7 @@ namespace {
 
 void ExampleStatusOr(std::vector<std::string> const& argv) {
   //! [example-status-or]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& project_id) {
     iam::IAMClient client(iam::MakeIAMConnection());
     // The actual type of `service_account` is
@@ -60,7 +60,7 @@ void ListServiceAccounts(std::vector<std::string> const& argv) {
         "list-service-accounts <project-id>");
   }
   //! [START iam_list_service_accounts] [iam-list-service-accounts]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& project_id) {
     iam::IAMClient client(iam::MakeIAMConnection());
     int count = 0;
@@ -85,7 +85,7 @@ void GetServiceAccount(std::vector<std::string> const& argv) {
         "get-service-account <service-account-name>");
   }
   //! [START iam_get_service_account] [iam-get-service-account]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     auto response = client.GetServiceAccount(name);
@@ -104,7 +104,7 @@ void CreateServiceAccount(std::vector<std::string> const& argv) {
         "<description>");
   }
   //! [START iam_create_service_account] [iam-create-service-account]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& project_id, std::string const& account_id,
      std::string const& display_name, std::string const& description) {
     iam::IAMClient client(iam::MakeIAMConnection());
@@ -127,7 +127,7 @@ void DeleteServiceAccount(std::vector<std::string> const& argv) {
         "delete-service-account <service-account-name>");
   }
   //! [START iam_delete_service_account] [iam-delete-service-account]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     auto response = client.DeleteServiceAccount(name);
@@ -145,7 +145,7 @@ void ListServiceAccountKeys(std::vector<std::string> const& argv) {
         "[<key-type>]*");
   }
   //! [START iam_list_keys] [iam-list-service-account-keys]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& service_account_name,
      std::vector<std::string> const& key_type_labels) {
     iam::IAMClient client(iam::MakeIAMConnection());
@@ -176,7 +176,7 @@ void GetServiceAccountKey(std::vector<std::string> const& argv) {
         "get-service-account-key <service-account-key-name>");
   }
   //! [START iam_get_service_account_key] [iam-get-service-account-key]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& key_name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     auto response = client.GetServiceAccountKey(
@@ -196,7 +196,7 @@ std::string CreateServiceAccountKey(std::vector<std::string> const& argv) {
         "create-service-account-key <service-account-name>");
   }
   //! [START iam_create_key] [iam-create-service-account-key]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   return [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     auto response = client.CreateServiceAccountKey(
@@ -221,7 +221,7 @@ void DeleteServiceAccountKey(std::vector<std::string> const& argv) {
         "delete-service-account-key <service-account-key-name>");
   }
   //! [START iam_delete_key] [iam-delete-service-account-key]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     auto response = client.DeleteServiceAccountKey(name);
@@ -237,7 +237,7 @@ void GetIamPolicy(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage("get-iam-policy <resource-name>");
   }
   //! [START iam_get_policy] [iam-get-iam-policy]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     auto response = client.GetIamPolicy(name);
@@ -254,7 +254,7 @@ void SetIamPolicy(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage("set-iam-policy <resource-name>");
   }
   //! [START iam_set_policy] [iam-set-iam-policy]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     auto response =
@@ -275,7 +275,7 @@ void TestIamPermissions(std::vector<std::string> const& argv) {
         "test-iam-permissions <resource-name> <permission> [<permission>]*");
   }
   //! [START iam_test_permissions] [iam-test-iam-permissions]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name, std::vector<std::string> const& permissions) {
     iam::IAMClient client(iam::MakeIAMConnection());
     auto response = client.TestIamPermissions(name, permissions);
@@ -293,7 +293,7 @@ void QueryGrantableRoles(std::vector<std::string> const& argv) {
         "query-grantable-roles <resource-name>");
   }
   //! [START iam_view_grantable_roles] [iam-query-grantable-roles]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& resource) {
     iam::IAMClient client(iam::MakeIAMConnection());
     int count = 0;
@@ -316,7 +316,7 @@ void CreateRole(std::vector<std::string> const& argv) {
         "create-role <parent project> <role_id> <permission> [<permission>]*");
   }
   //! [START iam_create_role] [iam-create-role]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& parent, std::string const& role_id,
      std::vector<std::string> const& included_permissions) {
     iam::IAMClient client(iam::MakeIAMConnection());
@@ -343,7 +343,7 @@ void DeleteRole(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage("delete-role <role-name>");
   }
   //! [START iam_delete_role] [iam-delete-role]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     google::iam::admin::v1::DeleteRoleRequest request;
@@ -363,7 +363,7 @@ void DisableServiceAccount(std::vector<std::string> const& argv) {
         "disable-service-account <service-account-name>");
   }
   //! [START iam_disable_service_account] [iam-disable-service-account]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     google::iam::admin::v1::DisableServiceAccountRequest request;
@@ -382,7 +382,7 @@ void EnableServiceAccount(std::vector<std::string> const& argv) {
         "enable-service-account <service-account-name>");
   }
   //! [START iam_enable_service_account] [iam-enable-service-account]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     google::iam::admin::v1::EnableServiceAccountRequest request;
@@ -401,7 +401,7 @@ void UpdateRole(std::vector<std::string> const& argv) {
         "update-role <role-name> <new-title>");
   }
   //! [START iam_edit_role] [iam-update-role]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name, std::string const& title) {
     iam::IAMClient client(iam::MakeIAMConnection());
     google::iam::admin::v1::UpdateRoleRequest request;
@@ -426,7 +426,7 @@ void GetRole(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage("get-role <role-name>");
   }
   //! [START iam_get_role] [iam-get-role]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     google::iam::admin::v1::GetRoleRequest request;
@@ -445,7 +445,7 @@ void ListRoles(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage("list-roles <parent>");
   }
   //! [START iam_list_roles] [iam-list-roles]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& project) {
     iam::IAMClient client(iam::MakeIAMConnection());
     int count = 0;
@@ -470,7 +470,7 @@ void QueryTestablePermissions(std::vector<std::string> const& argv) {
         "query-testable-permissions <resource-name>");
   }
   //! [START iam_query_testable_permissions] [iam-query-testable-permissions]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& resource) {
     iam::IAMClient client(iam::MakeIAMConnection());
     google::iam::admin::v1::QueryTestablePermissionsRequest request;
@@ -497,7 +497,7 @@ void PatchServiceAccount(std::vector<std::string> const& argv) {
         "patch-service-account <service-account-name> <new-display-name>");
   }
   //! [START iam_rename_service_account] [iam-patch-service-account]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name, std::string const& display_name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     google::iam::admin::v1::PatchServiceAccountRequest request;
@@ -522,7 +522,7 @@ void UndeleteRole(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage("undelete-role <role-name>");
   }
   //! [START iam_undelete_role] [iam-undelete-role]
-  namespace iam = ::google::cloud::iam;
+  namespace iam = ::google::cloud::iam_admin_v1;
   [](std::string const& name) {
     iam::IAMClient client(iam::MakeIAMConnection());
     google::iam::admin::v1::UndeleteRoleRequest request;

--- a/google/cloud/iam/samples/mock_iam.cc
+++ b/google/cloud/iam/samples/mock_iam.cc
@@ -14,16 +14,16 @@
 
 //! [all]
 //! [required-includes]
-#include "google/cloud/iam/iam_client.h"
-#include "google/cloud/iam/mocks/mock_iam_connection.h"
+#include "google/cloud/iam/admin/v1/iam_client.h"
+#include "google/cloud/iam/admin/v1/mocks/mock_iam_connection.h"
 #include <gmock/gmock.h>
 //! [required-includes]
 
 namespace {
 
 //! [helper-aliases]
-using ::google::cloud::iam_mocks::MockIAMConnection;
-namespace iam = ::google::cloud::iam;
+using ::google::cloud::iam_admin_v1_mocks::MockIAMConnection;
+namespace iam = ::google::cloud::iam_admin_v1;
 //! [helper-aliases]
 
 TEST(MockGetServiceAccountExample, GetServiceAccount) {

--- a/google/cloud/iam/samples/mock_iam_credentials.cc
+++ b/google/cloud/iam/samples/mock_iam_credentials.cc
@@ -14,16 +14,16 @@
 
 //! [all]
 //! [required-includes]
-#include "google/cloud/iam/iam_credentials_client.h"
-#include "google/cloud/iam/mocks/mock_iam_credentials_connection.h"
+#include "google/cloud/iam/credentials/v1/iam_credentials_client.h"
+#include "google/cloud/iam/credentials/v1/mocks/mock_iam_credentials_connection.h"
 #include <gmock/gmock.h>
 //! [required-includes]
 
 namespace {
 
 //! [helper-aliases]
-using ::google::cloud::iam_mocks::MockIAMCredentialsConnection;
-namespace iam = ::google::cloud::iam;
+using ::google::cloud::iam_credentials_v1_mocks::MockIAMCredentialsConnection;
+namespace iam = ::google::cloud::iam_credentials_v1;
 //! [helper-aliases]
 
 TEST(MockSignJwtExample, SignJwt) {


### PR DESCRIPTION
Part of the work for #10170 

Is anyone concerned that we are recommending both
- `namespace iam = ::google::cloud::iam_admin_v1` and
- `namespace iam = ::google::cloud::iam_credentials_v1` ?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11328)
<!-- Reviewable:end -->
