### PR TITLE
ci: initial docfx publication pipeline

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -156,7 +156,7 @@ stage_docfx "google-cloud-secretmanager" "cmake-out/google/cloud/secretmanager/d
 for feature in "${FEATURE_LIST[@]}"; do
   if [[ "${feature}" == "experimental-storage-grpc" ]]; then continue; fi
   if [[ "${feature}" == "grafeas" ]]; then continue; fi
-  # TODO(#.....) - publish more documents as we gain confidence
+  # TODO(#11430) - slowly change this limit until all libraries are published
   if [[ "${feature}" < "z" ]]; then continue; fi
   upload_docfx "google-cloud-${feature}" "cmake-out/google/cloud/${feature}/docfx"
 done

--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -176,7 +176,7 @@ function (google_cloud_cpp_doxygen_targets_impl library)
             COMMAND
                 doxygen2docfx
                 "${CMAKE_CURRENT_BINARY_DIR}/xml/${library}.doxygen.xml"
-                "${library}" "${VERSION}")
+                "${library}" "${PROJECT_VERSION}")
         add_dependencies(all-docfx ${library}-docfx)
     endif ()
 endfunction ()


### PR DESCRIPTION
Change the build to start the publication of DocFX documents for `common`, `kms`, and `secretmanager`. Once these work we will add additional libraries in a series of PRs. . The reference docs are not public yet, but fine tuning the output is easier if they are published internally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11427)
<!-- Reviewable:end -->
