### PR TITLE
impl(otel): set the tracing scope on HTTP requests

### DIFF
--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -58,12 +58,14 @@ TracingRestClient::TracingRestClient(std::unique_ptr<RestClient> impl)
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Delete(
     RestContext& context, RestRequest const& request) {
   auto span = MakeSpanHttp(request, "DELETE");
+  auto scope = opentelemetry::trace::Scope(span);
   return EndResponseSpan(std::move(span), impl_->Delete(context, request));
 }
 
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Get(
     RestContext& context, RestRequest const& request) {
   auto span = MakeSpanHttp(request, "GET");
+  auto scope = opentelemetry::trace::Scope(span);
   return EndResponseSpan(std::move(span), impl_->Get(context, request));
 }
 
@@ -71,6 +73,7 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Patch(
     RestContext& context, RestRequest const& request,
     std::vector<absl::Span<char const>> const& payload) {
   auto span = MakeSpanHttp(request, "POST");
+  auto scope = opentelemetry::trace::Scope(span);
   return EndResponseSpan(std::move(span),
                          impl_->Patch(context, request, payload));
 }
@@ -79,6 +82,7 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Post(
     RestContext& context, RestRequest const& request,
     std::vector<absl::Span<char const>> const& payload) {
   auto span = MakeSpanHttp(request, "POST");
+  auto scope = opentelemetry::trace::Scope(span);
   return EndResponseSpan(std::move(span),
                          impl_->Post(context, request, payload));
 }
@@ -87,6 +91,7 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Post(
     RestContext& context, RestRequest const& request,
     std::vector<std::pair<std::string, std::string>> const& form_data) {
   auto span = MakeSpanHttp(request, "PUT");
+  auto scope = opentelemetry::trace::Scope(span);
   return EndResponseSpan(std::move(span),
                          impl_->Post(context, request, form_data));
 }
@@ -95,6 +100,7 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Put(
     RestContext& context, RestRequest const& request,
     std::vector<absl::Span<char const>> const& payload) {
   auto span = MakeSpanHttp(request, "PUT");
+  auto scope = opentelemetry::trace::Scope(span);
   return EndResponseSpan(std::move(span),
                          impl_->Put(context, request, payload));
 }

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -40,6 +40,7 @@ using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
 using ::google::cloud::testing_util::SpanNamed;
 using ::testing::AllOf;
+using ::testing::AtLeast;
 using ::testing::ElementsAreArray;
 using ::testing::Eq;
 using ::testing::NotNull;
@@ -108,7 +109,6 @@ TEST(TracingRestClient, Delete) {
 }
 
 TEST(TracingRestClient, HasScope) {
-  namespace sc = ::opentelemetry::trace::SemanticConventions;
   auto span_catcher = InstallSpanCatcher();
 
   auto impl = std::make_unique<MockRestClient>();
@@ -120,7 +120,7 @@ TEST(TracingRestClient, HasScope) {
     auto response = std::make_unique<MockRestResponse>();
     EXPECT_CALL(*response, StatusCode)
         .WillRepeatedly(Return(HttpStatusCode::kOk));
-    EXPECT_CALL(*response, Headers).WillRepeatedly(Return(MockHeaders()));
+    EXPECT_CALL(*response, Headers).Times(AtLeast(1));
     EXPECT_CALL(std::move(*response), ExtractPayload).WillOnce([] {
       return MakeMockHttpPayloadSuccess(MockContents());
     });
@@ -129,7 +129,6 @@ TEST(TracingRestClient, HasScope) {
 
   auto constexpr kUrl = "https://storage.googleapis.com/storage/v1/b/my-bucket";
   RestRequest request(kUrl);
-  request.AddHeader("x-test-header-3", "value3");
 
   auto client = MakeTracingRestClient(std::move(impl));
   rest_internal::RestContext context;
@@ -138,31 +137,17 @@ TEST(TracingRestClient, HasScope) {
   auto response = *std::move(r);
   ASSERT_THAT(response, NotNull());
   EXPECT_THAT(response->StatusCode(), Eq(HttpStatusCode::kOk));
-  EXPECT_THAT(response->Headers(), ElementsAreArray(MockHeaders()));
   auto contents = ReadAll(std::move(*response).ExtractPayload());
   EXPECT_THAT(contents, IsOkAndHolds(MockContents()));
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(
-      spans,
-      UnorderedElementsAre(
-          // Request span
-          AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
-                SpanKindIsClient(),
-                SpanHasAttributes(
-                    SpanAttribute<std::string>(sc::kNetTransport,
-                                               sc::NetTransportValues::kIpTcp),
-                    SpanAttribute<std::string>(sc::kHttpMethod, "GET"),
-                    SpanAttribute<std::string>(sc::kHttpUrl, kUrl),
-                    SpanAttribute<std::string>("test.attribute", "test.value"),
-                    SpanAttribute<std::string>(
-                        "http.request.header.x-test-header-3", "value3"),
-                    SpanAttribute<std::string>(
-                        "http.response.header.x-test-header-1", "value1"),
-                    SpanAttribute<std::string>(
-                        "http.response.header.x-test-header-2", "value2"))),
-          // Read span on the HttpPayload
-          SpanNamed("Read"), SpanNamed("Read")));
+  EXPECT_THAT(spans,
+              UnorderedElementsAre(
+                  AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
+                        SpanKindIsClient(),
+                        SpanHasAttributes(SpanAttribute<std::string>(
+                            "test.attribute", "test.value"))),
+                  SpanNamed("Read"), SpanNamed("Read")));
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #11264

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11332)
<!-- Reviewable:end -->
