### PR TITLE
impl(docfx): skip generated pages

### DIFF
--- a/docfx/.clang-tidy
+++ b/docfx/.clang-tidy
@@ -2,4 +2,5 @@
 InheritParentConfig: true
 
 Checks: >
-  -misc-no-recursion
+  -misc-no-recursion,
+  -abseil-string-find-str-contains

--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -331,9 +331,7 @@ bool AppendIfRef(std::ostream& os, MarkdownContext const& ctx,
   // `:cloud:`). We need to escape them as "computer output", but only if they
   // are not escaped already.
   auto ref = link.str();
-  if (  // NOLINTNEXTLINE(abseil-string-find-str-contains)
-      ref.find("::") != std::string::npos &&
-      // NOLINTNEXTLINE(abseil-string-find-str-contains)
+  if (ref.find("::") != std::string::npos &&
       ref.find('`') == std::string::npos) {
     ref = "`" + ref + "`";
   }

--- a/docfx/doxygen_pages.cc
+++ b/docfx/doxygen_pages.cc
@@ -130,7 +130,7 @@ std::vector<TocEntry> PagesToc(Config const& cfg,
     // usually examples showing how to use a specific class. We link such
     // examples from the landing page, and they otherwise clutter the navigation
     // page.
-    if (id.find("::") != std::string_view::npos) continue;  // NOLINT
+    if (id.find("::") != std::string_view::npos) continue;
     std::ostringstream title;
     AppendTitle(title, MarkdownContext{}, page);
     auto filename =

--- a/docfx/doxygen_pages.cc
+++ b/docfx/doxygen_pages.cc
@@ -126,6 +126,11 @@ std::vector<TocEntry> PagesToc(Config const& cfg,
     auto const& page = i.node();
     if (!IncludeInPublicDocuments(cfg, page)) continue;
     auto const id = std::string_view{page.attribute("id").as_string()};
+    // We will skip groups with :: in their id. These are all generated pages,
+    // usually examples showing how to use a specific class. We link such
+    // examples from the landing page, and they otherwise clutter the navigation
+    // page.
+    if (id.find("::") != std::string_view::npos) continue;  // NOLINT
     std::ostringstream title;
     AppendTitle(title, MarkdownContext{}, page);
     auto filename =


### PR DESCRIPTION
We generate small doxygen "pages" to host the examples showing how to override the default endpoint and/or authentication mechanism. Listing these pages in the TOC just clutters things. I am adopting a convention that all (and only) generated pages will use `::` as part of their uid.

Part of the work for #11309

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11415)
<!-- Reviewable:end -->
