### PR TITLE
impl(rest): capture request metadata

### DIFF
--- a/google/cloud/internal/curl_handle.cc
+++ b/google/cloud/internal/curl_handle.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/curl_handle.h"
 #include "google/cloud/internal/binary_data_as_debug_string.h"
 #include "google/cloud/internal/curl_handle_factory.h"
+#include "google/cloud/internal/rest_context.h"
 #include "google/cloud/internal/strerror.h"
 #include "google/cloud/log.h"
 #include "absl/strings/match.h"
@@ -170,6 +171,44 @@ std::string CurlHandle::GetPeer() {
   return std::string{"[error-fetching-peer]"};
 }
 
+void CurlHandle::CaptureMetadata(RestContext& context) {
+  char* ip = nullptr;
+  long port = 0;  // NOLINT(google-runtime-int) - curl requires `long`
+  curl_off_t us;
+
+  auto e = curl_easy_getinfo(handle_.get(), CURLINFO_LOCAL_IP, &ip);
+  context.reset_local_ip_address();
+  if (e == CURLE_OK && ip != nullptr) context.set_local_ip_address(ip);
+
+  e = curl_easy_getinfo(handle_.get(), CURLINFO_LOCAL_PORT, &port);
+  context.reset_local_port();
+  if (e == CURLE_OK) context.set_local_port(static_cast<std::int32_t>(port));
+
+  ip = nullptr;
+  e = curl_easy_getinfo(handle_.get(), CURLINFO_PRIMARY_IP, &ip);
+  context.reset_primary_ip_address();
+  if (e == CURLE_OK && ip != nullptr) context.set_primary_ip_address(ip);
+
+  e = curl_easy_getinfo(handle_.get(), CURLINFO_PRIMARY_PORT, &port);
+  context.reset_primary_port();
+  if (e == CURLE_OK) context.set_primary_port(static_cast<std::int32_t>(port));
+
+  // Sometimes the durations returned here are 0us. That is useful information,
+  // as it represents things like "no DNS lookup performed (used the cache)", or
+  // "no connection time, reused an existing connection".
+  e = curl_easy_getinfo(handle_.get(), CURLINFO_NAMELOOKUP_TIME_T, &us);
+  context.reset_namelookup_time();
+  if (e == CURLE_OK) context.set_namelookup_time(std::chrono::microseconds(us));
+
+  e = curl_easy_getinfo(handle_.get(), CURLINFO_CONNECT_TIME_T, &us);
+  context.reset_connect_time();
+  if (e == CURLE_OK) context.set_connect_time(std::chrono::microseconds(us));
+
+  e = curl_easy_getinfo(handle_.get(), CURLINFO_APPCONNECT_TIME_T, &us);
+  context.reset_appconnect_time();
+  if (e == CURLE_OK) context.set_appconnect_time(std::chrono::microseconds(us));
+}
+
 void CurlHandle::EnableLogging(bool enabled) {
   if (enabled) {
     debug_info_ = std::make_shared<DebugInfo>();
@@ -198,12 +237,16 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
 
   std::ostringstream os;
   os << where << "() - CURL error [" << e << "]=" << curl_easy_strerror(e);
-  // Map the CURLE* errors using the documentation on:
+  // Map the CURLE* errors using the
+  // documentation on:
   //   https://curl.haxx.se/libcurl/c/libcurl-errors.html
-  // The error codes are listed in the same order as shown on that page, so
-  // one can quickly find out how an error code is handled. All the error codes
-  // are listed, but those that do not appear in old libcurl versions are
-  // commented out and handled by the `default:` case.
+  // The error codes are listed in the same
+  // order as shown on that page, so one can
+  // quickly find out how an error code is
+  // handled. All the error codes are listed,
+  // but those that do not appear in old
+  // libcurl versions are commented out and
+  // handled by the `default:` case.
   StatusCode code;
   switch (e) {
     case CURLE_UNSUPPORTED_PROTOCOL:
@@ -219,7 +262,8 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       code = StatusCode::kUnavailable;
       break;
 
-    // missing in some older libcurl versions:   CURLE_WEIRD_SERVER_REPLY
+    // missing in some older libcurl
+    // versions:   CURLE_WEIRD_SERVER_REPLY
     case CURLE_REMOTE_ACCESS_DENIED:
       code = StatusCode::kPermissionDenied;
       break;
@@ -255,8 +299,10 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       break;
 
     case CURLE_RANGE_ERROR:
-      // This is defined as "the server does not *support or *accept* range
-      // requests", so it means something stronger than "your range value is
+      // This is defined as "the server does
+      // not *support or *accept* range
+      // requests", so it means something
+      // stronger than "your range value is
       // not valid".
       code = StatusCode::kUnimplemented;
       break;
@@ -339,10 +385,14 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       break;
 
     case CURLE_AGAIN:
-      // This looks like a good candidate for kUnavailable, but it is only
-      // returned by curl_easy_{recv,send}, and should not with the
-      // configuration we use for libcurl, and the recovery action is to call
-      // curl_easy_{recv,send} again, which is not how this return value is used
+      // This looks like a good candidate for
+      // kUnavailable, but it is only
+      // returned by curl_easy_{recv,send},
+      // and should not with the
+      // configuration we use for libcurl,
+      // and the recovery action is to call
+      // curl_easy_{recv,send} again, which
+      // is not how this return value is used
       // (we restart the whole transfer).
       code = StatusCode::kUnknown;
       break;
@@ -358,21 +408,33 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       break;
 
     // cSpell:disable
-    // missing in some older libcurl versions:   CURLE_HTTP_RETURNED_ERROR
-    // missing in some older libcurl versions:   CURLE_NO_CONNECTION_AVAILABLE
-    // missing in some older libcurl versions:   CURLE_SSL_PINNEDPUBKEYNOTMATCH
-    // missing in some older libcurl versions:   CURLE_SSL_INVALIDCERTSTATUS
-    // missing in some older libcurl versions:   CURLE_HTTP2_STREAM
-    // missing in some older libcurl versions:   CURLE_RECURSIVE_API_CALL
-    // missing in some older libcurl versions:   CURLE_AUTH_ERROR
-    // missing in some older libcurl versions:   CURLE_HTTP3
-    // missing in some older libcurl versions:   CURLE_QUIC_CONNECT_ERROR
+    // missing in some older libcurl
+    // versions:   CURLE_HTTP_RETURNED_ERROR
+    // missing in some older libcurl
+    // versions:
+    // CURLE_NO_CONNECTION_AVAILABLE missing
+    // in some older libcurl versions:
+    // CURLE_SSL_PINNEDPUBKEYNOTMATCH missing
+    // in some older libcurl versions:
+    // CURLE_SSL_INVALIDCERTSTATUS missing in
+    // some older libcurl versions:
+    // CURLE_HTTP2_STREAM missing in some
+    // older libcurl versions:
+    // CURLE_RECURSIVE_API_CALL missing in
+    // some older libcurl versions:
+    // CURLE_AUTH_ERROR missing in some older
+    // libcurl versions:   CURLE_HTTP3
+    // missing in some older libcurl
+    // versions:   CURLE_QUIC_CONNECT_ERROR
     // cSpell:enable
     default:
-      // As described above, there are about 100 error codes, some are
-      // explicitly marked as obsolete, some are not available in all libcurl
-      // versions. Use this `default:` case to treat all such errors as
-      // `kUnavailable` and they will be retried.
+      // As described above, there are about
+      // 100 error codes, some are explicitly
+      // marked as obsolete, some are not
+      // available in all libcurl versions.
+      // Use this `default:` case to treat
+      // all such errors as `kUnavailable`
+      // and they will be retried.
       code = StatusCode::kUnavailable;
       break;
   }

--- a/google/cloud/internal/curl_handle.cc
+++ b/google/cloud/internal/curl_handle.cc
@@ -256,16 +256,12 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
 
   std::ostringstream os;
   os << where << "() - CURL error [" << e << "]=" << curl_easy_strerror(e);
-  // Map the CURLE* errors using the
-  // documentation on:
+  // Map the CURLE* errors using the documentation on:
   //   https://curl.haxx.se/libcurl/c/libcurl-errors.html
-  // The error codes are listed in the same
-  // order as shown on that page, so one can
-  // quickly find out how an error code is
-  // handled. All the error codes are listed,
-  // but those that do not appear in old
-  // libcurl versions are commented out and
-  // handled by the `default:` case.
+  // The error codes are listed in the same order as shown on that page, so
+  // one can quickly find out how an error code is handled. All the error codes
+  // are listed, but those that do not appear in old libcurl versions are
+  // commented out and handled by the `default:` case.
   StatusCode code;
   switch (e) {
     case CURLE_UNSUPPORTED_PROTOCOL:
@@ -281,8 +277,7 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       code = StatusCode::kUnavailable;
       break;
 
-    // missing in some older libcurl
-    // versions:   CURLE_WEIRD_SERVER_REPLY
+    // missing in some older libcurl versions:   CURLE_WEIRD_SERVER_REPLY
     case CURLE_REMOTE_ACCESS_DENIED:
       code = StatusCode::kPermissionDenied;
       break;
@@ -318,10 +313,8 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       break;
 
     case CURLE_RANGE_ERROR:
-      // This is defined as "the server does
-      // not *support or *accept* range
-      // requests", so it means something
-      // stronger than "your range value is
+      // This is defined as "the server does not *support or *accept* range
+      // requests", so it means something stronger than "your range value is
       // not valid".
       code = StatusCode::kUnimplemented;
       break;
@@ -404,14 +397,10 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       break;
 
     case CURLE_AGAIN:
-      // This looks like a good candidate for
-      // kUnavailable, but it is only
-      // returned by curl_easy_{recv,send},
-      // and should not with the
-      // configuration we use for libcurl,
-      // and the recovery action is to call
-      // curl_easy_{recv,send} again, which
-      // is not how this return value is used
+      // This looks like a good candidate for kUnavailable, but it is only
+      // returned by curl_easy_{recv,send}, and should not with the
+      // configuration we use for libcurl, and the recovery action is to call
+      // curl_easy_{recv,send} again, which is not how this return value is used
       // (we restart the whole transfer).
       code = StatusCode::kUnknown;
       break;
@@ -427,33 +416,21 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       break;
 
     // cSpell:disable
-    // missing in some older libcurl
-    // versions:   CURLE_HTTP_RETURNED_ERROR
-    // missing in some older libcurl
-    // versions:
-    // CURLE_NO_CONNECTION_AVAILABLE missing
-    // in some older libcurl versions:
-    // CURLE_SSL_PINNEDPUBKEYNOTMATCH missing
-    // in some older libcurl versions:
-    // CURLE_SSL_INVALIDCERTSTATUS missing in
-    // some older libcurl versions:
-    // CURLE_HTTP2_STREAM missing in some
-    // older libcurl versions:
-    // CURLE_RECURSIVE_API_CALL missing in
-    // some older libcurl versions:
-    // CURLE_AUTH_ERROR missing in some older
-    // libcurl versions:   CURLE_HTTP3
-    // missing in some older libcurl
-    // versions:   CURLE_QUIC_CONNECT_ERROR
+    // missing in some older libcurl versions:   CURLE_HTTP_RETURNED_ERROR
+    // missing in some older libcurl versions:   CURLE_NO_CONNECTION_AVAILABLE
+    // missing in some older libcurl versions:   CURLE_SSL_PINNEDPUBKEYNOTMATCH
+    // missing in some older libcurl versions:   CURLE_SSL_INVALIDCERTSTATUS
+    // missing in some older libcurl versions:   CURLE_HTTP2_STREAM
+    // missing in some older libcurl versions:   CURLE_RECURSIVE_API_CALL
+    // missing in some older libcurl versions:   CURLE_AUTH_ERROR
+    // missing in some older libcurl versions:   CURLE_HTTP3
+    // missing in some older libcurl versions:   CURLE_QUIC_CONNECT_ERROR
     // cSpell:enable
     default:
-      // As described above, there are about
-      // 100 error codes, some are explicitly
-      // marked as obsolete, some are not
-      // available in all libcurl versions.
-      // Use this `default:` case to treat
-      // all such errors as `kUnavailable`
-      // and they will be retried.
+      // As described above, there are about 100 error codes, some are
+      // explicitly marked as obsolete, some are not available in all libcurl
+      // versions. Use this `default:` case to treat all such errors as
+      // `kUnavailable` and they will be retried.
       code = StatusCode::kUnavailable;
       break;
   }

--- a/google/cloud/internal/curl_handle.h
+++ b/google/cloud/internal/curl_handle.h
@@ -30,6 +30,7 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class CurlHandleFactory;
+class RestContext;
 
 /**
  * Wraps CURL* handles in a safer C++ interface.
@@ -114,6 +115,8 @@ class CurlHandle {
    * contents of the string if there was an error are otherwise unspecified.
    */
   std::string GetPeer();
+
+  void CaptureMetadata(RestContext& context);
 
   Status EasyPause(int bitmask) {
     auto e = curl_easy_pause(handle_.get(), bitmask);

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -322,35 +322,35 @@ std::string CurlImpl::LastClientIpAddress() const {
   return factory_->LastClientIpAddress();
 }
 
-Status CurlImpl::MakeRequest(HttpMethod method,
+Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
                              std::vector<absl::Span<char const>> request) {
   Status status;
   status = handle_.SetOption(CURLOPT_CUSTOMREQUEST, HttpMethodToName(method));
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status = handle_.SetOption(CURLOPT_UPLOAD, 0L);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status =
       handle_.SetOption(CURLOPT_FOLLOWLOCATION, follow_location_ ? 1L : 0L);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
 
   if (method == HttpMethod::kGet) {
     status = handle_.SetOption(CURLOPT_NOPROGRESS, 1L);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     if (download_stall_timeout_ != std::chrono::seconds::zero()) {
       // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* long
       auto const timeout = static_cast<long>(download_stall_timeout_.count());
       // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* long
       auto const limit = static_cast<long>(download_stall_minimum_rate_);
       status = handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
-      if (!status.ok()) return OnTransferError(std::move(status));
+      if (!status.ok()) return OnTransferError(context, std::move(status));
       // Timeout if the request sends or receives less than 1 byte/second
       // (i.e.  effectively no bytes) for download_stall_timeout_.
       status = handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, limit);
-      if (!status.ok()) return OnTransferError(std::move(status));
+      if (!status.ok()) return OnTransferError(context, std::move(status));
       status = handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
-      if (!status.ok()) return OnTransferError(std::move(status));
+      if (!status.ok()) return OnTransferError(context, std::move(status));
     }
-    return MakeRequestImpl();
+    return MakeRequestImpl(context);
   }
 
   if (transfer_stall_timeout_ != std::chrono::seconds::zero()) {
@@ -359,48 +359,48 @@ Status CurlImpl::MakeRequest(HttpMethod method,
     // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* long
     auto const limit = static_cast<long>(transfer_stall_minimum_rate_);
     status = handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     // Timeout if the request sends or receives less than 1 byte/second
     // (i.e.  effectively no bytes) for transfer_stall_timeout_.
     status = handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, limit);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     status = handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
   }
 
   if (method == HttpMethod::kDelete || request.empty()) {
-    return MakeRequestImpl();
+    return MakeRequestImpl(context);
   }
 
   if (method == HttpMethod::kPost) {
     WriteVector writev{std::move(request)};
     curl_off_t const size = writev.size();
     status = handle_.SetOption(CURLOPT_POSTFIELDS, nullptr);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     status = handle_.SetOption(CURLOPT_POST, 1L);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     status = handle_.SetOption(CURLOPT_POSTFIELDSIZE_LARGE, size);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     status = handle_.SetOption(CURLOPT_READFUNCTION, &ReadFunction);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     status = handle_.SetOption(CURLOPT_READDATA, &writev);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     SetHeader("Expect:");
-    return MakeRequestImpl();
+    return MakeRequestImpl(context);
   }
 
   if (method == HttpMethod::kPut || method == HttpMethod::kPatch) {
     WriteVector writev{std::move(request)};
     curl_off_t const size = writev.size();
     status = handle_.SetOption(CURLOPT_READFUNCTION, &ReadFunction);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     status = handle_.SetOption(CURLOPT_READDATA, &writev);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     status = handle_.SetOption(CURLOPT_UPLOAD, 1L);
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
     status = handle_.SetOption(CURLOPT_INFILESIZE_LARGE, size);
-    if (!status.ok()) return OnTransferError(std::move(status));
-    return MakeRequestImpl();
+    if (!status.ok()) return OnTransferError(context, std::move(status));
+    return MakeRequestImpl(context);
   }
 
   return internal::InvalidArgumentError(
@@ -415,7 +415,10 @@ StatusOr<std::size_t> CurlImpl::Read(absl::Span<char> output) {
   if (output.empty()) {
     return internal::InvalidArgumentError("Output buffer cannot be empty");
   }
-  return ReadImpl(std::move(output));
+  // This context is discarded.  Any interesting information was already
+  // captured when the request was started.
+  RestContext context;
+  return ReadImpl(context, std::move(output));
 }
 
 std::size_t CurlImpl::WriteCallback(absl::Span<char> response) {
@@ -483,24 +486,24 @@ std::size_t CurlImpl::HeaderCallback(absl::Span<char> response) {
                               response.size());
 }
 
-Status CurlImpl::MakeRequestImpl() {
+Status CurlImpl::MakeRequestImpl(RestContext& context) {
   TRACE_STATE() << ", url_=" << url_;
 
   Status status;
   status = handle_.SetOption(CURLOPT_URL, url_.c_str());
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status = handle_.SetOption(CURLOPT_HTTPHEADER, request_headers_.get());
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status = handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   handle_.EnableLogging(logging_enabled_);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   handle_.SetSocketCallback(socket_options_);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status = handle_.SetOption(CURLOPT_NOSIGNAL, 1);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status = handle_.SetOption(CURLOPT_TCP_KEEPALIVE, 1L);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, (status));
 
   handle_.SetOptionUnchecked(CURLOPT_HTTP_VERSION,
                              VersionToCurlCode(http_version_));
@@ -520,10 +523,11 @@ Status CurlImpl::MakeRequestImpl() {
   // thus make available the status_code and headers. Any response data
   // should be put into the spill buffer, which makes them available for
   // subsequent calls to Read() after the headers have been extracted.
-  return ReadImpl({}).status();
+  return ReadImpl(context, {}).status();
 }
 
-StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
+StatusOr<std::size_t> CurlImpl::ReadImpl(RestContext& context,
+                                         absl::Span<char> output) {
   handle_.FlushDebug(__func__);
   avail_ = output;
   TRACE_STATE() << ", begin";
@@ -539,20 +543,20 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
 
   Status status;
   status = handle_.SetOption(CURLOPT_HEADERFUNCTION, &HeaderFunction);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status = handle_.SetOption(CURLOPT_HEADERDATA, this);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status = handle_.SetOption(CURLOPT_WRITEFUNCTION, &WriteFunction);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   status = handle_.SetOption(CURLOPT_WRITEDATA, this);
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
   handle_.FlushDebug(__func__);
 
   if (!curl_closed_ && paused_) {
     paused_ = false;
     status = handle_.EasyPause(CURLPAUSE_RECV_CONT);
     TRACE_STATE() << ", status=" << status;
-    if (!status.ok()) return OnTransferError(std::move(status));
+    if (!status.ok()) return OnTransferError(context, std::move(status));
   }
 
   if (avail_.empty()) {
@@ -567,8 +571,9 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
   }
 
   TRACE_STATE() << ", status=" << status;
-  if (!status.ok()) return OnTransferError(std::move(status));
+  if (!status.ok()) return OnTransferError(context, std::move(status));
 
+  handle_.CaptureMetadata(context);
   bytes_read = output.size() - avail_.size();
   if (curl_closed_) {
     OnTransferDone();
@@ -725,7 +730,8 @@ Status CurlImpl::WaitForHandles(int& repeats) {
   return {};
 }
 
-Status CurlImpl::OnTransferError(Status status) {
+Status CurlImpl::OnTransferError(RestContext& context, Status status) {
+  handle_.CaptureMetadata(context);
   // When there is a transfer error the handle is suspect. It could be pointing
   // to an invalid host, a host that is slow and trickling data, or otherwise
   // be in a bad state. Release the handle, but do not return it to the pool.

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -95,7 +95,7 @@ class CurlImpl {
     return received_headers_;
   }
 
-  Status MakeRequest(HttpMethod method,
+  Status MakeRequest(HttpMethod method, RestContext& context,
                      std::vector<absl::Span<char const>> request = {});
 
   bool HasUnreadData() const;
@@ -106,8 +106,8 @@ class CurlImpl {
   std::size_t HeaderCallback(absl::Span<char> response);
 
  private:
-  Status MakeRequestImpl();
-  StatusOr<std::size_t> ReadImpl(absl::Span<char> output);
+  Status MakeRequestImpl(RestContext& context);
+  StatusOr<std::size_t> ReadImpl(RestContext& context, absl::Span<char> output);
 
   // Cleanup the CURL handles, leaving them ready for reuse.
   void CleanupHandles();
@@ -118,7 +118,7 @@ class CurlImpl {
   // Wait until the underlying data can perform work.
   Status WaitForHandles(int& repeats);
 
-  Status OnTransferError(Status status);
+  Status OnTransferError(RestContext& context, Status status);
   void OnTransferDone();
 
   std::shared_ptr<CurlHandleFactory> factory_;

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -22,7 +22,6 @@
 #include "google/cloud/testing_util/contains_once.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/strings/match.h"
-#include <curl/curl.h>
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
 
@@ -508,8 +507,6 @@ TEST_F(RestClientIntegrationTest, CaptureMetadata) {
   auto response = *std::move(response_status);
   ASSERT_THAT(response->StatusCode(), Eq(HttpStatusCode::kOk));
 
-  // These should all be available after CURL >= 7.61.0
-#if CURL_AT_LEAST_VERSION(7, 61, 0)
   EXPECT_TRUE(context.local_ip_address());
   EXPECT_TRUE(context.local_port());
   EXPECT_TRUE(context.primary_ip_address());
@@ -529,7 +526,6 @@ TEST_F(RestClientIntegrationTest, CaptureMetadata) {
   } else {
     EXPECT_EQ(*context.appconnect_time(), std::chrono::microseconds(0));
   }
-#endif /* CURL_AT_LEAST_VERSION */
 
   auto body = ReadAll(std::move(*response).ExtractPayload());
   ASSERT_STATUS_OK(body);

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -18,8 +18,11 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/rest_client.h"
 #include "google/cloud/log.h"
+#include "google/cloud/testing_util/chrono_output.h"
 #include "google/cloud/testing_util/contains_once.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/match.h"
+#include <curl/curl.h>
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
 
@@ -489,6 +492,49 @@ TEST_F(RestClientIntegrationTest, RestContextHeaders) {
       << "body=" << *body;
   EXPECT_EQ(sent_headers->value("X-Test-Header-2", ""), "header-value-2")
       << "body=" << *body;
+}
+
+TEST_F(RestClientIntegrationTest, CaptureMetadata) {
+  auto client = MakeDefaultRestClient(url_, {});
+  RestRequest request;
+  request.SetPath("anything");
+  rest_internal::RestContext context;
+  auto response_status = RetryRestRequest([&] {
+    context.AddHeader({"x-test-header-1", "header-value-1"});
+    context.AddHeader({"x-test-header-2", "header-value-2"});
+    return client->Get(context, request);
+  });
+  ASSERT_STATUS_OK(response_status);
+  auto response = *std::move(response_status);
+  ASSERT_THAT(response->StatusCode(), Eq(HttpStatusCode::kOk));
+
+  // These should all be available after CURL >= 7.61.0
+#if CURL_AT_LEAST_VERSION(7, 61, 0)
+  EXPECT_TRUE(context.local_ip_address());
+  EXPECT_TRUE(context.local_port());
+  EXPECT_TRUE(context.primary_ip_address());
+  EXPECT_TRUE(context.primary_port());
+
+  ASSERT_TRUE(context.namelookup_time());
+  ASSERT_TRUE(context.connect_time());
+  ASSERT_TRUE(context.appconnect_time());
+  // Times are relative from the start of the request, the should be increasing:
+  // namelookup <= connect <= appconnect
+  EXPECT_GE(*context.connect_time(), *context.namelookup_time());
+  // For HTTPS connections we expect appconnect_time to be >= connect_time. For
+  // HTTP connections we expect it to be 0 (there is no SSL negotiation to
+  // perform).  A EXPECT_THAT() here would not be very readable.
+  if (absl::StartsWith(url_, "https://")) {
+    EXPECT_GE(*context.appconnect_time(), *context.connect_time());
+  } else {
+    EXPECT_EQ(*context.appconnect_time(), std::chrono::microseconds(0));
+  }
+#endif /* CURL_AT_LEAST_VERSION */
+
+  auto body = ReadAll(std::move(*response).ExtractPayload());
+  ASSERT_STATUS_OK(body);
+  auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
+  ASSERT_TRUE(parsed_response.is_object()) << "body=" << *body;
 }
 
 }  // namespace

--- a/google/cloud/internal/rest_context.h
+++ b/google/cloud/internal/rest_context.h
@@ -16,6 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_CONTEXT_H
 
 #include "google/cloud/version.h"
+#include "absl/types/optional.h"
+#include <chrono>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -53,9 +55,63 @@ class RestContext {
   // Header names are case-insensitive; header values are case-sensitive.
   std::vector<std::string> GetHeader(std::string header) const;
 
+  absl::optional<std::string> local_ip_address() const {
+    return local_ip_address_;
+  }
+  void reset_local_ip_address() { local_ip_address_.reset(); }
+  void set_local_ip_address(std::string a) { local_ip_address_ = std::move(a); }
+
+  absl::optional<std::int32_t> local_port() const { return local_port_; }
+  void reset_local_port() { local_port_.reset(); }
+  void set_local_port(std::int32_t p) { local_port_ = p; }
+
+  absl::optional<std::string> primary_ip_address() const {
+    return primary_ip_address_;
+  }
+  void reset_primary_ip_address() { primary_ip_address_.reset(); }
+  void set_primary_ip_address(std::string a) {
+    primary_ip_address_ = std::move(a);
+  }
+
+  absl::optional<std::int32_t> primary_port() const { return primary_port_; }
+  void reset_primary_port() { primary_port_.reset(); }
+  void set_primary_port(std::int32_t p) { primary_port_ = p; }
+
+  // The time spent in DNS lookups
+  absl::optional<std::chrono::microseconds> namelookup_time() const {
+    return namelookup_time_;
+  }
+  void reset_namelookup_time() { namelookup_time_.reset(); }
+  void set_namelookup_time(std::chrono::microseconds us) {
+    namelookup_time_ = us;
+  }
+
+  // The time spent setting the TCP/IP connection.
+  absl::optional<std::chrono::microseconds> connect_time() const {
+    return connect_time_;
+  }
+  void reset_connect_time() { connect_time_.reset(); }
+  void set_connect_time(std::chrono::microseconds us) { connect_time_ = us; }
+
+  // The time spent in the SSL handshake.
+  absl::optional<std::chrono::microseconds> appconnect_time() const {
+    return appconnect_time_;
+  }
+  void reset_appconnect_time() { appconnect_time_.reset(); }
+  void set_appconnect_time(std::chrono::microseconds us) {
+    appconnect_time_ = us;
+  }
+
  private:
   friend bool operator==(RestContext const& lhs, RestContext const& rhs);
   HttpHeaders headers_;
+  absl::optional<std::string> local_ip_address_;
+  absl::optional<std::int32_t> local_port_;
+  absl::optional<std::string> primary_ip_address_;
+  absl::optional<std::int32_t> primary_port_;
+  absl::optional<std::chrono::microseconds> namelookup_time_;
+  absl::optional<std::chrono::microseconds> connect_time_;
+  absl::optional<std::chrono::microseconds> appconnect_time_;
 };
 
 bool operator==(RestContext const& lhs, RestContext const& rhs);


### PR DESCRIPTION
This changes the `RestClient` implementation to capture each request metadata, such as the IP addresses and ports used in the request. The main motivation is to include this information in OTel tracing attributes, but could be used for other troubleshooting too.

Part of the work for #11264

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11331)
<!-- Reviewable:end -->
