### PR TITLE
impl(bigquery): Table custom classes logging

### DIFF
--- a/google/cloud/bigquery/bigquery_rest.cmake
+++ b/google/cloud/bigquery/bigquery_rest.cmake
@@ -75,7 +75,9 @@ add_library(
     v2/minimal/internal/rest_stub_utils.h
     v2/minimal/internal/table.cc
     v2/minimal/internal/table.h
+    v2/minimal/internal/table_constraints.cc
     v2/minimal/internal/table_constraints.h
+    v2/minimal/internal/table_partition.cc
     v2/minimal/internal/table_partition.h
     v2/minimal/internal/table_schema.cc
     v2/minimal/internal/table_schema.h

--- a/google/cloud/bigquery/google_cloud_cpp_bigquery_rest.bzl
+++ b/google/cloud/bigquery/google_cloud_cpp_bigquery_rest.bzl
@@ -83,6 +83,8 @@ google_cloud_cpp_bigquery_rest_srcs = [
     "v2/minimal/internal/job_rest_stub.cc",
     "v2/minimal/internal/job_rest_stub_factory.cc",
     "v2/minimal/internal/table.cc",
+    "v2/minimal/internal/table_constraints.cc",
+    "v2/minimal/internal/table_partition.cc",
     "v2/minimal/internal/table_schema.cc",
     "v2/minimal/internal/table_view.cc",
 ]

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
@@ -93,6 +93,16 @@ RoundingMode RoundingMode::RoundHalfEven() {
   return RoundingMode{"ROUND_HALF_EVEN"};
 }
 
+std::string ErrorProto::DebugString(absl::string_view name,
+                                    TracingOptions const& options,
+                                    int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("reason", reason)
+      .StringField("location", location)
+      .StringField("message", message)
+      .Build();
+}
+
 std::string RoundingMode::DebugString(absl::string_view name,
                                       TracingOptions const& options,
                                       int indent) const {

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
@@ -34,6 +34,10 @@ struct ErrorProto {
   std::string reason;
   std::string location;
   std::string message;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct TableReference {

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources_test.cc
@@ -448,6 +448,37 @@ TEST(CommonV2ResourcesTest, TableReferenceDebugString) {
 })");
 }
 
+TEST(CommonV2ResourcesTest, ErrorProtoDebugString) {
+  ErrorProto error;
+  error.reason = "e-reason";
+  error.location = "e-loc";
+  error.message = "e-mesg";
+
+  EXPECT_EQ(error.DebugString("ErrorProto", TracingOptions{}),
+            R"(ErrorProto {)"
+            R"( reason: "e-reason")"
+            R"( location: "e-loc")"
+            R"( message: "e-mesg")"
+            R"( })");
+
+  EXPECT_EQ(error.DebugString("ErrorProto",
+                              TracingOptions{}.SetOptions(
+                                  "truncate_string_field_longer_than=2")),
+            R"(ErrorProto {)"
+            R"( reason: "e-...<truncated>...")"
+            R"( location: "e-...<truncated>...")"
+            R"( message: "e-...<truncated>...")"
+            R"( })");
+
+  EXPECT_EQ(error.DebugString("ErrorProto", TracingOptions{}.SetOptions(
+                                                "single_line_mode=F")),
+            R"(ErrorProto {
+  reason: "e-reason"
+  location: "e-loc"
+  message: "e-mesg"
+})");
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/table.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table.cc
@@ -86,14 +86,11 @@ std::string ListFormatView::DebugString(absl::string_view name,
 std::string HivePartitioningOptions::DebugString(absl::string_view name,
                                                  TracingOptions const& options,
                                                  int indent) const {
-  // DebugFormatter does not support std::vector<std::string> currently.
-  // Uncomment the `fields` value once the support is available.
   return internal::DebugFormatter(name, options, indent)
       .StringField("mode", mode)
       .StringField("source_uri_prefix", source_uri_prefix)
       .Field("require_partition_filter", require_partition_filter)
-      .Field("num_fields", fields.size())
-      // .Field("fields", fields)
+      .Field("fields", fields)
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/table.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table.cc
@@ -13,12 +13,109 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/table.h"
+#include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/format_time_point.h"
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::string CloneDefinition::DebugString(absl::string_view name,
+                                         TracingOptions const& options,
+                                         int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .SubMessage("base_table_reference", base_table_reference)
+      .Field("clone_time", clone_time)
+      .Build();
+}
+
+std::string Table::DebugString(absl::string_view name,
+                               TracingOptions const& options,
+                               int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("kind", kind)
+      .StringField("etag", etag)
+      .StringField("id", id)
+      .StringField("self_link", self_link)
+      .StringField("friendly_name", friendly_name)
+      .StringField("description", description)
+      .StringField("type", type)
+      .StringField("location", location)
+      .StringField("default_collation", default_collation)
+      .StringField("max_staleness", max_staleness)
+      .Field("require_partition_filter", require_partition_filter)
+      .Field("case_insensitive", case_insensitive)
+      .Field("creation_time", creation_time)
+      .Field("expiration_time", expiration_time)
+      .Field("last_modified_time", last_modified_time)
+      .Field("num_time_travel_physical_bytes", num_time_travel_physical_bytes)
+      .Field("num_total_logical_bytes", num_total_logical_bytes)
+      .Field("num_active_logical_bytes", num_active_logical_bytes)
+      .Field("num_long_term_logical_bytes", num_long_term_logical_bytes)
+      .Field("num_total_physical_bytes", num_total_physical_bytes)
+      .Field("num_active_physical_bytes", num_active_physical_bytes)
+      .Field("num_long_term_physical_bytes", num_long_term_physical_bytes)
+      .Field("num_partitions", num_partitions)
+      .Field("num_bytes", num_bytes)
+      .Field("num_physical_bytes", num_physical_bytes)
+      .Field("num_long_term_bytes", num_long_term_bytes)
+      .Field("labels", labels)
+      .SubMessage("table_reference", table_reference)
+      .SubMessage("schema", schema)
+      .SubMessage("default_rounding_mode", default_rounding_mode)
+      .SubMessage("time_partitioning", time_partitioning)
+      .SubMessage("range_partitioning", range_partitioning)
+      .SubMessage("clustering", clustering)
+      .SubMessage("clone_definition", clone_definition)
+      .SubMessage("table_constraints", table_constraints)
+      .SubMessage("view", view)
+      .SubMessage("materialized_view", materialized_view)
+      .SubMessage("materialized_view_status", materialized_view_status)
+      .Build();
+}
+
+std::string ListFormatView::DebugString(absl::string_view name,
+                                        TracingOptions const& options,
+                                        int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .Field("use_legacy_sql", use_legacy_sql)
+      .Build();
+}
+
+std::string HivePartitioningOptions::DebugString(absl::string_view name,
+                                                 TracingOptions const& options,
+                                                 int indent) const {
+  // DebugFormatter does not support std::vector<std::string> currently.
+  // Uncomment the `fields` value once the support is available.
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("mode", mode)
+      .StringField("source_uri_prefix", source_uri_prefix)
+      .Field("require_partition_filter", require_partition_filter)
+      .Field("num_fields", fields.size())
+      // .Field("fields", fields)
+      .Build();
+}
+
+std::string ListFormatTable::DebugString(absl::string_view name,
+                                         TracingOptions const& options,
+                                         int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("kind", kind)
+      .StringField("id", id)
+      .StringField("friendly_name", friendly_name)
+      .StringField("type", type)
+      .SubMessage("table_reference", table_reference)
+      .SubMessage("time_partitioning", time_partitioning)
+      .SubMessage("range_partitioning", range_partitioning)
+      .SubMessage("clustering", clustering)
+      .SubMessage("hive_partitioning_options", hive_partitioning_options)
+      .SubMessage("view", view)
+      .Field("labels", labels)
+      .Field("creation_time", creation_time)
+      .Field("expiration_time", expiration_time)
+      .Build();
+}
 
 void to_json(nlohmann::json& j, CloneDefinition const& c) {
   j = nlohmann::json{

--- a/google/cloud/bigquery/v2/minimal/internal/table.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigquery/v2/minimal/internal/table_partition.h"
 #include "google/cloud/bigquery/v2/minimal/internal/table_schema.h"
 #include "google/cloud/bigquery/v2/minimal/internal/table_view.h"
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -39,6 +40,10 @@ using namespace nlohmann::literals;  // NOLINT
 struct CloneDefinition {
   TableReference base_table_reference;
   std::chrono::system_clock::time_point clone_time;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct Table {
@@ -88,10 +93,18 @@ struct Table {
   ViewDefinition view;
   MaterializedViewDefinition materialized_view;
   MaterializedViewStatus materialized_view_status;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct ListFormatView {
   bool use_legacy_sql = false;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ListFormatView, use_legacy_sql);
 
@@ -102,6 +115,10 @@ struct HivePartitioningOptions {
   bool require_partition_filter = false;
 
   std::vector<std::string> fields;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(HivePartitioningOptions, mode,
                                                 source_uri_prefix,
@@ -124,6 +141,10 @@ struct ListFormatTable {
   std::map<std::string, std::string> labels;
   std::chrono::milliseconds creation_time = std::chrono::milliseconds(0);
   std::chrono::milliseconds expiration_time = std::chrono::milliseconds(0);
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 void to_json(nlohmann::json& j, CloneDefinition const& c);

--- a/google/cloud/bigquery/v2/minimal/internal/table_constraints.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_constraints.cc
@@ -24,11 +24,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string PrimaryKey::DebugString(absl::string_view name,
                                     TracingOptions const& options,
                                     int indent) const {
-  // DebugFormatter does not support std::vector<std::string> currently.
-  // Uncomment the `columns` value once the support is available.
   return internal::DebugFormatter(name, options, indent)
-      .Field("num_columns", columns.size())
-      // .Field("columns", columns)
+      .Field("columns", columns)
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/table_constraints.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_constraints.cc
@@ -1,0 +1,66 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/v2/minimal/internal/table_constraints.h"
+#include "google/cloud/internal/debug_string.h"
+#include "google/cloud/internal/format_time_point.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::string PrimaryKey::DebugString(absl::string_view name,
+                                    TracingOptions const& options,
+                                    int indent) const {
+  // DebugFormatter does not support std::vector<std::string> currently.
+  // Uncomment the `columns` value once the support is available.
+  return internal::DebugFormatter(name, options, indent)
+      .Field("num_columns", columns.size())
+      // .Field("columns", columns)
+      .Build();
+}
+
+std::string ColumnReference::DebugString(absl::string_view name,
+                                         TracingOptions const& options,
+                                         int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("referencing_column", referencing_column)
+      .StringField("referenced_column", referenced_column)
+      .Build();
+}
+
+std::string ForeignKey::DebugString(absl::string_view name,
+                                    TracingOptions const& options,
+                                    int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("key_name", key_name)
+      .SubMessage("referenced_table", referenced_table)
+      .Field("column_references", column_references)
+      .Build();
+}
+
+std::string TableConstraints::DebugString(absl::string_view name,
+                                          TracingOptions const& options,
+                                          int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .SubMessage("primary_key", primary_key)
+      .Field("foreign_keys", foreign_keys)
+      .Build();
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigquery_v2_minimal_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/table_constraints.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table_constraints.h
@@ -17,7 +17,9 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h"
 #include "google/cloud/bigquery/v2/minimal/internal/table_partition.h"
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <string>
@@ -33,29 +35,45 @@ using namespace nlohmann::literals;  // NOLINT
 
 struct PrimaryKey {
   std::vector<std::string> columns;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(PrimaryKey, columns);
 
 struct ColumnReference {
   std::string referencing_column;
   std::string referenced_column;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ColumnReference,
                                                 referencing_column,
                                                 referenced_column);
 
 struct ForeignKey {
-  std::string name;
+  std::string key_name;
   TableReference referenced_table;
   std::vector<ColumnReference> column_references;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ForeignKey, name,
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ForeignKey, key_name,
                                                 referenced_table,
                                                 column_references);
 
 struct TableConstraints {
   PrimaryKey primary_key;
   std::vector<ForeignKey> foreign_keys;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(TableConstraints, primary_key,
                                                 foreign_keys);

--- a/google/cloud/bigquery/v2/minimal/internal/table_partition.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_partition.cc
@@ -53,11 +53,8 @@ std::string RangePartitioning::DebugString(absl::string_view name,
 std::string Clustering::DebugString(absl::string_view name,
                                     TracingOptions const& options,
                                     int indent) const {
-  // DebugFormatter does not support std::vector<std::string> currently.
-  // Uncomment the `fields` value once the support is available.
   return internal::DebugFormatter(name, options, indent)
-      .Field("num_fields", fields.size())
-      // .Field("fields", fields)
+      .Field("fields", fields)
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/table_partition.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_partition.cc
@@ -1,0 +1,67 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/v2/minimal/internal/table_partition.h"
+#include "google/cloud/internal/debug_string.h"
+#include "google/cloud/internal/format_time_point.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery_v2_minimal_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::string TimePartitioning::DebugString(absl::string_view name,
+                                          TracingOptions const& options,
+                                          int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("type", type)
+      .Field("expiration_time", expiration_time)
+      .StringField("field", field)
+      .Build();
+}
+
+std::string Range::DebugString(absl::string_view name,
+                               TracingOptions const& options,
+                               int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("start", start)
+      .StringField("end", end)
+      .StringField("interval", interval)
+      .Build();
+}
+
+std::string RangePartitioning::DebugString(absl::string_view name,
+                                           TracingOptions const& options,
+                                           int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("field", field)
+      .SubMessage("range", range)
+      .Build();
+}
+
+std::string Clustering::DebugString(absl::string_view name,
+                                    TracingOptions const& options,
+                                    int indent) const {
+  // DebugFormatter does not support std::vector<std::string> currently.
+  // Uncomment the `fields` value once the support is available.
+  return internal::DebugFormatter(name, options, indent)
+      .Field("num_fields", fields.size())
+      // .Field("fields", fields)
+      .Build();
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigquery_v2_minimal_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/v2/minimal/internal/table_partition.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table_partition.h
@@ -15,7 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_TABLE_PARTITION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_TABLE_PARTITION_H
 
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <string>
@@ -33,24 +35,40 @@ struct TimePartitioning {
   std::string type;
   std::chrono::milliseconds expiration_time;
   std::string field;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct Range {
   std::string start;
   std::string end;
   std::string interval;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Range, start, end, interval);
 
 struct RangePartitioning {
   std::string field;
   Range range;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(RangePartitioning, field,
                                                 range);
 
 struct Clustering {
   std::vector<std::string> fields;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Clustering, fields);
 

--- a/google/cloud/bigquery/v2/minimal/internal/table_schema.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_schema.cc
@@ -24,22 +24,16 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string CategoryList::DebugString(absl::string_view name,
                                       TracingOptions const& options,
                                       int indent) const {
-  // DebugFormatter does not support std::vector<std::string> currently.
-  // Uncomment the `names` value once the support is available.
   return internal::DebugFormatter(name, options, indent)
-      .Field("num_names", names.size())
-      //   .Field("names", names)
+      .Field("names", names)
       .Build();
 }
 
 std::string PolicyTagList::DebugString(absl::string_view name,
                                        TracingOptions const& options,
                                        int indent) const {
-  // DebugFormatter does not support std::vector<std::string> currently.
-  // Uncomment the `names` value once the support is available.
   return internal::DebugFormatter(name, options, indent)
-      .Field("num_names", names.size())
-      //   .Field("names", names)
+      .Field("names", names)
       .Build();
 }
 
@@ -53,19 +47,14 @@ std::string FieldElementType::DebugString(absl::string_view name,
 
 std::string DataClassificationTagList::DebugString(
     absl::string_view name, TracingOptions const& options, int indent) const {
-  // DebugFormatter does not support std::vector<std::string> currently.
-  // Uncomment the `names` value once the support is available.
   return internal::DebugFormatter(name, options, indent)
-      .Field("num_names", names.size())
-      // .Field("names", names)
+      .Field("names", names)
       .Build();
 }
 
 std::string TableFieldSchema::DebugString(absl::string_view fname,
                                           TracingOptions const& options,
                                           int indent) const {
-  // DebugFormatter does not support std::vector<std::string> currently.
-  // Uncomment the `fields` value once the support is available.
   return internal::DebugFormatter(fname, options, indent)
       .StringField("name", name)
       .StringField("type", type)
@@ -77,8 +66,6 @@ std::string TableFieldSchema::DebugString(absl::string_view fname,
       .Field("precision", precision)
       .Field("scale", scale)
       .Field("is_measure", is_measure)
-      .Field("num_fields", fields.size())
-      // .Field("fields", fields)
       .SubMessage("categories", categories)
       .SubMessage("policy_tags", policy_tags)
       .SubMessage("data_classification_tags", data_classification_tags)

--- a/google/cloud/bigquery/v2/minimal/internal/table_schema.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_schema.cc
@@ -13,12 +13,87 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/table_schema.h"
+#include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/format_time_point.h"
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::string CategoryList::DebugString(absl::string_view name,
+                                      TracingOptions const& options,
+                                      int indent) const {
+  // DebugFormatter does not support std::vector<std::string> currently.
+  // Uncomment the `names` value once the support is available.
+  return internal::DebugFormatter(name, options, indent)
+      .Field("num_names", names.size())
+      //   .Field("names", names)
+      .Build();
+}
+
+std::string PolicyTagList::DebugString(absl::string_view name,
+                                       TracingOptions const& options,
+                                       int indent) const {
+  // DebugFormatter does not support std::vector<std::string> currently.
+  // Uncomment the `names` value once the support is available.
+  return internal::DebugFormatter(name, options, indent)
+      .Field("num_names", names.size())
+      //   .Field("names", names)
+      .Build();
+}
+
+std::string FieldElementType::DebugString(absl::string_view name,
+                                          TracingOptions const& options,
+                                          int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("type", type)
+      .Build();
+}
+
+std::string DataClassificationTagList::DebugString(
+    absl::string_view name, TracingOptions const& options, int indent) const {
+  // DebugFormatter does not support std::vector<std::string> currently.
+  // Uncomment the `names` value once the support is available.
+  return internal::DebugFormatter(name, options, indent)
+      .Field("num_names", names.size())
+      // .Field("names", names)
+      .Build();
+}
+
+std::string TableFieldSchema::DebugString(absl::string_view fname,
+                                          TracingOptions const& options,
+                                          int indent) const {
+  // DebugFormatter does not support std::vector<std::string> currently.
+  // Uncomment the `fields` value once the support is available.
+  return internal::DebugFormatter(fname, options, indent)
+      .StringField("name", name)
+      .StringField("type", type)
+      .StringField("mode", mode)
+      .StringField("description", description)
+      .StringField("collation", collation)
+      .StringField("default_value_expression", default_value_expression)
+      .Field("max_length", max_length)
+      .Field("precision", precision)
+      .Field("scale", scale)
+      .Field("is_measure", is_measure)
+      .Field("num_fields", fields.size())
+      // .Field("fields", fields)
+      .SubMessage("categories", categories)
+      .SubMessage("policy_tags", policy_tags)
+      .SubMessage("data_classification_tags", data_classification_tags)
+      .SubMessage("rounding_mode", rounding_mode)
+      .SubMessage("range_element_type", range_element_type)
+      .Build();
+}
+
+std::string TableSchema::DebugString(absl::string_view name,
+                                     TracingOptions const& options,
+                                     int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .Field("fields", fields)
+      .Build();
+}
 
 // NOLINTBEGIN
 void to_json(nlohmann::json& j,

--- a/google/cloud/bigquery/v2/minimal/internal/table_schema.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table_schema.h
@@ -16,7 +16,9 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_TABLE_SCHEMA_H
 
 #include "google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h"
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <string>
@@ -32,22 +34,38 @@ using namespace nlohmann::literals;  // NOLINT
 
 struct CategoryList {
   std::vector<std::string> names;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(CategoryList, names);
 
 struct PolicyTagList {
   std::vector<std::string> names;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(PolicyTagList, names);
 
 struct DataClassificationTagList {
   std::vector<std::string> names;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(DataClassificationTagList,
                                                 names);
 
 struct FieldElementType {
   std::string type;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(FieldElementType, type);
 
@@ -73,10 +91,18 @@ struct TableFieldSchema {
   DataClassificationTagList data_classification_tags;
   RoundingMode rounding_mode;
   FieldElementType range_element_type;
+
+  std::string DebugString(absl::string_view fname,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct TableSchema {
   std::vector<TableFieldSchema> fields;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 void to_json(nlohmann::json& j, TableFieldSchema const& t);

--- a/google/cloud/bigquery/v2/minimal/internal/table_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_test.cc
@@ -443,10 +443,9 @@ TEST(TableTest, TableDebugString) {
       R"( precision: 0)"
       R"( scale: 0)"
       R"( is_measure: true)"
-      R"( num_fields: 0)"
-      R"( categories { num_names: 0 })"
-      R"( policy_tags { num_names: 0 })"
-      R"( data_classification_tags { num_names: 0 })"
+      R"( categories { })"
+      R"( policy_tags { })"
+      R"( data_classification_tags { })"
       R"( rounding_mode { value: "" })"
       R"( range_element_type {)"
       R"( type: "")"
@@ -470,7 +469,7 @@ TEST(TableTest, TableDebugString) {
       R"( })"
       R"( })"
       R"( clustering {)"
-      R"( num_fields: 1)"
+      R"( fields: "c-field-1")"
       R"( })"
       R"( clone_definition {)"
       R"( base_table_reference {)"
@@ -482,7 +481,7 @@ TEST(TableTest, TableDebugString) {
       R"( })"
       R"( table_constraints {)"
       R"( primary_key {)"
-      R"( num_columns: 1)"
+      R"( columns: "pcol-1")"
       R"( })"
       R"( foreign_keys {)"
       R"( key_name: "fkey-1")"
@@ -555,10 +554,9 @@ TEST(TableTest, TableDebugString) {
       R"( precision: 0)"
       R"( scale: 0)"
       R"( is_measure: true)"
-      R"( num_fields: 0)"
-      R"( categories { num_names: 0 })"
-      R"( policy_tags { num_names: 0 })"
-      R"( data_classification_tags { num_names: 0 })"
+      R"( categories { })"
+      R"( policy_tags { })"
+      R"( data_classification_tags { })"
       R"( rounding_mode { value: "" })"
       R"( range_element_type {)"
       R"( type: "")"
@@ -582,7 +580,7 @@ TEST(TableTest, TableDebugString) {
       R"( })"
       R"( })"
       R"( clustering {)"
-      R"( num_fields: 1)"
+      R"( fields: "c-field...<truncated>...")"
       R"( })"
       R"( clone_definition {)"
       R"( base_table_reference {)"
@@ -594,7 +592,7 @@ TEST(TableTest, TableDebugString) {
       R"( })"
       R"( table_constraints {)"
       R"( primary_key {)"
-      R"( num_columns: 1)"
+      R"( columns: "pcol-1")"
       R"( })"
       R"( foreign_keys {)"
       R"( key_name: "fkey-1")"
@@ -678,15 +676,11 @@ TEST(TableTest, TableDebugString) {
       precision: 0
       scale: 0
       is_measure: true
-      num_fields: 0
       categories {
-        num_names: 0
       }
       policy_tags {
-        num_names: 0
       }
       data_classification_tags {
-        num_names: 0
       }
       rounding_mode {
         value: ""
@@ -715,7 +709,7 @@ TEST(TableTest, TableDebugString) {
     }
   }
   clustering {
-    num_fields: 1
+    fields: "c-field-1"
   }
   clone_definition {
     base_table_reference {
@@ -729,7 +723,7 @@ TEST(TableTest, TableDebugString) {
   }
   table_constraints {
     primary_key {
-      num_columns: 1
+      columns: "pcol-1"
     }
     foreign_keys {
       key_name: "fkey-1"
@@ -766,6 +760,143 @@ TEST(TableTest, TableDebugString) {
     refresh_watermark {
       "1970-01-01T00:00:00.123Z"
     }
+  }
+})");
+}
+
+TEST(DatasetTest, ListFormatTableDebugString) {
+  auto table = MakeListFormatTable();
+
+  EXPECT_EQ(table.DebugString("Table", TracingOptions{}),
+            R"(Table {)"
+            R"( kind: "t-kind")"
+            R"( id: "t-id")"
+            R"( friendly_name: "t-friendlyname")"
+            R"( type: "t-type")"
+            R"( table_reference {)"
+            R"( project_id: "t-123")"
+            R"( dataset_id: "t-123")"
+            R"( table_id: "t-123")"
+            R"( })"
+            R"( time_partitioning {)"
+            R"( type: "")"
+            R"( expiration_time { "123ms" })"
+            R"( field: "time-partition-field")"
+            R"( })"
+            R"( range_partitioning {)"
+            R"( field: "range-partition-field")"
+            R"( range { start: "" end: "" interval: "" })"
+            R"( })"
+            R"( clustering {)"
+            R"( fields: "c-field-1")"
+            R"( })"
+            R"( hive_partitioning_options {)"
+            R"( mode: "h-mode")"
+            R"( source_uri_prefix: "")"
+            R"( require_partition_filter: true)"
+            R"( fields: "h-field-1")"
+            R"( } )"
+            R"(view {)"
+            R"( use_legacy_sql: true)"
+            R"( })"
+            R"( labels { key: "l1" value: "v1" })"
+            R"( labels { key: "l2" value: "v2" })"
+            R"( creation_time { "1ms" })"
+            R"( expiration_time { "1ms" })"
+            R"( })");
+
+  EXPECT_EQ(
+      table.DebugString("Table", TracingOptions{}.SetOptions(
+                                     "truncate_string_field_longer_than=7")),
+      R"(Table {)"
+      R"( kind: "t-kind")"
+      R"( id: "t-id")"
+      R"( friendly_name: "t-frien...<truncated>...")"
+      R"( type: "t-type")"
+      R"( table_reference {)"
+      R"( project_id: "t-123")"
+      R"( dataset_id: "t-123")"
+      R"( table_id: "t-123")"
+      R"( })"
+      R"( time_partitioning {)"
+      R"( type: "")"
+      R"( expiration_time { "123ms" })"
+      R"( field: "time-pa...<truncated>...")"
+      R"( })"
+      R"( range_partitioning {)"
+      R"( field: "range-p...<truncated>...")"
+      R"( range { start: "" end: "" interval: "" })"
+      R"( })"
+      R"( clustering {)"
+      R"( fields: "c-field...<truncated>...")"
+      R"( })"
+      R"( hive_partitioning_options {)"
+      R"( mode: "h-mode")"
+      R"( source_uri_prefix: "")"
+      R"( require_partition_filter: true)"
+      R"( fields: "h-field...<truncated>...")"
+      R"( } )"
+      R"(view {)"
+      R"( use_legacy_sql: true)"
+      R"( })"
+      R"( labels { key: "l1" value: "v1" })"
+      R"( labels { key: "l2" value: "v2" })"
+      R"( creation_time { "1ms" })"
+      R"( expiration_time { "1ms" })"
+      R"( })");
+
+  EXPECT_EQ(table.DebugString(
+                "Table", TracingOptions{}.SetOptions("single_line_mode=F")),
+            R"(Table {
+  kind: "t-kind"
+  id: "t-id"
+  friendly_name: "t-friendlyname"
+  type: "t-type"
+  table_reference {
+    project_id: "t-123"
+    dataset_id: "t-123"
+    table_id: "t-123"
+  }
+  time_partitioning {
+    type: ""
+    expiration_time {
+      "123ms"
+    }
+    field: "time-partition-field"
+  }
+  range_partitioning {
+    field: "range-partition-field"
+    range {
+      start: ""
+      end: ""
+      interval: ""
+    }
+  }
+  clustering {
+    fields: "c-field-1"
+  }
+  hive_partitioning_options {
+    mode: "h-mode"
+    source_uri_prefix: ""
+    require_partition_filter: true
+    fields: "h-field-1"
+  }
+  view {
+    use_legacy_sql: true
+  }
+  labels {
+    key: "l1"
+    value: "v1"
+  }
+  labels {
+    key: "l2"
+    value: "v2"
+  }
+  creation_time {
+    "1ms"
+  }
+  expiration_time {
+    "1ms"
   }
 })");
 }

--- a/google/cloud/bigquery/v2/minimal/internal/table_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_test.cc
@@ -131,7 +131,7 @@ Table MakeTable() {
 
   expected.table_constraints.primary_key.columns.emplace_back("pcol-1");
   ForeignKey fk;
-  fk.name = "fkey-1";
+  fk.key_name = "fkey-1";
   expected.table_constraints.foreign_keys.emplace_back(fk);
 
   expected.view.query = "select 1;";
@@ -221,8 +221,8 @@ void AssertEquals(Table const& lhs, Table const& rhs) {
 
   ASSERT_THAT(lhs.table_constraints.foreign_keys, Not(IsEmpty()));
   ASSERT_THAT(rhs.table_constraints.foreign_keys, Not(IsEmpty()));
-  EXPECT_EQ(lhs.table_constraints.foreign_keys[0].name,
-            rhs.table_constraints.foreign_keys[0].name);
+  EXPECT_EQ(lhs.table_constraints.foreign_keys[0].key_name,
+            rhs.table_constraints.foreign_keys[0].key_name);
 
   EXPECT_EQ(lhs.view.query, rhs.view.query);
   EXPECT_EQ(lhs.view.use_explicit_column_names,
@@ -315,7 +315,7 @@ std::string MakeTableJsonText() {
          R"("type":""},"rounding_mode":{"value":""})"
          R"(,"scale":0,"type":""}]},"self_link":"t-selflink")"
          R"(,"table_constraints":{"foreign_keys":[{"column_references":[])"
-         R"(,"name":"fkey-1","referenced_table":{"dataset_id":"")"
+         R"(,"key_name":"fkey-1","referenced_table":{"dataset_id":"")"
          R"(,"project_id":"","table_id":""}}])"
          R"(,"primary_key":{"columns":["pcol-1"]}},"table_reference":{)"
          R"("dataset_id":"t-123","project_id":"t-123")"
@@ -390,6 +390,384 @@ TEST(TableTest, ListFormatTableFromJson) {
   from_json(json, actual);
 
   AssertEquals(expected, actual);
+}
+
+TEST(TableTest, TableDebugString) {
+  Table table = MakeTable();
+
+  EXPECT_EQ(
+      table.DebugString("Table", TracingOptions{}),
+      R"(Table {)"
+      R"( kind: "t-kind")"
+      R"( etag: "t-etag")"
+      R"( id: "t-id")"
+      R"( self_link: "t-selflink")"
+      R"( friendly_name: "t-friendlyname")"
+      R"( description: "t-description")"
+      R"( type: "t-type")"
+      R"( location: "t-location")"
+      R"( default_collation: "t-defaultcollation")"
+      R"( max_staleness: "stale")"
+      R"( require_partition_filter: true)"
+      R"( case_insensitive: true)"
+      R"( creation_time { "1970-01-01T00:00:00.001Z" })"
+      R"( expiration_time { "1970-01-01T00:00:00.001Z" })"
+      R"( last_modified_time { "1970-01-01T00:00:00.001Z" })"
+      R"( num_time_travel_physical_bytes: 1)"
+      R"( num_total_logical_bytes: 1)"
+      R"( num_active_logical_bytes: 1)"
+      R"( num_long_term_logical_bytes: 1)"
+      R"( num_total_physical_bytes: 1)"
+      R"( num_active_physical_bytes: 1)"
+      R"( num_long_term_physical_bytes: 1)"
+      R"( num_partitions: 1)"
+      R"( num_bytes: 1)"
+      R"( num_physical_bytes: 1)"
+      R"( num_long_term_bytes: 1)"
+      R"( labels { key: "l1" value: "v1" })"
+      R"( labels { key: "l2" value: "v2" })"
+      R"( table_reference {)"
+      R"( project_id: "t-123")"
+      R"( dataset_id: "t-123")"
+      R"( table_id: "t-123")"
+      R"( })"
+      R"( schema {)"
+      R"( fields {)"
+      R"( name: "fname-1")"
+      R"( type: "")"
+      R"( mode: "fmode")"
+      R"( description: "")"
+      R"( collation: "")"
+      R"( default_value_expression: "")"
+      R"( max_length: 0)"
+      R"( precision: 0)"
+      R"( scale: 0)"
+      R"( is_measure: true)"
+      R"( num_fields: 0)"
+      R"( categories { num_names: 0 })"
+      R"( policy_tags { num_names: 0 })"
+      R"( data_classification_tags { num_names: 0 })"
+      R"( rounding_mode { value: "" })"
+      R"( range_element_type {)"
+      R"( type: "")"
+      R"( })"
+      R"( })"
+      R"( })"
+      R"( default_rounding_mode {)"
+      R"( value: "ROUND_HALF_EVEN")"
+      R"( })"
+      R"( time_partitioning {)"
+      R"( type: "")"
+      R"( expiration_time {)"
+      R"( "123ms")"
+      R"( })"
+      R"( field: "time-partition-field")"
+      R"( })"
+      R"( range_partitioning {)"
+      R"( field: "range-partition-field")"
+      R"( range {)"
+      R"( start: "" end: "" interval: "")"
+      R"( })"
+      R"( })"
+      R"( clustering {)"
+      R"( num_fields: 1)"
+      R"( })"
+      R"( clone_definition {)"
+      R"( base_table_reference {)"
+      R"( project_id: "t-123")"
+      R"( dataset_id: "t-123")"
+      R"( table_id: "t-123")"
+      R"( })"
+      R"( clone_time { "1970-01-01T00:00:00Z" })"
+      R"( })"
+      R"( table_constraints {)"
+      R"( primary_key {)"
+      R"( num_columns: 1)"
+      R"( })"
+      R"( foreign_keys {)"
+      R"( key_name: "fkey-1")"
+      R"( referenced_table {)"
+      R"( project_id: "" dataset_id: "" table_id: "")"
+      R"( })"
+      R"( })"
+      R"( })"
+      R"( view { query: "select 1;" use_legacy_sql: false use_explicit_column_names: true })"
+      R"( materialized_view {)"
+      R"( query: "select 1;")"
+      R"( max_staleness: "")"
+      R"( allow_non_incremental_definition: false)"
+      R"( enable_refresh: true)"
+      R"( refresh_interval_time { "0" })"
+      R"( last_refresh_time { "1970-01-01T00:00:00Z" })"
+      R"( })"
+      R"( materialized_view_status {)"
+      R"( last_refresh_status { reason: "" location: "" message: "" })"
+      R"( refresh_watermark { "1970-01-01T00:00:00.123Z" })"
+      R"( })"
+      R"( })");
+
+  EXPECT_EQ(
+      table.DebugString("Table", TracingOptions{}.SetOptions(
+                                     "truncate_string_field_longer_than=7")),
+      R"(Table {)"
+      R"( kind: "t-kind")"
+      R"( etag: "t-etag")"
+      R"( id: "t-id")"
+      R"( self_link: "t-selfl...<truncated>...")"
+      R"( friendly_name: "t-frien...<truncated>...")"
+      R"( description: "t-descr...<truncated>...")"
+      R"( type: "t-type")"
+      R"( location: "t-locat...<truncated>...")"
+      R"( default_collation: "t-defau...<truncated>...")"
+      R"( max_staleness: "stale")"
+      R"( require_partition_filter: true)"
+      R"( case_insensitive: true)"
+      R"( creation_time { "1970-01-01T00:00:00.001Z" })"
+      R"( expiration_time { "1970-01-01T00:00:00.001Z" })"
+      R"( last_modified_time { "1970-01-01T00:00:00.001Z" })"
+      R"( num_time_travel_physical_bytes: 1)"
+      R"( num_total_logical_bytes: 1)"
+      R"( num_active_logical_bytes: 1)"
+      R"( num_long_term_logical_bytes: 1)"
+      R"( num_total_physical_bytes: 1)"
+      R"( num_active_physical_bytes: 1)"
+      R"( num_long_term_physical_bytes: 1)"
+      R"( num_partitions: 1)"
+      R"( num_bytes: 1)"
+      R"( num_physical_bytes: 1)"
+      R"( num_long_term_bytes: 1)"
+      R"( labels { key: "l1" value: "v1" })"
+      R"( labels { key: "l2" value: "v2" })"
+      R"( table_reference {)"
+      R"( project_id: "t-123")"
+      R"( dataset_id: "t-123")"
+      R"( table_id: "t-123")"
+      R"( })"
+      R"( schema {)"
+      R"( fields {)"
+      R"( name: "fname-1")"
+      R"( type: "")"
+      R"( mode: "fmode")"
+      R"( description: "")"
+      R"( collation: "")"
+      R"( default_value_expression: "")"
+      R"( max_length: 0)"
+      R"( precision: 0)"
+      R"( scale: 0)"
+      R"( is_measure: true)"
+      R"( num_fields: 0)"
+      R"( categories { num_names: 0 })"
+      R"( policy_tags { num_names: 0 })"
+      R"( data_classification_tags { num_names: 0 })"
+      R"( rounding_mode { value: "" })"
+      R"( range_element_type {)"
+      R"( type: "")"
+      R"( })"
+      R"( })"
+      R"( })"
+      R"( default_rounding_mode {)"
+      R"( value: "ROUND_H...<truncated>...")"
+      R"( })"
+      R"( time_partitioning {)"
+      R"( type: "")"
+      R"( expiration_time {)"
+      R"( "123ms")"
+      R"( })"
+      R"( field: "time-pa...<truncated>...")"
+      R"( })"
+      R"( range_partitioning {)"
+      R"( field: "range-p...<truncated>...")"
+      R"( range {)"
+      R"( start: "" end: "" interval: "")"
+      R"( })"
+      R"( })"
+      R"( clustering {)"
+      R"( num_fields: 1)"
+      R"( })"
+      R"( clone_definition {)"
+      R"( base_table_reference {)"
+      R"( project_id: "t-123")"
+      R"( dataset_id: "t-123")"
+      R"( table_id: "t-123")"
+      R"( })"
+      R"( clone_time { "1970-01-01T00:00:00Z" })"
+      R"( })"
+      R"( table_constraints {)"
+      R"( primary_key {)"
+      R"( num_columns: 1)"
+      R"( })"
+      R"( foreign_keys {)"
+      R"( key_name: "fkey-1")"
+      R"( referenced_table {)"
+      R"( project_id: "" dataset_id: "" table_id: "")"
+      R"( })"
+      R"( })"
+      R"( })"
+      R"( view { query: "select ...<truncated>..." use_legacy_sql: false use_explicit_column_names: true })"
+      R"( materialized_view {)"
+      R"( query: "select ...<truncated>...")"
+      R"( max_staleness: "")"
+      R"( allow_non_incremental_definition: false)"
+      R"( enable_refresh: true)"
+      R"( refresh_interval_time { "0" })"
+      R"( last_refresh_time { "1970-01-01T00:00:00Z" })"
+      R"( })"
+      R"( materialized_view_status {)"
+      R"( last_refresh_status { reason: "" location: "" message: "" })"
+      R"( refresh_watermark { "1970-01-01T00:00:00.123Z" })"
+      R"( })"
+      R"( })");
+
+  EXPECT_EQ(table.DebugString(
+                "Table", TracingOptions{}.SetOptions("single_line_mode=F")),
+            R"(Table {
+  kind: "t-kind"
+  etag: "t-etag"
+  id: "t-id"
+  self_link: "t-selflink"
+  friendly_name: "t-friendlyname"
+  description: "t-description"
+  type: "t-type"
+  location: "t-location"
+  default_collation: "t-defaultcollation"
+  max_staleness: "stale"
+  require_partition_filter: true
+  case_insensitive: true
+  creation_time {
+    "1970-01-01T00:00:00.001Z"
+  }
+  expiration_time {
+    "1970-01-01T00:00:00.001Z"
+  }
+  last_modified_time {
+    "1970-01-01T00:00:00.001Z"
+  }
+  num_time_travel_physical_bytes: 1
+  num_total_logical_bytes: 1
+  num_active_logical_bytes: 1
+  num_long_term_logical_bytes: 1
+  num_total_physical_bytes: 1
+  num_active_physical_bytes: 1
+  num_long_term_physical_bytes: 1
+  num_partitions: 1
+  num_bytes: 1
+  num_physical_bytes: 1
+  num_long_term_bytes: 1
+  labels {
+    key: "l1"
+    value: "v1"
+  }
+  labels {
+    key: "l2"
+    value: "v2"
+  }
+  table_reference {
+    project_id: "t-123"
+    dataset_id: "t-123"
+    table_id: "t-123"
+  }
+  schema {
+    fields {
+      name: "fname-1"
+      type: ""
+      mode: "fmode"
+      description: ""
+      collation: ""
+      default_value_expression: ""
+      max_length: 0
+      precision: 0
+      scale: 0
+      is_measure: true
+      num_fields: 0
+      categories {
+        num_names: 0
+      }
+      policy_tags {
+        num_names: 0
+      }
+      data_classification_tags {
+        num_names: 0
+      }
+      rounding_mode {
+        value: ""
+      }
+      range_element_type {
+        type: ""
+      }
+    }
+  }
+  default_rounding_mode {
+    value: "ROUND_HALF_EVEN"
+  }
+  time_partitioning {
+    type: ""
+    expiration_time {
+      "123ms"
+    }
+    field: "time-partition-field"
+  }
+  range_partitioning {
+    field: "range-partition-field"
+    range {
+      start: ""
+      end: ""
+      interval: ""
+    }
+  }
+  clustering {
+    num_fields: 1
+  }
+  clone_definition {
+    base_table_reference {
+      project_id: "t-123"
+      dataset_id: "t-123"
+      table_id: "t-123"
+    }
+    clone_time {
+      "1970-01-01T00:00:00Z"
+    }
+  }
+  table_constraints {
+    primary_key {
+      num_columns: 1
+    }
+    foreign_keys {
+      key_name: "fkey-1"
+      referenced_table {
+        project_id: ""
+        dataset_id: ""
+        table_id: ""
+      }
+    }
+  }
+  view {
+    query: "select 1;"
+    use_legacy_sql: false
+    use_explicit_column_names: true
+  }
+  materialized_view {
+    query: "select 1;"
+    max_staleness: ""
+    allow_non_incremental_definition: false
+    enable_refresh: true
+    refresh_interval_time {
+      "0"
+    }
+    last_refresh_time {
+      "1970-01-01T00:00:00Z"
+    }
+  }
+  materialized_view_status {
+    last_refresh_status {
+      reason: ""
+      location: ""
+      message: ""
+    }
+    refresh_watermark {
+      "1970-01-01T00:00:00.123Z"
+    }
+  }
+})");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/table_view.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_view.cc
@@ -13,12 +13,54 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/table_view.h"
+#include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/format_time_point.h"
 
 namespace google {
 namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::string UserDefinedFunctionResource::DebugString(
+    absl::string_view name, TracingOptions const& options, int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("resource_uri", resource_uri)
+      .StringField("inline_code", inline_code)
+      .Build();
+}
+
+std::string ViewDefinition::DebugString(absl::string_view name,
+                                        TracingOptions const& options,
+                                        int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("query", query)
+      .Field("use_legacy_sql", use_legacy_sql)
+      .Field("use_explicit_column_names", use_explicit_column_names)
+      .Field("user_defined_function_resources", user_defined_function_resources)
+      .Build();
+}
+
+std::string MaterializedViewDefinition::DebugString(
+    absl::string_view name, TracingOptions const& options, int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("query", query)
+      .StringField("max_staleness", max_staleness)
+      .Field("allow_non_incremental_definition",
+             allow_non_incremental_definition)
+      .Field("enable_refresh", enable_refresh)
+      .Field("refresh_interval_time", refresh_interval_time)
+      .Field("last_refresh_time", last_refresh_time)
+      .Build();
+}
+
+std::string MaterializedViewStatus::DebugString(absl::string_view name,
+                                                TracingOptions const& options,
+                                                int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .SubMessage("last_refresh_status", last_refresh_status)
+      .Field("refresh_watermark", refresh_watermark)
+      .Build();
+}
 
 void to_json(nlohmann::json& j, MaterializedViewDefinition const& m) {
   j = nlohmann::json{

--- a/google/cloud/bigquery/v2/minimal/internal/table_view.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table_view.h
@@ -17,7 +17,9 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h"
 #include "google/cloud/bigquery/v2/minimal/internal/table_partition.h"
+#include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <string>
@@ -34,6 +36,10 @@ using namespace nlohmann::literals;  // NOLINT
 struct UserDefinedFunctionResource {
   std::string resource_uri;
   std::string inline_code;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(UserDefinedFunctionResource,
                                                 resource_uri, inline_code);
@@ -45,6 +51,10 @@ struct ViewDefinition {
   bool use_explicit_column_names = false;
 
   std::vector<UserDefinedFunctionResource> user_defined_function_resources;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
     ViewDefinition, query, use_legacy_sql, use_explicit_column_names,
@@ -59,11 +69,19 @@ struct MaterializedViewDefinition {
 
   std::chrono::milliseconds refresh_interval_time;
   std::chrono::system_clock::time_point last_refresh_time;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 struct MaterializedViewStatus {
   std::chrono::system_clock::time_point refresh_watermark;
   ErrorProto last_refresh_status;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
 };
 
 void to_json(nlohmann::json& j, MaterializedViewDefinition const& m);


### PR DESCRIPTION
This PR adds DebugString() member functions with unit tests, to all Table custom classes. This is in preparation for request and response logging for the Table logging decorator.

Please note that I have commented out all member values that are of type `std::vector<std::string>` as that is currently not supported in the DebugFormatter. 

bww@ is aware of the above.

Thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11475)
<!-- Reviewable:end -->
