### PR TITLE
fix(storage): support per-request options

### DIFF
--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -43,7 +43,8 @@ class CurlRestClient : public RestClient {
   static std::string HostHeader(Options const& options,
                                 std::string const& endpoint);
   CurlRestClient(std::string endpoint_address,
-                 std::shared_ptr<CurlHandleFactory> factory, Options options);
+                 std::shared_ptr<CurlHandleFactory> factory,
+                 std::shared_ptr<oauth2_internal::Credentials> credentials);
   ~CurlRestClient() override = default;
 
   CurlRestClient(CurlRestClient const&) = delete;
@@ -77,7 +78,6 @@ class CurlRestClient : public RestClient {
   std::shared_ptr<CurlHandleFactory> handle_factory_;
   std::string x_goog_api_client_header_;
   std::shared_ptr<oauth2_internal::Credentials> credentials_;
-  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -43,8 +43,7 @@ class CurlRestClient : public RestClient {
   static std::string HostHeader(Options const& options,
                                 std::string const& endpoint);
   CurlRestClient(std::string endpoint_address,
-                 std::shared_ptr<CurlHandleFactory> factory,
-                 std::shared_ptr<oauth2_internal::Credentials> credentials);
+                 std::shared_ptr<CurlHandleFactory> factory, Options options);
   ~CurlRestClient() override = default;
 
   CurlRestClient(CurlRestClient const&) = delete;
@@ -71,13 +70,15 @@ class CurlRestClient : public RestClient {
       std::vector<absl::Span<char const>> const& payload) override;
 
  private:
-  StatusOr<std::unique_ptr<CurlImpl>> CreateCurlImpl(
-      RestContext const& context, RestRequest const& request);
+  StatusOr<std::unique_ptr<CurlImpl>> CreateCurlImpl(RestContext const& context,
+                                                     RestRequest const& request,
+                                                     Options const& options);
 
   std::string endpoint_address_;
   std::shared_ptr<CurlHandleFactory> handle_factory_;
   std::string x_goog_api_client_header_;
   std::shared_ptr<oauth2_internal::Credentials> credentials_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -155,13 +155,13 @@ TEST_F(RestClientIntegrationTest, Get) {
 
 TEST_F(RestClientIntegrationTest, Delete) {
   options_.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
+  options_.set<UserIpOption>("127.0.0.1");
   auto client = MakeDefaultRestClient(url_, options_);
   RestRequest request;
   request.SetPath("delete");
   request.AddQueryParameter({"key", "value"});
   auto response_status = RetryRestRequest([&] {
-    rest_internal::RestContext context(
-        Options{}.set<UserIpOption>("127.0.0.1"));
+    rest_internal::RestContext context;
     return client->Delete(context, request);
   });
   ASSERT_STATUS_OK(response_status);

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -155,13 +155,13 @@ TEST_F(RestClientIntegrationTest, Get) {
 
 TEST_F(RestClientIntegrationTest, Delete) {
   options_.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
-  options_.set<UserIpOption>("127.0.0.1");
   auto client = MakeDefaultRestClient(url_, options_);
   RestRequest request;
   request.SetPath("delete");
   request.AddQueryParameter({"key", "value"});
   auto response_status = RetryRestRequest([&] {
-    rest_internal::RestContext context;
+    rest_internal::RestContext context(
+        Options{}.set<UserIpOption>("127.0.0.1"));
     return client->Delete(context, request);
   });
   ASSERT_STATUS_OK(response_status);
@@ -531,6 +531,31 @@ TEST_F(RestClientIntegrationTest, CaptureMetadata) {
   ASSERT_STATUS_OK(body);
   auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
   ASSERT_TRUE(parsed_response.is_object()) << "body=" << *body;
+}
+
+TEST_F(RestClientIntegrationTest, PerRequestOptions) {
+  auto client = MakeDefaultRestClient(url_, {});
+  RestRequest request;
+  request.SetPath("anything");
+  auto const version = google::cloud::version_string();
+  auto const p1 = "p1/" + google::cloud::version_string();
+  auto const p2 = "p2/" + google::cloud::version_string();
+  auto response_status = RetryRestRequest([&] {
+    rest_internal::RestContext context(
+        Options{}.set<UserAgentProductsOption>({p1, p2}));
+    return client->Get(context, request);
+  });
+  ASSERT_STATUS_OK(response_status);
+  auto response = *std::move(response_status);
+  ASSERT_THAT(response->StatusCode(), Eq(HttpStatusCode::kOk));
+  auto body = ReadAll(std::move(*response).ExtractPayload());
+  ASSERT_STATUS_OK(body);
+  auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
+  ASSERT_TRUE(parsed_response.is_object()) << "body=" << *body;
+  auto headers = parsed_response.find("headers");
+  ASSERT_TRUE(headers != parsed_response.end()) << "body=" << *body;
+  EXPECT_THAT(headers->value("User-Agent", ""), HasSubstr(p1));
+  EXPECT_THAT(headers->value("User-Agent", ""), HasSubstr(p2));
 }
 
 }  // namespace

--- a/google/cloud/internal/rest_context.h
+++ b/google/cloud/internal/rest_context.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_CONTEXT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_CONTEXT_H
 
+#include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
 #include <chrono>
@@ -36,7 +37,13 @@ class RestContext {
  public:
   using HttpHeaders = std::unordered_map<std::string, std::vector<std::string>>;
   RestContext() = default;
-  explicit RestContext(HttpHeaders headers) : headers_(std::move(headers)) {}
+  explicit RestContext(Options options, HttpHeaders headers)
+      : options_(std::move(options)), headers_(std::move(headers)) {}
+  explicit RestContext(Options options) : RestContext(std::move(options), {}) {}
+  explicit RestContext(HttpHeaders headers)
+      : RestContext({}, std::move(headers)) {}
+
+  Options const& options() const { return options_; }
 
   HttpHeaders const& headers() const { return headers_; }
 
@@ -104,6 +111,7 @@ class RestContext {
 
  private:
   friend bool operator==(RestContext const& lhs, RestContext const& rhs);
+  Options options_;
   HttpHeaders headers_;
   absl::optional<std::string> local_ip_address_;
   absl::optional<std::int32_t> local_port_;

--- a/google/cloud/storage/internal/bucket_acl_requests.h
+++ b/google/cloud/storage/internal/bucket_acl_requests.h
@@ -152,6 +152,7 @@ std::ostream& operator<<(std::ostream& os, UpdateBucketAclRequest const& r);
 class PatchBucketAclRequest
     : public GenericBucketAclRequest<PatchBucketAclRequest> {
  public:
+  PatchBucketAclRequest() = default;
   PatchBucketAclRequest(std::string bucket, std::string entity,
                         BucketAccessControl const& original,
                         BucketAccessControl const& new_acl);

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -302,6 +302,10 @@ std::ostream& operator<<(std::ostream& os, GetBucketIamPolicyRequest const& r) {
   return os << "}";
 }
 
+SetNativeBucketIamPolicyRequest::SetNativeBucketIamPolicyRequest()
+    : SetNativeBucketIamPolicyRequest(
+          std::string{}, NativeIamPolicy(std::vector<NativeIamBinding>{})) {}
+
 SetNativeBucketIamPolicyRequest::SetNativeBucketIamPolicyRequest(
     std::string bucket_name, NativeIamPolicy const& policy)
     : bucket_name_(std::move(bucket_name)),

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -213,6 +213,7 @@ std::ostream& operator<<(std::ostream& os, GetBucketIamPolicyRequest const& r);
 class SetNativeBucketIamPolicyRequest
     : public GenericRequest<SetNativeBucketIamPolicyRequest, UserProject> {
  public:
+  SetNativeBucketIamPolicyRequest();
   explicit SetNativeBucketIamPolicyRequest(std::string bucket_name,
                                            NativeIamPolicy const& policy);
 

--- a/google/cloud/storage/internal/default_object_acl_requests.h
+++ b/google/cloud/storage/internal/default_object_acl_requests.h
@@ -168,6 +168,7 @@ std::ostream& operator<<(std::ostream& os,
 class PatchDefaultObjectAclRequest
     : public GenericDefaultObjectAclRequest<PatchDefaultObjectAclRequest> {
  public:
+  PatchDefaultObjectAclRequest() = default;
   PatchDefaultObjectAclRequest(std::string bucket, std::string entity,
                                ObjectAccessControl const& original,
                                ObjectAccessControl const& new_acl);

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -118,6 +118,7 @@ class ListHmacKeysRequest
     : public GenericHmacKeyRequest<ListHmacKeysRequest, Deleted, MaxResults,
                                    ServiceAccountFilter> {
  public:
+  ListHmacKeysRequest() = default;
   explicit ListHmacKeysRequest(std::string project_id)
       : GenericHmacKeyRequest(std::move(project_id)) {}
 
@@ -150,6 +151,7 @@ std::ostream& operator<<(std::ostream& os, ListHmacKeysResponse const& r);
 class DeleteHmacKeyRequest
     : public GenericHmacKeyRequest<DeleteHmacKeyRequest> {
  public:
+  DeleteHmacKeyRequest() = default;
   explicit DeleteHmacKeyRequest(std::string project_id, std::string access_id)
       : GenericHmacKeyRequest(std::move(project_id)),
         access_id_(std::move(access_id)) {}
@@ -165,6 +167,7 @@ std::ostream& operator<<(std::ostream& os, DeleteHmacKeyRequest const& r);
 /// Represents a request to call the `HmacKeys: get` API.
 class GetHmacKeyRequest : public GenericHmacKeyRequest<GetHmacKeyRequest> {
  public:
+  GetHmacKeyRequest() = default;
   explicit GetHmacKeyRequest(std::string project_id, std::string access_id)
       : GenericHmacKeyRequest(std::move(project_id)),
         access_id_(std::move(access_id)) {}
@@ -181,6 +184,7 @@ std::ostream& operator<<(std::ostream& os, GetHmacKeyRequest const& r);
 class UpdateHmacKeyRequest
     : public GenericHmacKeyRequest<UpdateHmacKeyRequest> {
  public:
+  UpdateHmacKeyRequest() = default;
   explicit UpdateHmacKeyRequest(std::string project_id, std::string access_id,
                                 HmacKeyMetadata resource)
       : GenericHmacKeyRequest(std::move(project_id)),

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -152,6 +152,7 @@ std::ostream& operator<<(std::ostream& os, UpdateObjectAclRequest const& r);
 class PatchObjectAclRequest
     : public GenericObjectAclRequest<PatchObjectAclRequest> {
  public:
+  PatchObjectAclRequest() = default;
   PatchObjectAclRequest(std::string bucket, std::string object,
                         std::string entity, ObjectAccessControl const& original,
                         ObjectAccessControl const& new_acl);

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -161,6 +161,9 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r) {
   return os << "}";
 }
 
+InsertObjectMediaRequest::InsertObjectMediaRequest()
+    : hash_function_(CreateHashFunction(*this)) {}
+
 InsertObjectMediaRequest::InsertObjectMediaRequest(std::string bucket_name,
                                                    std::string object_name,
                                                    absl::string_view payload)

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -111,8 +111,7 @@ class InsertObjectMediaRequest
           MD5HashValue, PredefinedAcl, Projection, UserProject,
           UploadFromOffset, UploadLimit, WithObjectMetadata> {
  public:
-  InsertObjectMediaRequest() = default;
-
+  InsertObjectMediaRequest();
   InsertObjectMediaRequest(std::string bucket_name, std::string object_name,
                            absl::string_view payload);
 

--- a/google/cloud/storage/internal/rest_client_test.cc
+++ b/google/cloud/storage/internal/rest_client_test.cc
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/rest_client.h"
+#include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/testing_util/mock_rest_client.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <vector>
 
@@ -23,7 +26,20 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+using ::google::cloud::internal::OptionsSpan;
+using ::google::cloud::rest_internal::RestContext;
+using ::google::cloud::rest_internal::RestRequest;
+using ::google::cloud::storage::testing::canonical_errors::PermanentError;
+using ::google::cloud::testing_util::MockRestClient;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
+using ::testing::An;
+using ::testing::ElementsAre;
 using ::testing::Eq;
+using ::testing::HasSubstr;
+using ::testing::Matcher;
+using ::testing::ResultOf;
+using ::testing::Return;
 
 TEST(RestClientTest, ResolveStorageAuthorityProdEndpoint) {
   auto options =
@@ -83,6 +99,632 @@ TEST(RestClientTest, ResolveIamAuthorityOptionSpecified) {
           .set<AuthorityOption>("auth_option_set");
   auto result_options = RestClient::ResolveIamAuthority(options);
   EXPECT_THAT(result_options.get<AuthorityOption>(), Eq("auth_option_set"));
+}
+
+Options TestOptions() {
+  return Options{}
+      .set<UserAgentProductsOption>({"p1/v1", "p2/v2"})
+      .set<TargetApiVersionOption>("vTest");
+}
+
+Matcher<RestContext&> ExpectedContext() {
+  return ResultOf(
+      "context includes UserAgentProductsOption",
+      [](RestContext& context) {
+        return context.options().get<UserAgentProductsOption>();
+      },
+      ElementsAre("p1/v1", "p2/v2"));
+}
+
+Matcher<RestRequest const&> ExpectedRequest() {
+  return ResultOf(
+      "request includes TargetApiVersionOption",
+      [](RestRequest const& r) { return r.path(); },
+      HasSubstr("storage/vTest/"));
+}
+
+Matcher<std::vector<absl::Span<char const>> const&> ExpectedPayload() {
+  return An<std::vector<absl::Span<char const>> const&>();
+}
+
+TEST(RestClientTest, ListBuckets) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(TestOptions(), mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ListBuckets(ListBucketsRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, CreateBucket) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->CreateBucket(CreateBucketRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetBucketMetadata) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetBucketMetadata(GetBucketMetadataRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, DeleteBucket) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Delete(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->DeleteBucket(DeleteBucketRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, UpdateBucket) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->UpdateBucket(UpdateBucketRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, PatchBucket) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Patch(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->PatchBucket(PatchBucketRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetNativeBucketIamPolicy) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetNativeBucketIamPolicy(GetBucketIamPolicyRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, SetNativeBucketIamPolicy) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status =
+      tested->SetNativeBucketIamPolicy(SetNativeBucketIamPolicyRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, TestBucketIamPermissions) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status =
+      tested->TestBucketIamPermissions(TestBucketIamPermissionsRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, LockBucketRetentionPolicy) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status =
+      tested->LockBucketRetentionPolicy(LockBucketRetentionPolicyRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, InsertObjectMedia) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->InsertObjectMedia(InsertObjectMediaRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetObjectMetadata) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetObjectMetadata(GetObjectMetadataRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, ReadObject) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ReadObject(ReadObjectRangeRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, ListObjects) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ListObjects(ListObjectsRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, DeleteObject) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Delete(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->DeleteObject(DeleteObjectRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, UpdateObject) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->UpdateObject(UpdateObjectRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, PatchObject) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Patch(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->PatchObject(PatchObjectRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, ComposeObject) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ComposeObject(ComposeObjectRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, CreateResumableUpload) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->CreateResumableUpload(ResumableUploadRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, QueryResumableUpload) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), _, _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->QueryResumableUpload(QueryResumableUploadRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, DeleteResumableUpload) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Delete(ExpectedContext(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->DeleteResumableUpload(DeleteResumableUploadRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, UploadChunk) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), _, _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->UploadChunk(UploadChunkRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, ListBucketAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ListBucketAcl(ListBucketAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, CopyObject) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->CopyObject(CopyObjectRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, CreateBucketAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->CreateBucketAcl(CreateBucketAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetBucketAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetBucketAcl(GetBucketAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, DeleteBucketAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Delete(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->DeleteBucketAcl(DeleteBucketAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, UpdateBucketAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->UpdateBucketAcl(UpdateBucketAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, PatchBucketAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Patch(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->PatchBucketAcl(PatchBucketAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, ListObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ListObjectAcl(ListObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, CreateObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->CreateObjectAcl(CreateObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, DeleteObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Delete(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->DeleteObjectAcl(DeleteObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetObjectAcl(GetObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, UpdateObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->UpdateObjectAcl(UpdateObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, PatchObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Patch(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->PatchObjectAcl(PatchObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, RewriteObject) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->RewriteObject(RewriteObjectRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, ListDefaultObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ListDefaultObjectAcl(ListDefaultObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, CreateDefaultObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->CreateDefaultObjectAcl(CreateDefaultObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, DeleteDefaultObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Delete(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->DeleteDefaultObjectAcl(DeleteDefaultObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetDefaultObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetDefaultObjectAcl(GetDefaultObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, UpdateDefaultObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->UpdateDefaultObjectAcl(UpdateDefaultObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, PatchDefaultObjectAcl) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Patch(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->PatchDefaultObjectAcl(PatchDefaultObjectAclRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetServiceAccount) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetServiceAccount(GetProjectServiceAccountRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, ListHmacKeys) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ListHmacKeys(ListHmacKeysRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, CreateHmacKey) {
+  auto mock = std::make_shared<MockRestClient>();
+  auto expected_payload =
+      An<std::vector<std::pair<std::string, std::string>> const&>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), expected_payload))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->CreateHmacKey(CreateHmacKeyRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, DeleteHmacKey) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Delete(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->DeleteHmacKey(DeleteHmacKeyRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetHmacKey) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetHmacKey(GetHmacKeyRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, UpdateHmacKey) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Put(ExpectedContext(), ExpectedRequest(), _))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->UpdateHmacKey(UpdateHmacKeyRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, SignBlob) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Post(ExpectedContext(), _, ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->SignBlob(SignBlobRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, ListNotifications) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->ListNotifications(ListNotificationsRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, CreateNotification) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock,
+              Post(ExpectedContext(), ExpectedRequest(), ExpectedPayload()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->CreateNotification(CreateNotificationRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, GetNotification) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->GetNotification(GetNotificationRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
+}
+
+TEST(RestClientTest, DeleteNotification) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Delete(ExpectedContext(), ExpectedRequest()))
+      .WillOnce(Return(PermanentError()));
+  auto tested = RestClient::Create(Options{}, mock, mock);
+  OptionsSpan span(TestOptions());
+  auto status = tested->DeleteNotification(DeleteNotificationRequest());
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), PermanentError().message()));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/sign_blob_requests.h
+++ b/google/cloud/storage/internal/sign_blob_requests.h
@@ -48,6 +48,7 @@ namespace internal {
 class SignBlobRequest
     : public internal::GenericRequestBase<SignBlobRequest, CustomHeader> {
  public:
+  SignBlobRequest() = default;
   explicit SignBlobRequest(std::string service_account,
                            std::string base64_encoded_blob,
                            std::vector<std::string> delegates)


### PR DESCRIPTION
With the `rest_internal::RestClient` implementation we were not respecting some per-request options. This changes the implementation of `rest_internal::RestClient` to use the options provided in `rest_internal::RestContext`. That seemed cleaner than using the options span.

I gave myself some leeway by adding default constructors to some `storage::internal::*Request` classes. It makes it easier to write unit tests where the contents of the request are uninteresting.

I included an integration test in `rest_internal::RestClient`.

Fixes #11441

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11445)
<!-- Reviewable:end -->
