### PR TITLE
impl(otel): map attribute keys

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -32,9 +32,9 @@ bool IsTrailByte(char x) { return static_cast<signed char>(x) < -0x40; }
 // Trace's semantics for label keys. So translate from one to the other.
 //
 // See: https://cloud.google.com/trace/docs/trace-labels#canonical_labels
-opentelemetry::nostd::string_view MapKey(
-    opentelemetry::nostd::string_view key) {
-  static auto const* m = new std::map<std::string, std::string>{
+void MapKey(opentelemetry::nostd::string_view& key) {
+  static auto const* m = new std::map<opentelemetry::nostd::string_view,
+                                      opentelemetry::nostd::string_view>{
       {"http.host", "/http/host"},
       {"http.method", "/http/method"},
       {"http.target", "/http/path"},
@@ -46,9 +46,8 @@ opentelemetry::nostd::string_view MapKey(
       {"http.scheme", "/http/client_protocol"},
       {"http.route", "/http/route"},
   };
-  auto it = m->find({key.data(), key.size()});
-  if (it == m->end()) return key;
-  return it->second;
+  auto it = m->find(key);
+  if (it != m->end()) key = it->second;
 }
 
 class AttributeVisitor {
@@ -117,7 +116,7 @@ class AttributeVisitor {
     // We drop attributes whose keys are too long.
     if (key_.size() > kAttributeKeyStringLimit) return nullptr;
 
-    key_ = MapKey(key_);
+    MapKey(key_);
 
     auto& map = *attributes_.mutable_attribute_map();
     // We do not do any sampling. We just accept the first N attributes we are

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -304,6 +304,29 @@ TEST(AddAttribute, DropsCompositeAttributes) {
   }
 }
 
+TEST(AddAttribute, MapsKeysForCloudTrace) {
+  struct TestCase {
+    std::string input_key;
+    std::string expected_key;
+  };
+
+  for (auto const& t : std::vector<TestCase>{
+           {"http.host", "/http/host"},
+           {"http.method", "/http/method"},
+           {"http.target", "/http/path"},
+           {"http.status_code", "/http/status_code"},
+           {"http.url", "/http/url"},
+           {"http.user_agent", "/http/user_agent"},
+           {"http.request_content_length", "/http/request/size"},
+           {"http.response_content_length", "/http/response/size"},
+           {"http.scheme", "/http/client_protocol"},
+           {"http.route", "/http/route"}}) {
+    v2::Span::Attributes attributes;
+    AddAttribute(attributes, t.input_key, "value", /*limit=*/32);
+    EXPECT_THAT(attributes, Attributes(ElementsAre(Pair(t.expected_key, _))));
+  }
+}
+
 TEST(Recordable, AddEvent) {
   auto now = std::chrono::system_clock::now();
   auto expected_time = absl::FromChrono(now);


### PR DESCRIPTION
Part of the work for #11156 

Translate between OpenTelemetry semantic conventions for attribute names and Cloud Trace semantics for labels.

This is probably a "big whoop". I suspect it will matter more when we get into monitored resources. As far as I can tell this is the only difference:

![image](https://user-images.githubusercontent.com/23088558/235069032-dd53c7ee-d969-4931-aaf9-f9c0bcf90a20.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11425)
<!-- Reviewable:end -->
