### PR TITLE
impl(generator): finish package naming support

### DIFF
--- a/generator/internal/discovery_file.cc
+++ b/generator/internal/discovery_file.cc
@@ -15,7 +15,6 @@
 #include "generator/internal/discovery_file.h"
 #include "generator/internal/codegen_utils.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
-#include "google/cloud/internal/make_status.h"
 #include "absl/strings/str_format.h"
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
@@ -98,17 +97,14 @@ package $package_name$;
 
 Status DiscoveryFile::WriteFile(
     std::string const& product_name,
-    std::map<std::string, DiscoveryTypeVertex> const* types) const {
-  if (types == nullptr) {
-    return internal::InternalError("types is nullptr");
-  }
+    std::map<std::string, DiscoveryTypeVertex> const& types) const {
   std::string version_dir_path = file_path_.substr(0, file_path_.rfind('/'));
   std::string service_dir_path =
       version_dir_path.substr(0, version_dir_path.rfind('/'));
   MakeDirectory(service_dir_path);
   MakeDirectory(version_dir_path);
   std::ofstream os(file_path_);
-  return FormatFile(product_name, *types, os);
+  return FormatFile(product_name, types, os);
 }
 
 }  // namespace generator_internal

--- a/generator/internal/discovery_file.h
+++ b/generator/internal/discovery_file.h
@@ -56,7 +56,7 @@ class DiscoveryFile {
   // Creates necessary directories and writes the file to disk.
   Status WriteFile(
       std::string const& product_name,
-      std::map<std::string, DiscoveryTypeVertex> const* types) const;
+      std::map<std::string, DiscoveryTypeVertex> const& types) const;
 
  private:
   DiscoveryResource const* resource_;

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -33,6 +33,10 @@ class DiscoveryResource {
   std::string const& name() const { return name_; }
   std::string const& package_name() const { return package_name_; }
   nlohmann::json const& json() const { return json_; }
+  std::map<std::string, DiscoveryTypeVertex const*> const& response_types()
+      const {
+    return response_types_;
+  }
 
   void AddRequestType(std::string name, DiscoveryTypeVertex const* type);
 

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -48,7 +48,7 @@ std::map<std::string, DiscoveryResource> ExtractResources(
 
 // Determines the name of the response type for each method and verifies it
 // exists in the collection of DiscoveryTypeVertex objects.
-StatusOr<std::string> DetermineAndVerifyResponseTypeName(
+StatusOr<DiscoveryTypeVertex const*> DetermineAndVerifyResponseType(
     nlohmann::json const& method_json, DiscoveryResource& resource,
     std::map<std::string, DiscoveryTypeVertex>& types);
 

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -213,10 +213,9 @@ TEST(DetermineAndVerifyResponseTypeNameTest, ResponseWithRef) {
   DiscoveryResource resource;
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "", response_type_json});
-  auto response =
-      DetermineAndVerifyResponseTypeName(method_json, resource, types);
+  auto response = DetermineAndVerifyResponseType(method_json, resource, types);
   ASSERT_STATUS_OK(response);
-  EXPECT_THAT(*response, Eq("Foo"));
+  EXPECT_THAT((*response)->name(), Eq("Foo"));
 }
 
 TEST(DetermineAndVerifyResponseTypeNameTest, ResponseMissingRef) {
@@ -233,8 +232,7 @@ TEST(DetermineAndVerifyResponseTypeNameTest, ResponseMissingRef) {
   DiscoveryResource resource;
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "", response_type_json});
-  auto response =
-      DetermineAndVerifyResponseTypeName(method_json, resource, types);
+  auto response = DetermineAndVerifyResponseType(method_json, resource, types);
   EXPECT_THAT(response, StatusIs(StatusCode::kInvalidArgument,
                                  HasSubstr("Missing $ref field in response")));
 }
@@ -250,10 +248,9 @@ TEST(DetermineAndVerifyResponseTypeNameTest, ResponseFieldMissing) {
   DiscoveryResource resource;
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "", response_type_json});
-  auto response =
-      DetermineAndVerifyResponseTypeName(method_json, resource, types);
+  auto response = DetermineAndVerifyResponseType(method_json, resource, types);
   ASSERT_STATUS_OK(response);
-  EXPECT_THAT(*response, IsEmpty());
+  EXPECT_THAT(*response, Eq(nullptr));
 }
 
 TEST(SynthesizeRequestTypeTest, OperationResponseWithRefRequestField) {


### PR DESCRIPTION
part of the work for #10980 

In order to make both the type name and package name available, `DetermineAndVerifyResponseType` now returns a pointer to the type object instead of just the type_name.

Also changed DiscoveryFile::WriteFile to accept types by const& as std::async is happy to accept a const& arg without leaning on std::ref.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11384)
<!-- Reviewable:end -->
