### PR TITLE
impl(docfx): escape text in `<ulink>` elements

### DIFF
--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -477,6 +477,7 @@ TEST(Doxygen2Markdown, ParagraphSimpleContents) {
         <para id='test-009'><ref refid="classgoogle_1_1cloud_1_1Options" kindref="compound">google::cloud::Options</ref></para>
         <para id='test-010'><ref refid="classgoogle_1_1cloud_1_1Options" kindref="compound">Options</ref></para>
         <para id='test-011'>abc<zwj/>123</para>
+        <para id='test-012'><ulink url="https://example.com/">google::cloud::Test</ulink></para>
     </doxygen>)xml";
 
   struct TestCase {
@@ -496,6 +497,7 @@ TEST(Doxygen2Markdown, ParagraphSimpleContents) {
        "\n\n[`google::cloud::Options`](xref:classgoogle_1_1cloud_1_1Options)"},
       {"test-010", "\n\n[Options](xref:classgoogle_1_1cloud_1_1Options)"},
       {"test-011", "\n\nabc123"},
+      {"test-012", "\n\n[`google::cloud::Test`](https://example.com/)"},
   };
 
   pugi::xml_document doc;

--- a/docfx/doxygen2syntax.cc
+++ b/docfx/doxygen2syntax.cc
@@ -378,7 +378,7 @@ void AppendFunctionSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
       yaml << YAML::EndMap;
     }
     // Generate the template parameters as normal parameters, as there does not
-    // seem to be other way to document them.
+    // seem to be any other way to document them.
     for (auto const& i : tparams) {
       auto type = std::string{i.child("type").child_value()};
       yaml << YAML::BeginMap  //


### PR DESCRIPTION
Part of the work for #11309

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11418)
<!-- Reviewable:end -->
