### PR TITLE
impl(otel): `TracingRestClient` tracing propagation

### DIFF
--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -31,9 +31,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace {
 
-// We always inject the CloudTraceContext, these requests are going to GCP where
-// the X-Cloud-Trace-Context header can connect the request with the internal
-// tracing service.
+// We always inject the CloudTraceContext. Typically, these requests are going
+// to GCP where the X-Cloud-Trace-Context header can connect the request with
+// the internal tracing service.
 void InjectCloudTraceContext(RestContext& ctx,
                              opentelemetry::trace::Span const& span) {
   auto context = span.GetContext();

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 #include "google/cloud/internal/tracing_rest_client.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/rest_opentelemetry.h"
 #include "google/cloud/internal/tracing_http_payload.h"
 #include "google/cloud/internal/tracing_rest_response.h"
+#include "absl/strings/numbers.h"
+#include <array>
+#include <cstdint>
 
 namespace google {
 namespace cloud {
@@ -24,6 +28,35 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+namespace {
+
+// We always inject the CloudTraceContext, these requests are going to GCP where
+// the X-Cloud-Trace-Context header can connect the request with the internal
+// tracing service.
+void InjectCloudTraceContext(RestContext& ctx,
+                             opentelemetry::trace::Span const& span) {
+  auto context = span.GetContext();
+  if (!context.IsValid()) return;
+
+  using opentelemetry::trace::SpanId;
+  using opentelemetry::trace::TraceId;
+  std::array<char, 2 * TraceId::kSize> trace_id;
+  context.trace_id().ToLowerBase16(trace_id);
+  std::array<char, 2 * SpanId::kSize> span_id;
+  context.span_id().ToLowerBase16(span_id);
+  std::uint64_t value;
+  if (!absl::SimpleHexAtoi(absl::string_view{span_id.data(), span_id.size()},
+                           &value)) {
+    return;
+  }
+  ctx.AddHeader(
+      "X-Cloud-Trace-Context",
+      absl::StrCat(absl::string_view{trace_id.data(), trace_id.size()}, "/",
+                   value, ";o=1"));
+}
+
+}  // namespace
 
 void ExtractAttributes(StatusOr<std::unique_ptr<RestResponse>> const& value,
                        opentelemetry::trace::Span& span) {
@@ -59,6 +92,8 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Delete(
     RestContext& context, RestRequest const& request) {
   auto span = MakeSpanHttp(request, "DELETE");
   auto scope = opentelemetry::trace::Scope(span);
+  InjectTraceContext(context, internal::CurrentOptions());
+  InjectCloudTraceContext(context, *span);
   return EndResponseSpan(std::move(span), impl_->Delete(context, request));
 }
 
@@ -66,14 +101,18 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Get(
     RestContext& context, RestRequest const& request) {
   auto span = MakeSpanHttp(request, "GET");
   auto scope = opentelemetry::trace::Scope(span);
+  InjectTraceContext(context, internal::CurrentOptions());
+  InjectCloudTraceContext(context, *span);
   return EndResponseSpan(std::move(span), impl_->Get(context, request));
 }
 
 StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Patch(
     RestContext& context, RestRequest const& request,
     std::vector<absl::Span<char const>> const& payload) {
-  auto span = MakeSpanHttp(request, "POST");
+  auto span = MakeSpanHttp(request, "PATCH");
   auto scope = opentelemetry::trace::Scope(span);
+  InjectTraceContext(context, internal::CurrentOptions());
+  InjectCloudTraceContext(context, *span);
   return EndResponseSpan(std::move(span),
                          impl_->Patch(context, request, payload));
 }
@@ -83,6 +122,8 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Post(
     std::vector<absl::Span<char const>> const& payload) {
   auto span = MakeSpanHttp(request, "POST");
   auto scope = opentelemetry::trace::Scope(span);
+  InjectTraceContext(context, internal::CurrentOptions());
+  InjectCloudTraceContext(context, *span);
   return EndResponseSpan(std::move(span),
                          impl_->Post(context, request, payload));
 }
@@ -92,6 +133,8 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Post(
     std::vector<std::pair<std::string, std::string>> const& form_data) {
   auto span = MakeSpanHttp(request, "PUT");
   auto scope = opentelemetry::trace::Scope(span);
+  InjectTraceContext(context, internal::CurrentOptions());
+  InjectCloudTraceContext(context, *span);
   return EndResponseSpan(std::move(span),
                          impl_->Post(context, request, form_data));
 }
@@ -101,6 +144,8 @@ StatusOr<std::unique_ptr<RestResponse>> TracingRestClient::Put(
     std::vector<absl::Span<char const>> const& payload) {
   auto span = MakeSpanHttp(request, "PUT");
   auto scope = opentelemetry::trace::Scope(span);
+  InjectTraceContext(context, internal::CurrentOptions());
+  InjectCloudTraceContext(context, *span);
   return EndResponseSpan(std::move(span),
                          impl_->Put(context, request, payload));
 }

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -167,9 +167,6 @@ TEST(TracingRestClient, HasCloudTraceContext) {
   };
   EXPECT_CALL(*impl, Patch(expected_headers_matcher(), _, _))
       .WillOnce([](auto&, auto const&, auto const&) {
-        // Inject an attribute to the current span, which should be the request
-        // span.
-        auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
         auto response = std::make_unique<MockRestResponse>();
         EXPECT_CALL(*response, StatusCode)
             .WillRepeatedly(Return(HttpStatusCode::kOk));
@@ -223,9 +220,6 @@ TEST(TracingRestClient, WithTraceparent) {
       ::testing::An<std::vector<absl::Span<char const>> const&>();
   EXPECT_CALL(*impl, Post(expected_headers_matcher(), _, disambiguate_overload))
       .WillOnce([](auto&, auto const&, auto const&) {
-        // Inject an attribute to the current span, which should be the request
-        // span.
-        auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
         auto response = std::make_unique<MockRestResponse>();
         EXPECT_CALL(*response, StatusCode)
             .WillRepeatedly(Return(HttpStatusCode::kOk));

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/trace/propagation/http_trace_context.h>
 #include <opentelemetry/trace/semantic_conventions.h>
 
 namespace google {
@@ -39,11 +40,15 @@ using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
 using ::google::cloud::testing_util::SpanNamed;
+using ::testing::_;
 using ::testing::AllOf;
 using ::testing::AtLeast;
+using ::testing::Contains;
 using ::testing::ElementsAreArray;
 using ::testing::Eq;
 using ::testing::NotNull;
+using ::testing::Pair;
+using ::testing::ResultOf;
 using ::testing::Return;
 using ::testing::UnorderedElementsAre;
 
@@ -148,6 +153,107 @@ TEST(TracingRestClient, HasScope) {
                         SpanHasAttributes(SpanAttribute<std::string>(
                             "test.attribute", "test.value"))),
                   SpanNamed("Read"), SpanNamed("Read")));
+}
+
+TEST(TracingRestClient, HasCloudTraceContext) {
+  auto span_catcher = InstallSpanCatcher();
+
+  auto impl = std::make_unique<MockRestClient>();
+  auto expected_headers_matcher = [] {
+    return ResultOf(
+        "headers have x-cloud-trace-context",
+        [](RestContext const& c) { return c.headers(); },
+        Contains(Pair("x-cloud-trace-context", _)));
+  };
+  EXPECT_CALL(*impl, Patch(expected_headers_matcher(), _, _))
+      .WillOnce([](auto&, auto const&, auto const&) {
+        // Inject an attribute to the current span, which should be the request
+        // span.
+        auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
+        auto response = std::make_unique<MockRestResponse>();
+        EXPECT_CALL(*response, StatusCode)
+            .WillRepeatedly(Return(HttpStatusCode::kOk));
+        EXPECT_CALL(*response, Headers).Times(AtLeast(1));
+        EXPECT_CALL(std::move(*response), ExtractPayload).WillOnce([] {
+          return MakeMockHttpPayloadSuccess(MockContents());
+        });
+        return std::unique_ptr<RestResponse>(std::move(response));
+      });
+
+  auto constexpr kUrl = "https://storage.googleapis.com/storage/v1/b/my-bucket";
+  RestRequest request(kUrl);
+
+  auto client = MakeTracingRestClient(std::move(impl));
+  rest_internal::RestContext context;
+  auto r = client->Patch(context, request, {});
+  ASSERT_STATUS_OK(r);
+  auto response = *std::move(r);
+  ASSERT_THAT(response, NotNull());
+  EXPECT_THAT(response->StatusCode(), Eq(HttpStatusCode::kOk));
+  auto contents = ReadAll(std::move(*response).ExtractPayload());
+  EXPECT_THAT(contents, IsOkAndHolds(MockContents()));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans,
+              UnorderedElementsAre(SpanNamed("HTTP/PATCH"), SpanNamed("Read"),
+                                   SpanNamed("Read")));
+}
+
+TEST(TracingRestClient, WithTraceparent) {
+  auto span_catcher = InstallSpanCatcher();
+
+  // Set the global propagator.
+  auto propagator =
+      std::make_shared<opentelemetry::trace::propagation::HttpTraceContext>();
+  opentelemetry::context::propagation::GlobalTextMapPropagator::
+      SetGlobalPropagator(
+          opentelemetry::nostd::shared_ptr<
+              opentelemetry::context::propagation::TextMapPropagator>(
+              propagator));
+
+  auto impl = std::make_unique<MockRestClient>();
+  auto expected_headers_matcher = [] {
+    return ResultOf(
+        "headers have x-cloud-trace-context",
+        [](RestContext const& c) { return c.headers(); },
+        AllOf(Contains(Pair("x-cloud-trace-context", _)),
+              Contains(Pair("traceparent", _))));
+  };
+  auto disambiguate_overload =
+      ::testing::An<std::vector<absl::Span<char const>> const&>();
+  EXPECT_CALL(*impl, Post(expected_headers_matcher(), _, disambiguate_overload))
+      .WillOnce([](auto&, auto const&, auto const&) {
+        // Inject an attribute to the current span, which should be the request
+        // span.
+        auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
+        auto response = std::make_unique<MockRestResponse>();
+        EXPECT_CALL(*response, StatusCode)
+            .WillRepeatedly(Return(HttpStatusCode::kOk));
+        EXPECT_CALL(*response, Headers).Times(AtLeast(1));
+        EXPECT_CALL(std::move(*response), ExtractPayload).WillOnce([] {
+          return MakeMockHttpPayloadSuccess(MockContents());
+        });
+        return std::unique_ptr<RestResponse>(std::move(response));
+      });
+
+  auto constexpr kUrl = "https://storage.googleapis.com/storage/v1/b/my-bucket";
+  RestRequest request(kUrl);
+
+  auto client = MakeTracingRestClient(std::move(impl));
+  rest_internal::RestContext context;
+  auto r =
+      client->Post(context, request, std::vector<absl::Span<char const>>{});
+  ASSERT_STATUS_OK(r);
+  auto response = *std::move(r);
+  ASSERT_THAT(response, NotNull());
+  EXPECT_THAT(response->StatusCode(), Eq(HttpStatusCode::kOk));
+  auto contents = ReadAll(std::move(*response).ExtractPayload());
+  EXPECT_THAT(contents, IsOkAndHolds(MockContents()));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans,
+              UnorderedElementsAre(SpanNamed("HTTP/POST"), SpanNamed("Read"),
+                                   SpanNamed("Read")));
 }
 
 }  // namespace


### PR DESCRIPTION
With this change the `TracingRestClient` always includes the `x-cloud-trace-context` header and any other configured tracing propagators.

Fixes #11264

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11352)
<!-- Reviewable:end -->
