### PR TITLE
cleanup(docfx): use `pugi::xml_node` as pointers

### DIFF
--- a/docfx/doxygen2children.cc
+++ b/docfx/doxygen2children.cc
@@ -20,11 +20,10 @@
 
 namespace docfx {
 
-std::vector<std::string> Children(YamlContext const& ctx,
-                                  pugi::xml_node const& node) {
+std::vector<std::string> Children(YamlContext const& ctx, pugi::xml_node node) {
   std::vector<std::string> children;
   auto const nested = NestedYamlContext(ctx, node);
-  for (auto const& child : node.children("sectiondef")) {
+  for (auto const child : node.children("sectiondef")) {
     if (!IncludeInPublicDocuments(nested.config, child)) continue;
     auto more = Children(nested, child);
     children.insert(children.end(), std::make_move_iterator(more.begin()),
@@ -34,19 +33,19 @@ std::vector<std::string> Children(YamlContext const& ctx,
   // (the left-side navigation). Repeating them as children renders incorrectly.
   // We could fix that, but we do not have enough namespaces to make this
   // worthwhile.
-  for (auto const& child : node.children("innerclass")) {
+  for (auto const child : node.children("innerclass")) {
     if (!IncludeInPublicDocuments(nested.config, child)) continue;
     auto const refid = std::string_view{child.attribute("refid").as_string()};
     if (!refid.empty()) children.emplace_back(refid);
   }
-  for (auto const& child : node.children("memberdef")) {
+  for (auto const child : node.children("memberdef")) {
     if (!IncludeInPublicDocuments(nested.config, child)) continue;
     auto id = std::string{child.attribute("id").as_string()};
     // Mocked functions are not children.
     if (nested.mocked_ids.count(id) != 0) continue;
     if (!id.empty()) children.push_back(std::move(id));
   }
-  for (auto const& child : node.children("enumvalue")) {
+  for (auto const child : node.children("enumvalue")) {
     if (!IncludeInPublicDocuments(nested.config, child)) continue;
     auto const id = std::string_view{child.attribute("id").as_string()};
     if (!id.empty()) children.emplace_back(id);

--- a/docfx/doxygen2children.h
+++ b/docfx/doxygen2children.h
@@ -28,8 +28,7 @@ namespace docfx {
 // and represented as a YAML map. One of the elements in this map is a sequence
 // that lists all the "children" of that entity. For example, a class would
 // list all the uids for the (public) class member functions.
-std::vector<std::string> Children(YamlContext const& ctx,
-                                  pugi::xml_node const& node);
+std::vector<std::string> Children(YamlContext const& ctx, pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/doxygen2docfx.cc
+++ b/docfx/doxygen2docfx.cc
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) try {
   std::ofstream("toc.yml") << docfx::Doxygen2Toc(config, doc);
 
   for (auto const& i : doc.select_nodes("//compounddef")) {
-    auto const& node = i.node();
+    auto const node = i.node();
     if (!docfx::IncludeInPublicDocuments(config, node)) continue;
     auto const kind = std::string_view{node.attribute("kind").as_string()};
     auto const id = std::string{node.attribute("id").as_string()};

--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -49,13 +49,13 @@ std::string EscapeCodeLink(std::string link) {
 //    </xsd:complexType>
 // clang-format on
 bool AppendIfSect4(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node) {
+                   pugi::xml_node node) {
   if (std::string_view{node.name()} != "sect4") return false;
   // A single '#' title is reserved for the document title. The sect4 title uses
   // '#####':
   os << "\n\n##### ";
   AppendTitle(os, ctx, node);
-  for (auto const& child : node) {
+  for (auto const child : node) {
     // Unexpected: internal -> we do not use this.
     if (std::string_view(child.name()) == "title") continue;  // already handled
     if (AppendIfParagraph(os, ctx, child)) continue;
@@ -80,13 +80,13 @@ bool AppendIfSect4(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfSect3(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node) {
+                   pugi::xml_node node) {
   if (std::string_view{node.name()} != "sect3") return false;
   // A single '#' title is reserved for the document title. The sect3 title
   // uses '####'.
   os << "\n\n#### ";
   AppendTitle(os, ctx, node);
-  for (auto const& child : node) {
+  for (auto const child : node) {
     // Unexpected: internal -> we do not use this.
     if (std::string_view(child.name()) == "title") continue;  // already handled
     if (AppendIfParagraph(os, ctx, child)) continue;
@@ -113,13 +113,13 @@ bool AppendIfSect3(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfSect2(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node) {
+                   pugi::xml_node node) {
   if (std::string_view{node.name()} != "sect2") return false;
   // A single '#' title is reserved for the document title. The sect2 title
   // uses '###':
   os << "\n\n### ";
   AppendTitle(os, ctx, node);
-  for (auto const& child : node) {
+  for (auto const child : node) {
     // Unexpected: internal -> we do not use this.
     if (std::string_view(child.name()) == "title") continue;  // already handled
     if (AppendIfParagraph(os, ctx, child)) continue;
@@ -145,13 +145,13 @@ bool AppendIfSect2(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node) {
+                   pugi::xml_node node) {
   if (std::string_view{node.name()} != "sect1") return false;
   // A single '#' title is reserved for the document title. The sect1 title
   // uses '##':
   os << "\n\n## ";
   AppendTitle(os, ctx, node);
-  for (auto const& child : node) {
+  for (auto const child : node) {
     // Unexpected: internal -> we do not use this.
     if (std::string_view(child.name()) == "title") continue;  // already handled
     if (AppendIfParagraph(os, ctx, child)) continue;
@@ -174,7 +174,7 @@ bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfXRefSect(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (std::string_view{node.name()} != "xrefsect") return false;
   // Add the title in bold, then some
   os << "**" << node.child_value("xreftitle") << "**";
@@ -195,10 +195,10 @@ bool AppendIfXRefSect(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 void AppendDescriptionType(std::ostream& os, MarkdownContext const& ctx,
-                           pugi::xml_node const& node) {
+                           pugi::xml_node node) {
   auto nested = ctx;
   bool first_paragraph = true;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (!first_paragraph) nested.paragraph_start = "\n\n";
     first_paragraph = false;
     // Unexpected: title, internal -> we do not use this...
@@ -215,21 +215,21 @@ void AppendDescriptionType(std::ostream& os, MarkdownContext const& ctx,
 }
 
 bool AppendIfDetailedDescription(std::ostream& os, MarkdownContext const& ctx,
-                                 pugi::xml_node const& node) {
+                                 pugi::xml_node node) {
   if (std::string_view{node.name()} != "detaileddescription") return false;
   AppendDescriptionType(os, ctx, node);
   return true;
 }
 
 bool AppendIfBriefDescription(std::ostream& os, MarkdownContext const& ctx,
-                              pugi::xml_node const& node) {
+                              pugi::xml_node node) {
   if (std::string_view{node.name()} != "briefdescription") return false;
   AppendDescriptionType(os, ctx, node);
   return true;
 }
 
 bool AppendIfPlainText(std::ostream& os, MarkdownContext const& ctx,
-                       pugi::xml_node const& node) {
+                       pugi::xml_node node) {
   if (!std::string_view{node.name()}.empty() || !node.attributes().empty()) {
     return false;
   }
@@ -258,7 +258,7 @@ bool AppendIfPlainText(std::ostream& os, MarkdownContext const& ctx,
 //     <xsd:attribute name="url" type="xsd:string" />
 //   </xsd:complexType>
 bool AppendIfULink(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node) {
+                   pugi::xml_node node) {
   if (std::string_view{node.name()} != "ulink") return false;
   std::ostringstream link;
   for (auto const child : node) {
@@ -277,11 +277,11 @@ bool AppendIfULink(std::ostream& os, MarkdownContext const& ctx,
 //     <xsd:group ref="docCmdGroup" minOccurs="0" maxOccurs="unbounded" />
 //   </xsd:complexType>
 bool AppendIfBold(std::ostream& os, MarkdownContext const& ctx,
-                  pugi::xml_node const& node) {
+                  pugi::xml_node node) {
   if (std::string_view{node.name()} != "bold") return false;
   auto nested = ctx;
   nested.decorators.emplace_back("**");
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfDocCmdGroup(os, nested, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -291,11 +291,11 @@ bool AppendIfBold(std::ostream& os, MarkdownContext const& ctx,
 // The `strike` elements are of type `docMarkupType`. More details in
 // `AppendIfBold()`.
 bool AppendIfStrike(std::ostream& os, MarkdownContext const& ctx,
-                    pugi::xml_node const& node) {
+                    pugi::xml_node node) {
   if (std::string_view{node.name()} != "strike") return false;
   auto nested = ctx;
   nested.decorators.emplace_back("~");
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfDocCmdGroup(os, nested, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -305,11 +305,11 @@ bool AppendIfStrike(std::ostream& os, MarkdownContext const& ctx,
 // The `strike` elements are of type `docMarkupType`. More details in
 // `AppendIfBold()`.
 bool AppendIfEmphasis(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (std::string_view{node.name()} != "emphasis") return false;
   auto nested = ctx;
   nested.decorators.emplace_back("*");
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfDocCmdGroup(os, nested, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -319,11 +319,11 @@ bool AppendIfEmphasis(std::ostream& os, MarkdownContext const& ctx,
 // The `computeroutput` elements are of type `docMarkupType`. More details in
 // `AppendIfBold()`.
 bool AppendIfComputerOutput(std::ostream& os, MarkdownContext const& ctx,
-                            pugi::xml_node const& node) {
+                            pugi::xml_node node) {
   if (std::string_view{node.name()} != "computeroutput") return false;
   auto nested = ctx;
   nested.decorators.emplace_back("`");
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfDocCmdGroup(os, nested, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -344,7 +344,7 @@ bool AppendIfComputerOutput(std::ostream& os, MarkdownContext const& ctx,
 //   <xsd:attribute name="external" type="xsd:string" />
 // </xsd:complexType>
 bool AppendIfRef(std::ostream& os, MarkdownContext const& ctx,
-                 pugi::xml_node const& node) {
+                 pugi::xml_node node) {
   if (std::string_view{node.name()} != "ref") return false;
 
   std::ostringstream link;
@@ -364,7 +364,7 @@ bool AppendIfRef(std::ostream& os, MarkdownContext const& ctx,
 
 // The `ndash` element is just a convenient way to represent long dashes.
 bool AppendIfNDash(std::ostream& os, MarkdownContext const& /*ctx*/,
-                   pugi::xml_node const& node) {
+                   pugi::xml_node node) {
   if (std::string_view{node.name()} != "ndash") return false;
   os << "&ndash;";
   return true;
@@ -373,7 +373,7 @@ bool AppendIfNDash(std::ostream& os, MarkdownContext const& /*ctx*/,
 // The `linebreak` represents a linebreak. Use `<br>` because we are targeting
 // a dialect of markdown that supports it.
 bool AppendIfLinebreak(std::ostream& os, MarkdownContext const& /*ctx*/,
-                       pugi::xml_node const& node) {
+                       pugi::xml_node node) {
   if (std::string_view{node.name()} != "linebreak") return false;
   os << "<br>";
   return true;
@@ -423,7 +423,7 @@ bool AppendIfLinebreak(std::ostream& os, MarkdownContext const& /*ctx*/,
 //   </xsd:choice>
 // </xsd:group>
 bool AppendIfDocTitleCmdGroup(std::ostream& os, MarkdownContext const& ctx,
-                              pugi::xml_node const& node) {
+                              pugi::xml_node node) {
   if (AppendIfPlainText(os, ctx, node)) return true;
   if (AppendIfULink(os, ctx, node)) return true;
   if (AppendIfBold(os, ctx, node)) return true;
@@ -477,7 +477,7 @@ bool AppendIfDocTitleCmdGroup(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:choice>
 // </xsd:group>
 bool AppendIfDocCmdGroup(std::ostream& os, MarkdownContext const& ctx,
-                         pugi::xml_node const& node) {
+                         pugi::xml_node node) {
   auto const name = std::string_view{node.name()};
   // <parameterlist> is part of the detailed description for functions. In
   // DocFX YAML the parameters get their own YAML elements, and do not need
@@ -516,10 +516,10 @@ bool AppendIfDocCmdGroup(std::ostream& os, MarkdownContext const& ctx,
 // The `<xsd:group>` signifies that there may be 0 or more (unbounded) number of
 // `docCmdGroup` child elements.
 bool AppendIfParagraph(std::ostream& os, MarkdownContext const& ctx,
-                       pugi::xml_node const& node) {
+                       pugi::xml_node node) {
   if (std::string_view{node.name()} != "para") return false;
   os << ctx.paragraph_start << ctx.paragraph_indent;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfDocCmdGroup(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -538,12 +538,12 @@ bool AppendIfParagraph(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfProgramListing(std::ostream& os, MarkdownContext const& ctx,
-                            pugi::xml_node const& node) {
+                            pugi::xml_node node) {
   if (std::string_view{node.name()} != "programlisting") return false;
   // Start with a new paragraph, with the right level of indentation, and a new
   // code fence.
   os << ctx.paragraph_start << ctx.paragraph_indent << "```cpp";
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfCodeline(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -553,7 +553,7 @@ bool AppendIfProgramListing(std::ostream& os, MarkdownContext const& ctx,
 
 // The type for `verbatim` is a simple string.
 bool AppendIfVerbatim(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (std::string_view{node.name()} != "verbatim") return false;
   os << ctx.paragraph_start << ctx.paragraph_indent << "```\n"
      << ctx.paragraph_indent << node.child_value() << "\n"
@@ -571,9 +571,9 @@ bool AppendIfVerbatim(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfParBlock(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (std::string_view{node.name()} != "parblock") return false;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfParagraph(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -594,9 +594,9 @@ bool AppendIfParBlock(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfTable(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node) {
+                   pugi::xml_node node) {
   if (std::string_view{node.name()} != "table") return false;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfTableRow(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -613,13 +613,13 @@ bool AppendIfTable(std::ostream& os, MarkdownContext const& ctx,
 //    </xsd:complexType>
 // clang-format on
 bool AppendIfTableRow(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (std::string_view{node.name()} != "row") return false;
   os << "\n" << ctx.paragraph_indent;
   auto nested = ctx;
   nested.paragraph_indent = "";
   nested.paragraph_start = "| ";
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfTableEntry(os, nested, child)) {
       nested.paragraph_start = " | ";
       continue;
@@ -630,7 +630,7 @@ bool AppendIfTableRow(std::ostream& os, MarkdownContext const& ctx,
   // This may not work for tables with colspan, but it is good enough for the
   // documents we have in `google-cloud-cpp`.
   auto nheaders =
-      std::count_if(node.begin(), node.end(), [](auto const& child) {
+      std::count_if(node.begin(), node.end(), [](pugi::xml_node child) {
         return std::string_view{child.name()} == "entry" &&
                std::string_view{child.attribute("thead").as_string()} == "yes";
       });
@@ -663,10 +663,10 @@ bool AppendIfTableRow(std::ostream& os, MarkdownContext const& ctx,
 //    </xsd:complexType>
 // clang-format on
 bool AppendIfTableEntry(std::ostream& os, MarkdownContext const& ctx,
-                        pugi::xml_node const& node) {
+                        pugi::xml_node node) {
   if (std::string_view{node.name()} != "entry") return false;
   auto nested = ctx;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfParagraph(os, nested, child)) {
       nested.paragraph_start = " ";
       continue;
@@ -692,10 +692,10 @@ bool AppendIfTableEntry(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfCodeline(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (std::string_view{node.name()} != "codeline") return false;
   os << "\n" << ctx.paragraph_indent;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfHighlight(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -713,9 +713,9 @@ bool AppendIfCodeline(std::ostream& os, MarkdownContext const& ctx,
 //     <xsd:attribute name="class" type="DoxHighlightClass" />
 //   </xsd:complexType>
 bool AppendIfHighlight(std::ostream& os, MarkdownContext const& ctx,
-                       pugi::xml_node const& node) {
+                       pugi::xml_node node) {
   if (std::string_view{node.name()} != "highlight") return false;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfPlainText(os, ctx, child)) continue;
     if (AppendIfHighlightSp(os, ctx, child)) continue;
     if (AppendIfHighlightRef(os, ctx, child)) continue;
@@ -731,7 +731,7 @@ bool AppendIfHighlight(std::ostream& os, MarkdownContext const& ctx,
 //     <xsd:attribute name="value" type="xsd:integer" use="optional"/>
 //   </xsd:complexType>
 bool AppendIfHighlightSp(std::ostream& os, MarkdownContext const& /*ctx*/,
-                         pugi::xml_node const& node) {
+                         pugi::xml_node node) {
   if (std::string_view{node.name()} != "sp") return false;
   // Leave the 'value' attribute unhandled. It is probably the number of spaces,
   // but without documentation it is hard to say. Since it is unused, this
@@ -751,9 +751,9 @@ bool AppendIfHighlightSp(std::ostream& os, MarkdownContext const& /*ctx*/,
 //     <xsd:attribute name="external" type="xsd:string" />
 //   </xsd:complexType>
 bool AppendIfHighlightRef(std::ostream& os, MarkdownContext const& ctx,
-                          pugi::xml_node const& node) {
+                          pugi::xml_node node) {
   if (std::string_view{node.name()} != "ref") return false;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfDocTitleCmdGroup(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -762,12 +762,12 @@ bool AppendIfHighlightRef(std::ostream& os, MarkdownContext const& ctx,
 
 /// Handle `orderedlist` elements.
 bool AppendIfOrderedList(std::ostream& os, MarkdownContext const& ctx,
-                         pugi::xml_node const& node) {
+                         pugi::xml_node node) {
   if (std::string_view{node.name()} != "orderedlist") return false;
   auto nested = ctx;
   nested.paragraph_indent = std::string(ctx.paragraph_indent.size(), ' ');
   nested.item_prefix = "1. ";
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfListItem(os, nested, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -775,12 +775,12 @@ bool AppendIfOrderedList(std::ostream& os, MarkdownContext const& ctx,
 }
 
 bool AppendIfItemizedList(std::ostream& os, MarkdownContext const& ctx,
-                          pugi::xml_node const& node) {
+                          pugi::xml_node node) {
   if (std::string_view{node.name()} != "itemizedlist") return false;
   auto nested = ctx;
   nested.paragraph_indent = std::string(ctx.paragraph_indent.size(), ' ');
   nested.item_prefix = "- ";
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfListItem(os, nested, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -788,14 +788,14 @@ bool AppendIfItemizedList(std::ostream& os, MarkdownContext const& ctx,
 }
 
 bool AppendIfListItem(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (std::string_view{node.name()} != "listitem") return false;
   // The first paragraph is the list item is indented as needed, and starts
   // with the item prefix (typically "- " or "1. ").
   auto nested = ctx;
   nested.paragraph_start = "\n";
   nested.paragraph_indent = ctx.paragraph_indent + ctx.item_prefix;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfParagraph(os, nested, child)) {
       // Subsequence paragraphs within the same list item require a blank line
       nested.paragraph_start = "\n\n";
@@ -825,13 +825,13 @@ bool AppendIfListItem(std::ostream& os, MarkdownContext const& ctx,
 //     </xsd:sequence>
 //   </xsd:group>
 bool AppendIfVariableList(std::ostream& os, MarkdownContext const& ctx,
-                          pugi::xml_node const& node) {
+                          pugi::xml_node node) {
   if (std::string_view{node.name()} != "variablelist") return false;
 
   auto nested = ctx;
   nested.paragraph_start = "\n";
   nested.paragraph_indent = ctx.paragraph_indent + "- ";
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfVariableListEntry(os, nested, child)) {
       // Subsequence paragraphs within the same list item require a blank line
       nested.paragraph_start = "\n\n";
@@ -860,12 +860,12 @@ bool AppendIfVariableList(std::ostream& os, MarkdownContext const& ctx,
 //     <xsd:group ref="docTitleCmdGroup" minOccurs="0" maxOccurs="unbounded" />
 //   </xsd:complexType>
 bool AppendIfVariableListEntry(std::ostream& os, MarkdownContext const& ctx,
-                               pugi::xml_node const& node) {
+                               pugi::xml_node node) {
   if (std::string_view{node.name()} != "varlistentry") return false;
   auto const term = node.child("term");
   if (!term) MissingElement(__func__, "term", node);
   os << ctx.paragraph_start << ctx.paragraph_indent;
-  for (auto const& child : term) {
+  for (auto const child : term) {
     if (AppendIfDocTitleCmdGroup(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -882,9 +882,9 @@ bool AppendIfVariableListEntry(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfVariableListItem(std::ostream& os, MarkdownContext const& ctx,
-                              pugi::xml_node const& node) {
+                              pugi::xml_node node) {
   if (std::string_view{node.name()} != "listitem") return false;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfParagraph(os, ctx, child)) continue;
     UnknownChildType(__func__, child);
   }
@@ -932,7 +932,7 @@ bool AppendIfVariableListItem(std::ostream& os, MarkdownContext const& ctx,
 //   </xsd:complexType>
 // clang-format on
 bool AppendIfSimpleSect(std::ostream& os, MarkdownContext const& ctx,
-                        pugi::xml_node const& node) {
+                        pugi::xml_node node) {
   if (std::string_view{node.name()} != "simplesect") return false;
   static auto const* const kUseH6 = [] {
     return new std::unordered_set<std::string>{
@@ -977,7 +977,7 @@ bool AppendIfSimpleSect(std::ostream& os, MarkdownContext const& ctx,
     throw std::runtime_error(std::move(os).str());
   }
 
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (std::string_view{child.name()} == "title") continue;
     if (AppendIfParagraph(os, nested, child)) continue;
     UnknownChildType(__func__, child);
@@ -986,18 +986,18 @@ bool AppendIfSimpleSect(std::ostream& os, MarkdownContext const& ctx,
 }
 
 bool AppendIfAnchor(std::ostream& /*os*/, MarkdownContext const& /*ctx*/,
-                    pugi::xml_node const& node) {
+                    pugi::xml_node node) {
   // Do not generate any code for anchors, they have no obvious mapping to
   // Markdown.
   return std::string_view{node.name()} == "anchor";
 }
 
 void AppendTitle(std::ostream& os, MarkdownContext const& ctx,
-                 pugi::xml_node const& node) {
+                 pugi::xml_node node) {
   // The XML schema says there is only one of these, but it is easier to write
   // the loop.
   for (auto const& title : node.children("title")) {
-    for (auto const& child : title) {
+    for (auto const child : title) {
       if (AppendIfPlainText(os, ctx, child)) continue;
       UnknownChildType(__func__, child);
     }

--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -996,7 +996,7 @@ void AppendTitle(std::ostream& os, MarkdownContext const& ctx,
                  pugi::xml_node node) {
   // The XML schema says there is only one of these, but it is easier to write
   // the loop.
-  for (auto const& title : node.children("title")) {
+  for (auto const title : node.children("title")) {
     for (auto const child : title) {
       if (AppendIfPlainText(os, ctx, child)) continue;
       UnknownChildType(__func__, child);

--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -38,35 +38,35 @@ struct MarkdownContext {
 
 /// Handles a sect4 node.
 bool AppendIfSect4(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node);
+                   pugi::xml_node node);
 
 /// Handles a sect3 node.
 bool AppendIfSect3(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node);
+                   pugi::xml_node node);
 
 /// Handles a sect2 node.
 bool AppendIfSect2(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node);
+                   pugi::xml_node node);
 
 /// Handles a sect1 node.
 bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node);
+                   pugi::xml_node node);
 
 /// Handles a `<xrefsect>` node.
 bool AppendIfXRefSect(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 /// Outputs a description node.
 void AppendDescriptionType(std::ostream& os, MarkdownContext const& ctx,
-                           pugi::xml_node const& node);
+                           pugi::xml_node node);
 
 /// Handles a detailed description node.
 bool AppendIfDetailedDescription(std::ostream& os, MarkdownContext const& ctx,
-                                 pugi::xml_node const& node);
+                                 pugi::xml_node node);
 
 /// Handles a brief description node.
 bool AppendIfBriefDescription(std::ostream& os, MarkdownContext const& ctx,
-                              pugi::xml_node const& node);
+                              pugi::xml_node node);
 
 /**
  * Handle plain text nodes.
@@ -87,99 +87,99 @@ bool AppendIfBriefDescription(std::ostream& os, MarkdownContext const& ctx,
  * representation.
  */
 bool AppendIfPlainText(std::ostream& os, MarkdownContext const& ctx,
-                       pugi::xml_node const& node);
+                       pugi::xml_node node);
 
 /// Handles nodes with URL links.
 bool AppendIfULink(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node);
+                   pugi::xml_node node);
 
 /// Handles nodes with **bold** text.
 bool AppendIfBold(std::ostream& os, MarkdownContext const& ctx,
-                  pugi::xml_node const& node);
+                  pugi::xml_node node);
 
 /// Handles nodes with ~strike through~ text.
 bool AppendIfStrike(std::ostream& os, MarkdownContext const& ctx,
-                    pugi::xml_node const& node);
+                    pugi::xml_node node);
 
 /// Handles *emphasis* in text.
 bool AppendIfEmphasis(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 /// Handles nodes with `computer output`.
 bool AppendIfComputerOutput(std::ostream& os, MarkdownContext const& ctx,
-                            pugi::xml_node const& node);
+                            pugi::xml_node node);
 
 /// Handles `ref` nodes: all forms of links.
 bool AppendIfRef(std::ostream& os, MarkdownContext const& ctx,
-                 pugi::xml_node const& node);
+                 pugi::xml_node node);
 
 /// Handles `ndash` elements.
 bool AppendIfNDash(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node);
+                   pugi::xml_node node);
 
 /// Part of the implementation of AppendIfParagraph().
 bool AppendIfDocTitleCmdGroup(std::ostream& os, MarkdownContext const& ctx,
-                              pugi::xml_node const& node);
+                              pugi::xml_node node);
 
 /// Part of the implementation of AppendIfParagraph().
 bool AppendIfDocCmdGroup(std::ostream& os, MarkdownContext const& ctx,
-                         pugi::xml_node const& node);
+                         pugi::xml_node node);
 
 /// Handle full paragraphs.
 bool AppendIfParagraph(std::ostream& os, MarkdownContext const& ctx,
-                       pugi::xml_node const& node);
+                       pugi::xml_node node);
 
 /// Handle `programlisting` elements.
 bool AppendIfProgramListing(std::ostream& os, MarkdownContext const& ctx,
-                            pugi::xml_node const& node);
+                            pugi::xml_node node);
 
 /// Handle `verbatim` elements.
 bool AppendIfVerbatim(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 /// Handle `<parblock>` elements.
 bool AppendIfParBlock(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 /// Handle `<table>` elements.
 bool AppendIfTable(std::ostream& os, MarkdownContext const& ctx,
-                   pugi::xml_node const& node);
+                   pugi::xml_node node);
 
 /// Handle `<row>` elements in a `<table>`.
 bool AppendIfTableRow(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 /// Handle `<entry>` elements in a `<table>`.
 bool AppendIfTableEntry(std::ostream& os, MarkdownContext const& ctx,
-                        pugi::xml_node const& node);
+                        pugi::xml_node node);
 
 /// Handle `codeline` elements.
 bool AppendIfCodeline(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 /// Handle `highlight` elements.
 bool AppendIfHighlight(std::ostream& os, MarkdownContext const& ctx,
-                       pugi::xml_node const& node);
+                       pugi::xml_node node);
 
 /// Handle `sp` elements embedded in `highlight` elements.
 bool AppendIfHighlightSp(std::ostream& os, MarkdownContext const& ctx,
-                         pugi::xml_node const& node);
+                         pugi::xml_node node);
 
 /// Handle `ref` elements embedded in `highlight` elements.
 bool AppendIfHighlightRef(std::ostream& os, MarkdownContext const& ctx,
-                          pugi::xml_node const& node);
+                          pugi::xml_node node);
 
 /// Handle itemized lists.
 bool AppendIfItemizedList(std::ostream& os, MarkdownContext const& ctx,
-                          pugi::xml_node const& node);
+                          pugi::xml_node node);
 
 /// Handle `orderedlist` elements.
 bool AppendIfOrderedList(std::ostream& os, MarkdownContext const& ctx,
-                         pugi::xml_node const& node);
+                         pugi::xml_node node);
 
 /// Handle a single list item.
 bool AppendIfListItem(std::ostream& os, MarkdownContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 /**
  * Handle `variablelist` elements.
@@ -188,27 +188,27 @@ bool AppendIfListItem(std::ostream& os, MarkdownContext const& ctx,
  * terms (a linked code entity), and a sequence of text.
  */
 bool AppendIfVariableList(std::ostream& os, MarkdownContext const& ctx,
-                          pugi::xml_node const& node);
+                          pugi::xml_node node);
 
 /// Handle a single `varlistentry` element.
 bool AppendIfVariableListEntry(std::ostream& os, MarkdownContext const& ctx,
-                               pugi::xml_node const& node);
+                               pugi::xml_node node);
 
 /// Handle a single `listitem` in a variable list.
 bool AppendIfVariableListItem(std::ostream& os, MarkdownContext const& ctx,
-                              pugi::xml_node const& node);
+                              pugi::xml_node node);
 
 /// Handle a `simplesect` element (a section without sub-sections).
 bool AppendIfSimpleSect(std::ostream& os, MarkdownContext const& ctx,
-                        pugi::xml_node const& node);
+                        pugi::xml_node node);
 
 /// Handle an `anchor` element.
 bool AppendIfAnchor(std::ostream& os, MarkdownContext const& ctx,
-                    pugi::xml_node const& node);
+                    pugi::xml_node node);
 
 /// Handle the title for a section-like element.
 void AppendTitle(std::ostream& os, MarkdownContext const& ctx,
-                 pugi::xml_node const& node);
+                 pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/doxygen2references.cc
+++ b/docfx/doxygen2references.cc
@@ -21,7 +21,7 @@ namespace docfx {
 namespace {
 
 std::list<Reference> RecurseReferences(YamlContext const& ctx,
-                                       pugi::xml_node const& node) {
+                                       pugi::xml_node node) {
   std::list<Reference> references;
   for (auto const& c : node) {
     references.splice(references.end(), ExtractReferences(ctx, c));
@@ -44,7 +44,7 @@ YAML::Emitter& operator<<(YAML::Emitter& yaml, Reference const& rhs) {
 
 // Generate the `references` element in a DocFX YAML.
 std::list<Reference> ExtractReferences(YamlContext const& ctx,
-                                       pugi::xml_node const& node) {
+                                       pugi::xml_node node) {
   if (!IncludeInPublicDocuments(ctx.config, node)) return {};
 
   auto const name = std::string_view{node.name()};

--- a/docfx/doxygen2references.h
+++ b/docfx/doxygen2references.h
@@ -54,7 +54,7 @@ YAML::Emitter& operator<<(YAML::Emitter& yaml, Reference const& rhs);
 
 // Generate the `references` element in a DocFX YAML.
 std::list<Reference> ExtractReferences(YamlContext const& ctx,
-                                       pugi::xml_node const& node);
+                                       pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/doxygen2syntax.cc
+++ b/docfx/doxygen2syntax.cc
@@ -101,7 +101,7 @@ void TemplateParamListSyntaxContent(std::ostream& os, pugi::xml_node node) {
   if (!templateparamlist) return;
   os << "template <";
   auto sep = std::string_view{"\n    "};
-  for (auto const& param : templateparamlist) {
+  for (auto const param : templateparamlist) {
     if (std::string_view{param.name()} != "param") {
       UnknownChildType(__func__, param);
     }
@@ -154,8 +154,8 @@ std::string ReturnDescription(YamlContext const& /*ctx*/, pugi::xml_node node) {
 // clang-format on
 bool ParameterItemMatchesName(std::string_view parameter_name,
                               pugi::xml_node item) {
-  for (auto const& list : item.children("parameternamelist")) {
-    for (auto const& name : list.children("parametername")) {
+  for (auto const list : item.children("parameternamelist")) {
+    for (auto const name : list.children("parametername")) {
       if (std::string_view{name.child_value()} == parameter_name) return true;
     }
   }
@@ -169,7 +169,7 @@ std::string ParameterDescription(YamlContext const& /*ctx*/,
   // part of the *function* description.
   auto selected = node.select_node(".//parameterlist[@kind='param']");
   if (!selected) return {};
-  for (auto const& item : selected.node()) {
+  for (auto const item : selected.node()) {
     if (!ParameterItemMatchesName(parameter_name, item)) continue;
     std::ostringstream os;
     MarkdownContext mdctx;
@@ -191,7 +191,7 @@ std::string TemplateParameterDescription(YamlContext const& /*ctx*/,
   // part of the *function* description.
   auto selected = node.select_node(".//parameterlist[@kind='templateparam']");
   if (!selected) return {};
-  for (auto const& item : selected.node()) {
+  for (auto const item : selected.node()) {
     if (!ParameterItemMatchesName(type, item)) continue;
     std::ostringstream os;
     MarkdownContext mdctx;

--- a/docfx/doxygen2syntax.cc
+++ b/docfx/doxygen2syntax.cc
@@ -21,7 +21,7 @@ namespace docfx {
 namespace {
 
 void AppendLocation(YAML::Emitter& yaml, YamlContext const& ctx,
-                    pugi::xml_node const& node, char const* name_attribute) {
+                    pugi::xml_node node, char const* name_attribute) {
   auto const name = std::string_view{node.child(name_attribute).child_value()};
   auto const location = node.child("location");
   if (name.empty() || !location) return;
@@ -69,9 +69,9 @@ void AppendLocation(YAML::Emitter& yaml, YamlContext const& ctx,
 //     </xsd:simpleContent>
 //   </xsd:complexType>
 // clang-format on
-std::string LinkedTextType(pugi::xml_node const& node) {
+std::string LinkedTextType(pugi::xml_node node) {
   std::ostringstream os;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     auto const name = std::string_view{child.name()};
     if (name == "ref") {
       os << child.child_value();
@@ -96,8 +96,7 @@ std::string HtmlEscape(std::string_view text) {
   return clean;
 }
 
-void TemplateParamListSyntaxContent(std::ostream& os,
-                                    pugi::xml_node const& node) {
+void TemplateParamListSyntaxContent(std::ostream& os, pugi::xml_node node) {
   auto templateparamlist = node.child("templateparamlist");
   if (!templateparamlist) return;
   os << "template <";
@@ -116,8 +115,7 @@ void TemplateParamListSyntaxContent(std::ostream& os,
   os << ">\n";
 }
 
-std::string ReturnDescription(YamlContext const& /*ctx*/,
-                              pugi::xml_node const& node) {
+std::string ReturnDescription(YamlContext const& /*ctx*/, pugi::xml_node node) {
   // The return description, if present, is in a `<simplesect>` node that is
   // part of the *function* description.
   auto selected = node.select_node(".//simplesect[@kind='return']");
@@ -155,7 +153,7 @@ std::string ReturnDescription(YamlContext const& /*ctx*/,
 //   </xsd:complexType>
 // clang-format on
 bool ParameterItemMatchesName(std::string_view parameter_name,
-                              pugi::xml_node const& item) {
+                              pugi::xml_node item) {
   for (auto const& list : item.children("parameternamelist")) {
     for (auto const& name : list.children("parametername")) {
       if (std::string_view{name.child_value()} == parameter_name) return true;
@@ -165,7 +163,7 @@ bool ParameterItemMatchesName(std::string_view parameter_name,
 }
 
 std::string ParameterDescription(YamlContext const& /*ctx*/,
-                                 pugi::xml_node const& node,
+                                 pugi::xml_node node,
                                  std::string_view parameter_name) {
   // The parameter description, if present, is in a `<simplesect>` node that is
   // part of the *function* description.
@@ -183,7 +181,7 @@ std::string ParameterDescription(YamlContext const& /*ctx*/,
 }
 
 std::string TemplateParameterDescription(YamlContext const& /*ctx*/,
-                                         pugi::xml_node const& node,
+                                         pugi::xml_node node,
                                          std::string_view type) {
   auto const prefix = std::string_view{"typename "};
   if (type.substr(0, prefix.size()) == prefix) {
@@ -206,12 +204,12 @@ std::string TemplateParameterDescription(YamlContext const& /*ctx*/,
 
 }  // namespace
 
-std::string EnumSyntaxContent(pugi::xml_node const& node) {
+std::string EnumSyntaxContent(pugi::xml_node node) {
   std::ostringstream os;
   auto const strong = std::string_view{node.attribute("strong").as_string()};
   os << "enum " << (strong == "yes" ? "class " : "")
      << node.child_value("qualifiedname") << " {\n";
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (std::string_view{child.name()} != "enumvalue") continue;
     os << "  " << child.child_value("name") << ",\n";
   }
@@ -219,21 +217,21 @@ std::string EnumSyntaxContent(pugi::xml_node const& node) {
   return std::move(os).str();
 }
 
-std::string TypedefSyntaxContent(pugi::xml_node const& node) {
+std::string TypedefSyntaxContent(pugi::xml_node node) {
   std::ostringstream os;
   os << "using " << node.child_value("qualifiedname") << " =\n"  //
      << "  " << LinkedTextType(node.child("type")) << ";";
   return std::move(os).str();
 }
 
-std::string VariableSyntaxContent(pugi::xml_node const& node) {
+std::string VariableSyntaxContent(pugi::xml_node node) {
   std::ostringstream os;
   os << LinkedTextType(node.child("type")) << " " << node.child_value("name")
      << ";";
   return std::move(os).str();
 }
 
-std::string FriendSyntaxContent(pugi::xml_node const& node) {
+std::string FriendSyntaxContent(pugi::xml_node node) {
   auto type = std::string_view{node.child_value("type")};
   if (type == "class" || type == "struct") {
     std::ostringstream os;
@@ -244,7 +242,7 @@ std::string FriendSyntaxContent(pugi::xml_node const& node) {
   return FunctionSyntaxContent(node, "friend ");
 }
 
-std::string FunctionSyntaxContent(pugi::xml_node const& node,
+std::string FunctionSyntaxContent(pugi::xml_node node,
                                   std::string_view prefix) {
   std::ostringstream os;
   TemplateParamListSyntaxContent(os, node);
@@ -268,8 +266,7 @@ std::string FunctionSyntaxContent(pugi::xml_node const& node,
   return std::move(os).str();
 }
 
-std::string ClassSyntaxContent(pugi::xml_node const& node,
-                               std::string_view prefix) {
+std::string ClassSyntaxContent(pugi::xml_node node, std::string_view prefix) {
   // struct vs class
   auto const* const kind = node.attribute("kind").as_string();
   // If the `node` is a  '<compounddef>' element, the name of the documented
@@ -287,19 +284,18 @@ std::string ClassSyntaxContent(pugi::xml_node const& node,
   return std::move(os).str();
 }
 
-std::string StructSyntaxContent(pugi::xml_node const& node,
-                                std::string_view prefix) {
+std::string StructSyntaxContent(pugi::xml_node node, std::string_view prefix) {
   return ClassSyntaxContent(node, prefix);
 }
 
-std::string NamespaceSyntaxContent(pugi::xml_node const& node) {
+std::string NamespaceSyntaxContent(pugi::xml_node node) {
   std::ostringstream os;
   os << "namespace " << node.child_value("compoundname") << " { ... };";
   return std::move(os).str();
 }
 
 void AppendEnumSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //
@@ -309,7 +305,7 @@ void AppendEnumSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 void AppendTypedefSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                         pugi::xml_node const& node) {
+                         pugi::xml_node node) {
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //
@@ -319,7 +315,7 @@ void AppendTypedefSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 void AppendFriendSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                        pugi::xml_node const& node) {
+                        pugi::xml_node node) {
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //
@@ -329,7 +325,7 @@ void AppendFriendSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 void AppendVariableSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                          pugi::xml_node const& node) {
+                          pugi::xml_node node) {
   auto full_name = std::string{node.child("qualifiedname").child_value()};
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
@@ -340,7 +336,7 @@ void AppendVariableSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 void AppendFunctionSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                          pugi::xml_node const& node) {
+                          pugi::xml_node node) {
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //
@@ -397,7 +393,7 @@ void AppendFunctionSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 void AppendClassSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                       pugi::xml_node const& node) {
+                       pugi::xml_node node) {
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //
@@ -407,7 +403,7 @@ void AppendClassSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 void AppendStructSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                        pugi::xml_node const& node) {
+                        pugi::xml_node node) {
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //
@@ -417,7 +413,7 @@ void AppendStructSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 void AppendNamespaceSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                           pugi::xml_node const& node) {
+                           pugi::xml_node node) {
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //

--- a/docfx/doxygen2syntax.h
+++ b/docfx/doxygen2syntax.h
@@ -33,63 +33,63 @@ namespace docfx {
 // - The value of enums (if applicable).
 
 // Generate the `syntax.content` element for an enum.
-std::string EnumSyntaxContent(pugi::xml_node const& node);
+std::string EnumSyntaxContent(pugi::xml_node node);
 
 // Generate the `syntax.content` element for a typedef.
-std::string TypedefSyntaxContent(pugi::xml_node const& node);
+std::string TypedefSyntaxContent(pugi::xml_node node);
 
 // Generate the `syntax.content` element for a friend.
-std::string FriendSyntaxContent(pugi::xml_node const& node);
+std::string FriendSyntaxContent(pugi::xml_node node);
 
 // Generate the `syntax.content` element for a variable.
-std::string VariableSyntaxContent(pugi::xml_node const& node);
+std::string VariableSyntaxContent(pugi::xml_node node);
 
 // Generate the `syntax.content` element for a function.
-std::string FunctionSyntaxContent(pugi::xml_node const& node,
+std::string FunctionSyntaxContent(pugi::xml_node node,
                                   std::string_view prefix = {});
 
 // Generate the `syntax.content` element for a class.
-std::string ClassSyntaxContent(pugi::xml_node const& node,
+std::string ClassSyntaxContent(pugi::xml_node node,
                                std::string_view prefix = {});
 
 // Generate the `syntax.content` element for a struct.
-std::string StructSyntaxContent(pugi::xml_node const& node,
+std::string StructSyntaxContent(pugi::xml_node node,
                                 std::string_view prefix = {});
 
 // Generate the `syntax.content` element for a namespace.
-std::string NamespaceSyntaxContent(pugi::xml_node const& node);
+std::string NamespaceSyntaxContent(pugi::xml_node node);
 
 // Generate the `syntax` element for an enum.
 void AppendEnumSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 // Generate the `syntax` element for an typedef.
 void AppendTypedefSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                         pugi::xml_node const& node);
+                         pugi::xml_node node);
 
 // Generate the `syntax` element for a friend.
 void AppendFriendSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                        pugi::xml_node const& node);
+                        pugi::xml_node node);
 
 // Generate the `syntax` element for an variable.
 void AppendVariableSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                          pugi::xml_node const& node);
+                          pugi::xml_node node);
 
 // Generate the `syntax` element for a function.
 void AppendFunctionSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                          pugi::xml_node const& node);
+                          pugi::xml_node node);
 
 // Generate the `syntax` element for a class.
 void AppendClassSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                       pugi::xml_node const& node);
+                       pugi::xml_node node);
 
 // Generate the `syntax` element for a struct.
 void AppendStructSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                        pugi::xml_node const& node);
+                        pugi::xml_node node);
 
 // Generate the `syntax` element for a namespace.
 void AppendNamespaceSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
-                           pugi::xml_node const& node);
+                           pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -28,11 +28,11 @@
 namespace docfx {
 namespace {
 
-auto kind(pugi::xml_node const& node) {
+auto kind(pugi::xml_node node) {
   return std::string_view{node.attribute("kind").as_string()};
 }
 
-bool IgnoreForRecurse(pugi::xml_node const& node) {
+bool IgnoreForRecurse(pugi::xml_node node) {
   static auto const* const kNames = [] {
     return new std::set<std::string>{
         // Handled by each AppendIf*() function
@@ -64,8 +64,8 @@ bool IgnoreForRecurse(pugi::xml_node const& node) {
 }
 
 void CompoundRecurse(YAML::Emitter& yaml, YamlContext const& ctx,
-                     pugi::xml_node const& node) {
-  for (auto const& child : node) {
+                     pugi::xml_node node) {
+  for (auto const child : node) {
     if (!IncludeInPublicDocuments(ctx.config, child)) continue;
     if (IgnoreForRecurse(child)) continue;
     if (AppendIfSectionDef(yaml, ctx, child)) continue;
@@ -82,7 +82,7 @@ void CompoundRecurse(YAML::Emitter& yaml, YamlContext const& ctx,
   }
 }
 
-std::string Summary(pugi::xml_node const& node) {
+std::string Summary(pugi::xml_node node) {
   std::ostringstream os;
   MarkdownContext ctx;
   ctx.paragraph_start = "";
@@ -94,7 +94,7 @@ std::string Summary(pugi::xml_node const& node) {
   return std::move(os).str();
 }
 
-std::string Conceptual(pugi::xml_node const& node) {
+std::string Conceptual(pugi::xml_node node) {
   std::ostringstream os;
   MarkdownContext ctx;
   ctx.paragraph_start = "";
@@ -108,7 +108,7 @@ std::string Conceptual(pugi::xml_node const& node) {
   return std::move(os).str();
 }
 
-void AppendDescription(YAML::Emitter& yaml, pugi::xml_node const& node) {
+void AppendDescription(YAML::Emitter& yaml, pugi::xml_node node) {
   auto const summary = Summary(node);
   if (!summary.empty()) {
     yaml << YAML::Key << "summary" << YAML::Value << YAML::Literal << summary;
@@ -129,7 +129,7 @@ std::vector<TocEntry> CompoundToc(Config const& cfg,
   // classes, structs) are always part of a namespace and will appear in the
   // references from them.
   for (auto const& i : doc.select_nodes("//compounddef[@kind='namespace']")) {
-    auto const& node = i.node();
+    auto const node = i.node();
     if (!IncludeInPublicDocuments(cfg, node)) continue;
     auto const id = std::string{node.attribute("id").as_string()};
     auto const name =
@@ -141,7 +141,7 @@ std::vector<TocEntry> CompoundToc(Config const& cfg,
   return result;
 }
 
-std::string Compound2Yaml(Config const& cfg, pugi::xml_node const& node) {
+std::string Compound2Yaml(Config const& cfg, pugi::xml_node node) {
   YAML::Emitter yaml;
   YamlContext ctx;
   ctx.config = cfg;
@@ -171,7 +171,7 @@ std::string EndDocFxYaml(YAML::Emitter& yaml) {
 }
 
 bool AppendIfEnumValue(YAML::Emitter& yaml, YamlContext const& ctx,
-                       pugi::xml_node const& node) {
+                       pugi::xml_node node) {
   if (std::string_view{node.name()} != "enumvalue") return false;
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto const name = std::string_view{node.child("name").child_value()};
@@ -189,7 +189,7 @@ bool AppendIfEnumValue(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 bool AppendIfEnum(YAML::Emitter& yaml, YamlContext const& ctx,
-                  pugi::xml_node const& node) {
+                  pugi::xml_node node) {
   if (kind(node) != "enum") return false;
   if (node.attribute("id").empty()) MissingAttribute(__func__, "id", node);
   auto const id = std::string_view{node.attribute("id").as_string()};
@@ -210,14 +210,14 @@ bool AppendIfEnum(YAML::Emitter& yaml, YamlContext const& ctx,
   yaml << YAML::EndMap;
   auto nested = ctx;
   nested.parent_id = id;
-  for (auto const& child : node) {
+  for (auto const child : node) {
     if (AppendIfEnumValue(yaml, nested, child)) continue;
   }
   return true;
 }
 
 bool AppendIfTypedef(YAML::Emitter& yaml, YamlContext const& ctx,
-                     pugi::xml_node const& node) {
+                     pugi::xml_node node) {
   if (kind(node) != "typedef") return false;
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto const name = std::string_view{node.child("name").child_value()};
@@ -239,7 +239,7 @@ bool AppendIfTypedef(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 bool AppendIfFriend(YAML::Emitter& yaml, YamlContext const& ctx,
-                    pugi::xml_node const& node) {
+                    pugi::xml_node node) {
   if (kind(node) != "friend") return false;
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto const name = std::string_view{node.child("name").child_value()};
@@ -261,7 +261,7 @@ bool AppendIfFriend(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 bool AppendIfVariable(YAML::Emitter& yaml, YamlContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (kind(node) != "variable") return false;
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto const name = std::string_view{node.child("name").child_value()};
@@ -283,7 +283,7 @@ bool AppendIfVariable(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 bool AppendIfFunction(YAML::Emitter& yaml, YamlContext const& ctx,
-                      pugi::xml_node const& node) {
+                      pugi::xml_node node) {
   if (kind(node) != "function") return false;
   auto const name = std::string{node.child("name").child_value()};
   if (name == "MOCK_METHOD") return true;
@@ -335,14 +335,14 @@ Consult the gMock documentation to use this mock in your tests.
 }
 
 bool AppendIfSectionDef(YAML::Emitter& yaml, YamlContext const& ctx,
-                        pugi::xml_node const& node) {
+                        pugi::xml_node node) {
   if (std::string_view{node.name()} != "sectiondef") return false;
   CompoundRecurse(yaml, ctx, node);
   return true;
 }
 
 bool AppendIfNamespace(YAML::Emitter& yaml, YamlContext const& ctx,
-                       pugi::xml_node const& node) {
+                       pugi::xml_node node) {
   if (kind(node) != "namespace") return false;
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto const name = std::string_view{node.child("compoundname").child_value()};
@@ -365,7 +365,7 @@ bool AppendIfNamespace(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 bool AppendIfClass(YAML::Emitter& yaml, YamlContext const& ctx,
-                   pugi::xml_node const& node) {
+                   pugi::xml_node node) {
   if (kind(node) != "class") return false;
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto const name = std::string_view{node.child("compoundname").child_value()};
@@ -388,7 +388,7 @@ bool AppendIfClass(YAML::Emitter& yaml, YamlContext const& ctx,
 }
 
 bool AppendIfStruct(YAML::Emitter& yaml, YamlContext const& ctx,
-                    pugi::xml_node const& node) {
+                    pugi::xml_node node) {
   if (kind(node) != "struct") return false;
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto const name = std::string_view{node.child("compoundname").child_value()};

--- a/docfx/doxygen2yaml.h
+++ b/docfx/doxygen2yaml.h
@@ -29,50 +29,50 @@ std::vector<TocEntry> CompoundToc(Config const& cfg,
 
 // Generate the YAML file contents for `<compounddef>` nodes representing C++
 // types.
-std::string Compound2Yaml(Config const& cfg, pugi::xml_node const& node);
+std::string Compound2Yaml(Config const& cfg, pugi::xml_node node);
 
 // Close the preamble elements required by DocFx and return the file contents.
 std::string EndDocFxYaml(YAML::Emitter& yaml);
 
 // Create a YAML entry for an enum value.
 bool AppendIfEnumValue(YAML::Emitter& yaml, YamlContext const& ctx,
-                       pugi::xml_node const& node);
+                       pugi::xml_node node);
 
 // Create a YAML entry for an enum definition.
 bool AppendIfEnum(YAML::Emitter& yaml, YamlContext const& ctx,
-                  pugi::xml_node const& node);
+                  pugi::xml_node node);
 
 // Create a YAML entry for a typedef definition.
 bool AppendIfTypedef(YAML::Emitter& yaml, YamlContext const& ctx,
-                     pugi::xml_node const& node);
+                     pugi::xml_node node);
 
 // Create a YAML entry for a friend definition.
 bool AppendIfFriend(YAML::Emitter& yaml, YamlContext const& ctx,
-                    pugi::xml_node const& node);
+                    pugi::xml_node node);
 
 // Create a YAML entry for a variable definition.
 bool AppendIfVariable(YAML::Emitter& yaml, YamlContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 // Create a YAML entry for a function declaration.
 bool AppendIfFunction(YAML::Emitter& yaml, YamlContext const& ctx,
-                      pugi::xml_node const& node);
+                      pugi::xml_node node);
 
 // Create YAML entries for a <sectiondef> and its children.
 bool AppendIfSectionDef(YAML::Emitter& yaml, YamlContext const& ctx,
-                        pugi::xml_node const& node);
+                        pugi::xml_node node);
 
 // Create YAML entries for a namespace and its children.
 bool AppendIfNamespace(YAML::Emitter& yaml, YamlContext const& ctx,
-                       pugi::xml_node const& node);
+                       pugi::xml_node node);
 
 // Create YAML entries for a class and its children.
 bool AppendIfClass(YAML::Emitter& yaml, YamlContext const& ctx,
-                   pugi::xml_node const& node);
+                   pugi::xml_node node);
 
 // Create YAML entries for a struct and its children.
 bool AppendIfStruct(YAML::Emitter& yaml, YamlContext const& ctx,
-                    pugi::xml_node const& node);
+                    pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/doxygen_errors.cc
+++ b/docfx/doxygen_errors.cc
@@ -19,8 +19,7 @@
 namespace docfx {
 
 [[noreturn]] void MissingAttribute(std::string_view where,
-                                   std::string_view name,
-                                   pugi::xml_node const& node) {
+                                   std::string_view name, pugi::xml_node node) {
   std::ostringstream os;
   os << "Missing attribute <" << name << "> in " << where << "(): node=";
   node.print(os, /*indent=*/"", /*flags=*/pugi::format_raw);
@@ -28,7 +27,7 @@ namespace docfx {
 }
 
 [[noreturn]] void MissingElement(std::string_view where, std::string_view name,
-                                 pugi::xml_node const& node) {
+                                 pugi::xml_node node) {
   std::ostringstream os;
   os << "Missing element <" << name << " in " << where << "(): node=";
   node.print(os, /*indent=*/"", /*flags=*/pugi::format_raw);
@@ -36,7 +35,7 @@ namespace docfx {
 }
 
 [[noreturn]] void UnknownChildType(std::string_view where,
-                                   pugi::xml_node const& child) {
+                                   pugi::xml_node child) {
   std::ostringstream os;
   os << "Unknown child in " << where << "(): node=";
   child.print(os, /*indent=*/"", /*flags=*/pugi::format_raw);

--- a/docfx/doxygen_errors.h
+++ b/docfx/doxygen_errors.h
@@ -22,16 +22,15 @@ namespace docfx {
 
 /// Throws an exception indicating an expected attribute is missing.
 [[noreturn]] void MissingAttribute(std::string_view where,
-                                   std::string_view name,
-                                   pugi::xml_node const& node);
+                                   std::string_view name, pugi::xml_node node);
 
 /// Throws an exception indicating an expected element is missing.
 [[noreturn]] void MissingElement(std::string_view where, std::string_view name,
-                                 pugi::xml_node const& node);
+                                 pugi::xml_node node);
 
 /// Throws an exception indicating child node with an unknown type was found.
 [[noreturn]] void UnknownChildType(std::string_view where,
-                                   pugi::xml_node const& child);
+                                   pugi::xml_node child);
 
 }  // namespace docfx
 

--- a/docfx/doxygen_groups.cc
+++ b/docfx/doxygen_groups.cc
@@ -23,8 +23,8 @@
 namespace docfx {
 namespace {
 
-void AppendReferences(YAML::Emitter& yaml, pugi::xml_node const& node) {
-  for (auto const& child : node) {
+void AppendReferences(YAML::Emitter& yaml, pugi::xml_node node) {
+  for (auto child : node) {
     auto const name = std::string_view{child.name()};
     if (name == "sectiondef") {
       AppendReferences(yaml, child);
@@ -52,7 +52,7 @@ std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc) {
   auto nodes = doc.select_nodes("//*[@kind='group']");
   std::transform(nodes.begin(), nodes.end(), std::back_inserter(result),
                  [](auto const& i) {
-                   auto const& group = i.node();
+                   auto const group = i.node();
                    auto const id =
                        std::string{group.attribute("id").as_string()};
                    std::ostringstream title;
@@ -64,7 +64,7 @@ std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc) {
   return result;
 }
 
-std::string Group2Yaml(pugi::xml_node const& node) {
+std::string Group2Yaml(pugi::xml_node node) {
   auto const id = std::string{node.attribute("id").as_string()};
   auto const title = [&] {
     std::ostringstream os;
@@ -151,7 +151,7 @@ std::string Group2Yaml(pugi::xml_node const& node) {
 //   <xsd:attribute name="abstract" type="DoxBool" use="optional"/>
 // </xsd:complexType>
 // clang-format on
-std::string Group2SummaryMarkdown(pugi::xml_node const& node) {
+std::string Group2SummaryMarkdown(pugi::xml_node node) {
   if (std::string_view{node.name()} != "compounddef" ||
       std::string_view{node.attribute("kind").as_string()} != "group") {
     std::ostringstream os;
@@ -165,7 +165,7 @@ std::string Group2SummaryMarkdown(pugi::xml_node const& node) {
   os << "# ";
   AppendTitle(os, ctx, node);
   os << "\n";
-  for (auto const& child : node) {
+  for (auto child : node) {
     auto name = std::string_view(child.name());
     if (name == "compoundname") continue;      // no markdown output
     if (name == "briefdescription") continue;  // no markdown output

--- a/docfx/doxygen_groups.h
+++ b/docfx/doxygen_groups.h
@@ -27,10 +27,10 @@ namespace docfx {
 std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc);
 
 /// Generates the YAML contents for a given group node.
-std::string Group2Yaml(pugi::xml_node const& node);
+std::string Group2Yaml(pugi::xml_node node);
 
 /// Generate the description of the group.
-std::string Group2SummaryMarkdown(pugi::xml_node const& node);
+std::string Group2SummaryMarkdown(pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/doxygen_pages.cc
+++ b/docfx/doxygen_pages.cc
@@ -80,7 +80,7 @@ namespace docfx {
 //   <xsd:attribute name="abstract" type="DoxBool" use="optional"/>
 // </xsd:complexType>
 // clang-format on
-std::string Page2Markdown(pugi::xml_node const& node) {
+std::string Page2Markdown(pugi::xml_node node) {
   if (std::string_view{node.name()} != "compounddef" ||
       std::string_view{node.attribute("kind").as_string()} != "page") {
     std::ostringstream os;
@@ -99,7 +99,7 @@ std::string Page2Markdown(pugi::xml_node const& node) {
   MarkdownContext ctx;
   AppendTitle(os, ctx, node);
   os << "\n";
-  for (auto const& child : node) {
+  for (auto child : node) {
     auto name = std::string_view(child.name());
     if (name == "compoundname") continue;      // no markdown output
     if (name == "briefdescription") continue;  // no markdown output
@@ -123,7 +123,7 @@ std::vector<TocEntry> PagesToc(Config const& cfg,
   std::vector<TocEntry> result;
   result.reserve(nodes.size());
   for (auto const& i : nodes) {
-    auto const& page = i.node();
+    auto const page = i.node();
     if (!IncludeInPublicDocuments(cfg, page)) continue;
     auto const id = std::string_view{page.attribute("id").as_string()};
     // Skip endpoint and authorization override snippets.

--- a/docfx/doxygen_pages.h
+++ b/docfx/doxygen_pages.h
@@ -28,7 +28,7 @@ namespace docfx {
  *
  * This creates the root MarkdownContext, so no need to consume it.
  */
-std::string Page2Markdown(pugi::xml_node const& node);
+std::string Page2Markdown(pugi::xml_node node);
 
 // Get the table of contents for pages.
 std::vector<TocEntry> PagesToc(Config const& cfg,

--- a/docfx/function_classifiers.cc
+++ b/docfx/function_classifiers.cc
@@ -18,13 +18,13 @@
 
 namespace docfx {
 
-bool IsOperator(pugi::xml_node const& node) {
+bool IsOperator(pugi::xml_node node) {
   auto const name = std::string_view{node.child("name").child_value()};
   return name.find("operator") != std::string_view::npos;
 }
 
-bool IsConstructor(pugi::xml_node const& node) {
-  auto is_empty = [](auto const& child) {
+bool IsConstructor(pugi::xml_node node) {
+  auto is_empty = [](pugi::xml_node child) {
     auto const name = std::string_view{child.name()};
     if (name == "ref") return std::string_view{child.child_value()}.empty();
     return std::string_view{child.value()}.empty();

--- a/docfx/function_classifiers.h
+++ b/docfx/function_classifiers.h
@@ -20,10 +20,10 @@
 namespace docfx {
 
 // Determine if a function is a constructor.
-bool IsConstructor(pugi::xml_node const& node);
+bool IsConstructor(pugi::xml_node node);
 
 // Determine if a function is an operator.
-bool IsOperator(pugi::xml_node const& node);
+bool IsOperator(pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/public_docs.cc
+++ b/docfx/public_docs.cc
@@ -17,13 +17,13 @@
 namespace docfx {
 namespace {
 
-auto kind(pugi::xml_node const& node) {
+auto kind(pugi::xml_node node) {
   return std::string_view{node.attribute("kind").as_string()};
 }
 
 }  // namespace
 
-bool IncludeInPublicDocuments(Config const& cfg, pugi::xml_node const& node) {
+bool IncludeInPublicDocuments(Config const& cfg, pugi::xml_node node) {
   // We do not generate documents for files and directories.
   if (kind(node) == "file" || kind(node) == "dir") return false;
   // Doxygen groups private attributes / functions in <sectiondef> elements of

--- a/docfx/public_docs.h
+++ b/docfx/public_docs.h
@@ -26,7 +26,7 @@ namespace docfx {
 // member variables, private functions, or any names in the `*internal*`
 // namespaces. This helper allows us to short circuit the recursion over the
 // doxygen structure when an element is not needed for the public docs.
-bool IncludeInPublicDocuments(Config const& cfg, pugi::xml_node const& node);
+bool IncludeInPublicDocuments(Config const& cfg, pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/yaml_context.cc
+++ b/docfx/yaml_context.cc
@@ -32,14 +32,14 @@ namespace {
 // What we do is use the information from the inherited function (from 2) and
 // give it the `uid` from the `MOCK_METHOD()` (from 1).
 std::unordered_map<std::string, std::string> MockingFunctions(
-    Config const& config, pugi::xml_node const& node) {
+    Config const& config, pugi::xml_node node) {
   std::unordered_map<std::string, std::string> mocked;
-  for (auto const& child : node.children("sectiondef")) {
+  for (auto const child : node.children("sectiondef")) {
     if (!IncludeInPublicDocuments(config, node)) continue;
     auto more = MockingFunctions(config, child);
     mocked.insert(more.begin(), more.end());
   }
-  for (auto const& child : node.children("memberdef")) {
+  for (auto const child : node.children("memberdef")) {
     auto const id = std::string_view{child.attribute("id").as_string()};
     auto const kind = std::string_view{child.attribute("kind").as_string()};
     if (id.empty() || kind != "function") continue;
@@ -62,14 +62,14 @@ std::unordered_map<std::string, std::string> MockingFunctions(
 
 std::unordered_set<std::string> MockedIds(
     std::unordered_map<std::string, std::string> const& mocked_functions,
-    Config const& config, pugi::xml_node const& node) {
+    Config const& config, pugi::xml_node node) {
   std::unordered_set<std::string> mocked;
-  for (auto const& child : node.children("sectiondef")) {
+  for (auto const child : node.children("sectiondef")) {
     if (!IncludeInPublicDocuments(config, node)) continue;
     auto more = MockedIds(mocked_functions, config, child);
     mocked.insert(more.begin(), more.end());
   }
-  for (auto const& child : node.children("memberdef")) {
+  for (auto const child : node.children("memberdef")) {
     auto const id = std::string_view{child.attribute("id").as_string()};
     auto const kind = std::string_view{child.attribute("kind").as_string()};
     if (id.empty() || kind != "function") continue;
@@ -84,8 +84,7 @@ std::unordered_set<std::string> MockedIds(
 
 }  // namespace
 
-YamlContext NestedYamlContext(YamlContext const& ctx,
-                              pugi::xml_node const& node) {
+YamlContext NestedYamlContext(YamlContext const& ctx, pugi::xml_node node) {
   auto const id = std::string{node.attribute("id").as_string()};
   auto nested = ctx;
   nested.parent_id = id;

--- a/docfx/yaml_context.h
+++ b/docfx/yaml_context.h
@@ -36,8 +36,7 @@ struct YamlContext {
 };
 
 /// Creates a new context to recurse over @p node
-YamlContext NestedYamlContext(YamlContext const& ctx,
-                              pugi::xml_node const& node);
+YamlContext NestedYamlContext(YamlContext const& ctx, pugi::xml_node node);
 
 }  // namespace docfx
 


### PR DESCRIPTION
A `pugi::xml_node` is akin to an iterator or a pointer. They should be passed by value and not by `const&`. It is possible some additional cleanups will be needed, but this should have caught most cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11482)
<!-- Reviewable:end -->
