### PR TITLE
refactor(generator): replace multistring constructors with struct parameter

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(
     internal/connection_rest_generator.h
     internal/descriptor_utils.cc
     internal/descriptor_utils.h
+    internal/discovery_document.h
     internal/discovery_file.cc
     internal/discovery_file.h
     internal/discovery_resource.cc

--- a/generator/google_cloud_cpp_generator.bzl
+++ b/generator/google_cloud_cpp_generator.bzl
@@ -26,6 +26,7 @@ google_cloud_cpp_generator_hdrs = [
     "internal/connection_impl_rest_generator.h",
     "internal/connection_rest_generator.h",
     "internal/descriptor_utils.h",
+    "internal/discovery_document.h",
     "internal/discovery_file.h",
     "internal/discovery_resource.h",
     "internal/discovery_to_proto.h",

--- a/generator/internal/discovery_document.h
+++ b/generator/internal/discovery_document.h
@@ -1,0 +1,35 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_DOCUMENT_H
+#define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_DOCUMENT_H
+
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace generator_internal {
+
+struct DiscoveryDocumentProperties {
+  std::string base_path;
+  std::string default_hostname;
+  std::string product_name;
+  std::string version;
+};
+
+}  // namespace generator_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_DOCUMENT_H

--- a/generator/internal/discovery_file.h
+++ b/generator/internal/discovery_file.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_FILE_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_FILE_H
 
+#include "generator/internal/discovery_document.h"
 #include "generator/internal/discovery_resource.h"
 #include "generator/internal/discovery_type_vertex.h"
 #include "google/cloud/status.h"
@@ -33,7 +34,7 @@ class DiscoveryFile {
 
   // Set resources == nullptr to indicate the file only contains messages.
   DiscoveryFile(DiscoveryResource const* resource, std::string file_path,
-                std::string package_name, std::string version,
+                std::string package_name,
                 std::vector<DiscoveryTypeVertex const*> types);
 
   std::string const& file_path() const { return file_path_; }
@@ -49,20 +50,19 @@ class DiscoveryFile {
   }
 
   // Writes the file to output_stream.
-  Status FormatFile(std::string const& product_name,
+  Status FormatFile(DiscoveryDocumentProperties const& document_properties,
                     std::map<std::string, DiscoveryTypeVertex> const& types,
                     std::ostream& output_stream) const;
 
   // Creates necessary directories and writes the file to disk.
   Status WriteFile(
-      std::string const& product_name,
+      DiscoveryDocumentProperties const& document_properties,
       std::map<std::string, DiscoveryTypeVertex> const& types) const;
 
  private:
   DiscoveryResource const* resource_;
   std::string file_path_;
   std::string package_name_;
-  std::string version_;
   std::set<std::string> import_paths_;
   std::vector<DiscoveryTypeVertex const*> types_;
 };

--- a/generator/internal/discovery_file_test.cc
+++ b/generator/internal/discovery_file_test.cc
@@ -214,8 +214,7 @@ message GetMyResourcesRequest {
   auto get_request_type_json =
       nlohmann::json::parse(kGetRequestTypeJson, nullptr, false);
   ASSERT_TRUE(get_request_type_json.is_object());
-  DiscoveryResource r("myResources", "my.package.name", "https://default.host",
-                      "my/service", resource_json);
+  DiscoveryResource r("myResources", "my.package.name", resource_json);
   DiscoveryTypeVertex do_foo_request_type("DoFooRequest", "my.package.name",
                                           do_foo_request_type_json);
   DiscoveryTypeVertex get_request_type(
@@ -225,13 +224,14 @@ message GetMyResourcesRequest {
   DiscoveryTypeVertex operation_type("Operation", "other.package",
                                      operation_type_json);
   r.AddResponseType("Operation", &operation_type);
-  DiscoveryFile f(&r, "my_path", "my.package.name", "v1",
-                  r.GetRequestTypesList());
+  DiscoveryFile f(&r, "my_path", "my.package.name", r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  auto result = f.FormatFile("my_product", types, os);
+  DiscoveryDocumentProperties document_properties{
+      "my/service", "https://default.host", "my_product", "v1"};
+  auto result = f.FormatFile(document_properties, types, os);
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(os.str(), Eq(kExpectedProto));
 }
@@ -315,8 +315,7 @@ message GetMyResourcesRequest {
   auto get_request_type_json =
       nlohmann::json::parse(kGetRequestTypeJson, nullptr, false);
   ASSERT_TRUE(get_request_type_json.is_object());
-  DiscoveryResource r("myResources", "my.package.name", "https://default.host",
-                      "my/service", resource_json);
+  DiscoveryResource r("myResources", "my.package.name", resource_json);
   DiscoveryTypeVertex do_foo_request_type("DoFooRequest", "my.package.name",
                                           do_foo_request_type_json);
   DiscoveryTypeVertex get_request_type(
@@ -326,12 +325,13 @@ message GetMyResourcesRequest {
   DiscoveryTypeVertex operation_type("Operation", "other.package",
                                      operation_type_json);
   r.AddResponseType("Operation", &operation_type);
-  DiscoveryFile f(&r, "my_path", "my.package.name", "v1",
-                  r.GetRequestTypesList());
+  DiscoveryFile f(&r, "my_path", "my.package.name", r.GetRequestTypesList());
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  auto result = f.FormatFile("my_product", types, os);
+  DiscoveryDocumentProperties document_properties{
+      "my/service", "https://default.host", "my_product", "v1"};
+  auto result = f.FormatFile(document_properties, types, os);
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(os.str(), Eq(kExpectedProto));
 }
@@ -389,12 +389,13 @@ message GetMyResourcesRequest {
                                           do_foo_request_type_json);
   DiscoveryTypeVertex get_request_type("GetMyResourcesRequest", "",
                                        get_request_type_json);
-  DiscoveryFile f(nullptr, "my_path", "my.package.name", "v1",
+  DiscoveryFile f(nullptr, "my_path", "my.package.name",
                   {&do_foo_request_type, &get_request_type});
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  auto result = f.FormatFile("my_product", types, os);
+  DiscoveryDocumentProperties document_properties{"", "", "my_product", "v1"};
+  auto result = f.FormatFile(document_properties, types, os);
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(os.str(), Eq(kExpectedProto));
 }
@@ -446,14 +447,14 @@ service MyResources {
 )""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
-  DiscoveryResource r("myResources", "", "https://default.host", "my/service",
-                      resource_json);
-  DiscoveryFile f(&r, "my_path", "my.package.name", "v1",
-                  r.GetRequestTypesList());
+  DiscoveryResource r("myResources", "", resource_json);
+  DiscoveryFile f(&r, "my_path", "my.package.name", r.GetRequestTypesList());
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  auto result = f.FormatFile("my_product", types, os);
+  DiscoveryDocumentProperties document_properties{
+      "my/service", "https://default.host", "my_product", "v1"};
+  auto result = f.FormatFile(document_properties, types, os);
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(os.str(), Eq(kExpectedProto));
 }
@@ -495,21 +496,20 @@ TEST(DiscoveryFile, FormatFileResourceScopeError) {
   auto get_request_type_json =
       nlohmann::json::parse(kGetRequestTypeJson, nullptr, false);
   ASSERT_TRUE(get_request_type_json.is_object());
-  DiscoveryResource r("myResources", "", "https://default.host", "my/service",
-                      resource_json);
+  DiscoveryResource r("myResources", "", resource_json);
   DiscoveryTypeVertex do_foo_request_type("DoFooRequest", "",
                                           do_foo_request_type_json);
   DiscoveryTypeVertex get_request_type("GetMyResourcesRequest", "",
                                        get_request_type_json);
   r.AddRequestType("DoFooRequest", &do_foo_request_type);
   r.AddRequestType("GetMyResourcesRequest", &get_request_type);
-  DiscoveryFile f(&r, "my_path", "my.package.name", "v1",
-                  r.GetRequestTypesList());
+  DiscoveryFile f(&r, "my_path", "my.package.name", r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  auto result = f.FormatFile("my_product", types, os);
+  DiscoveryDocumentProperties document_properties{"", "", "my_product", "v1"};
+  auto result = f.FormatFile(document_properties, types, os);
   EXPECT_THAT(result,
               StatusIs(StatusCode::kInvalidArgument, HasSubstr("scope")));
 }
@@ -547,8 +547,7 @@ TEST(DiscoveryFile, FormatFileTypeMissingError) {
   auto get_request_type_json =
       nlohmann::json::parse(kGetRequestTypeJson, nullptr, false);
   ASSERT_TRUE(get_request_type_json.is_object());
-  DiscoveryResource r("myResources", "", "https://default.host", "my/service",
-                      resource_json);
+  DiscoveryResource r("myResources", "", resource_json);
   DiscoveryTypeVertex do_foo_request_type("DoFooRequest", "",
                                           do_foo_request_type_json);
   DiscoveryTypeVertex get_request_type("GetMyResourcesRequest", "",
@@ -559,13 +558,13 @@ TEST(DiscoveryFile, FormatFileTypeMissingError) {
                                      operation_type_json);
   r.AddResponseType("Operation", &operation_type);
 
-  DiscoveryFile f(&r, "my_path", "my.package.name", "v1",
-                  r.GetRequestTypesList());
+  DiscoveryFile f(&r, "my_path", "my.package.name", r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  auto result = f.FormatFile("my_product", types, os);
+  DiscoveryDocumentProperties document_properties{"", "", "my_product", "v1"};
+  auto result = f.FormatFile(document_properties, types, os);
   EXPECT_THAT(result, StatusIs(StatusCode::kInvalidArgument,
                                HasSubstr("neither $ref nor type")));
 }

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_RESOURCE_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_RESOURCE_H
 
+#include "generator/internal/discovery_document.h"
 #include "generator/internal/discovery_type_vertex.h"
 #include <nlohmann/json.hpp>
 #include <string>
@@ -27,7 +28,6 @@ class DiscoveryResource {
  public:
   DiscoveryResource();
   DiscoveryResource(std::string name, std::string package_name,
-                    std::string default_host, std::string base_path,
                     nlohmann::json json);
 
   std::string const& name() const { return name_; }
@@ -52,9 +52,9 @@ class DiscoveryResource {
 
   // Examines the method JSON to determine the google.api.http,
   // google.api.method_signature, and google.cloud.operation_service options.
-  StatusOr<std::string> FormatRpcOptions(
-      nlohmann::json const& method_json,
-      DiscoveryTypeVertex const* request_type) const;
+  static StatusOr<std::string> FormatRpcOptions(
+      nlohmann::json const& method_json, std::string const& base_path,
+      DiscoveryTypeVertex const* request_type);
 
   // Summarize all the scopes found in the resource methods for inclusion as
   // a service level google.api.oauth_scopes option.
@@ -70,13 +70,12 @@ class DiscoveryResource {
   // are concatenated with the resource name.
   std::string FormatMethodName(std::string method_name) const;
 
-  StatusOr<std::string> JsonToProtobufService() const;
+  StatusOr<std::string> JsonToProtobufService(
+      DiscoveryDocumentProperties const& document_properties) const;
 
  private:
   std::string name_;
   std::string package_name_;
-  std::string default_host_;
-  std::string base_path_;
   nlohmann::json json_;
   std::map<std::string, DiscoveryTypeVertex const*> request_types_;
   std::map<std::string, DiscoveryTypeVertex const*> response_types_;

--- a/generator/internal/discovery_resource_test.cc
+++ b/generator/internal/discovery_resource_test.cc
@@ -60,9 +60,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -94,9 +95,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPatchZone) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -128,9 +130,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegion) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -155,9 +158,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobal) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -186,9 +190,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationResponse) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -207,9 +212,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetNoParams) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -233,9 +239,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetNoParamsOperation) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -249,9 +256,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsMissingPath) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   EXPECT_THAT(
       options,
       StatusIs(StatusCode::kInvalidArgument,
@@ -267,9 +275,10 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsMissingHttpMethod) {
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
-  DiscoveryResource r("myTests", "", "", "base/path", method_json);
+  DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options = r.FormatRpcOptions(method_json, &t);
+  auto options =
+      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
   EXPECT_THAT(
       options,
       StatusIs(StatusCode::kInvalidArgument,
@@ -298,7 +307,7 @@ TEST(DiscoveryResourceTest, FormatOAuthScopesPresent) {
 )""";
   auto json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryResource r("myTests", "", "", "", json);
+  DiscoveryResource r("myTests", "", json);
   auto scopes = r.FormatOAuthScopes();
   ASSERT_STATUS_OK(scopes);
   EXPECT_THAT(*scopes, Eq(kExpectedProto));
@@ -315,7 +324,7 @@ TEST(DiscoveryResourceTest, FormatOAuthScopesZeroScopes) {
 })""";
   auto json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryResource r("myTests", "", "", "", json);
+  DiscoveryResource r("myTests", "", json);
   auto scopes = r.FormatOAuthScopes();
   EXPECT_THAT(
       scopes,
@@ -332,7 +341,7 @@ TEST(DiscoveryResourceTest, FormatOAuthScopesNotPresent) {
 })""";
   auto json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryResource r("myTests", "", "", "", json);
+  DiscoveryResource r("myTests", "", json);
   auto scopes = r.FormatOAuthScopes();
   EXPECT_THAT(
       scopes,
@@ -344,7 +353,7 @@ TEST(DiscoveryResourceTest, FormatFilePath) {
   auto constexpr kResourceJson = R"""({})""";
   auto json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryResource r("myTests", "", "", "", json);
+  DiscoveryResource r("myTests", "", json);
   EXPECT_THAT(r.FormatFilePath("product", "v2", "/tmp"),
               Eq("/tmp/google/cloud/product/my_tests/v2/my_tests.proto"));
 }
@@ -353,7 +362,7 @@ TEST(DiscoveryResourceTest, FormatMethodName) {
   auto constexpr kResourceJson = R"""({})""";
   auto json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryResource r("myTests", "", "", "", json);
+  DiscoveryResource r("myTests", "", json);
   EXPECT_THAT(r.FormatMethodName("aggregatedList"),
               Eq("AggregatedListMyTests"));
   EXPECT_THAT(r.FormatMethodName("delete"), Eq("DeleteMyTests"));
@@ -450,8 +459,7 @@ service MyResources {
   auto do_foo_request_type_json =
       nlohmann::json::parse(kDoFooRequestTypeJson, nullptr, false);
   ASSERT_TRUE(do_foo_request_type_json.is_object());
-  DiscoveryResource r("myResources", "this.package", "https://my.endpoint.com",
-                      "base/path", resource_json);
+  DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryTypeVertex t("GetMyResourcesRequest", "this.package",
                         get_request_type_json);
   DiscoveryTypeVertex t2("DoFooRequest", "this.package",
@@ -460,7 +468,9 @@ service MyResources {
   r.AddRequestType("DoFooRequest", &t2);
   DiscoveryTypeVertex t3("Operation", "other.package", operation_type_json);
   r.AddResponseType("Operation", &t3);
-  auto emitted_proto = r.JsonToProtobufService();
+  DiscoveryDocumentProperties document_properties{
+      "base/path", "https://my.endpoint.com", "", ""};
+  auto emitted_proto = r.JsonToProtobufService(document_properties);
   ASSERT_STATUS_OK(emitted_proto);
   EXPECT_THAT(*emitted_proto, Eq(kExpectedProto));
 }
@@ -485,12 +495,13 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingOAuthScopes) {
   auto get_request_type_json =
       nlohmann::json::parse(kGetRequestTypeJson, nullptr, false);
   ASSERT_TRUE(get_request_type_json.is_object());
-  DiscoveryResource r("myResources", "this.package", "https://my.endpoint.com",
-                      "base/path", resource_json);
+  DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryTypeVertex t("GetMyResourcesRequest", "this.package",
                         get_request_type_json);
   r.AddRequestType("GetMyResourcesRequest", &t);
-  auto emitted_proto = r.JsonToProtobufService();
+  DiscoveryDocumentProperties document_properties{
+      "base/path", "https://my.endpoint.com", "", ""};
+  auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,
       StatusIs(StatusCode::kInvalidArgument,
@@ -524,9 +535,10 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingRequestType) {
 })""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
-  DiscoveryResource r("myResources", "this.package", "https://my.endpoint.com",
-                      "base/path", resource_json);
-  auto emitted_proto = r.JsonToProtobufService();
+  DiscoveryResource r("myResources", "this.package", resource_json);
+  DiscoveryDocumentProperties document_properties{
+      "base/path", "https://my.endpoint.com", "", ""};
+  auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,
       StatusIs(
@@ -563,9 +575,10 @@ service MyResources {
 )""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
-  DiscoveryResource r("myResources", "this.package", "https://my.endpoint.com",
-                      "base/path", resource_json);
-  auto emitted_proto = r.JsonToProtobufService();
+  DiscoveryResource r("myResources", "this.package", resource_json);
+  DiscoveryDocumentProperties document_properties{
+      "base/path", "https://my.endpoint.com", "", ""};
+  auto emitted_proto = r.JsonToProtobufService(document_properties);
   ASSERT_STATUS_OK(emitted_proto);
   EXPECT_THAT(*emitted_proto, Eq(kExpectedProto));
 }
@@ -592,12 +605,13 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceErrorFormattingRpcOptions) {
   auto get_request_type_json =
       nlohmann::json::parse(kGetRequestTypeJson, nullptr, false);
   ASSERT_TRUE(get_request_type_json.is_object());
-  DiscoveryResource r("myResources", "this.package", "https://my.endpoint.com",
-                      "base/path", resource_json);
+  DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryTypeVertex t("GetMyResourcesRequest", "this.package",
                         get_request_type_json);
   r.AddRequestType("GetMyResourcesRequest", &t);
-  auto emitted_proto = r.JsonToProtobufService();
+  DiscoveryDocumentProperties document_properties{
+      "base/path", "https://my.endpoint.com", "", ""};
+  auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,
       StatusIs(StatusCode::kInvalidArgument,

--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -144,7 +144,6 @@ std::map<std::string, DiscoveryResource> ExtractResources(
             absl::StrFormat(kResourcePackageNameFormat,
                             document_properties.product_name, resource_name,
                             document_properties.version),
-            document_properties.default_hostname, document_properties.base_path,
             r.value()});
   }
   return resources;
@@ -294,8 +293,7 @@ std::vector<DiscoveryFile> CreateFilesFromResources(
         &r.second,
         r.second.FormatFilePath(document_properties.product_name,
                                 document_properties.version, output_path),
-        r.second.package_name(), document_properties.version,
-        r.second.GetRequestTypesList()}
+        r.second.package_name(), r.second.GetRequestTypesList()}
                         .AddImportPath("google/cloud/$product_name$/$version$/"
                                        "internal/common.proto"));
   }
@@ -331,7 +329,7 @@ std::vector<DiscoveryFile> AssignResourcesAndTypesToFiles(
       absl::StrFormat(kCommonPackageNameFormat,
                       document_properties.product_name,
                       document_properties.version),
-      document_properties.version, std::move(common_types));
+      std::move(common_types));
   return files;
 }
 

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_TO_PROTO_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_TO_PROTO_H
 
+#include "generator/internal/discovery_document.h"
 #include "generator/internal/discovery_file.h"
 #include "generator/internal/discovery_resource.h"
 #include "generator/internal/discovery_type_vertex.h"
@@ -26,13 +27,6 @@
 namespace google {
 namespace cloud {
 namespace generator_internal {
-
-struct DiscoveryDocumentProperties {
-  std::string base_path;
-  std::string default_hostname;
-  std::string product_name;
-  std::string version;
-};
 
 // Creates a DiscoveryTypeVertex for every schema object defined in the
 // Discovery Document.

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -318,7 +318,7 @@ TEST(SynthesizeRequestTypeTest, OperationResponseWithRefRequestField) {
   auto const expected_request_type_json =
       nlohmann::json::parse(kExpectedRequestTypeJson, nullptr, false);
   ASSERT_TRUE(expected_request_type_json.is_object());
-  DiscoveryResource resource("foos", "", "", "", resource_json);
+  DiscoveryResource resource("foos", "", resource_json);
   auto result =
       SynthesizeRequestType(method_json, resource, "Operation", "create");
   ASSERT_STATUS_OK(result);
@@ -390,7 +390,7 @@ TEST(SynthesizeRequestTypeTest,
   auto const expected_request_type_json =
       nlohmann::json::parse(kExpectedRequestTypeJson, nullptr, false);
   ASSERT_TRUE(expected_request_type_json.is_object());
-  DiscoveryResource resource("foos", "", "", "", resource_json);
+  DiscoveryResource resource("foos", "", resource_json);
   auto result =
       SynthesizeRequestType(method_json, resource, "Operation", "create");
   ASSERT_STATUS_OK(result);
@@ -451,7 +451,7 @@ TEST(SynthesizeRequestTypeTest, NonOperationWithoutRequestField) {
   auto const expected_request_type_json =
       nlohmann::json::parse(kExpectedRequestTypeJson, nullptr, false);
   ASSERT_TRUE(expected_request_type_json.is_object());
-  DiscoveryResource resource("foos", "", "", "", resource_json);
+  DiscoveryResource resource("foos", "", resource_json);
   auto result = SynthesizeRequestType(method_json, resource, "Foo", "get");
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(result->json(), Eq(expected_request_type_json));
@@ -470,7 +470,7 @@ TEST(SynthesizeRequestTypeTest, MethodJsonMissingParameters) {
 })""";
   auto method_json = nlohmann::json::parse(kMethodJson, nullptr, false);
   ASSERT_TRUE(method_json.is_object());
-  DiscoveryResource resource("foos", "", "", "", resource_json);
+  DiscoveryResource resource("foos", "", resource_json);
   auto result =
       SynthesizeRequestType(method_json, resource, "Operation", "create");
   EXPECT_THAT(
@@ -545,7 +545,7 @@ TEST(SynthesizeRequestTypeTest, OperationResponseMissingRefInRequest) {
   auto const expected_request_type_json =
       nlohmann::json::parse(kExpectedRequestTypeJson, nullptr, false);
   ASSERT_TRUE(expected_request_type_json.is_object());
-  DiscoveryResource resource("foos", "", "", "", resource_json);
+  DiscoveryResource resource("foos", "", resource_json);
   auto result =
       SynthesizeRequestType(method_json, resource, "Operation", "create");
   EXPECT_THAT(
@@ -598,8 +598,7 @@ TEST(ProcessMethodRequestsAndResponsesTest, RequestWithOperationResponse) {
       nlohmann::json::parse(kOperationTypeJson, nullptr, false);
   ASSERT_TRUE(operation_type_json.is_object());
   std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos",
-                    DiscoveryResource("foos", "", "", "", resource_json));
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Operation",
                 DiscoveryTypeVertex("Operation", "", operation_type_json));
@@ -627,8 +626,7 @@ TEST(ProcessMethodRequestsAndResponsesTest, MethodWithEmptyRequest) {
       nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
   std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos",
-                    DiscoveryResource("foos", "", "", "", resource_json));
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
   auto result = ProcessMethodRequestsAndResponses(resources, types);
   ASSERT_STATUS_OK(result);
@@ -677,8 +675,7 @@ TEST(ProcessMethodRequestsAndResponsesTest, ResponseError) {
       nlohmann::json::parse(kOperationTypeJson, nullptr, false);
   ASSERT_TRUE(operation_type_json.is_object());
   std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos",
-                    DiscoveryResource("foos", "", "", "", resource_json));
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Operation", DiscoveryTypeVertex("", "", operation_type_json));
   auto result = ProcessMethodRequestsAndResponses(resources, types);
@@ -730,8 +727,7 @@ TEST(ProcessMethodRequestsAndResponsesTest, RequestError) {
       nlohmann::json::parse(kOperationTypeJson, nullptr, false);
   ASSERT_TRUE(operation_type_json.is_object());
   std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos",
-                    DiscoveryResource("foos", "", "", "", resource_json));
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Operation", DiscoveryTypeVertex("", "", operation_type_json));
   auto result = ProcessMethodRequestsAndResponses(resources, types);
@@ -787,8 +783,7 @@ TEST(ProcessMethodRequestsAndResponsesTest, TypeInsertError) {
       nlohmann::json::parse(kEmptyTypeJson, nullptr, false);
   ASSERT_TRUE(empty_type_json.is_object());
   std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos",
-                    DiscoveryResource("foos", "", "", "", resource_json));
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Operation",
                 DiscoveryTypeVertex("Operation", "", operation_type_json));
@@ -841,7 +836,7 @@ TEST(CreateFilesFromResourcesTest, NonEmptyResources) {
   resources.emplace(
       "foos",
       DiscoveryResource("foos", "google.cloud.cpp.product_name.foos.version",
-                        "", "", resource_json));
+                        resource_json));
   DiscoveryDocumentProperties props{"", "", "product_name", "version"};
   auto result = CreateFilesFromResources(resources, props, "tmp");
   ASSERT_THAT(result, SizeIs(1));
@@ -898,8 +893,7 @@ TEST(AssignResourcesAndTypesToFilesTest,
       nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
   std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos",
-                    DiscoveryResource("foos", "", "", "", resource_json));
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
   auto constexpr kSynthesizedTypeJson = R"""({
 "synthesized_request": true


### PR DESCRIPTION
fixes #11377 

Some classes were holding top level document properties as member variables. As most such properties were strings this led to constructors with lots of repeated strings, reducing readability and introducing potential sources of future errors. In order to remedy this, member variables were removed from classes where it made sense and are now instead passed only to the methods that needed them via the existing `DiscoveryDocumentProperties` struct.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11391)
<!-- Reviewable:end -->
