### PR TITLE
impl(otel): a simplified tracing initializer

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -163,6 +163,8 @@ function integration::bazel_with_emulators() {
     "google/cloud/pubsublite/..."
     # Unified Rest Credentials test
     "google/cloud:internal_unified_rest_credentials_integration_test"
+    # The OpenTelemetry integration tests are limited by quota
+    "google/cloud/opentelemetry/integration_tests/..."
   )
 
   production_tests_tag_filters="integration-test"

--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -29,8 +29,8 @@ google_cloud_cpp_doxygen_targets("opentelemetry" DEPENDS cloud-docs
 
 add_library(
     google_cloud_cpp_opentelemetry # cmake-format: sort
-    internal/recordable.cc internal/recordable.h trace_exporter.cc
-    trace_exporter.h)
+    configure_basic_tracing.cc configure_basic_tracing.h internal/recordable.cc
+    internal/recordable.h trace_exporter.cc trace_exporter.h)
 target_link_libraries(google_cloud_cpp_opentelemetry
                       PUBLIC google-cloud-cpp::trace opentelemetry-cpp::trace)
 google_cloud_cpp_add_common_options(google_cloud_cpp_opentelemetry)

--- a/google/cloud/opentelemetry/configure_basic_tracing.cc
+++ b/google/cloud/opentelemetry/configure_basic_tracing.cc
@@ -29,21 +29,23 @@ class BasicTracingConfigurationImpl : public BasicTracingConfiguration {
  public:
   explicit BasicTracingConfigurationImpl(
       std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> provider)
-      : provider_(std::move(provider)) {
+      : provider_(std::move(provider)),
+        previous_(opentelemetry::trace::Provider::GetTracerProvider()) {
     opentelemetry::trace::Provider::SetTracerProvider(
         opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>(
             provider_));
   }
+
   ~BasicTracingConfigurationImpl() override {
     if (provider_) provider_->ForceFlush(std::chrono::microseconds(1000));
-    // Clear the global tracer provider.
-    opentelemetry::trace::Provider::SetTracerProvider(
-        opentelemetry::nostd::shared_ptr<
-            opentelemetry::trace::TracerProvider>());
+    // Reset the global tracer provider.
+    opentelemetry::trace::Provider::SetTracerProvider(std::move(previous_));
   }
 
  private:
   std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> provider_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>
+      previous_;
 };
 
 }  // namespace

