### PR TITLE
Update script and docs for setup

### DIFF
--- a/ci/install-cloud-sdk.sh
+++ b/ci/install-cloud-sdk.sh
@@ -26,7 +26,11 @@ ARCH="$(uname -p)"
 if [[ "${ARCH}" == "aarch64" ]]; then
   # The tarball uses this name
   ARCH="arm"
-fi
+else 
+  # For x86_64, uname -p might give unknown 
+  ARCH="$(uname -m)"
+fi 
+
 readonly ARCH
 
 components=(

--- a/doc/contributor/howto-guide-setup-development-workstation.md
+++ b/doc/contributor/howto-guide-setup-development-workstation.md
@@ -61,6 +61,11 @@ sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang
 sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100
 ```
 
+Note: newer versions of Ubuntu might require 
+````console
+sudo apt install -y clang libc++-dev libc++abi-dev cmake ninja-build
+ ```
+
 Install the buildifier tool, which we use to format `BUILD.bazel` files:
 
 ```console
@@ -127,7 +132,7 @@ on the [Google Cloud SDK website](https://cloud.google.com/sdk/) for
 alternatives.
 
 ```console
-./ci/install-cloud-sdk.sh
+sudo ./ci/install-cloud-sdk.sh
 ```
 
 ### (Optional) Enable clang-based tooling in your IDE


### PR DESCRIPTION
* Update doc to handle x86_64 (uname -p produces unknown for x86_64 on my VM)
* Add sudo before running the install google sdk script so the mkdir commands can create directories
* Add a note about installing clangtidy in newer versions of ubuntu

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11476)
<!-- Reviewable:end -->
