### PR TITLE
impl(bigquery): refactored JobLogWrapper template function

### DIFF
--- a/google/cloud/bigquery/bigquery_rest.cmake
+++ b/google/cloud/bigquery/bigquery_rest.cmake
@@ -56,6 +56,7 @@ add_library(
     v2/minimal/internal/job_rest_stub_factory.cc
     v2/minimal/internal/job_rest_stub_factory.h
     v2/minimal/internal/job_retry_policy.h
+    v2/minimal/internal/log_wrapper.h
     v2/minimal/internal/rest_stub_utils.h)
 target_include_directories(
     google_cloud_cpp_bigquery_rest

--- a/google/cloud/bigquery/google_cloud_cpp_bigquery_rest.bzl
+++ b/google/cloud/bigquery/google_cloud_cpp_bigquery_rest.bzl
@@ -38,6 +38,7 @@ google_cloud_cpp_bigquery_rest_hdrs = [
     "v2/minimal/internal/job_rest_stub.h",
     "v2/minimal/internal/job_rest_stub_factory.h",
     "v2/minimal/internal/job_retry_policy.h",
+    "v2/minimal/internal/log_wrapper.h",
     "v2/minimal/internal/rest_stub_utils.h",
 ]
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
@@ -15,50 +15,15 @@
 // Implementation of internal interface for Bigquery V2 Job resource.
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_logging.h"
+#include "google/cloud/bigquery/v2/minimal/internal/log_wrapper.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
-#include "google/cloud/internal/debug_string.h"
-#include "google/cloud/internal/debug_string_status.h"
-#include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/rest_context.h"
-#include "google/cloud/log.h"
 #include "google/cloud/status_or.h"
-#include "absl/strings/string_view.h"
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-template <typename Functor, typename Request,
-          typename Result = google::cloud::internal::invoke_result_t<
-              Functor, rest_internal::RestContext&, Request const&>>
-Result JobLogWrapper(Functor&& functor, rest_internal::RestContext& context,
-                     Request const& request, char const* where,
-                     absl::string_view request_name,
-                     absl::string_view response_name,
-                     TracingOptions const& options) {
-  auto formatter = [options](std::string* out, auto const& header) {
-    const auto* delim = options.single_line_mode() ? "&" : "\n";
-    absl::StrAppend(
-        out, " { name: \"", header.first, "\" value: \"",
-        internal::DebugString(absl::StrJoin(header.second, delim), options),
-        "\" }");
-  };
-  GCP_LOG(DEBUG) << where << "() << "
-                 << request.DebugString(request_name, options) << ", Context {"
-                 << absl::StrJoin(context.headers(), "", formatter) << " }";
-
-  auto response = functor(context, request);
-  if (!response) {
-    GCP_LOG(DEBUG) << where << "() >> status="
-                   << internal::DebugString(response.status(), options);
-  } else {
-    GCP_LOG(DEBUG) << where << "() >> response="
-                   << response->DebugString(response_name, options);
-  }
-
-  return response;
-}
 
 BigQueryJobLogging::BigQueryJobLogging(
     std::shared_ptr<BigQueryJobRestStub> child, TracingOptions tracing_options,
@@ -71,7 +36,7 @@ BigQueryJobLogging::BigQueryJobLogging(
 // not a protobuf message.
 StatusOr<GetJobResponse> BigQueryJobLogging::GetJob(
     rest_internal::RestContext& rest_context, GetJobRequest const& request) {
-  return JobLogWrapper(
+  return LogWrapper(
       [this](rest_internal::RestContext& rest_context,
              GetJobRequest const& request) {
         return child_->GetJob(rest_context, request);
@@ -86,7 +51,7 @@ StatusOr<GetJobResponse> BigQueryJobLogging::GetJob(
 // not a protobuf message.
 StatusOr<ListJobsResponse> BigQueryJobLogging::ListJobs(
     rest_internal::RestContext& rest_context, ListJobsRequest const& request) {
-  return JobLogWrapper(
+  return LogWrapper(
       [this](rest_internal::RestContext& rest_context,
              ListJobsRequest const& request) {
         return child_->ListJobs(rest_context, request);

--- a/google/cloud/bigquery/v2/minimal/internal/log_wrapper.h
+++ b/google/cloud/bigquery/v2/minimal/internal/log_wrapper.h
@@ -1,0 +1,68 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_LOG_WRAPPER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_LOG_WRAPPER_H
+
+#include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/internal/debug_string.h"
+#include "google/cloud/internal/debug_string_status.h"
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/rest_context.h"
+#include "google/cloud/log.h"
+#include "google/cloud/status_or.h"
+#include "absl/strings/string_view.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+template <typename Functor, typename Request,
+          typename Result = google::cloud::internal::invoke_result_t<
+              Functor, rest_internal::RestContext&, Request const&>>
+Result LogWrapper(Functor&& functor, rest_internal::RestContext& context,
+                  Request const& request, char const* where,
+                  absl::string_view request_name,
+                  absl::string_view response_name,
+                  TracingOptions const& options) {
+  auto formatter = [options](std::string* out, auto const& header) {
+    const auto* delim = options.single_line_mode() ? "&" : "\n";
+    absl::StrAppend(
+        out, " { name: \"", header.first, "\" value: \"",
+        internal::DebugString(absl::StrJoin(header.second, delim), options),
+        "\" }");
+  };
+  GCP_LOG(DEBUG) << where << "() << "
+                 << request.DebugString(request_name, options) << ", Context {"
+                 << absl::StrJoin(context.headers(), "", formatter) << " }";
+
+  auto response = functor(context, request);
+  if (!response) {
+    GCP_LOG(DEBUG) << where << "() >> status="
+                   << internal::DebugString(response.status(), options);
+  } else {
+    GCP_LOG(DEBUG) << where << "() >> response="
+                   << response->DebugString(response_name, options);
+  }
+
+  return response;
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigquery_v2_minimal_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_LOG_WRAPPER_H


### PR DESCRIPTION
Refactored JobLogWrapper template function to a separate header so it can be used from multiple places e.g. dataset logging decorator

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11350)
<!-- Reviewable:end -->
