### PR TITLE
cleanup: use canonical references to google protobuf

### DIFF
--- a/google/cloud/internal/rest_stub_helpers.cc
+++ b/google/cloud/internal/rest_stub_helpers.cc
@@ -48,7 +48,7 @@ Status RestResponseToProto(google::protobuf::Message& destination,
 Status ProtoRequestToJsonPayload(google::protobuf::Message const& request,
                                  std::string& json_payload) {
   auto proto_to_json_status =
-      protobuf::util::MessageToJsonString(request, &json_payload);
+      google::protobuf::util::MessageToJsonString(request, &json_payload);
   if (!proto_to_json_status.ok()) {
     return internal::InternalError(
         std::string(proto_to_json_status.message()),

--- a/google/cloud/internal/rest_stub_helpers.h
+++ b/google/cloud/internal/rest_stub_helpers.h
@@ -22,7 +22,7 @@
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include "google/protobuf/util/json_util.h"
+#include <google/protobuf/util/json_util.h>
 #include <string>
 
 namespace google {


### PR DESCRIPTION
Use the canonical include syntax and namespace qualification for Google Protobuf references so that downstream code-rewriting rules are applied correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11471)
<!-- Reviewable:end -->
