### PR TITLE
impl(otel): add top level target; rename bool_flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,7 +39,7 @@ test --test_env=GTEST_SHUFFLE --test_env=GTEST_RANDOM_SEED
 
 # By default, build the library with OpenTelemetry
 build --@io_opentelemetry_cpp//api:with_abseil
-build --//:experimental-opentelemetry
+build --//:enable-experimental-opentelemetry
 
 # Clang Sanitizers, use with (for example):
 #

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -134,8 +134,15 @@ cc_library(
     ],
 )
 
-bool_flag(
+cc_library(
     name = "experimental-opentelemetry",
+    deps = [
+        "//google/cloud/opentelemetry:google_cloud_cpp_opentelemetry",
+    ],
+)
+
+bool_flag(
+    name = "enable-experimental-opentelemetry",
     build_setting_default = False,
     visibility = ["//:__subpackages__"],
 )

--- a/ci/cloudbuild/builds/otel-disabled-bazel.sh
+++ b/ci/cloudbuild/builds/otel-disabled-bazel.sh
@@ -23,5 +23,5 @@ export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
-args+=("--//:experimental-opentelemetry=false")
+args+=("--//:enable-experimental-opentelemetry=false")
 bazel test "${args[@]}" --test_tag_filters=-integration-test ...

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -30,14 +30,16 @@ capture_build_info(
 config_setting(
     name = "enable_opentelemetry_valid",
     flag_values = {
-        "//:experimental-opentelemetry": "true",
+        "//:enable-experimental-opentelemetry": "true",
         "@io_opentelemetry_cpp//api:with_abseil": "true",
     },
 )
 
 config_setting(
     name = "disable_opentelemetry",
-    flag_values = {"//:experimental-opentelemetry": "false"},
+    flag_values = {
+        "//:enable-experimental-opentelemetry": "false",
+    },
 )
 
 load(":google_cloud_cpp_common.bzl", "google_cloud_cpp_common_hdrs", "google_cloud_cpp_common_srcs")

--- a/google/cloud/opentelemetry/BUILD.bazel
+++ b/google/cloud/opentelemetry/BUILD.bazel
@@ -22,7 +22,7 @@ cc_library(
     name = "google_cloud_cpp_opentelemetry",
     srcs = google_cloud_cpp_opentelemetry_srcs,
     hdrs = google_cloud_cpp_opentelemetry_hdrs,
-    visibility = ["//:__subpackages__"],
+    visibility = ["//:__pkg__"],
     deps = [
         "//:trace",
         "@com_google_googleapis//google/rpc:code_cc_proto",

--- a/google/cloud/opentelemetry/integration_tests/BUILD.bazel
+++ b/google/cloud/opentelemetry/integration_tests/BUILD.bazel
@@ -24,7 +24,7 @@ load(":tests.bzl", "opentelemetry_integration_tests")
     srcs = [test],
     tags = ["integration-test"],
     deps = [
-        "//google/cloud/opentelemetry:google_cloud_cpp_opentelemetry",
+        "//:experimental-opentelemetry",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
Part of the work for #11156 

Add an experimental top level bazel target for the opentelemetry exporter library. This requires renaming the flag that builds common with a dep on `opentelemetry-cpp`.

Naming continues to be hard. I don't love that `//:enable-experimental-opentelemetry` is independent of `//:experimental-opentelemetry`, but oh well.

The best alternatives I came up with for the `bool_flag`s were:
- `//:experimental-opentelemetry_instrumentation`
- `//:enable-experimental-opentelemetry_instrumentation`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11389)
<!-- Reviewable:end -->
