### PR TITLE
impl(otel): streaming write tracing wrapper

### DIFF
--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -73,6 +73,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/streaming_write_rpc.h",
     "internal/streaming_write_rpc_impl.h",
     "internal/streaming_write_rpc_logging.h",
+    "internal/streaming_write_rpc_tracing.h",
     "internal/time_utils.h",
     "internal/unified_grpc_credentials.h",
 ]

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -95,6 +95,7 @@ add_library(
     internal/streaming_write_rpc_impl.cc
     internal/streaming_write_rpc_impl.h
     internal/streaming_write_rpc_logging.h
+    internal/streaming_write_rpc_tracing.h
     internal/time_utils.cc
     internal/time_utils.h
     internal/unified_grpc_credentials.cc
@@ -266,6 +267,7 @@ if (BUILD_TESTING)
         internal/streaming_read_rpc_tracing_test.cc
         internal/streaming_write_rpc_logging_test.cc
         internal/streaming_write_rpc_test.cc
+        internal/streaming_write_rpc_tracing_test.cc
         internal/time_utils_test.cc
         internal/unified_grpc_credentials_test.cc)
 

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -56,6 +56,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/streaming_read_rpc_tracing_test.cc",
     "internal/streaming_write_rpc_logging_test.cc",
     "internal/streaming_write_rpc_test.cc",
+    "internal/streaming_write_rpc_tracing_test.cc",
     "internal/time_utils_test.cc",
     "internal/unified_grpc_credentials_test.cc",
 ]

--- a/google/cloud/internal/streaming_write_rpc_tracing.h
+++ b/google/cloud/internal/streaming_write_rpc_tracing.h
@@ -1,0 +1,87 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_TRACING_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_TRACING_H
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/grpc_opentelemetry.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/streaming_write_rpc.h"
+#include "google/cloud/version.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+/**
+ * Tracing decorator for StreamingWriteRpc.
+ */
+template <typename RequestType, typename ResponseType>
+class StreamingWriteRpcTracing
+    : public StreamingWriteRpc<RequestType, ResponseType> {
+ public:
+  StreamingWriteRpcTracing(
+      std::shared_ptr<grpc::ClientContext> context,
+      std::unique_ptr<StreamingWriteRpc<RequestType, ResponseType>> impl,
+      opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span)
+      : context_(std::move(context)),
+        impl_(std::move(impl)),
+        span_(std::move(span)) {}
+
+  ~StreamingWriteRpcTracing() override {
+    EndSpan(*std::move(context_), *std::move(span_), Status());
+  }
+
+  void Cancel() override {
+    span_->AddEvent("cancel");
+    impl_->Cancel();
+  }
+
+  bool Write(RequestType const& request, grpc::WriteOptions options) override {
+    auto is_last = options.is_last_message();
+    auto success = impl_->Write(request, std::move(options));
+    span_->AddEvent("message", {{"message.type", "SENT"},
+                                {"message.id", ++write_count_},
+                                {"message.is_last", is_last},
+                                {"message.success", success}});
+    return success;
+  }
+
+  StatusOr<ResponseType> Close() override {
+    span_->AddEvent("close");
+    return EndSpan(*std::move(context_), *std::move(span_), impl_->Close());
+  }
+
+  StreamingRpcMetadata GetRequestMetadata() const override {
+    return impl_->GetRequestMetadata();
+  }
+
+ private:
+  std::shared_ptr<grpc::ClientContext> context_;
+  std::unique_ptr<StreamingWriteRpc<RequestType, ResponseType>> impl_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span_;
+  int write_count_ = 0;
+};
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_TRACING_H

