### PR TITLE
cleanup(bigquery): use versioned clients in samples

### DIFF
--- a/google/cloud/bigquery/doc/bigquery-read-mock.dox
+++ b/google/cloud/bigquery/doc/bigquery-read-mock.dox
@@ -17,7 +17,8 @@ The example uses a number of aliases to save typing and improve readability:
 
 @snippet mock_bigquery_read.cc helper-aliases
 
-Create a mocking object for `google::cloud::bigquery::BigQueryReadConnection`:
+Create a mocking object for
+`google::cloud::bigquery_storage_v1::BigQueryReadConnection`:
 
 @snippet mock_bigquery_read.cc create-mock
 
@@ -27,7 +28,7 @@ write the rest of the code:
 @snippet mock_bigquery_read.cc setup-expectations
 
 With the expectations in place, create a
-`google::cloud::bigquery::BigQueryReadClient` object:
+`google::cloud::bigquery_storage_v1::BigQueryReadClient` object:
 
 @snippet mock_bigquery_read.cc create-client
 

--- a/google/cloud/bigquery/samples/bigquery_read_samples.cc
+++ b/google/cloud/bigquery/samples/bigquery_read_samples.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigquery/bigquery_read_client.h"
+#include "google/cloud/bigquery/storage/v1/bigquery_read_client.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/example_driver.h"
@@ -31,7 +31,7 @@ void ExampleStatusOr(std::vector<std::string> const& argv) {
         "example-status-or <project-id> <table-name>");
   }
   //! [example-status-or]
-  namespace bigquery = ::google::cloud::bigquery;
+  namespace bigquery = ::google::cloud::bigquery_storage_v1;
   [](std::string const& project_id, std::string const& table_name) {
     int max_stream_count = 1;
     google::cloud::bigquery::storage::v1::ReadSession read_session;
@@ -60,7 +60,7 @@ void CreateReadSession(std::vector<std::string> const& argv) {
         "create-read-session <project-id> <table-name>");
   }
   //! [bigquery-create-read-session]
-  namespace bigquery = ::google::cloud::bigquery;
+  namespace bigquery = ::google::cloud::bigquery_storage_v1;
   [](std::string const& project_id, std::string const& table_name) {
     bigquery::BigQueryReadClient client(bigquery::MakeBigQueryReadConnection());
     int max_stream_count = 1;
@@ -86,7 +86,7 @@ void ReadRows(std::vector<std::string> const& argv) {
         "read-rows <project-id> <table-name> [<row-restriction>]");
   }
   //! [bigquery-read-rows]
-  namespace bigquery = ::google::cloud::bigquery;
+  namespace bigquery = ::google::cloud::bigquery_storage_v1;
   [](std::string const& project_id, std::string const& table_name,
      std::string const& row_restriction) {
     bigquery::BigQueryReadClient client(bigquery::MakeBigQueryReadConnection());
@@ -119,7 +119,7 @@ void SplitReadStream(std::vector<std::string> const& argv) {
         "split-read-stream <project-id> <table-name> [<row-restriction>]");
   }
   //! [bigquery-split-read-stream]
-  namespace bigquery = ::google::cloud::bigquery;
+  namespace bigquery = ::google::cloud::bigquery_storage_v1;
   [](std::string const& project_id, std::string const& table_name,
      std::string const& row_restriction) {
     bigquery::BigQueryReadClient client(bigquery::MakeBigQueryReadConnection());

--- a/google/cloud/bigquery/samples/mock_bigquery_read.cc
+++ b/google/cloud/bigquery/samples/mock_bigquery_read.cc
@@ -14,16 +14,16 @@
 
 //! [all]
 //! [required-includes]
-#include "google/cloud/bigquery/bigquery_read_client.h"
-#include "google/cloud/bigquery/mocks/mock_bigquery_read_connection.h"
+#include "google/cloud/bigquery/storage/v1/bigquery_read_client.h"
+#include "google/cloud/bigquery/storage/v1/mocks/mock_bigquery_read_connection.h"
 #include <gmock/gmock.h>
 //! [required-includes]
 
 namespace {
 
 //! [helper-aliases]
-using ::google::cloud::bigquery_mocks::MockBigQueryReadConnection;
-namespace bigquery = ::google::cloud::bigquery;
+using ::google::cloud::bigquery_storage_v1_mocks::MockBigQueryReadConnection;
+namespace bigquery = ::google::cloud::bigquery_storage_v1;
 //! [helper-aliases]
 
 TEST(MockCreateReadSessionExample, CreateReadSession) {


### PR DESCRIPTION
Fixes #10170

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11329)
<!-- Reviewable:end -->
