### PR TITLE
impl(GCS+gRPC): use gRPC options in hybrid client

### DIFF
--- a/google/cloud/storage/grpc_plugin_test.cc
+++ b/google/cloud/storage/grpc_plugin_test.cc
@@ -118,6 +118,20 @@ TEST(GrpcPluginTest, MediaConfigCreatesHybrid) {
   ASSERT_THAT(hybrid, NotNull());
 }
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
+TEST(GrpcPluginTest, HybridUsesGrpcBufferOptions) {
+  // Explicitly disable logging, which may be enabled by our CI builds.
+  auto logging =
+      ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
+  auto config =
+      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
+  auto client = DefaultGrpcClient(TestOptions().set<GrpcPluginOption>("media"));
+  EXPECT_GE(
+      client.raw_client()->options().get<storage::UploadBufferSizeOption>(),
+      32 * 1024 * 1024L);
+}
+#include "google/cloud/internal/diagnostics_pop.inc"
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -33,10 +33,10 @@ HybridClient::HybridClient(Options const& options)
           storage::internal::DefaultOptionsWithCredentials(options))) {}
 
 storage::ClientOptions const& HybridClient::client_options() const {
-  return rest_->client_options();
+  return grpc_->client_options();
 }
 
-Options HybridClient::options() const { return rest_->options(); }
+Options HybridClient::options() const { return grpc_->options(); }
 
 StatusOr<storage::internal::ListBucketsResponse> HybridClient::ListBuckets(
     storage::internal::ListBucketsRequest const& request) {


### PR DESCRIPTION
This is mostly to use the right default buffer sizes for uploads and downloads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11419)
<!-- Reviewable:end -->
