### PR TITLE
ci(otel): reduce Cloud Trace quota usage

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -157,14 +157,10 @@ function integration::bazel_with_emulators() {
     "google/cloud/iam/..."
     # Logging integration tests
     "google/cloud/logging/..."
-    # OpenTelemetry integration tests
-    "google/cloud/opentelemetry/..."
     # Pub/Sub Lite integration tests
     "google/cloud/pubsublite/..."
     # Unified Rest Credentials test
     "google/cloud:internal_unified_rest_credentials_integration_test"
-    # The OpenTelemetry integration tests are limited by quota
-    "google/cloud/opentelemetry/integration_tests/..."
   )
 
   production_tests_tag_filters="integration-test"


### PR DESCRIPTION
Cease to run the OpenTelemetry integration tests against production for each GCB bazel build that uses `lib/integration.sh`.

Note that the tests still run as part of `integration-production`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11367)
<!-- Reviewable:end -->
