### PR TITLE
docs(otel): upload docs

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -170,5 +170,6 @@ upload_docs "google-cloud-common" "cmake-out/google/cloud/html"
 for feature in "${FEATURE_LIST[@]}"; do
   if [[ "${feature}" == "experimental-storage-grpc" ]]; then continue; fi
   if [[ "${feature}" == "grafeas" ]]; then continue; fi
+  if [[ "${feature}" == "experimental-opentelemetry" ]]; then feature="opentelemetry"; fi
   upload_docs "google-cloud-${feature}" "cmake-out/google/cloud/${feature}/html"
 done

--- a/google/cloud/opentelemetry/trace_exporter.h
+++ b/google/cloud/opentelemetry/trace_exporter.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-// Make an OpenTelemetry Trace Exporter for Google Cloud Trace.
+/// Make an OpenTelemetry Trace Exporter for Google Cloud Trace.
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> MakeTraceExporter(
     Project project, Options options = {});
 


### PR DESCRIPTION
Part of the work for #11156 

In order to upload the docs for `experimental-opentelemetry`, we must drop the `experimental-` prefix.

Previously, `publish-docs` would say:
```
2023-04-28T18:35:47Z (+1000s): Directory not found: cmake-out/google/cloud/experimental-opentelemetry/html, skipping
```
e.g. https://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/11433/5c9cb195cef4fd14d845a55f9eb6a6ee6eee0985/fedora-37-cmake-publish-docs/log-61f41343-0f05-4477-8dc4-c491a50276fa.txt

Now it says:
```
--------------------------------------------------
|   Uploading docs: google-cloud-opentelemetry   |
--------------------------------------------------
2023-04-28T17:08:49Z (+978s): docs_dir=cmake-out/google/cloud/opentelemetry/html
docuploader > Wrote metadata to docs.metadata.
docuploader > Let's upload some docs!
docuploader > Loading up your metadata.
docuploader > Looks like we're uploading google-cloud-opentelemetry version HEAD for cpp.
docuploader > Sit tight, I'm tarring up your docs in ..
```

https://console.cloud.google.com/cloud-build/builds;region=us-east1/99c893d2-02aa-4b2d-828e-59475f547392;tab=detail?project=cloud-cpp-testing-resources

---

Also, while we're here, use a doxygen comment for `MakeTraceExporter`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11437)
<!-- Reviewable:end -->
