### PR TITLE
ci: extend Bazel 4.2 testing for one release

### DIFF
--- a/ci/cloudbuild/builds/bazel-oldest.sh
+++ b/ci/cloudbuild/builds/bazel-oldest.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-export USE_BAZEL_VERSION=5.4.0
+export USE_BAZEL_VERSION=4.2.4
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh


### PR DESCRIPTION
This will simplify adoption by one of our customers and ease the transition to GCS+gRPC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11443)
<!-- Reviewable:end -->