--- a/google/cloud/opentelemetry/configure_basic_tracing.cc
+++ b/google/cloud/opentelemetry/configure_basic_tracing.cc
@@ -1,0 +1,73 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/opentelemetry/trace_exporter.h"
+#include <opentelemetry/sdk/trace/batch_span_processor.h>
+#include <opentelemetry/sdk/trace/samplers/trace_id_ratio_factory.h>
+#include <opentelemetry/sdk/trace/tracer_provider.h>
+#include <opentelemetry/trace/provider.h>
+
+namespace google {
+namespace cloud {
+namespace otel {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+class BasicTracingConfigurationImpl : public BasicTracingConfiguration {
+ public:
+  explicit BasicTracingConfigurationImpl(
+      std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> provider)
+      : provider_(std::move(provider)) {
+    opentelemetry::trace::Provider::SetTracerProvider(
+        opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>(
+            provider_));
+  }
+  ~BasicTracingConfigurationImpl() override {
+    if (provider_) provider_->ForceFlush(std::chrono::microseconds(1000));
+    // Clear the global tracer provider.
+    opentelemetry::trace::Provider::SetTracerProvider(
+        opentelemetry::nostd::shared_ptr<
+            opentelemetry::trace::TracerProvider>());
+  }
+
+ private:
+  std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> provider_;
+};
+
+}  // namespace
+
+std::unique_ptr<BasicTracingConfiguration> ConfigureBasicTracing(
+    Project project, Options options) {
+  // Just return a nullptr if the project is not configured. This is intended
+  // as a function to make things easy, no reason to return complicated errors.
+  if (project.project_id().empty()) return {};
+  auto ratio = options.has<BasicTracingRateOption>()
+                   ? options.get<BasicTracingRateOption>()
+                   : 1.0;
+  auto processor =
+      std::make_unique<opentelemetry::sdk::trace::BatchSpanProcessor>(
+          MakeTraceExporter(std::move(project), std::move(options)),
+          opentelemetry::sdk::trace::BatchSpanProcessorOptions{});
+  auto provider = std::make_shared<opentelemetry::sdk::trace::TracerProvider>(
+      std::move(processor), opentelemetry::sdk::resource::Resource::Create({}),
+      opentelemetry::sdk::trace::TraceIdRatioBasedSamplerFactory::Create(
+          ratio));
+  return std::make_unique<BasicTracingConfigurationImpl>(std::move(provider));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/opentelemetry/configure_basic_tracing.h
+++ b/google/cloud/opentelemetry/configure_basic_tracing.h
@@ -38,22 +38,35 @@ class BasicTracingConfiguration {
  * `google-cloud-cpp` libraries use [OpenTelemetry] to provide telemetry into
  * their operation at runtime.
  *
+ * You do not need to add OpenTelemetry instrumentation to your code. The C++
+ * client libraries are already instrumented and all sampled RPCs will be sent
+ * to Cloud Trace. However, you may want to add instrumentation if multiple
+ * RPCs are performed as part of a single logical "operation" in your
+ * application.
+ *
+ * OpenTelemetry traces, including those reported by the C++ client libraries
+ * start as soon as this function returns. Tracing stops when the object
+ * returned by this function is deleted.
+ *
  * OpenTelemetry is very configurable, supporting different sampling rates and
  * filters, multiple "exporters" to send the collected data to different
  * services, and multiple mechanisms to chain requests as they move from one
- * program to the next.
+ * program to the next. We do not expect this function will meet the needs of
+ * all applications. However, some applications will want a basic configuration
+ * that works with Gooogle Cloud Trace.
  *
- * We anticipate that some applications will want a basic configuration that
- * works with Gooogle Cloud Trace. Use this function to create such
- * configuration.
+ * This function uses the [OpenTelemetry C++ API] to change the global trace
+ * provider (`opentelemetry::trace::Provider::#SetTraceProvider()`). Do not use
+ * this function if your application needs fine control over OpenTelemetry
+ * settings.
  *
  * @note If you are using CMake as your build system, OpenTelemetry is not
  *     enabled by default in `google-cloud-cpp`. Please consult the build
  *     documentation to enable the additional libraries.
  *
+ * @par Usage Example
+ * @parblock
  * Change your build scripts to also the library that provides this function.
- * With CMake that is `google-cloud-cpp::experimental-opentelemetry`, with Bazel
- * that is `//:TBD`.
  *
  * Change your application to call this function once, for example in `main()`
  * as follows:
@@ -71,16 +84,9 @@ class BasicTracingConfiguration {
  * }
  * @endcode
  *
- * Where `[TRACING PROECT]` is the project id where you want to store the
+ * Where `[TRACING PROJECT]` is the project id where you want to store the
  * traces.
- *
- * Tracing stops when the object returned by this function goes out of scope.
- *
- * You do not need to add OpenTelemetry instrumentation to your code, the C++
- * client libraries are already instrumented and all sampled RPCs will be sent
- * to Cloud Trace. However, you may want to add instrumentation if multiple
- * RPCs are performed as part of a single logical "operation" in your
- * application.
+ * @endparblock
  *
  * @par Permissions
  * @parblock
@@ -105,7 +111,7 @@ class BasicTracingConfiguration {
  * By default this function configures the application to trace all requests.
  * This is useful for troubleshooting, but it is excessive if you want to enable
  * tracing by default and use the results to gather latency statistics. To
- * reduce the sampling rate use @ref `BasicTracingRateOption`. If desired,
+ * reduce the sampling rate use `@ref BasicTracingRateOption`. If desired,
  * you can use an environment variable (or any other configuration source)
  * to initialize its value.
  *
@@ -123,14 +129,15 @@ class BasicTracingConfiguration {
  *
  * @param project the project to send the traces to.
  * @param options how to configure the traces. The configuration parameters
- *     include @ref `BasicTracingRateOption`,
- *     @ref `google::cloud::UnifiedCredentialsOption`.
+ *     include `@ref BasicTracingRateOption`,
+ *     `@ref google::cloud::UnifiedCredentialsOption`.
  *
  * @see https://cloud.google.com/trace/docs/iam for more information about IAM
  *     permissions for Cloud Trace.
  *
  * [Cloud Trace]: https://cloud.google.com/trace
  * [OpenTelemetry]: https://opentelemetry.io
+ * [OpenTelemetry C++ API]: https://opentelemetry-cpp.readthedocs.io/en/latest/
  * [Application Default Credentials]:
  * https://cloud.google.com/docs/authentication#adc
  */
@@ -140,7 +147,7 @@ std::unique_ptr<BasicTracingConfiguration> ConfigureBasicTracing(
 /**
  * Configure the tracing rate for basic tracing.
  *
- * @see @ref `ConfigureBasicTracing` for more information.
+ * @see `@ref ConfigureBasicTracing()` for more information.
  */
 struct BasicTracingRateOption {
   using Type = double;

--- a/google/cloud/opentelemetry/configure_basic_tracing.h
+++ b/google/cloud/opentelemetry/configure_basic_tracing.h
@@ -30,7 +30,7 @@ class BasicTracingConfiguration {
   virtual ~BasicTracingConfiguration() = default;
 };
 
-// TODO(#....) - complete the documentation on how to link this library.
+// TODO(#11360) - reference the quickstart when discussing program linking.
 /**
  * Configure the application for basic request tracing.
  *

--- a/google/cloud/opentelemetry/configure_basic_tracing.h
+++ b/google/cloud/opentelemetry/configure_basic_tracing.h
@@ -1,0 +1,154 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_CONFIGURE_BASIC_TRACING_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_CONFIGURE_BASIC_TRACING_H
+
+#include "google/cloud/options.h"
+#include "google/cloud/project.h"
+#include "google/cloud/version.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace otel {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+/// Implementation details for `ConfigureBasicTracing`.
+class BasicTracingConfiguration {
+ public:
+  virtual ~BasicTracingConfiguration() = default;
+};
+
+// TODO(#....) - complete the documentation on how to link this library.
+/**
+ * Configure the application for basic request tracing.
+ *
+ * This function configures basic request tracing to [Cloud Trace]. The
+ * `google-cloud-cpp` libraries use [OpenTelemetry] to provide telemetry into
+ * their operation at runtime.
+ *
+ * OpenTelemetry is very configurable, supporting different sampling rates and
+ * filters, multiple "exporters" to send the collected data to different
+ * services, and multiple mechanisms to chain requests as they move from one
+ * program to the next.
+ *
+ * We anticipate that some applications will want a basic configuration that
+ * works with Gooogle Cloud Trace. Use this function to create such
+ * configuration.
+ *
+ * @note If you are using CMake as your build system, OpenTelemetry is not
+ *     enabled by default in `google-cloud-cpp`. Please consult the build
+ *     documentation to enable the additional libraries.
+ *
+ * Change your build scripts to also the library that provides this function.
+ * With CMake that is `google-cloud-cpp::experimental-opentelemetry`, with Bazel
+ * that is `//:TBD`.
+ *
+ * Change your application to call this function once, for example in `main()`
+ * as follows:
+ *
+ * @code
+ * #include <google/cloud/opentelemetry/configure_basic_tracing.h>
+ *
+ * ...
+ *
+ * int main(...) {
+ * ...
+ *   auto tracing_project = std::string([TRACING PROJECT]);
+ *   auto tracing = google::cloud::opentelemetry::ConfigureBasicTracing(
+ *       google::cloud::Project(tracing_project));
+ * }
+ * @endcode
+ *
+ * Where `[TRACING PROECT]` is the project id where you want to store the
+ * traces.
+ *
+ * Tracing stops when the object returned by this function goes out of scope.
+ *
+ * You do not need to add OpenTelemetry instrumentation to your code, the C++
+ * client libraries are already instrumented and all sampled RPCs will be sent
+ * to Cloud Trace. However, you may want to add instrumentation if multiple
+ * RPCs are performed as part of a single logical "operation" in your
+ * application.
+ *
+ * @par Permissions
+ * @parblock
+ * The principal (user or service account) running your application
+ * will need `cloud.traces.patch` permissions on the project where you send
+ * the traces. These permissions are typically granted as part of the
+ * `roles/cloudtrace.agent` role. If the principal configured in your
+ * [Application Default Credentials] does not have these permissions you will
+ * need to provide a different set of credentials:
+ *
+ * @code
+ *   auto credentials = google::cloud::MakeServiceAccountCredentials(...);
+ *   auto tracing = google::cloud::opentelemetry::ConfigureBasicTracing(
+ *       google::cloud::Project(tracing_project),
+ *       google::cloud::Options{}
+ *           .set<google::cloud::UnifiedCredentialsOption>(credentials));
+ * @endcode
+ * @endparblock
+ *
+ * @par Sampling Rate
+ * @parblock
+ * By default this function configures the application to trace all requests.
+ * This is useful for troubleshooting, but it is excessive if you want to enable
+ * tracing by default and use the results to gather latency statistics. To
+ * reduce the sampling rate use @ref `BasicTracingRateOption`. If desired,
+ * you can use an environment variable (or any other configuration source)
+ * to initialize its value.
+ *
+ * @code
+ *   auto const rate = [](char const* v) -> double {
+ *     if (v == nullptr) return 0.01; // By default use 1% sampling.
+ *     return std::stoi(v) / 100.0;
+ *   }(std::getenv("MY_CONFIG_VARIABLE"))
+ *   auto tracing = google::cloud::opentelemetry::ConfigureBasicTracing(
+ *       google::cloud::Project(tracing_project),
+ *       google::cloud::Options{}
+ *           .set<google::cloud::opentelemetry::BasicTracingRateOption>(rate));
+ * @endcode
+ * @endparblock
+ *
+ * @param project the project to send the traces to.
+ * @param options how to configure the traces. The configuration parameters
+ *     include @ref `BasicTracingRateOption`,
+ *     @ref `google::cloud::UnifiedCredentialsOption`.
+ *
+ * @see https://cloud.google.com/trace/docs/iam for more information about IAM
+ *     permissions for Cloud Trace.
+ *
+ * [Cloud Trace]: https://cloud.google.com/trace
+ * [OpenTelemetry]: https://opentelemetry.io
+ * [Application Default Credentials]:
+ * https://cloud.google.com/docs/authentication#adc
+ */
+std::unique_ptr<BasicTracingConfiguration> ConfigureBasicTracing(
+    Project project, Options options = {});
+
+/**
+ * Configure the tracing rate for basic tracing.
+ *
+ * @see @ref `ConfigureBasicTracing` for more information.
+ */
+struct BasicTracingRateOption {
+  using Type = double;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_CONFIGURE_BASIC_TRACING_H

--- a/google/cloud/opentelemetry/configure_basic_tracing.h
+++ b/google/cloud/opentelemetry/configure_basic_tracing.h
@@ -35,8 +35,8 @@ class BasicTracingConfiguration {
  * Configure the application for basic request tracing.
  *
  * This function configures basic request tracing to [Cloud Trace]. The
- * `google-cloud-cpp` libraries use [OpenTelemetry] to provide telemetry into
- * their operation at runtime.
+ * `google-cloud-cpp` libraries use [OpenTelemetry] to provide observability
+ * into their operation at runtime.
  *
  * You do not need to add OpenTelemetry instrumentation to your code. The C++
  * client libraries are already instrumented and all sampled RPCs will be sent
@@ -66,7 +66,8 @@ class BasicTracingConfiguration {
  *
  * @par Usage Example
  * @parblock
- * Change your build scripts to also the library that provides this function.
+ * Change your build scripts to also build and link the library that provides
+ * this function.
  *
  * Change your application to call this function once, for example in `main()`
  * as follows:

--- a/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry.bzl
+++ b/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry.bzl
@@ -17,11 +17,13 @@
 """Automatically generated source lists for google_cloud_cpp_opentelemetry - DO NOT EDIT."""
 
 google_cloud_cpp_opentelemetry_hdrs = [
+    "configure_basic_tracing.h",
     "internal/recordable.h",
     "trace_exporter.h",
 ]
 
 google_cloud_cpp_opentelemetry_srcs = [
+    "configure_basic_tracing.cc",
     "internal/recordable.cc",
     "trace_exporter.cc",
 ]

--- a/google/cloud/opentelemetry/integration_tests/CMakeLists.txt
+++ b/google/cloud/opentelemetry/integration_tests/CMakeLists.txt
@@ -20,8 +20,10 @@
 # target, and the target names are also weird.
 find_package(GTest CONFIG REQUIRED)
 
-set(opentelemetry_integration_tests # cmake-format: sort
-                                    trace_exporter_integration_test.cc)
+set(opentelemetry_integration_tests
+    # cmake-format: sort
+    configure_basic_tracing_integration_test.cc
+    trace_exporter_integration_test.cc)
 
 # Export the list of unit tests to a .bzl file so we do not need to maintain the
 # list in two places.

--- a/google/cloud/opentelemetry/integration_tests/configure_basic_tracing_integration_test.cc
+++ b/google/cloud/opentelemetry/integration_tests/configure_basic_tracing_integration_test.cc
@@ -32,8 +32,6 @@ namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::testing::AllOf;
-using ::testing::Contains;
 using ::testing::IsEmpty;
 using ::testing::Not;
 

--- a/google/cloud/opentelemetry/integration_tests/configure_basic_tracing_integration_test.cc
+++ b/google/cloud/opentelemetry/integration_tests/configure_basic_tracing_integration_test.cc
@@ -1,0 +1,96 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/trace/v1/trace_client.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <opentelemetry/sdk/trace/simple_processor.h>
+#include <opentelemetry/sdk/trace/tracer.h>
+#include <opentelemetry/sdk/trace/tracer_provider_factory.h>
+#include <opentelemetry/trace/provider.h>
+#include <opentelemetry/trace/span.h>
+#include <opentelemetry/trace/tracer.h>
+
+namespace google {
+namespace cloud {
+namespace otel {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+TEST(ConfigureBasicTracing, Basic) {
+  auto project_id = internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+  ASSERT_THAT(project_id, Not(IsEmpty()));
+
+  // Create a basic tracing configuration.
+  auto project = Project(project_id);
+  auto configuration = ConfigureBasicTracing(project);
+
+  // Create a span.
+  auto provider = opentelemetry::trace::Provider::GetTracerProvider();
+  auto tracer = provider->GetTracer("gcloud-cpp");
+
+  // Create a test span, which should get exported to Cloud Trace.
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+  auto const name =
+      "span-" + google::cloud::internal::Sample(generator, 32, "0123456789");
+
+  auto span = tracer->StartSpan(name);
+  opentelemetry::trace::StartSpanOptions options;
+  options.kind = opentelemetry::trace::SpanKind::kClient;
+  auto const elapsed = std::chrono::milliseconds(20);
+  options.start_steady_time = std::chrono::steady_clock::now() - elapsed;
+  options.start_system_time = std::chrono::system_clock::now() - elapsed;
+  span->End();
+  // Flush the data.
+  configuration.reset();
+
+  auto trace_client =
+      trace_v1::TraceServiceClient(trace_v1::MakeTraceServiceConnection());
+
+  // A GetTraceRequest can only look up traces by trace ID, and the trace ID is
+  // randomly assigned in the internals of OTel. We use ListTracesRequest(),
+  // which can filter on span names.
+  google::devtools::cloudtrace::v1::ListTracesRequest req;
+  req.set_project_id(project_id);
+  // The filter "+root:<NAME>" means: list traces that contain spans whose name
+  // exactly matches "<NAME>".
+  req.set_filter("+root:" + name);
+
+  // Implement a retry loop to wait for the traces to propagate in Cloud Trace.
+  for (auto backoff : {1, 2, 4, 8, 16, 32, 0}) {
+    ASSERT_NE(backoff, 0) << "Trace did not show up in Cloud Trace";
+    auto traces = trace_client.ListTraces(req);
+    auto trace = traces.begin();
+    if (trace != traces.end()) {
+      ASSERT_STATUS_OK(*trace);
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(backoff));
+  }
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/opentelemetry/integration_tests/tests.bzl
+++ b/google/cloud/opentelemetry/integration_tests/tests.bzl
@@ -17,5 +17,6 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 opentelemetry_integration_tests = [
+    "configure_basic_tracing_integration_test.cc",
     "trace_exporter_integration_test.cc",
 ]


### PR DESCRIPTION
For many applications we can provide a one-liner that initializes OpenTelemetry. Some applications will need more elaborate initialization, but making things easy for the common case is valuable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11359)
<!-- Reviewable:end -->
