### PR TITLE
impl(bigquery): Dataset and Table classes cleanup

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h"
+#include "google/cloud/internal/debug_string.h"
+#include "google/cloud/internal/format_time_point.h"
 
 namespace google {
 namespace cloud {
@@ -78,6 +80,45 @@ void from_json(nlohmann::json const& j, QueryParameterValue& q) {
     j.at("struct_values").get_to(q.struct_values);
 }
 // NOLINTEND
+
+RoundingMode RoundingMode::UnSpecified() {
+  return RoundingMode{"ROUNDING_MODE_UNSPECIFIED"};
+}
+
+RoundingMode RoundingMode::RoundHalfAwayFromZero() {
+  return RoundingMode{"ROUND_HALF_AWAY_FROM_ZERO"};
+}
+
+RoundingMode RoundingMode::RoundHalfEven() {
+  return RoundingMode{"ROUND_HALF_EVEN"};
+}
+
+std::string RoundingMode::DebugString(absl::string_view name,
+                                      TracingOptions const& options,
+                                      int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("value", value)
+      .Build();
+}
+
+std::string DatasetReference::DebugString(absl::string_view name,
+                                          TracingOptions const& options,
+                                          int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("project_id", project_id)
+      .StringField("dataset_id", dataset_id)
+      .Build();
+}
+
+std::string TableReference::DebugString(absl::string_view name,
+                                        TracingOptions const& options,
+                                        int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("project_id", project_id)
+      .StringField("dataset_id", dataset_id)
+      .StringField("table_id", table_id)
+      .Build();
+}
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
@@ -15,7 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_COMMON_V2_RESOURCES_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_COMMON_V2_RESOURCES_H
 
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <nlohmann/json.hpp>
 #include <string>
 
@@ -38,12 +40,33 @@ struct TableReference {
   std::string project_id;
   std::string dataset_id;
   std::string table_id;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct DatasetReference {
   std::string dataset_id;
   std::string project_id;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
+
+struct RoundingMode {
+  static RoundingMode UnSpecified();
+  static RoundingMode RoundHalfAwayFromZero();
+  static RoundingMode RoundHalfEven();
+
+  std::string value;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(RoundingMode, value);
 
 // Self referential and circular structures below is based on the bigquery v2
 // QueryParameterType and QueryParameterValue proto definitions. Disabling

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources_test.cc
@@ -311,6 +311,143 @@ TEST(CommonV2ResourcesTest, QueryParameterToJson) {
   EXPECT_EQ(j, expected_text);
 }
 
+TEST(CommonV2ResourcesTest, DatasetReferenceFromJson) {
+  std::string text =
+      R"({
+          "dataset_id":"d123",
+          "project_id":"p123"
+      })";
+  auto json = nlohmann::json::parse(text, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  DatasetReference actual;
+  from_json(json, actual);
+
+  DatasetReference expected;
+  expected.dataset_id = "d123";
+  expected.project_id = "p123";
+
+  EXPECT_EQ(expected.dataset_id, actual.dataset_id);
+  EXPECT_EQ(expected.project_id, actual.project_id);
+}
+
+TEST(CommonV2ResourcesTest, DatasetReferenceToJson) {
+  auto const expected_json =
+      R"({
+          "dataset_id":"d123",
+          "project_id":"p123"
+      })"_json;
+
+  DatasetReference expected;
+  expected.dataset_id = "d123";
+  expected.project_id = "p123";
+
+  nlohmann::json actual_json;
+  to_json(actual_json, expected);
+
+  EXPECT_EQ(expected_json, actual_json);
+}
+
+TEST(CommonV2ResourcesTest, TableReferenceFromJson) {
+  std::string text =
+      R"({
+          "dataset_id":"d123",
+          "project_id":"p123",
+          "table_id":"t123"
+      })";
+  auto json = nlohmann::json::parse(text, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  TableReference actual;
+  from_json(json, actual);
+
+  TableReference expected;
+  expected.dataset_id = "d123";
+  expected.project_id = "p123";
+  expected.table_id = "t123";
+
+  EXPECT_EQ(expected.dataset_id, actual.dataset_id);
+  EXPECT_EQ(expected.project_id, actual.project_id);
+  EXPECT_EQ(expected.table_id, actual.table_id);
+}
+
+TEST(CommonV2ResourcesTest, TableReferenceToJson) {
+  auto const expected_json =
+      R"({
+          "dataset_id":"d123",
+          "project_id":"p123",
+          "table_id":"t123"
+      })"_json;
+
+  TableReference expected;
+  expected.dataset_id = "d123";
+  expected.project_id = "p123";
+  expected.table_id = "t123";
+
+  nlohmann::json actual_json;
+  to_json(actual_json, expected);
+
+  EXPECT_EQ(expected_json, actual_json);
+}
+
+TEST(CommonV2ResourcesTest, DatasetReferenceDebugString) {
+  DatasetReference dataset;
+  dataset.dataset_id = "d123";
+  dataset.project_id = "p123";
+
+  EXPECT_EQ(dataset.DebugString("DatasetReference", TracingOptions{}),
+            R"(DatasetReference {)"
+            R"( project_id: "p123")"
+            R"( dataset_id: "d123")"
+            R"( })");
+
+  EXPECT_EQ(dataset.DebugString("DatasetReference",
+                                TracingOptions{}.SetOptions(
+                                    "truncate_string_field_longer_than=2")),
+            R"(DatasetReference {)"
+            R"( project_id: "p1...<truncated>...")"
+            R"( dataset_id: "d1...<truncated>...")"
+            R"( })");
+
+  EXPECT_EQ(dataset.DebugString("DatasetReference", TracingOptions{}.SetOptions(
+                                                        "single_line_mode=F")),
+            R"(DatasetReference {
+  project_id: "p123"
+  dataset_id: "d123"
+})");
+}
+
+TEST(CommonV2ResourcesTest, TableReferenceDebugString) {
+  TableReference table;
+  table.dataset_id = "d123";
+  table.project_id = "p123";
+  table.table_id = "t123";
+
+  EXPECT_EQ(table.DebugString("TableReference", TracingOptions{}),
+            R"(TableReference {)"
+            R"( project_id: "p123")"
+            R"( dataset_id: "d123")"
+            R"( table_id: "t123")"
+            R"( })");
+
+  EXPECT_EQ(table.DebugString("TableReference",
+                              TracingOptions{}.SetOptions(
+                                  "truncate_string_field_longer_than=2")),
+            R"(TableReference {)"
+            R"( project_id: "p1...<truncated>...")"
+            R"( dataset_id: "d1...<truncated>...")"
+            R"( table_id: "t1...<truncated>...")"
+            R"( })");
+
+  EXPECT_EQ(table.DebugString("TableReference", TracingOptions{}.SetOptions(
+                                                    "single_line_mode=F")),
+            R"(TableReference {
+  project_id: "p123"
+  dataset_id: "d123"
+  table_id: "t123"
+})");
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/dataset.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset.cc
@@ -22,59 +22,24 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StorageBillingModel StorageBillingModel::UnSpecified() {
-  StorageBillingModel model;
-  model.value = "STORAGE_BILLING_MODEL_UNSPECIFIED";
-  return model;
+  return StorageBillingModel{"STORAGE_BILLING_MODEL_UNSPECIFIED"};
 }
 
 StorageBillingModel StorageBillingModel::Logical() {
-  StorageBillingModel model;
-  model.value = "LOGICAL";
-  return model;
+  return StorageBillingModel{"LOGICAL"};
 }
 
 StorageBillingModel StorageBillingModel::Physical() {
-  StorageBillingModel model;
-  model.value = "PHYSICAL";
-  return model;
+  return StorageBillingModel{"PHYSICAL"};
 }
 
 TargetType TargetType::UnSpecified() {
-  TargetType type;
-  type.value = "TARGET_TYPE_UNSPECIFIED";
-  return type;
+  return TargetType{"TARGET_TYPE_UNSPECIFIED"};
 }
 
