### PR TITLE
cleanup(otel): instrumentation scope

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -302,8 +302,9 @@ void Recordable::SetInstrumentationScope(
     opentelemetry::sdk::instrumentationscope::InstrumentationScope const&
         instrumentation_scope) noexcept {
   SetAttribute("otel.scope.name", instrumentation_scope.GetName());
-  if (instrumentation_scope.GetVersion().empty()) return;
-  SetAttribute("otel.scope.version", instrumentation_scope.GetVersion());
+  if (!instrumentation_scope.GetVersion().empty()) {
+    SetAttribute("otel.scope.version", instrumentation_scope.GetVersion());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -301,10 +301,9 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept {
 void Recordable::SetInstrumentationScope(
     opentelemetry::sdk::instrumentationscope::InstrumentationScope const&
         instrumentation_scope) noexcept {
-  SetAttribute("otel.instrumentation_library.name",
-               instrumentation_scope.GetName());
-  SetAttribute("otel.instrumentation_library.version",
-               instrumentation_scope.GetVersion());
+  SetAttribute("otel.scope.name", instrumentation_scope.GetName());
+  if (instrumentation_scope.GetVersion().empty()) return;
+  SetAttribute("otel.scope.version", instrumentation_scope.GetVersion());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -566,10 +566,21 @@ TEST(Recordable, SetInstrumentationScope) {
   auto proto = std::move(rec).as_proto();
   EXPECT_THAT(proto.attributes(),
               Attributes(UnorderedElementsAre(
-                  Pair("otel.instrumentation_library.name",
-                       AttributeValue("test-name")),
-                  Pair("otel.instrumentation_library.version",
-                       AttributeValue("test-version")))));
+                  Pair("otel.scope.name", AttributeValue("test-name")),
+                  Pair("otel.scope.version", AttributeValue("test-version")))));
+}
+
+TEST(Recordable, SetInstrumentationScopeOmitsEmptyVersion) {
+  auto scope =
+      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
+          "test-name");
+
+  auto rec = Recordable(Project(kProjectId));
+  rec.SetInstrumentationScope(*scope);
+  auto proto = std::move(rec).as_proto();
+  EXPECT_THAT(proto.attributes(),
+              Attributes(UnorderedElementsAre(
+                  Pair("otel.scope.name", AttributeValue("test-name")))));
 }
 
 }  // namespace


### PR DESCRIPTION
Mini cleanup. The version is an optional argument to create a tracer. So there's no point in adding an empty attribute for it when it is not set.

Also rename the keys. The names are shorter. The Go exporter uses these names at HEAD. I think the exporter spec is just stale.

https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/327f5866b4fc60227d44c666c9ccb160a8ef9bf6/exporter/trace/trace_proto.go#L68-L69

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11424)
<!-- Reviewable:end -->
