### PR TITLE
fix(docfx): skip nested namespaces in children list

### DIFF
--- a/docfx/doxygen2children.cc
+++ b/docfx/doxygen2children.cc
@@ -30,10 +30,10 @@ std::vector<std::string> Children(YamlContext const& ctx,
     children.insert(children.end(), std::make_move_iterator(more.begin()),
                     std::make_move_iterator(more.end()));
   }
-  for (auto const& child : node.children("innernamespace")) {
-    auto const refid = std::string_view{child.attribute("refid").as_string()};
-    if (!refid.empty()) children.emplace_back(refid);
-  }
+  // Skip the <innernamespace> elements. All namespaces appear in the ToC
+  // (the left-side navigation). Repeating them as children renders incorrectly.
+  // We could fix that, but we do not have enough namespaces to make this
+  // worthwhile.
   for (auto const& child : node.children("innerclass")) {
     if (!IncludeInPublicDocuments(nested.config, child)) continue;
     auto const refid = std::string_view{child.attribute("refid").as_string()};

--- a/docfx/doxygen2children_test.cc
+++ b/docfx/doxygen2children_test.cc
@@ -130,7 +130,6 @@ TEST(Doxygen2ChildrenTest, Namespace) {
       UnorderedElementsAre(
           "structgoogle_1_1cloud_1_1AccessTokenLifetimeOption",
           "classgoogle_1_1cloud_1_1AsyncOperation",
-          "namespacegoogle_1_1cloud_1_1mocks",
           "namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c"));
 }
 

--- a/docfx/doxygen2references.cc
+++ b/docfx/doxygen2references.cc
@@ -50,6 +50,7 @@ std::list<Reference> ExtractReferences(YamlContext const& ctx,
   auto const name = std::string_view{node.name()};
   // Skip <innernamespace> elements. They are listed in ToC (the left-side
   // navigation).
+  if (name == "innernamespace") return {};
   if (name == "innerclass") {
     auto const uid = std::string{node.attribute("refid").as_string()};
     return {Reference(uid, node.child_value())};

--- a/docfx/doxygen2references.cc
+++ b/docfx/doxygen2references.cc
@@ -48,10 +48,8 @@ std::list<Reference> ExtractReferences(YamlContext const& ctx,
   if (!IncludeInPublicDocuments(ctx.config, node)) return {};
 
   auto const name = std::string_view{node.name()};
-  if (name == "innernamespace") {
-    auto const uid = std::string{node.attribute("refid").as_string()};
-    return {Reference(uid, node.child_value())};
-  }
+  // Skip <innernamespace> elements. They are listed in ToC (the left-side
+  // navigation).
   if (name == "innerclass") {
     auto const uid = std::string{node.attribute("refid").as_string()};
     return {Reference(uid, node.child_value())};

--- a/docfx/doxygen2references_test.cc
+++ b/docfx/doxygen2references_test.cc
@@ -142,8 +142,6 @@ TEST(Doxygen2ReferencesTest, Namespace) {
                     "google::cloud::AccessTokenLifetimeOption"),
           Reference("classgoogle_1_1cloud_1_1AsyncOperation",
                     "google::cloud::AsyncOperation"),
-          Reference("namespacegoogle_1_1cloud_1_1mocks",
-                    "google::cloud::mocks"),
           Reference(
               "namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c",
               "google::cloud::Idempotency")));


### PR DESCRIPTION
Listing the nested namespaces as children is (arguably) technically correct, but it does not render right, and does not aid in navigation.

Fixes #11452

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11483)
<!-- Reviewable:end -->