-TargetType TargetType::Views() {
-  TargetType type;
-  type.value = "VIEWS";
-  return type;
-}
+TargetType TargetType::Views() { return TargetType{"VIEWS"}; }
 
-TargetType TargetType::Routines() {
-  TargetType type;
-  type.value = "ROUTINES";
-  return type;
-}
-
-TableFieldSchemaRoundingMode TableFieldSchemaRoundingMode::UnSpecified() {
-  TableFieldSchemaRoundingMode mode;
-  mode.value = "ROUNDING_MODE_UNSPECIFIED";
-  return mode;
-}
-
-TableFieldSchemaRoundingMode
-TableFieldSchemaRoundingMode::RoundHalfAwayFromZero() {
-  TableFieldSchemaRoundingMode mode;
-  mode.value = "ROUND_HALF_AWAY_FROM_ZERO";
-  return mode;
-}
-
-TableFieldSchemaRoundingMode TableFieldSchemaRoundingMode::RoundHalfEven() {
-  TableFieldSchemaRoundingMode mode;
-  mode.value = "ROUND_HALF_EVEN";
-  return mode;
-}
+TargetType TargetType::Routines() { return TargetType{"ROUTINES"}; }
 
 void to_json(nlohmann::json& j, Dataset const& d) {
   j = nlohmann::json{
@@ -175,25 +140,6 @@ void from_json(nlohmann::json const& j, Dataset& d) {
     j.at("storage_billing_model").get_to(d.storage_billing_model);
 }
 
-std::string DatasetReference::DebugString(absl::string_view name,
-                                          TracingOptions const& options,
-                                          int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("project_id", project_id)
-      .StringField("dataset_id", dataset_id)
-      .Build();
-}
-
-std::string TableReference::DebugString(absl::string_view name,
-                                        TracingOptions const& options,
-                                        int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("project_id", project_id)
-      .StringField("dataset_id", dataset_id)
-      .StringField("table_id", table_id)
-      .Build();
-}
-
 std::string LinkedDatasetSource::DebugString(absl::string_view name,
                                              TracingOptions const& options,
                                              int indent) const {
@@ -225,13 +171,6 @@ std::string StorageBillingModel::DebugString(absl::string_view name,
                                              int indent) const {
   return internal::DebugFormatter(name, options, indent)
       .StringField("storage_billing_model_value", value)
-      .Build();
-}
-
-std::string TableFieldSchemaRoundingMode::DebugString(
-    absl::string_view name, TracingOptions const& options, int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("rounding_mode_value", value)
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/dataset.h
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset.h
@@ -15,6 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_DATASET_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_DATASET_H
 
+#include "google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h"
+#include "google/cloud/bigquery/v2/minimal/internal/table_schema.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
@@ -58,31 +60,6 @@ struct TargetType {
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(TargetType, value);
 
-struct TableFieldSchemaRoundingMode {
-  static TableFieldSchemaRoundingMode UnSpecified();
-  static TableFieldSchemaRoundingMode RoundHalfAwayFromZero();
-  static TableFieldSchemaRoundingMode RoundHalfEven();
-
-  std::string value;
-
-  std::string DebugString(absl::string_view name,
-                          TracingOptions const& options = {},
-                          int indent = 0) const;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(TableFieldSchemaRoundingMode,
-                                                value);
-
-struct DatasetReference {
-  std::string dataset_id;
-  std::string project_id;
-
-  std::string DebugString(absl::string_view name,
-                          TracingOptions const& options = {},
-                          int indent = 0) const;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(DatasetReference, dataset_id,
-                                                project_id);
-
 struct LinkedDatasetSource {
   DatasetReference source_dataset;
 
@@ -92,18 +69,6 @@ struct LinkedDatasetSource {
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(LinkedDatasetSource,
                                                 source_dataset);
-
-struct TableReference {
-  std::string project_id;
-  std::string dataset_id;
-  std::string table_id;
-
-  std::string DebugString(absl::string_view name,
-                          TracingOptions const& options = {},
-                          int indent = 0) const;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(TableReference, dataset_id,
-                                                project_id, table_id);
 
 struct RoutineReference {
   std::string project_id;
@@ -227,7 +192,7 @@ struct Dataset {
   DatasetReference dataset_reference;
   LinkedDatasetSource linked_dataset_source;
   ExternalDatasetReference external_dataset_reference;
-  TableFieldSchemaRoundingMode default_rounding_mode;
+  RoundingMode default_rounding_mode;
 
   StorageBillingModel storage_billing_model;
 

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
@@ -224,7 +224,7 @@ TEST(GetDatasetResponseTest, DebugString) {
             R"( })"
             R"( })"
             R"( default_rounding_mode {)"
-            R"( rounding_mode_value: "")"
+            R"( value: "")"
             R"( })"
             R"( storage_billing_model {)"
             R"( storage_billing_model_value: "")"
@@ -283,7 +283,7 @@ TEST(GetDatasetResponseTest, DebugString) {
             R"( })"
             R"( })"
             R"( default_rounding_mode {)"
-            R"( rounding_mode_value: "")"
+            R"( value: "")"
             R"( })"
             R"( storage_billing_model {)"
             R"( storage_billing_model_value: "")"
@@ -352,7 +352,7 @@ TEST(GetDatasetResponseTest, DebugString) {
       }
     }
     default_rounding_mode {
-      rounding_mode_value: ""
+      value: ""
     }
     storage_billing_model {
       storage_billing_model_value: ""

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_test.cc
@@ -92,8 +92,7 @@ Dataset MakeDataset() {
   expected.linked_dataset_source.source_dataset = dataset_ref;
   expected.external_dataset_reference.hive_database.catalog_id = "c1";
   expected.external_dataset_reference.hive_database.database = "d1";
-  expected.default_rounding_mode =
-      TableFieldSchemaRoundingMode::RoundHalfEven();
+  expected.default_rounding_mode = RoundingMode::RoundHalfEven();
   expected.storage_billing_model = StorageBillingModel::Logical();
 
   return expected;
@@ -370,7 +369,7 @@ TEST(DatasetTest, DatasetDebugString) {
       R"( })"
       R"( })"
       R"( default_rounding_mode {)"
-      R"( rounding_mode_value: "ROUND_HALF_EVEN")"
+      R"( value: "ROUND_HALF_EVEN")"
       R"( })"
       R"( storage_billing_model { storage_billing_model_value: "LOGICAL" })"
       R"( })");
@@ -429,7 +428,7 @@ TEST(DatasetTest, DatasetDebugString) {
       R"( })"
       R"( })"
       R"( default_rounding_mode {)"
-      R"( rounding_mode_value: "ROUND_H...<truncated>...")"
+      R"( value: "ROUND_H...<truncated>...")"
       R"( })"
       R"( storage_billing_model { storage_billing_model_value: "LOGICAL" })"
       R"( })");
@@ -525,7 +524,7 @@ TEST(DatasetTest, DatasetDebugString) {
     }
   }
   default_rounding_mode {
-    rounding_mode_value: "ROUND_HALF_EVEN"
+    value: "ROUND_HALF_EVEN"
   }
   storage_billing_model {
     storage_billing_model_value: "LOGICAL"

--- a/google/cloud/bigquery/v2/minimal/internal/table_schema.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_schema.cc
@@ -20,18 +20,6 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-RoundingMode RoundingMode::UnSpecified() {
-  return RoundingMode{"ROUNDING_MODE_UNSPECIFIED"};
-}
-
-RoundingMode RoundingMode::RoundHalfAwayFromZero() {
-  return RoundingMode{"ROUND_HALF_AWAY_FROM_ZERO"};
-}
-
-RoundingMode RoundingMode::RoundHalfEven() {
-  return RoundingMode{"ROUND_HALF_EVEN"};
-}
-
 // NOLINTBEGIN
 void to_json(nlohmann::json& j,
              std::vector<std::shared_ptr<TableFieldSchema>> const& t) {

--- a/google/cloud/bigquery/v2/minimal/internal/table_schema.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table_schema.h
@@ -46,15 +46,6 @@ struct DataClassificationTagList {
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(DataClassificationTagList,
                                                 names);
 
-struct RoundingMode {
-  static RoundingMode UnSpecified();
-  static RoundingMode RoundHalfAwayFromZero();
-  static RoundingMode RoundHalfEven();
-
-  std::string value;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(RoundingMode, value);
-
 struct FieldElementType {
   std::string type;
 };


### PR DESCRIPTION
This PR contains following refactor/cleanup specific to Dataset and Table custom classes

1) Deduplicated common resources used by both Dataset and Table classes by moving them to common_v2_resources.h

2) Cleanup of enum values

3) Added unit tests for the resources moved to common_v2_resources

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11465)
<!-- Reviewable:end -->
