### PR TITLE
fix(spanner): propagate Options through SessionPool callbacks

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -459,6 +459,8 @@ class BasicExperiment : public Experiment {
   }
 
  protected:
+  // Note that by bypassing the Client layer we are not instantiating
+  // an `OptionsSpan`, so `CurrentOptions()` will be empty if called.
   virtual std::vector<RowCpuSample> ViaStub(
       Config const& config, int thread_count, int channel_count,
       spanner::Database const& database,

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -32,6 +32,7 @@ struct SessionPoolFriendForTest {
                            std::shared_ptr<SpannerStub> const& stub,
                            std::map<std::string, std::string> const& labels,
                            std::string const& role, int num_sessions) {
+    internal::OptionsSpan span(session_pool->opts_);
     return session_pool->AsyncBatchCreateSessions(cq, stub, labels, role,
                                                   num_sessions);
   }
@@ -39,12 +40,14 @@ struct SessionPoolFriendForTest {
   static future<Status> AsyncDeleteSession(
       std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
       std::shared_ptr<SpannerStub> const& stub, std::string session_name) {
+    internal::OptionsSpan span(session_pool->opts_);
     return session_pool->AsyncDeleteSession(cq, stub, std::move(session_name));
   }
 
   static future<StatusOr<google::spanner::v1::ResultSet>> AsyncRefreshSession(
       std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
       std::shared_ptr<SpannerStub> const& stub, std::string session_name) {
+    internal::OptionsSpan span(session_pool->opts_);
     return session_pool->AsyncRefreshSession(cq, stub, std::move(session_name));
   }
 };

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/internal/async_retry_loop.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include <grpcpp/grpcpp.h>
 #include <algorithm>
@@ -75,10 +76,11 @@ SessionPool::SessionPool(spanner::Database db,
 }
 
 void SessionPool::Initialize() {
+  internal::OptionsSpan span(opts_);
   auto const min_sessions = opts_.get<spanner::SessionPoolMinSessionsOption>();
   if (min_sessions > 0) {
     std::unique_lock<std::mutex> lk(mu_);
-    (void)Grow(lk, min_sessions, WaitForSessionAllocation::kWait);
+    Grow(lk, min_sessions, WaitForSessionAllocation::kWait);
   }
   ScheduleBackgroundWork(std::chrono::seconds(5));
 }
@@ -199,7 +201,7 @@ Status SessionPool::Grow(std::unique_lock<std::mutex>& lk,
                          int sessions_to_create,
                          WaitForSessionAllocation wait) {
   auto create_counts = ComputeCreateCounts(sessions_to_create);
-  if (!create_counts.ok()) {
+  if (!create_counts.ok() || create_counts->empty()) {
     return create_counts.status();
   }
   create_calls_in_progress_ += static_cast<int>(create_counts->size());
@@ -286,6 +288,10 @@ Status SessionPool::CreateSessions(
 }
 
 StatusOr<SessionHolder> SessionPool::Allocate(bool dissociate_from_pool) {
+  // We choose to ignore the internal::CurrentOptions() here as it is
+  // non-deterministic when RPCs to create sessions are actually made.
+  // It is clearer if we just stick with the construction-time Options.
+  internal::OptionsSpan span(opts_);
   std::unique_lock<std::mutex> lk(mu_);
   for (;;) {
     if (!sessions_.empty()) {

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -91,9 +91,14 @@ using SpannerPolicyOptionList =
                SpannerPollingPolicyOption>;
 
 /**
- * Option for `google::cloud::Options` to, when present and false, suppress
- * adding headers to distinguish requests served by the leader v/s non-leader
- * region.
+ * Control "route to leader region" headers.
+ *
+ * Unless this option is present and `false` the client library will send
+ * headers that route the request to the leader region.
+ *
+ * @see https://cloud.google.com/spanner/docs/instance-configurations
+ * for more information on multi-regional spanner instances and the role of
+ * leader regions.
  *
  * @ingroup spanner-options
  */

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -91,6 +91,17 @@ using SpannerPolicyOptionList =
                SpannerPollingPolicyOption>;
 
 /**
+ * Option for `google::cloud::Options` to, when present and false, suppress
+ * adding headers to distinguish requests served by the leader v/s non-leader
+ * region.
+ *
+ * @ingroup spanner-options
+ */
+struct RouteToLeaderOption {
+  using Type = bool;
+};
+
+/**
  * Option for `google::cloud::Options` to set the database role used for
  * session creation.
  *
@@ -181,23 +192,11 @@ struct SessionPoolLabelsOption {
 /**
  * List of all SessionPool options. Pass to `spanner::MakeConnection()`.
  */
-using SessionPoolOptionList =
-    OptionList<SessionCreatorRoleOption, SessionPoolMinSessionsOption,
-               SessionPoolMaxSessionsPerChannelOption,
-               SessionPoolMaxIdleSessionsOption,
-               SessionPoolActionOnExhaustionOption,
-               SessionPoolKeepAliveIntervalOption, SessionPoolLabelsOption>;
-
-/**
- * Option for `google::cloud::Options` to, when present and false, suppress
- * adding headers to distinguish requests served by the leader v/s non-leader
- * region.
- *
- * @ingroup spanner-options
- */
-struct RouteToLeaderOption {
-  using Type = bool;
-};
+using SessionPoolOptionList = OptionList<
+    RouteToLeaderOption, SessionCreatorRoleOption, SessionPoolMinSessionsOption,
+    SessionPoolMaxSessionsPerChannelOption, SessionPoolMaxIdleSessionsOption,
+    SessionPoolActionOnExhaustionOption, SessionPoolKeepAliveIntervalOption,
+    SessionPoolLabelsOption>;
 
 /**
  * Option for `google::cloud::Options` to set the optimizer version used in an


### PR DESCRIPTION
`BatchCreateSessions()` calls made during the `SessionPool` callback chain depend on the prevailing options to determine whether the RPC should be routed to a region leader.  So, we need to ensure that the construction-time options are propagated through those callbacks by instantiating `OptionsSpan` objects when appropriate.

Add similar `OptionsSpan` objects to `session_pool_integration_test.cc`, which uses "FriendForTest" access to reach into `SessionPool`, bypassing the normal span instantiation.

Add unit tests to verify that the "x-goog-spanner-route-to-leader" header is now set appropriately when the `RouteToLeaderOption` is both enabled and disabled.

Add `RouteToLeaderOption` to the `SessionPoolOptionList`, marking it as a valid option to pass to `spanner::MakeConnection()`.

Also add a slight optimization to `SessionPool::Grow()`, which skips even trying to create sessions when `ComputeCreateCounts()` returns an empty vector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11344)
<!-- Reviewable:end -->