--- a/google/cloud/internal/streaming_write_rpc_tracing_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_tracing_test.cc
@@ -1,0 +1,179 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/streaming_write_rpc_tracing.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::EventNamed;
+using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::SpanEventAttributesAre;
+using ::google::cloud::testing_util::SpanHasAttributes;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Pair;
+using ::testing::Return;
+
+template <typename RequestType, typename ResponseType>
+class MockStreamingWriteRpc
+    : public StreamingWriteRpc<RequestType, ResponseType> {
+ public:
+  ~MockStreamingWriteRpc() override = default;
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(bool, Write, (RequestType const&, grpc::WriteOptions),
+              (override));
+  MOCK_METHOD(StatusOr<ResponseType>, Close, (), (override));
+  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+};
+
+using MockStream = MockStreamingWriteRpc<int, int>;
+using TestedStream = StreamingWriteRpcTracing<int, int>;
+
+TEST(StreamingWriteRpcTracingTest, Cancel) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Cancel).WillOnce([span] {
+    // Verify that our "cancel" event is added before calling `TryCancel()` on
+    // the underlying stream.
+    span->AddEvent("test-only: underlying stream cancel");
+  });
+  EXPECT_CALL(*mock, Close).WillOnce(Return(5));
+
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  stream.Cancel();
+  stream.Close();
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(
+          AllOf(SpanNamed("span"),
+                SpanEventsAre(EventNamed("cancel"),
+                              EventNamed("test-only: underlying stream cancel"),
+                              EventNamed("close")))));
+}
+
+TEST(StreamingWriteRpcTracingTest, Write) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Write)
+      .WillOnce(Return(true))
+      .WillOnce(Return(false))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*mock, Close).WillOnce(Return(5));
+
+  auto span = MakeSpan("span");
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  stream.Write(100, grpc::WriteOptions{});
+  stream.Write(200, grpc::WriteOptions{});
+  stream.Write(300, grpc::WriteOptions{}.set_last_message());
+  stream.Close();
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanNamed("span"),
+          SpanEventsAre(
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "SENT"),
+                        SpanAttribute<int>("message.id", 1),
+                        SpanAttribute<bool>("message.is_last", false),
+                        SpanAttribute<bool>("message.success", true))),
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "SENT"),
+                        SpanAttribute<int>("message.id", 2),
+                        SpanAttribute<bool>("message.is_last", false),
+                        SpanAttribute<bool>("message.success", false))),
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "SENT"),
+                        SpanAttribute<int>("message.id", 3),
+                        SpanAttribute<bool>("message.is_last", true),
+                        SpanAttribute<bool>("message.success", true))),
+              EventNamed("close")))));
+}
+
+TEST(StreamingWriteRpcTracingTest, Close) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Close).WillOnce(Return(5));
+
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  stream.Close();
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans,
+              ElementsAre(AllOf(SpanNamed("span"),
+                                SpanHasAttributes(SpanAttribute<std::string>(
+                                    "grpc.peer", _)))));
+}
+
+TEST(StreamingWriteRpcTracingTest, GetRequestMetadata) {
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, GetRequestMetadata)
+      .WillOnce(Return(StreamingRpcMetadata{{"key", "value"}}));
+
+  auto span = MakeSpan("span");
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  auto md = stream.GetRequestMetadata();
+  EXPECT_THAT(md, ElementsAre(Pair("key", "value")));
+}
+
+TEST(StreamingWriteRpcTracingTest, SpanEndsOnDestruction) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  {
+    auto mock = std::make_unique<MockStream>();
+    auto span = MakeSpan("span");
+    TestedStream stream(std::make_shared<grpc::ClientContext>(),
+                        std::move(mock), span);
+
+    auto spans = span_catcher->GetSpans();
+    EXPECT_THAT(spans, IsEmpty());
+  }
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, ElementsAre(SpanNamed("span")));
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY


### PR DESCRIPTION
Part of the work for #10619

If I don't get around to it, the corresponding change in the generator is here: https://github.com/dbolduc/google-cloud-cpp/tree/otel-streaming-write-stub

Leads to traces like:
![image](https://user-images.githubusercontent.com/23088558/235288349-ca0bf70b-5654-48a6-9888-1b8d5d3cda7d.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11440)
<!-- Reviewable:end -->
