### PR TITLE
cleanup(spanner): some accumulated Spanner comment cleanup

### DIFF
--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -644,8 +644,8 @@ class Client {
   StatusOr<PartitionedDmlResult> ExecutePartitionedDml(SqlStatement statement,
                                                        Options opts = {});
 
-  /// @name Backwards compatibility for ClientOptions.
   ///@{
+  /// @name Backwards compatibility for ClientOptions.
   explicit Client(std::shared_ptr<Connection> conn, ClientOptions const& opts)
       : Client(std::move(conn), Options(opts)) {}
   explicit Client(std::shared_ptr<Connection> conn,

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -304,7 +304,7 @@ struct PartitionsMaximumOption {
  * partitions returned from `Client::PartitionRead()` or `PartitionQuery()`.
  *
  * If true, the requests from the subsequent partitioned `Client::Read()`
- * and `Client::ExecuteQuery()` requests will be executed via Spanner
+ * and `Client::ExecuteQuery()` requests will be executed via Spanner-
  * independent compute resources.
  *
  * @ingroup spanner-options

--- a/google/cloud/spanner/partition_options.h
+++ b/google/cloud/spanner/partition_options.h
@@ -59,7 +59,7 @@ struct PartitionOptions {
    * Use "data boost" in the returned partitions.
    *
    * If true, the requests from the subsequent partitioned `Client::Read()`
-   * and `Client::ExecuteQuery()` requests will be executed via Spanner
+   * and `Client::ExecuteQuery()` requests will be executed via Spanner-
    * independent compute resources.
    */
   bool data_boost = false;

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -83,7 +83,7 @@ StatusOr<QueryPartition> DeserializeQueryPartition(
  * Instances of `QueryPartition` are created by `Client::PartitionQuery`. Once
  * created, `QueryPartition` objects can be serialized, transmitted to separate
  * processes, and used to read data in parallel using `Client::ExecuteQuery`.
- * If `data_boost` is set, those requests will be executed via Spanner
+ * If `data_boost` is set, those requests will be executed via Spanner-
  * independent compute resources.
  */
 class QueryPartition {

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -84,7 +84,7 @@ StatusOr<ReadPartition> DeserializeReadPartition(
  * Instances of `ReadPartition` are created by `Client::PartitionRead`.
  * Once created, `ReadPartition` objects can be serialized, transmitted to
  * separate processes, and used to read data in parallel using `Client::Read`.
- * If `data_boost` is set, those requests will be executed via Spanner
+ * If `data_boost` is set, those requests will be executed via Spanner-
  * independent compute resources.
  */
 class ReadPartition {


### PR DESCRIPTION
- Move the `@name` for `ClientOptions` compatibility calls to within the doxygen group, just like all the other such groups.

- Clarify that the compute resources used for the "DataBoost" feature are independent of Spanner, rather than some special category of "independent" resources supplied by Spanner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11345)
<!-- Reviewable:end -->
