### PR TITLE
refactor(otel): tests use abstract tracing Options

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_connection_test.cc
@@ -337,17 +337,19 @@ TEST(GoldenKitchenSinkConnectionTest, CheckExpectedOptions) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::Not;
 
 TEST(GoldenKitchenSinkConnectionTest, TracingEnabled) {
-  using ::google::cloud::testing_util::SpanNamed;
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options =
+  auto options = EnableTracing(
       Options{}
-          .set<internal::OpenTelemetryTracingOption>(true)
           .set<EndpointOption>("localhost:1")
           .set<GoldenKitchenSinkRetryPolicyOption>(
-              GoldenKitchenSinkLimitedErrorCountRetryPolicy(0).clone());
+              GoldenKitchenSinkLimitedErrorCountRetryPolicy(0).clone()));
   auto conn = MakeGoldenKitchenSinkConnection(std::move(options));
   // Make a call, which should fail fast. The error itself is not important.
   (void)conn->DoNothing({});
@@ -359,16 +361,13 @@ TEST(GoldenKitchenSinkConnectionTest, TracingEnabled) {
 }
 
 TEST(GoldenKitchenSinkConnectionTest, TracingDisabled) {
-  using ::google::cloud::testing_util::SpanNamed;
-  using ::testing::Not;
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options =
+  auto options = DisableTracing(
       Options{}
-          .set<internal::OpenTelemetryTracingOption>(false)
           .set<EndpointOption>("localhost:1")
           .set<GoldenKitchenSinkRetryPolicyOption>(
-              GoldenKitchenSinkLimitedErrorCountRetryPolicy(0).clone());
+              GoldenKitchenSinkLimitedErrorCountRetryPolicy(0).clone()));
   auto conn = MakeGoldenKitchenSinkConnection(std::move(options));
   // Make a call, which should fail fast. The error itself is not important.
   (void)conn->DoNothing({});

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_factory_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_factory_test.cc
@@ -70,14 +70,15 @@ TEST_F(GoldenKitchenSinkStubFactoryTest, DefaultStubWithAuth) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::Not;
 
 TEST_F(GoldenKitchenSinkStubFactoryTest, DefaultStubWithTracingEnabled) {
-  using ::google::cloud::testing_util::SpanNamed;
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options = Options{}
-                     .set<internal::OpenTelemetryTracingOption>(true)
-                     .set<EndpointOption>("localhost:1");
+  auto options = EnableTracing(Options{}.set<EndpointOption>("localhost:1"));
   auto stub =
       CreateDefaultGoldenKitchenSinkStub(CompletionQueue{}, std::move(options));
   grpc::ClientContext context;
@@ -90,13 +91,9 @@ TEST_F(GoldenKitchenSinkStubFactoryTest, DefaultStubWithTracingEnabled) {
 }
 
 TEST_F(GoldenKitchenSinkStubFactoryTest, DefaultStubWithTracingDisabled) {
-  using ::google::cloud::testing_util::SpanNamed;
-  using ::testing::Not;
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options = Options{}
-                     .set<internal::OpenTelemetryTracingOption>(false)
-                     .set<EndpointOption>("localhost:1");
+  auto options = DisableTracing(Options{}.set<EndpointOption>("localhost:1"));
   auto stub =
       CreateDefaultGoldenKitchenSinkStub(CompletionQueue{}, std::move(options));
   grpc::ClientContext context;

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
@@ -34,7 +34,8 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::Return;
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::SpanAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
@@ -345,9 +346,7 @@ TEST(MakeGoldenKitchenSinkTracingConnection, TracingEnabled) {
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_shared<MockGoldenKitchenSinkConnection>();
-  EXPECT_CALL(*mock, options)
-      .WillOnce(
-          Return(Options{}.set<internal::OpenTelemetryTracingOption>(true)));
+  EXPECT_CALL(*mock, options).WillOnce(Return(EnableTracing(Options{})));
   EXPECT_CALL(*mock, DoNothing)
       .WillOnce(Return(internal::AbortedError("fail")));
 
@@ -363,9 +362,7 @@ TEST(MakeGoldenKitchenSinkTracingConnection, TracingDisabled) {
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_shared<MockGoldenKitchenSinkConnection>();
-  EXPECT_CALL(*mock, options)
-      .WillOnce(
-          Return(Options{}.set<internal::OpenTelemetryTracingOption>(false)));
+  EXPECT_CALL(*mock, options).WillOnce(Return(DisableTracing(Options{})));
   EXPECT_CALL(*mock, DoNothing)
       .WillOnce(Return(internal::AbortedError("fail")));
 

--- a/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
@@ -1375,17 +1375,19 @@ TEST(GoldenThingAdminConnectionTest, CheckExpectedOptions) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::Not;
 
 TEST(GoldenThingAdminConnectionTest, TracingEnabled) {
-  using ::google::cloud::testing_util::SpanNamed;
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options =
+  auto options = EnableTracing(
       Options{}
-          .set<internal::OpenTelemetryTracingOption>(true)
           .set<EndpointOption>("localhost:1")
           .set<GoldenThingAdminRetryPolicyOption>(
-              GoldenThingAdminLimitedErrorCountRetryPolicy(0).clone());
+              GoldenThingAdminLimitedErrorCountRetryPolicy(0).clone()));
   auto conn = MakeGoldenThingAdminConnection(std::move(options));
   // Make a call, which should fail fast. The error itself is not important.
   (void)conn->DeleteBackup({});
@@ -1397,16 +1399,13 @@ TEST(GoldenThingAdminConnectionTest, TracingEnabled) {
 }
 
 TEST(GoldenThingAdminConnectionTest, TracingDisabled) {
-  using ::google::cloud::testing_util::SpanNamed;
-  using ::testing::Not;
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options =
+  auto options = DisableTracing(
       Options{}
-          .set<internal::OpenTelemetryTracingOption>(false)
           .set<EndpointOption>("localhost:1")
           .set<GoldenThingAdminRetryPolicyOption>(
-              GoldenThingAdminLimitedErrorCountRetryPolicy(0).clone());
+              GoldenThingAdminLimitedErrorCountRetryPolicy(0).clone()));
   auto conn = MakeGoldenThingAdminConnection(std::move(options));
   // Make a call, which should fail fast. The error itself is not important.
   (void)conn->DeleteBackup({});

--- a/generator/integration_tests/tests/golden_thing_admin_stub_factory_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_stub_factory_test.cc
@@ -73,14 +73,15 @@ TEST_F(GoldenStubFactoryTest, DefaultStubWithAuth) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::Not;
 
 TEST_F(GoldenStubFactoryTest, DefaultStubWithTracingEnabled) {
-  using ::google::cloud::testing_util::SpanNamed;
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options = Options{}
-                     .set<internal::OpenTelemetryTracingOption>(true)
-                     .set<EndpointOption>("localhost:1");
+  auto options = EnableTracing(Options{}.set<EndpointOption>("localhost:1"));
   auto stub =
       CreateDefaultGoldenThingAdminStub(CompletionQueue{}, std::move(options));
   grpc::ClientContext context;
@@ -94,13 +95,9 @@ TEST_F(GoldenStubFactoryTest, DefaultStubWithTracingEnabled) {
 }
 
 TEST_F(GoldenStubFactoryTest, DefaultStubWithTracingDisabled) {
-  using ::google::cloud::testing_util::SpanNamed;
-  using ::testing::Not;
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options = Options{}
-                     .set<internal::OpenTelemetryTracingOption>(false)
-                     .set<EndpointOption>("localhost:1");
+  auto options = DisableTracing(Options{}.set<EndpointOption>("localhost:1"));
   auto stub =
       CreateDefaultGoldenThingAdminStub(CompletionQueue{}, std::move(options));
   grpc::ClientContext context;

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_connection_test.cc
@@ -34,7 +34,8 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::Return;
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::SpanAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
@@ -589,9 +590,7 @@ TEST(MakeGoldenThingAdminTracingConnection, TracingEnabled) {
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_shared<MockGoldenThingAdminConnection>();
-  EXPECT_CALL(*mock, options)
-      .WillOnce(
-          Return(Options{}.set<internal::OpenTelemetryTracingOption>(true)));
+  EXPECT_CALL(*mock, options).WillOnce(Return(EnableTracing(Options{})));
   EXPECT_CALL(*mock, DropDatabase)
       .WillOnce(Return(internal::AbortedError("fail")));
 
@@ -607,9 +606,7 @@ TEST(MakeGoldenThingAdminTracingConnection, TracingDisabled) {
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_shared<MockGoldenThingAdminConnection>();
-  EXPECT_CALL(*mock, options)
-      .WillOnce(
-          Return(Options{}.set<internal::OpenTelemetryTracingOption>(false)));
+  EXPECT_CALL(*mock, options).WillOnce(Return(DisableTracing(Options{})));
   EXPECT_CALL(*mock, DropDatabase)
       .WillOnce(Return(internal::AbortedError("fail")));
 

--- a/google/cloud/internal/async_polling_loop_test.cc
+++ b/google/cloud/internal/async_polling_loop_test.cc
@@ -623,7 +623,7 @@ TEST(AsyncPollingLoopTest, ConfigurePollContext) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::IsActive;
 using ::google::cloud::testing_util::SpanAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
@@ -660,7 +660,7 @@ TEST(AsyncPollingLoopTest, TracedAsyncBackoff) {
   EXPECT_CALL(*policy, WaitPeriod)
       .WillRepeatedly(Return(std::chrono::milliseconds(1)));
 
-  OptionsSpan o(Options{}.set<OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
   (void)AsyncPollingLoop(cq, make_ready_future(make_status_or(starting_op)),
                          MakePoll(mock), MakeCancel(mock), std::move(policy),
                          "test-function")
@@ -715,7 +715,7 @@ TEST(AsyncPollingLoopTest, SpanActiveThroughout) {
       .WillRepeatedly(Return(std::chrono::milliseconds(1)));
 
   auto scope = opentelemetry::trace::Scope(span);
-  OptionsSpan o(Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
   auto pending = AsyncPollingLoop(
       cq, make_ready_future(make_status_or(starting_op)), MakePoll(mock),
       MakeCancel(mock), std::move(policy), "test-function");
@@ -747,7 +747,7 @@ TEST(AsyncPollingLoopTest, TraceCapturesOperationName) {
   CompletionQueue cq;
 
   auto scope = opentelemetry::trace::Scope(span);
-  OptionsSpan o(Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
   (void)AsyncPollingLoop(cq, make_ready_future(make_status_or(op)),
                          MakePoll(mock), MakeCancel(mock), std::move(policy),
                          "test-function")

--- a/google/cloud/internal/async_rest_polling_loop_test.cc
+++ b/google/cloud/internal/async_rest_polling_loop_test.cc
@@ -565,7 +565,7 @@ TEST(AsyncRestPollingLoopTest, PollThenCancelDuringPoll) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::IsActive;
 using ::google::cloud::testing_util::SpanAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
@@ -602,8 +602,7 @@ TEST(AsyncRestPollingLoopTest, TracedAsyncBackoff) {
   EXPECT_CALL(*policy, WaitPeriod)
       .WillRepeatedly(Return(std::chrono::milliseconds(1)));
 
-  internal::OptionsSpan o(
-      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  internal::OptionsSpan o(EnableTracing(Options{}));
   (void)AsyncRestPollingLoop(cq, make_ready_future(make_status_or(starting_op)),
                              MakePoll(mock), MakeCancel(mock),
                              std::move(policy), "test-function")
@@ -658,8 +657,7 @@ TEST(AsyncRestPollingLoopTest, SpanActiveThroughout) {
       .WillRepeatedly(Return(std::chrono::milliseconds(1)));
 
   auto scope = opentelemetry::trace::Scope(span);
-  internal::OptionsSpan o(
-      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  internal::OptionsSpan o(EnableTracing(Options{}));
   auto pending = AsyncRestPollingLoop(
       cq, make_ready_future(make_status_or(starting_op)), MakePoll(mock),
       MakeCancel(mock), std::move(policy), "test-function");
@@ -691,8 +689,7 @@ TEST(AsyncRestPollingLoopTest, TraceCapturesOperationName) {
   CompletionQueue cq;
 
   auto scope = opentelemetry::trace::Scope(span);
-  internal::OptionsSpan o(
-      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  internal::OptionsSpan o(EnableTracing(Options{}));
   (void)AsyncRestPollingLoop(cq, make_ready_future(make_status_or(op)),
                              MakePoll(mock), MakeCancel(mock),
                              std::move(policy), "test-function")

--- a/google/cloud/internal/async_rest_retry_loop_test.cc
+++ b/google/cloud/internal/async_rest_retry_loop_test.cc
@@ -550,7 +550,7 @@ TEST_F(AsyncRestRetryLoopCancelTest, ShutdownDuringTimer) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::IsActive;
 using ::google::cloud::testing_util::SpanNamed;
 using ::testing::AllOf;
@@ -560,8 +560,7 @@ using ::testing::SizeIs;
 TEST(AsyncRestRetryLoopTest, TracedBackoff) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  internal::OptionsSpan o(
-      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  internal::OptionsSpan o(EnableTracing(Options{}));
   AutomaticallyCreatedRestBackgroundThreads background;
   (void)AsyncRestRetryLoop(
       TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
@@ -584,8 +583,7 @@ TEST(AsyncRestRetryLoopTest, CallSpanActiveThroughout) {
   AsyncSequencer<StatusOr<int>> sequencer;
   auto span = internal::MakeSpan("span");
   auto scope = opentelemetry::trace::Scope(span);
-  internal::OptionsSpan o(
-      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  internal::OptionsSpan o(EnableTracing(Options{}));
 
   AutomaticallyCreatedRestBackgroundThreads background;
   future<StatusOr<int>> actual = AsyncRestRetryLoop(
@@ -608,8 +606,7 @@ TEST(AsyncRestRetryLoopTest, CallSpanActiveDuringCancel) {
 
   auto span = internal::MakeSpan("span");
   auto scope = opentelemetry::trace::Scope(span);
-  internal::OptionsSpan o(
-      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  internal::OptionsSpan o(EnableTracing(Options{}));
 
   promise<StatusOr<int>> p([&] { EXPECT_THAT(span, IsActive()); });
 

--- a/google/cloud/internal/async_retry_loop_test.cc
+++ b/google/cloud/internal/async_retry_loop_test.cc
@@ -561,7 +561,7 @@ TEST_F(AsyncRetryLoopCancelTest, ShutdownDuringTimer) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::IsActive;
 using ::google::cloud::testing_util::SpanNamed;
 using ::testing::AllOf;
@@ -571,7 +571,7 @@ using ::testing::SizeIs;
 TEST(AsyncRetryLoopTest, TracedBackoff) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  OptionsSpan o(Options{}.set<OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
   AutomaticallyCreatedBackgroundThreads background;
   (void)AsyncRetryLoop(
       TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
@@ -593,7 +593,7 @@ TEST(AsyncRetryLoopTest, CallSpanActiveThroughout) {
   AsyncSequencer<StatusOr<int>> sequencer;
   auto span = MakeSpan("span");
   auto scope = opentelemetry::trace::Scope(span);
-  OptionsSpan o(Options{}.set<OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
 
   AutomaticallyCreatedBackgroundThreads background;
   future<StatusOr<int>> actual = AsyncRetryLoop(
@@ -616,7 +616,7 @@ TEST(AsyncRetryLoopTest, CallSpanActiveDuringCancel) {
 
   auto span = MakeSpan("span");
   auto scope = opentelemetry::trace::Scope(span);
-  OptionsSpan o(Options{}.set<OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
 
   promise<StatusOr<int>> p([span] { EXPECT_THAT(span, IsActive()); });
 

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -36,7 +36,8 @@ using ::testing::ByMove;
 using ::testing::Return;
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::SpanAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
@@ -153,7 +154,7 @@ TEST(OpenTelemetry, TracedAsyncBackoffEnabled) {
           make_status_or(std::chrono::system_clock::now())))));
   CompletionQueue cq(mock_cq);
 
-  OptionsSpan span(Options{}.set<OpenTelemetryTracingOption>(true));
+  OptionsSpan span(EnableTracing(Options{}));
   auto f = TracedAsyncBackoff(cq, duration);
   EXPECT_STATUS_OK(f.get());
 
@@ -176,7 +177,7 @@ TEST(OpenTelemetry, TracedAsyncBackoffDisabled) {
               CancelledError("cancelled")))));
   CompletionQueue cq(mock_cq);
 
-  OptionsSpan span(Options{}.set<OpenTelemetryTracingOption>(false));
+  OptionsSpan span(DisableTracing(Options{}));
   auto f = TracedAsyncBackoff(cq, duration);
   EXPECT_THAT(f.get(), StatusIs(StatusCode::kCancelled, "cancelled"));
 

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -34,7 +34,8 @@ using ms = std::chrono::milliseconds;
 using ::testing::MockFunction;
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
+using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::SpanAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
@@ -291,7 +292,7 @@ TEST(OpenTelemetry, MakeTracedSleeperEnabled) {
   MockFunction<void(ms)> mock_sleeper;
   EXPECT_CALL(mock_sleeper, Call(ms(42)));
 
-  OptionsSpan span(Options{}.set<OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
   auto sleeper = mock_sleeper.AsStdFunction();
   auto result = MakeTracedSleeper(sleeper);
   result(ms(42));
@@ -307,7 +308,7 @@ TEST(OpenTelemetry, MakeTracedSleeperDisabled) {
   MockFunction<void(ms)> mock_sleeper;
   EXPECT_CALL(mock_sleeper, Call(ms(42)));
 
-  OptionsSpan span(Options{}.set<OpenTelemetryTracingOption>(false));
+  OptionsSpan o(DisableTracing(Options{}));
   auto sleeper = mock_sleeper.AsStdFunction();
   auto result = MakeTracedSleeper(sleeper);
   result(ms(42));
@@ -322,7 +323,7 @@ TEST(OpenTelemetry, AddSpanAttributeEnabled) {
 
   auto span = MakeSpan("span");
   auto scope = opentelemetry::trace::Scope(span);
-  OptionsSpan o(Options{}.set<OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
   AddSpanAttribute("key", "value");
   span->End();
 
@@ -338,7 +339,7 @@ TEST(OpenTelemetry, AddSpanAttributeDisabled) {
 
   auto span = MakeSpan("span");
   auto scope = opentelemetry::trace::Scope(span);
-  OptionsSpan o(Options{}.set<OpenTelemetryTracingOption>(false));
+  OptionsSpan o(DisableTracing(Options{}));
   AddSpanAttribute("key", "value");
   span->End();
 

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -34,8 +34,8 @@ using ms = std::chrono::milliseconds;
 using ::testing::MockFunction;
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::SpanAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;

--- a/google/cloud/internal/rest_retry_loop_test.cc
+++ b/google/cloud/internal/rest_retry_loop_test.cc
@@ -200,15 +200,17 @@ TEST(RestRetryLoopTest, TooManyTransientFailuresIdempotent) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::AllOf;
+using ::testing::Each;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
 
 TEST(RestRetryLoopTest, TracingEnabled) {
-  using ::google::cloud::testing_util::SpanNamed;
-  using ::testing::AllOf;
-  using ::testing::Each;
-  using ::testing::SizeIs;
   auto span_catcher = testing_util::InstallSpanCatcher();
-  internal::OptionsSpan span(
-      Options{}.set<internal::OpenTelemetryTracingOption>(true));
+  internal::OptionsSpan o(EnableTracing(Options{}));
 
   StatusOr<int> actual = RestRetryLoop(
       TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
@@ -222,10 +224,8 @@ TEST(RestRetryLoopTest, TracingEnabled) {
 }
 
 TEST(RestRetryLoopTest, TracingDisabled) {
-  using ::testing::IsEmpty;
   auto span_catcher = testing_util::InstallSpanCatcher();
-  internal::OptionsSpan span(
-      Options{}.set<internal::OpenTelemetryTracingOption>(false));
+  internal::OptionsSpan o(DisableTracing(Options{}));
 
   StatusOr<int> actual = RestRetryLoop(
       TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,

--- a/google/cloud/internal/retry_loop_test.cc
+++ b/google/cloud/internal/retry_loop_test.cc
@@ -213,14 +213,17 @@ TEST(RetryLoopTest, ConfigureContext) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::AllOf;
+using ::testing::Each;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
 
 TEST(RetryLoopTest, TracingEnabled) {
-  using ::google::cloud::testing_util::SpanNamed;
-  using ::testing::AllOf;
-  using ::testing::Each;
-  using ::testing::SizeIs;
   auto span_catcher = testing_util::InstallSpanCatcher();
-  OptionsSpan span(Options{}.set<OpenTelemetryTracingOption>(true));
+  OptionsSpan o(EnableTracing(Options{}));
 
   StatusOr<int> actual = RetryLoop(
       TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
@@ -234,9 +237,8 @@ TEST(RetryLoopTest, TracingEnabled) {
 }
 
 TEST(RetryLoopTest, TracingDisabled) {
-  using ::testing::IsEmpty;
   auto span_catcher = testing_util::InstallSpanCatcher();
-  OptionsSpan span(Options{}.set<OpenTelemetryTracingOption>(false));
+  OptionsSpan o(DisableTracing(Options{}));
 
   StatusOr<int> actual = RetryLoop(
       TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -613,7 +613,7 @@ TEST(RetryClientTest, UploadFinalChunkQueryTooManyMissingPayloads) {
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-using ::google::cloud::internal::OpenTelemetryTracingOption;
+using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::SpanNamed;
 using ::testing::ElementsAre;
@@ -625,7 +625,7 @@ TEST(RetryClientTest, BackoffSpansSimple) {
   auto client = storage_internal::MakeTracingClient(
       RetryClient::Create(std::shared_ptr<internal::RawClient>(mock)));
   google::cloud::internal::OptionsSpan const span(
-      BasicTestPolicies().set<OpenTelemetryTracingOption>(true));
+      EnableTracing(BasicTestPolicies()));
   EXPECT_CALL(*mock, GetObjectMetadata)
       .WillRepeatedly(Return(TransientError()));
   auto response = client->GetObjectMetadata(GetObjectMetadataRequest());
@@ -642,7 +642,7 @@ TEST(RetryClientTest, BackoffSpansUploadChunk) {
   auto client = storage_internal::MakeTracingClient(
       RetryClient::Create(std::shared_ptr<internal::RawClient>(mock)));
   google::cloud::internal::OptionsSpan const span(
-      BasicTestPolicies().set<OpenTelemetryTracingOption>(true));
+      EnableTracing(BasicTestPolicies()));
 
   ::testing::InSequence sequence;
   EXPECT_CALL(*mock, UploadChunk).WillOnce(Return(TransientError()));

--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -166,6 +166,14 @@ std::shared_ptr<MockTextMapPropagator> InstallMockPropagator() {
   return mock;
 }
 
+Options EnableTracing(Options options) {
+  return options.set<internal::OpenTelemetryTracingOption>(true);
+}
+
+Options DisableTracing(Options options) {
+  return options.set<internal::OpenTelemetryTracingOption>(false);
+}
+
 }  // namespace testing_util
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -16,6 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_OPENTELEMETRY_MATCHERS_H
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/opentelemetry_options.h"
+#include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
 #include <opentelemetry/context/propagation/text_map_propagator.h>
@@ -232,6 +234,13 @@ class MockTextMapPropagator
  * 2. the tests within a fixture do not execute in parallel
  */
 std::shared_ptr<MockTextMapPropagator> InstallMockPropagator();
+
+// Returns options with OpenTelemetry tracing enabled. Uses the global tracer
+// provider.
+Options EnableTracing(Options options);
+
+// Returns options with OpenTelemetry tracing disabled.
+Options DisableTracing(Options options);
 
 }  // namespace testing_util
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Use a single source to produce testing options that have tracing enabled/disabled. (Except in the test for `TracingEnabled()`.

This saves some future refactoring, if we change the tracing enabled formula. (e.g. if we move `OpenTelemetryTracingOption` out of internal).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11420)
<!-- Reviewable:end -->
