### PR TITLE
impl(docfx): another TOC cleanup attempt

### DIFF
--- a/docfx/doxygen_pages.cc
+++ b/docfx/doxygen_pages.cc
@@ -126,11 +126,9 @@ std::vector<TocEntry> PagesToc(Config const& cfg,
     auto const& page = i.node();
     if (!IncludeInPublicDocuments(cfg, page)) continue;
     auto const id = std::string_view{page.attribute("id").as_string()};
-    // We will skip groups with :: in their id. These are all generated pages,
-    // usually examples showing how to use a specific class. We link such
-    // examples from the landing page, and they otherwise clutter the navigation
-    // page.
-    if (id.find("::") != std::string_view::npos) continue;
+    // Skip endpoint and authorization override snippets.
+    if (id.find("-endpoint-snippet") != std::string_view::npos) continue;
+    if (id.find("-account-snippet") != std::string_view::npos) continue;
     std::ostringstream title;
     AppendTitle(title, MarkdownContext{}, page);
     auto filename =

--- a/docfx/doxygen_pages_test.cc
+++ b/docfx/doxygen_pages_test.cc
@@ -124,6 +124,20 @@ TEST(DoxygenPages, PagesToc) {
           </briefdescription>
           <detaileddescription><para>More details about the index.</para></detaileddescription>
         </compounddef>
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="secretmanager_v1_1_1SecretManagerServiceClient-endpoint-snippet" kind="page">
+          <compoundname>secretmanager_v1::SecretManagerServiceClient-endpoint-snippet</compoundname>
+          <title>Override secretmanager_v1::SecretManagerServiceClient Endpoint Configuration</title>
+          <briefdescription><para>Some brief description.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about the snippet.</para></detaileddescription>
+        </compounddef>
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="secretmanager_v1_1_1SecretManagerServiceClient-service-account-snippet" kind="page">
+          <compoundname>secretmanager_v1::SecretManagerServiceClient-service-account-snippet</compoundname>
+          <title>Override secretmanager_v1::SecretManagerServiceClient Authentication Default</title>
+          <briefdescription><para>Some brief description.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about the snippet.</para></detaileddescription>
+        </compounddef>
       </doxygen>)xml";
 
   pugi::xml_document doc;


### PR DESCRIPTION
Skipping pages with `::` in their id does not work because the snippet pages have `::` in their **name**. I realized that all the snippet pages that we generate have a more obvious pattern to search for, so let's use that.

Part of the work for #11428

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11432)
<!-- Reviewable:end -->
