### PR TITLE
doc: regenerate new environment-variables.dox files

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -665,6 +665,7 @@ the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section $library$-env-endpoint Endpoint Overrides
+
 <!-- inject-endpoint-env-vars-start -->
 <!-- inject-endpoint-env-vars-end -->
 
@@ -734,20 +735,20 @@ client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
 
-* Packaging maintainers or developers who prefer to install the library in a
+- Packaging maintainers or developers who prefer to install the library in a
   fixed directory (such as `/usr/local` or `/opt`) should consult the
   [packaging guide](/doc/packaging.md).
 - Developers who prefer using a package manager such as
   [vcpkg](https://vcpkg.io), or [Conda](https://conda.io), should follow the
   instructions for their package manager.
-* Developers wanting to use the libraries as part of a larger CMake or Bazel
+- Developers wanting to use the libraries as part of a larger CMake or Bazel
   project should consult the current document. Note that there are similar
   documents for each library in their corresponding directories.
-* Developers wanting to compile the library just to run some examples or
+- Developers wanting to compile the library just to run some examples or
   tests should consult the
   [building and installing](/README.md#building-and-installing) section of the
   top-level README file.
-* Contributors and developers to `google-cloud-cpp` should consult the guide to
+- Contributors and developers to `google-cloud-cpp` should consult the guide to
   [set up a development workstation][howto-setup-dev-workstation].
 
 [howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md

--- a/google/cloud/accessapproval/doc/environment-variables.dox
+++ b/google/cloud/accessapproval/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page accessapproval-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section accessapproval-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section accessapproval-logging Logging
+@see google::cloud::EndpointOption
+
+@section accessapproval-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/accesscontextmanager/doc/environment-variables.dox
+++ b/google/cloud/accesscontextmanager/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page accesscontextmanager-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section accesscontextmanager-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section accesscontextmanager-logging Logging
+@see google::cloud::EndpointOption
+
+@section accesscontextmanager-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/advisorynotifications/doc/environment-variables.dox
+++ b/google/cloud/advisorynotifications/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page advisorynotifications-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section advisorynotifications-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section advisorynotifications-logging Logging
+@see google::cloud::EndpointOption
+
+@section advisorynotifications-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/alloydb/doc/environment-variables.dox
+++ b/google/cloud/alloydb/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page alloydb-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section alloydb-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section alloydb-logging Logging
+@see google::cloud::EndpointOption
+
+@section alloydb-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/apigateway/doc/environment-variables.dox
+++ b/google/cloud/apigateway/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page apigateway-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section apigateway-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section apigateway-logging Logging
+@see google::cloud::EndpointOption
+
+@section apigateway-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/apigeeconnect/doc/environment-variables.dox
+++ b/google/cloud/apigeeconnect/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page apigeeconnect-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section apigeeconnect-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section apigeeconnect-logging Logging
+@see google::cloud::EndpointOption
+
+@section apigeeconnect-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/apikeys/doc/environment-variables.dox
+++ b/google/cloud/apikeys/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page apikeys-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section apikeys-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section apikeys-logging Logging
+@see google::cloud::EndpointOption
+
+@section apikeys-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/appengine/doc/environment-variables.dox
+++ b/google/cloud/appengine/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page appengine-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section appengine-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -45,7 +44,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section appengine-logging Logging
+@see google::cloud::EndpointOption
+
+@section appengine-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/artifactregistry/doc/environment-variables.dox
+++ b/google/cloud/artifactregistry/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page artifactregistry-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section artifactregistry-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section artifactregistry-logging Logging
+@see google::cloud::EndpointOption
+
+@section artifactregistry-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/asset/doc/environment-variables.dox
+++ b/google/cloud/asset/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page asset-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section asset-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section asset-logging Logging
+@see google::cloud::EndpointOption
+
+@section asset-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/assuredworkloads/doc/environment-variables.dox
+++ b/google/cloud/assuredworkloads/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page assuredworkloads-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section assuredworkloads-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section assuredworkloads-logging Logging
+@see google::cloud::EndpointOption
+
+@section assuredworkloads-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/automl/doc/environment-variables.dox
+++ b/google/cloud/automl/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page automl-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section automl-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section automl-logging Logging
+@see google::cloud::EndpointOption
+
+@section automl-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/baremetalsolution/doc/environment-variables.dox
+++ b/google/cloud/baremetalsolution/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page baremetalsolution-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section baremetalsolution-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section baremetalsolution-logging Logging
+@see google::cloud::EndpointOption
+
+@section baremetalsolution-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/batch/doc/environment-variables.dox
+++ b/google/cloud/batch/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page batch-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section batch-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section batch-logging Logging
+@see google::cloud::EndpointOption
+
+@section batch-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/beyondcorp/doc/environment-variables.dox
+++ b/google/cloud/beyondcorp/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page beyondcorp-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section beyondcorp-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -33,7 +32,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section beyondcorp-logging Logging
+@see google::cloud::EndpointOption
+
+@section beyondcorp-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/bigquery/doc/environment-variables.dox
+++ b/google/cloud/bigquery/doc/environment-variables.dox
@@ -3,14 +3,10 @@
 @page bigquery-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section bigquery-env-endpoint Endpoint Overrides
-
-
-There are several environment variables that can be set to configure certain
-behaviors in the library.
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -52,7 +48,9 @@ behaviors in the library.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section bigquery-logging Logging
+@see google::cloud::EndpointOption
+
+@section bigquery-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/billing/doc/environment-variables.dox
+++ b/google/cloud/billing/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page billing-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section billing-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -25,7 +24,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section billing-logging Logging
+@see google::cloud::EndpointOption
+
+@section billing-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/binaryauthorization/doc/environment-variables.dox
+++ b/google/cloud/binaryauthorization/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page binaryauthorization-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section binaryauthorization-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -25,7 +24,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section binaryauthorization-logging Logging
+@see google::cloud::EndpointOption
+
+@section binaryauthorization-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/certificatemanager/doc/environment-variables.dox
+++ b/google/cloud/certificatemanager/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page certificatemanager-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section certificatemanager-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section certificatemanager-logging Logging
+@see google::cloud::EndpointOption
+
+@section certificatemanager-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/channel/doc/environment-variables.dox
+++ b/google/cloud/channel/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page channel-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section channel-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section channel-logging Logging
+@see google::cloud::EndpointOption
+
+@section channel-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/cloudbuild/doc/environment-variables.dox
+++ b/google/cloud/cloudbuild/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page cloudbuild-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section cloudbuild-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section cloudbuild-logging Logging
+@see google::cloud::EndpointOption
+
+@section cloudbuild-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/composer/doc/environment-variables.dox
+++ b/google/cloud/composer/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page composer-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section composer-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section composer-logging Logging
+@see google::cloud::EndpointOption
+
+@section composer-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/confidentialcomputing/doc/environment-variables.dox
+++ b/google/cloud/confidentialcomputing/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page confidentialcomputing-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section confidentialcomputing-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section confidentialcomputing-logging Logging
+@see google::cloud::EndpointOption
+
+@section confidentialcomputing-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/connectors/doc/environment-variables.dox
+++ b/google/cloud/connectors/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page connectors-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section connectors-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section connectors-logging Logging
+@see google::cloud::EndpointOption
+
+@section connectors-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/contactcenterinsights/doc/environment-variables.dox
+++ b/google/cloud/contactcenterinsights/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page contactcenterinsights-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section contactcenterinsights-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section contactcenterinsights-logging Logging
+@see google::cloud::EndpointOption
+
+@section contactcenterinsights-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/container/doc/environment-variables.dox
+++ b/google/cloud/container/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page container-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section container-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section container-logging Logging
+@see google::cloud::EndpointOption
+
+@section container-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/containeranalysis/doc/environment-variables.dox
+++ b/google/cloud/containeranalysis/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page containeranalysis-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section containeranalysis-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section containeranalysis-logging Logging
+@see google::cloud::EndpointOption
+
+@section containeranalysis-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/datacatalog/doc/environment-variables.dox
+++ b/google/cloud/datacatalog/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page datacatalog-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section datacatalog-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -29,7 +28,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section datacatalog-logging Logging
+@see google::cloud::EndpointOption
+
+@section datacatalog-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/datamigration/doc/environment-variables.dox
+++ b/google/cloud/datamigration/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page datamigration-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section datamigration-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section datamigration-logging Logging
+@see google::cloud::EndpointOption
+
+@section datamigration-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dataplex/doc/environment-variables.dox
+++ b/google/cloud/dataplex/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page dataplex-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section dataplex-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -25,7 +24,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section dataplex-logging Logging
+@see google::cloud::EndpointOption
+
+@section dataplex-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dataproc/doc/environment-variables.dox
+++ b/google/cloud/dataproc/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page dataproc-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section dataproc-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -33,7 +32,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section dataproc-logging Logging
+@see google::cloud::EndpointOption
+
+@section dataproc-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/datastream/doc/environment-variables.dox
+++ b/google/cloud/datastream/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page datastream-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section datastream-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section datastream-logging Logging
+@see google::cloud::EndpointOption
+
+@section datastream-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/debugger/doc/environment-variables.dox
+++ b/google/cloud/debugger/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page debugger-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section debugger-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section debugger-logging Logging
+@see google::cloud::EndpointOption
+
+@section debugger-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/deploy/doc/environment-variables.dox
+++ b/google/cloud/deploy/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page deploy-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section deploy-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section deploy-logging Logging
+@see google::cloud::EndpointOption
+
+@section deploy-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dialogflow_cx/doc/environment-variables.dox
+++ b/google/cloud/dialogflow_cx/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page dialogflow_cx-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section dialogflow_cx-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -77,7 +76,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section dialogflow_cx-logging Logging
+@see google::cloud::EndpointOption
+
+@section dialogflow_cx-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dialogflow_es/doc/environment-variables.dox
+++ b/google/cloud/dialogflow_es/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page dialogflow_es-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section dialogflow_es-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -81,7 +80,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section dialogflow_es-logging Logging
+@see google::cloud::EndpointOption
+
+@section dialogflow_es-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dlp/doc/environment-variables.dox
+++ b/google/cloud/dlp/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page dlp-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section dlp-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section dlp-logging Logging
+@see google::cloud::EndpointOption
+
+@section dlp-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/documentai/doc/environment-variables.dox
+++ b/google/cloud/documentai/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page documentai-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section documentai-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section documentai-logging Logging
+@see google::cloud::EndpointOption
+
+@section documentai-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/edgecontainer/doc/environment-variables.dox
+++ b/google/cloud/edgecontainer/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page edgecontainer-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section edgecontainer-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section edgecontainer-logging Logging
+@see google::cloud::EndpointOption
+
+@section edgecontainer-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/eventarc/doc/environment-variables.dox
+++ b/google/cloud/eventarc/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page eventarc-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section eventarc-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section eventarc-logging Logging
+@see google::cloud::EndpointOption
+
+@section eventarc-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/filestore/doc/environment-variables.dox
+++ b/google/cloud/filestore/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page filestore-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section filestore-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section filestore-logging Logging
+@see google::cloud::EndpointOption
+
+@section filestore-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/functions/doc/environment-variables.dox
+++ b/google/cloud/functions/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page functions-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section functions-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section functions-logging Logging
+@see google::cloud::EndpointOption
+
+@section functions-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/gameservices/doc/environment-variables.dox
+++ b/google/cloud/gameservices/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page gameservices-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section gameservices-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -29,7 +28,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section gameservices-logging Logging
+@see google::cloud::EndpointOption
+
+@section gameservices-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/gkehub/doc/environment-variables.dox
+++ b/google/cloud/gkehub/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page gkehub-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section gkehub-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section gkehub-logging Logging
+@see google::cloud::EndpointOption
+
+@section gkehub-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/gkemulticloud/doc/environment-variables.dox
+++ b/google/cloud/gkemulticloud/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page gkemulticloud-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section gkemulticloud-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -25,7 +24,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section gkemulticloud-logging Logging
+@see google::cloud::EndpointOption
+
+@section gkemulticloud-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/iam/doc/environment-variables.dox
+++ b/google/cloud/iam/doc/environment-variables.dox
@@ -3,14 +3,10 @@
 @page iam-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section iam-env-endpoint Endpoint Overrides
-
-
-There are several environment variables that can be set to configure certain
-behaviors in the library.
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -32,7 +28,9 @@ behaviors in the library.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section iam-logging Logging
+@see google::cloud::EndpointOption
+
+@section iam-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/iap/doc/environment-variables.dox
+++ b/google/cloud/iap/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page iap-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section iap-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section iap-logging Logging
+@see google::cloud::EndpointOption
+
+@section iap-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/ids/doc/environment-variables.dox
+++ b/google/cloud/ids/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page ids-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section ids-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section ids-logging Logging
+@see google::cloud::EndpointOption
+
+@section ids-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/iot/doc/environment-variables.dox
+++ b/google/cloud/iot/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page iot-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section iot-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section iot-logging Logging
+@see google::cloud::EndpointOption
+
+@section iot-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/kms/doc/environment-variables.dox
+++ b/google/cloud/kms/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page kms-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section kms-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -29,7 +28,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section kms-logging Logging
+@see google::cloud::EndpointOption
+
+@section kms-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/language/doc/environment-variables.dox
+++ b/google/cloud/language/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page language-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section language-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section language-logging Logging
+@see google::cloud::EndpointOption
+
+@section language-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/logging/doc/environment-variables.dox
+++ b/google/cloud/logging/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page logging-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section logging-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section logging-logging Logging
+@see google::cloud::EndpointOption
+
+@section logging-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/managedidentities/doc/environment-variables.dox
+++ b/google/cloud/managedidentities/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page managedidentities-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section managedidentities-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section managedidentities-logging Logging
+@see google::cloud::EndpointOption
+
+@section managedidentities-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/memcache/doc/environment-variables.dox
+++ b/google/cloud/memcache/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page memcache-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section memcache-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section memcache-logging Logging
+@see google::cloud::EndpointOption
+
+@section memcache-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/monitoring/doc/environment-variables.dox
+++ b/google/cloud/monitoring/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page monitoring-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section monitoring-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -49,7 +48,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section monitoring-logging Logging
+@see google::cloud::EndpointOption
+
+@section monitoring-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/networkconnectivity/doc/environment-variables.dox
+++ b/google/cloud/networkconnectivity/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page networkconnectivity-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section networkconnectivity-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section networkconnectivity-logging Logging
+@see google::cloud::EndpointOption
+
+@section networkconnectivity-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/networkmanagement/doc/environment-variables.dox
+++ b/google/cloud/networkmanagement/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page networkmanagement-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section networkmanagement-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section networkmanagement-logging Logging
+@see google::cloud::EndpointOption
+
+@section networkmanagement-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/notebooks/doc/environment-variables.dox
+++ b/google/cloud/notebooks/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page notebooks-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section notebooks-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section notebooks-logging Logging
+@see google::cloud::EndpointOption
+
+@section notebooks-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/optimization/doc/environment-variables.dox
+++ b/google/cloud/optimization/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page optimization-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section optimization-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section optimization-logging Logging
+@see google::cloud::EndpointOption
+
+@section optimization-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/orgpolicy/doc/environment-variables.dox
+++ b/google/cloud/orgpolicy/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page orgpolicy-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section orgpolicy-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section orgpolicy-logging Logging
+@see google::cloud::EndpointOption
+
+@section orgpolicy-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/osconfig/doc/environment-variables.dox
+++ b/google/cloud/osconfig/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page osconfig-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section osconfig-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section osconfig-logging Logging
+@see google::cloud::EndpointOption
+
+@section osconfig-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/oslogin/doc/environment-variables.dox
+++ b/google/cloud/oslogin/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page oslogin-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section oslogin-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section oslogin-logging Logging
+@see google::cloud::EndpointOption
+
+@section oslogin-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/policytroubleshooter/doc/environment-variables.dox
+++ b/google/cloud/policytroubleshooter/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page policytroubleshooter-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section policytroubleshooter-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section policytroubleshooter-logging Logging
+@see google::cloud::EndpointOption
+
+@section policytroubleshooter-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/privateca/doc/environment-variables.dox
+++ b/google/cloud/privateca/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page privateca-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section privateca-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section privateca-logging Logging
+@see google::cloud::EndpointOption
+
+@section privateca-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/profiler/doc/environment-variables.dox
+++ b/google/cloud/profiler/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page profiler-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section profiler-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section profiler-logging Logging
+@see google::cloud::EndpointOption
+
+@section profiler-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/pubsublite/doc/environment-variables.dox
+++ b/google/cloud/pubsublite/doc/environment-variables.dox
@@ -3,7 +3,7 @@
 @page pubsublite-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section pubsublite-env-endpoint Endpoint Overrides

--- a/google/cloud/recommender/doc/environment-variables.dox
+++ b/google/cloud/recommender/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page recommender-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section recommender-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section recommender-logging Logging
+@see google::cloud::EndpointOption
+
+@section recommender-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/redis/doc/environment-variables.dox
+++ b/google/cloud/redis/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page redis-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section redis-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section redis-logging Logging
+@see google::cloud::EndpointOption
+
+@section redis-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/resourcemanager/doc/environment-variables.dox
+++ b/google/cloud/resourcemanager/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page resourcemanager-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section resourcemanager-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -25,7 +24,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section resourcemanager-logging Logging
+@see google::cloud::EndpointOption
+
+@section resourcemanager-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/resourcesettings/doc/environment-variables.dox
+++ b/google/cloud/resourcesettings/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page resourcesettings-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section resourcesettings-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section resourcesettings-logging Logging
+@see google::cloud::EndpointOption
+
+@section resourcesettings-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/retail/doc/environment-variables.dox
+++ b/google/cloud/retail/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page retail-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section retail-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -37,7 +36,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section retail-logging Logging
+@see google::cloud::EndpointOption
+
+@section retail-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/run/doc/environment-variables.dox
+++ b/google/cloud/run/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page run-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section run-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section run-logging Logging
+@see google::cloud::EndpointOption
+
+@section run-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/scheduler/doc/environment-variables.dox
+++ b/google/cloud/scheduler/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page scheduler-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section scheduler-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section scheduler-logging Logging
+@see google::cloud::EndpointOption
+
+@section scheduler-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/secretmanager/doc/environment-variables.dox
+++ b/google/cloud/secretmanager/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page secretmanager-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section secretmanager-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section secretmanager-logging Logging
+@see google::cloud::EndpointOption
+
+@section secretmanager-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/securitycenter/doc/environment-variables.dox
+++ b/google/cloud/securitycenter/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page securitycenter-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section securitycenter-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section securitycenter-logging Logging
+@see google::cloud::EndpointOption
+
+@section securitycenter-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/servicecontrol/doc/environment-variables.dox
+++ b/google/cloud/servicecontrol/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page servicecontrol-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section servicecontrol-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section servicecontrol-logging Logging
+@see google::cloud::EndpointOption
+
+@section servicecontrol-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/servicedirectory/doc/environment-variables.dox
+++ b/google/cloud/servicedirectory/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page servicedirectory-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section servicedirectory-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section servicedirectory-logging Logging
+@see google::cloud::EndpointOption
+
+@section servicedirectory-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/servicemanagement/doc/environment-variables.dox
+++ b/google/cloud/servicemanagement/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page servicemanagement-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section servicemanagement-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section servicemanagement-logging Logging
+@see google::cloud::EndpointOption
+
+@section servicemanagement-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/serviceusage/doc/environment-variables.dox
+++ b/google/cloud/serviceusage/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page serviceusage-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section serviceusage-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section serviceusage-logging Logging
+@see google::cloud::EndpointOption
+
+@section serviceusage-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/shell/doc/environment-variables.dox
+++ b/google/cloud/shell/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page shell-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section shell-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section shell-logging Logging
+@see google::cloud::EndpointOption
+
+@section shell-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/speech/doc/environment-variables.dox
+++ b/google/cloud/speech/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page speech-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section speech-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section speech-logging Logging
+@see google::cloud::EndpointOption
+
+@section speech-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/sql/doc/environment-variables.dox
+++ b/google/cloud/sql/doc/environment-variables.dox
@@ -3,7 +3,7 @@
 @page sql-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section sql-env-endpoint Endpoint Overrides

--- a/google/cloud/storageinsights/doc/environment-variables.dox
+++ b/google/cloud/storageinsights/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page storageinsights-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section storageinsights-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section storageinsights-logging Logging
+@see google::cloud::EndpointOption
+
+@section storageinsights-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/storagetransfer/doc/environment-variables.dox
+++ b/google/cloud/storagetransfer/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page storagetransfer-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section storagetransfer-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section storagetransfer-logging Logging
+@see google::cloud::EndpointOption
+
+@section storagetransfer-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/talent/doc/environment-variables.dox
+++ b/google/cloud/talent/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page talent-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section talent-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -33,7 +32,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section talent-logging Logging
+@see google::cloud::EndpointOption
+
+@section talent-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/tasks/doc/environment-variables.dox
+++ b/google/cloud/tasks/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page tasks-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section tasks-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section tasks-logging Logging
+@see google::cloud::EndpointOption
+
+@section tasks-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/texttospeech/doc/environment-variables.dox
+++ b/google/cloud/texttospeech/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page texttospeech-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section texttospeech-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section texttospeech-logging Logging
+@see google::cloud::EndpointOption
+
+@section texttospeech-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/tpu/doc/environment-variables.dox
+++ b/google/cloud/tpu/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page tpu-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section tpu-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section tpu-logging Logging
+@see google::cloud::EndpointOption
+
+@section tpu-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/trace/doc/environment-variables.dox
+++ b/google/cloud/trace/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page trace-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section trace-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section trace-logging Logging
+@see google::cloud::EndpointOption
+
+@section trace-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/translate/doc/environment-variables.dox
+++ b/google/cloud/translate/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page translate-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section translate-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section translate-logging Logging
+@see google::cloud::EndpointOption
+
+@section translate-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/video/doc/environment-variables.dox
+++ b/google/cloud/video/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page video-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section video-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -25,7 +24,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section video-logging Logging
+@see google::cloud::EndpointOption
+
+@section video-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/videointelligence/doc/environment-variables.dox
+++ b/google/cloud/videointelligence/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page videointelligence-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section videointelligence-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section videointelligence-logging Logging
+@see google::cloud::EndpointOption
+
+@section videointelligence-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/vision/doc/environment-variables.dox
+++ b/google/cloud/vision/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page vision-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section vision-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section vision-logging Logging
+@see google::cloud::EndpointOption
+
+@section vision-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/vmmigration/doc/environment-variables.dox
+++ b/google/cloud/vmmigration/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page vmmigration-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section vmmigration-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section vmmigration-logging Logging
+@see google::cloud::EndpointOption
+
+@section vmmigration-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/vmwareengine/doc/environment-variables.dox
+++ b/google/cloud/vmwareengine/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page vmwareengine-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section vmwareengine-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section vmwareengine-logging Logging
+@see google::cloud::EndpointOption
+
+@section vmwareengine-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/vpcaccess/doc/environment-variables.dox
+++ b/google/cloud/vpcaccess/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page vpcaccess-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section vpcaccess-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section vpcaccess-logging Logging
+@see google::cloud::EndpointOption
+
+@section vpcaccess-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/webrisk/doc/environment-variables.dox
+++ b/google/cloud/webrisk/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page webrisk-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section webrisk-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section webrisk-logging Logging
+@see google::cloud::EndpointOption
+
+@section webrisk-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/websecurityscanner/doc/environment-variables.dox
+++ b/google/cloud/websecurityscanner/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page websecurityscanner-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section websecurityscanner-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section websecurityscanner-logging Logging
+@see google::cloud::EndpointOption
+
+@section websecurityscanner-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/workflows/doc/environment-variables.dox
+++ b/google/cloud/workflows/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page workflows-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section workflows-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -21,7 +20,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section workflows-logging Logging
+@see google::cloud::EndpointOption
+
+@section workflows-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/workstations/doc/environment-variables.dox
+++ b/google/cloud/workstations/doc/environment-variables.dox
@@ -3,11 +3,10 @@
 @page workstations-env Environment Variables
 
 A number of environment variables can be used to configure the behavior of
-the library.  There are also functions to configure this behavior in code. The
+the library. There are also functions to configure this behavior in code. The
 environment variables are convenient when troubleshooting problems.
 
 @section workstations-env-endpoint Endpoint Overrides
-
 
 <!-- inject-endpoint-env-vars-start -->
 
@@ -17,7 +16,9 @@ environment variables are convenient when troubleshooting problems.
 
 <!-- inject-endpoint-env-vars-end -->
 
-@section workstations-logging Logging
+@see google::cloud::EndpointOption
+
+@section workstations-env-logging Logging
 
 `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc`: turns on tracing for most gRPC
 calls. The library injects an additional Stub decorator that prints each gRPC


### PR DESCRIPTION
See #11381 for the new `environment-variables.dox` files, but
now restore the blank line from the scaffolding I erroneously
suggested we should remove.

The regeneration will also:
- add the `google:cloud:EndpointOption` reference to the
  "\<service>-env-endpoint" section, and
- correct the name of the "\<service>-env-logging" section.

And while we're there, use the `mdformat`-preferred syntax for
top-level unordered lists in the quickstart README.  There is no
point in generating something that `mdformat` will overwrite.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11387)
<!-- Reviewable:end -->
