### PR TITLE
impl(docfx): generate full table of contents

### DIFF
--- a/docfx/doxygen2toc.cc
+++ b/docfx/doxygen2toc.cc
@@ -13,50 +13,323 @@
 // limitations under the License.
 
 #include "docfx/doxygen2toc.h"
+#include "docfx/doxygen2markdown.h"
 #include "docfx/doxygen2yaml.h"
 #include "docfx/doxygen_groups.h"
 #include "docfx/doxygen_pages.h"
+#include "docfx/function_classifiers.h"
+#include "docfx/public_docs.h"
 #include <yaml-cpp/yaml.h>
+#include <functional>
+#include <iostream>
+#include <map>
 #include <sstream>
 
 namespace docfx {
+namespace {
+
+std::shared_ptr<TocEntry> NamedEntry(std::string_view name) {
+  auto entry = std::make_shared<TocEntry>();
+  entry->name = name;
+  return entry;
+}
+
+std::shared_ptr<TocEntry> CompoundEntry(pugi::xml_node node) {
+  auto const id = std::string_view{node.attribute("id").as_string()};
+  auto const name = std::string_view{node.child("compoundname").child_value()};
+  auto overview = NamedEntry("Overview");
+  overview->attr.emplace("uid", id);
+  auto entry = NamedEntry(name);
+  entry->items.push_back(std::move(overview));
+  return entry;
+}
+
+std::shared_ptr<TocEntry> MemberEntry(pugi::xml_node node) {
+  auto const id = std::string_view{node.attribute("id").as_string()};
+  auto const name = std::string_view{node.child("qualifiedname").child_value()};
+  auto overview = NamedEntry("Overview");
+  overview->attr.emplace("uid", id);
+  auto entry = NamedEntry(name);
+  entry->items.push_back(std::move(overview));
+  return entry;
+}
+
+std::shared_ptr<TocEntry> EnumValueEntry(pugi::xml_node node) {
+  auto const id = std::string_view{node.attribute("id").as_string()};
+  auto const name = std::string_view{node.child("name").child_value()};
+  auto entry = NamedEntry(name);
+  entry->attr.emplace("uid", id);
+  return entry;
+}
+
+bool IsNamespace(pugi::xml_node node) {
+  return std::string_view{node.attribute("kind").as_string()} == "namespace";
+}
+
+bool IsClass(pugi::xml_node node) {
+  return std::string_view{node.attribute("kind").as_string()} == "class";
+}
+
+bool IsStruct(pugi::xml_node node) {
+  return std::string_view{node.attribute("kind").as_string()} == "struct";
+}
+
+bool IsEnum(pugi::xml_node node) {
+  return std::string_view{node.attribute("kind").as_string()} == "enum";
+}
+
+bool IsTypedef(pugi::xml_node node) {
+  return std::string_view{node.attribute("kind").as_string()} == "typedef";
+}
+
+TocItems NamespaceToc(Config const& cfg, pugi::xml_document const& doc,
+                      pugi::xml_node node);
+TocItems ClassToc(Config const& cfg, pugi::xml_document const& doc,
+                  pugi::xml_node node);
+TocItems EnumToc(Config const& cfg, pugi::xml_document const& doc,
+                 pugi::xml_node node);
+
+// Generate ToC entries for any elements
+TocItems GenericToc(Config const& cfg, pugi::xml_document const& doc,
+                    pugi::xml_node node) {
+  if (!IncludeInPublicDocuments(cfg, node)) return {};
+  if (IsClass(node)) return ClassToc(cfg, doc, node);
+  if (IsStruct(node)) return ClassToc(cfg, doc, node);
+  if (IsEnum(node)) return EnumToc(cfg, doc, node);
+  if (IsNamespace(node)) return NamespaceToc(cfg, doc, node);
+  auto const element = std::string_view{node.name()};
+  if (element == "memberdef") return {MemberEntry(node)};
+  if (element == "enumvalue") return {EnumValueEntry(node)};
+  return {};
+}
+
+// Recursively build the ToC.
+//
+// This function only generates a ToC for some elements in the first level of
+// recursion. This makes it possible to "group" the elements by some predicate,
+// e.g. all the "Constructors" are grouped. The filtering does not recurse
+// for things like "classes" we want to list all the attributes of the matching
+// classes.
+template <typename Predicate>
+TocItems Recurse(Config const& cfg, pugi::xml_document const& doc,
+                 pugi::xml_node node, Predicate&& pred) {
+  if (!IncludeInPublicDocuments(cfg, node)) return {};
+  TocItems items;
+  for (auto const child : node) {
+    if (!IncludeInPublicDocuments(cfg, child)) continue;
+    auto const element = std::string_view{child.name()};
+    // A <sectiondef> element defines groups of members, such as, "public
+    // functions", or "private member variables". They currently do not get
+    // a representation in the ToC.
+    if (element == "sectiondef") {
+      items.splice(items.end(),
+                   Recurse(cfg, doc, child, std::forward<Predicate>(pred)));
+      continue;
+    }
+    // In the Doxygen XML file classes are referenced, but not defined, as
+    // a child element of the namespace element.  That is, the XML structure is:
+    //
+    // clang-format off
+    //   <doxygen>
+    //      <compounddef kind="namespace" id="namespacefoo">
+    //        <innerclass refid="classfoo_1_1Bar">foo::Bar</innerclass>
+    //      </compounddef>
+    //      <compounddef kind="class" id="classfoo_1_1Bar">
+    //      </compounddef>
+    //   </doxygen>
+    // clang-format on
+    //
+    // We want the classes to appear inside the namespace, so we need to lookup
+    // the referenced class and generate its ToC recursively.
+    if (element == "innerclass") {
+      pugi::xpath_variable_set vars;
+      vars.add("id", pugi::xpath_type_string);
+      vars.set("id", child.attribute("refid").as_string());
+      auto query = pugi::xpath_query("//compounddef[@id = string($id)]", &vars);
+      auto child = doc.select_node(query);
+      // Skip the referenced element if it does not match the predicate.
+      if (!child || !pred(child.node())) continue;
+      items.splice(items.end(), GenericToc(cfg, doc, child.node()));
+      continue;
+    }
+    // Skip the element if it does not match the predicate.
+    if (!pred(child)) continue;
+    items.splice(items.end(), GenericToc(cfg, doc, child));
+  }
+  return items;
+}
+
+using TocItemsProducer = std::function<TocItems()>;
+
+TocItems NamespaceToc(Config const& cfg, pugi::xml_document const& doc,
+                      pugi::xml_node node) {
+  if (!IncludeInPublicDocuments(cfg, node)) return {};
+  auto entry = CompoundEntry(node);
+  struct Node {
+    std::string_view name;
+    TocItemsProducer producer;
+  } nodes[] = {
+      {"Classes", [&] { return Recurse(cfg, doc, node, IsClass); }},
+      {"Structs", [&] { return Recurse(cfg, doc, node, IsStruct); }},
+      {"Functions", [&] { return Recurse(cfg, doc, node, IsPlainFunction); }},
+      {"Operators", [&] { return Recurse(cfg, doc, node, IsOperator); }},
+      {"Enums", [&] { return Recurse(cfg, doc, node, IsEnum); }},
+      {"Types", [&] { return Recurse(cfg, doc, node, IsTypedef); }},
+  };
+  for (auto const& [name, generator] : nodes) {
+    auto items = generator();
+    if (items.empty()) continue;
+    auto node = NamedEntry(name);
+    node->items = std::move(items);
+    entry->items.push_back(node);
+  }
+  return {std::move(entry)};
+}
+
+TocItems ClassToc(Config const& cfg, pugi::xml_document const& doc,
+                  pugi::xml_node node) {
+  if (!IncludeInPublicDocuments(cfg, node)) return {};
+  auto entry = CompoundEntry(node);
+  struct Node {
+    std::string_view name;
+    TocItemsProducer producer;
+  } nodes[] = {
+      {"Types", [&] { return Recurse(cfg, doc, node, IsTypedef); }},
+      {"Constructors", [&] { return Recurse(cfg, doc, node, IsConstructor); }},
+      {"Operators", [&] { return Recurse(cfg, doc, node, IsOperator); }},
+      {"Functions", [&] { return Recurse(cfg, doc, node, IsPlainFunction); }},
+      {"Enums", [&] { return Recurse(cfg, doc, node, IsEnum); }},
+      // Skip these. They also appear as `<innerclass>` elements in the
+      // namespace.
+      // {"Classes", [&] { return Recurse(cfg, doc, node, IsClass); }},
+      // {"Structs", [&] { return Recurse(cfg, doc, node, IsStruct); }},
+  };
+  for (auto const& [name, generator] : nodes) {
+    auto items = generator();
+    if (items.empty()) continue;
+    auto node = NamedEntry(name);
+    node->items = std::move(items);
+    entry->items.push_back(node);
+  }
+  return {std::move(entry)};
+}
+
+TocItems EnumToc(Config const& cfg, pugi::xml_document const& doc,
+                 pugi::xml_node node) {
+  if (!IncludeInPublicDocuments(cfg, node)) return {};
+  auto entry = MemberEntry(node);
+  for (auto const child : node) {
+    if (!IncludeInPublicDocuments(cfg, child)) continue;
+    auto const element = std::string_view{child.name()};
+    if (element == "enumvalue") {
+      entry->items.splice(entry->items.end(), GenericToc(cfg, doc, child));
+      continue;
+    }
+  }
+  return {std::move(entry)};
+}
+
+TocItems Indexpage(Config const& /*config*/, pugi::xml_document const& doc) {
+  pugi::xpath_variable_set vars;
+  vars.add("id", pugi::xpath_type_string);
+  vars.set("id", "indexpage");
+  auto query = pugi::xpath_query("//compounddef[@id = string($id)]", &vars);
+  auto child = doc.select_node(query);
+  if (!child) return {};
+  std::ostringstream title;
+  AppendTitle(title, MarkdownContext{}, child.node());
+  auto entry = NamedEntry(title.str());
+  entry->attr.emplace("href", "index.md");
+  entry->attr.emplace("uid", "indexpage");
+  return {std::move(entry)};
+}
+
+TocItems Pages(Config const& config, pugi::xml_document const& doc) {
+  TocItems items;
+  for (auto const& i : doc.select_nodes("//*[@kind='page']")) {
+    auto const page = i.node();
+    if (!IncludeInPublicDocuments(config, page)) continue;
+    auto const id = std::string_view{page.attribute("id").as_string()};
+    // Skip endpoint and authorization override snippets.
+    if (id.find("-endpoint-snippet") != std::string_view::npos) continue;
+    if (id.find("-account-snippet") != std::string_view::npos) continue;
+    if (id == "indexpage") continue;
+    std::ostringstream title;
+    AppendTitle(title, MarkdownContext{}, page);
+    auto entry = NamedEntry(title.str());
+    entry->attr.emplace("href", std::string{id} + ".md");
+    entry->attr.emplace("uid", id);
+    items.push_back(std::move(entry));
+  }
+  return items;
+}
+
+TocItems Groups(Config const& /*config*/, pugi::xml_document const& doc) {
+  TocItems items;
+  for (auto const& i : doc.select_nodes("//*[@kind='group']")) {
+    auto const group = i.node();
+    auto const id = std::string{group.attribute("id").as_string()};
+    std::ostringstream title;
+    AppendTitle(title, MarkdownContext{}, group);
+    auto entry = NamedEntry(title.str());
+    entry->attr.emplace("href", std::string{id} + ".yml");
+    entry->attr.emplace("uid", id);
+    items.push_back(std::move(entry));
+  }
+  return items;
+}
+
+TocItems Namespaces(Config const& config, pugi::xml_document const& doc) {
+  TocItems items;
+  for (auto const& i : doc.select_nodes("//compounddef[@kind='namespace']")) {
+    if (!IncludeInPublicDocuments(config, i.node())) continue;
+    items.splice(items.end(), NamespaceToc(config, doc, i.node()));
+  }
+  return items;
+}
+
+void Toc2Yaml(YAML::Emitter& out, TocEntry const& e) {
+  out << YAML::BeginMap;
+  out << YAML::Key << "name" << YAML::Value << e.name;
+  for (auto const& [key, value] : e.attr) {
+    out << YAML::Key << key << YAML::Value << value;
+  }
+  if (!e.items.empty()) {
+    out << YAML::Key << "items" << YAML::Value << YAML::BeginSeq;
+    for (auto const& entry : e.items) Toc2Yaml(out, *entry);
+    out << YAML::EndSeq;
+  }
+  out << YAML::EndMap;
+}
+
+TocEntry BuildToc(Config const& config, pugi::xml_document const& doc) {
+  TocEntry toc;
+  toc.name = std::string{"cloud.google.com/cpp/"} + config.library;
+  toc.items.splice(toc.items.end(), Indexpage(config, doc));
+  struct Node {
+    std::string_view name;
+    std::function<TocItems(Config const&, pugi::xml_document const&)> generator;
+  } nodes[] = {
+      {"In-Depth Topics", Pages},
+      {"Modules", Groups},
+      {"Namespaces", Namespaces},
+  };
+  for (auto const& [name, generator] : nodes) {
+    auto items = generator(config, doc);
+    if (items.empty()) continue;
+    auto node = NamedEntry(name);
+    node->items = std::move(items);
+    toc.items.push_back(node);
+  }
+  return toc;
+}
+
+}  // namespace
 
 std::string Doxygen2Toc(Config const& config, pugi::xml_document const& doc) {
-  auto const uid = std::string{"cloud.google.com/cpp/"} + config.library;
+  auto const toc = BuildToc(config, doc);
   YAML::Emitter out;
-  out << YAML::BeginMap                                        //
-      << YAML::Key << "name" << YAML::Value << config.library  //
-      << YAML::Key << "items" << YAML::Value                   //
-      << YAML::BeginSeq;
-  auto pages = PagesToc(config, doc);
-  if (!pages.empty()) {
-    auto const& e = pages.front();
-    out << YAML::BeginMap                                    //
-        << YAML::Key << "name" << YAML::Value << e.name      //
-        << YAML::Key << "href" << YAML::Value << e.filename  //
-        << YAML::EndMap;
-    pages.erase(pages.begin());
-  }
-  for (auto const& e : CompoundToc(config, doc)) {
-    out << YAML::BeginMap                                //
-        << YAML::Key << "uid" << YAML::Value << e.uid    //
-        << YAML::Key << "name" << YAML::Value << e.name  //
-        << YAML::EndMap;
-  }
-  for (auto const& e : pages) {
-    out << YAML::BeginMap                                    //
-        << YAML::Key << "name" << YAML::Value << e.name      //
-        << YAML::Key << "href" << YAML::Value << e.filename  //
-        << YAML::EndMap;
-  }
-  for (auto const& e : GroupsToc(doc)) {
-    out << YAML::BeginMap                                //
-        << YAML::Key << "uid" << YAML::Value << e.uid    //
-        << YAML::Key << "name" << YAML::Value << e.name  //
-        << YAML::EndMap;
-  }
-  out << YAML::EndSeq << YAML::EndMap;
-
+  Toc2Yaml(out, toc);
   std::ostringstream os;
   os << "### YamlMime:TableOfContent\n" << out.c_str() << "\n";
   return std::move(os).str();

--- a/docfx/doxygen2toc.h
+++ b/docfx/doxygen2toc.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN2TOC_H
 
 #include "docfx/config.h"
+#include "docfx/toc_entry.h"
 #include <pugixml.hpp>
 #include <string>
 

--- a/docfx/doxygen2toc_test.cc
+++ b/docfx/doxygen2toc_test.cc
@@ -52,16 +52,27 @@ TEST(Doxygen2Toc, Simple) {
     </doxygen>)xml";
 
   auto constexpr kExpected = R"""(### YamlMime:TableOfContent
-name: cloud
+name: cloud.google.com/cpp/cloud
 items:
   - name: The Page Title
     href: index.md
-  - uid: namespacegoogle_1_1cloud
-    name: google::cloud
-  - name: Error Handling
-    href: common-error-handling.md
-  - uid: group__terminate
-    name: Terminate Group Title
+    uid: indexpage
+  - name: In-Depth Topics
+    items:
+      - name: Error Handling
+        href: common-error-handling.md
+        uid: common-error-handling
+  - name: Modules
+    items:
+      - name: Terminate Group Title
+        href: group__terminate.yml
+        uid: group__terminate
+  - name: Namespaces
+    items:
+      - name: google::cloud
+        items:
+          - name: Overview
+            uid: namespacegoogle_1_1cloud
 )""";
 
   pugi::xml_document doc;
@@ -70,6 +81,200 @@ items:
   auto const actual = Doxygen2Toc(config, doc);
 
   EXPECT_EQ(kExpected, actual);
+}
+
+TEST(Doxygen2Toc, PagesToc) {
+  auto constexpr kXml =
+      R"xml(<?xml version="1.0" standalone="yes"?><doxygen version="1.9.1" xml:lang="en-US">
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="common-error-handling" kind="page">
+          <compoundname>common-error-handling</compoundname>
+          <title>Error Handling</title>
+          <briefdescription><para>An overview of error handling in the Google Cloud C++ client libraries.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about error handling.</para></detaileddescription>
+        </compounddef>
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="indexpage" kind="page">
+          <compoundname>index</compoundname>
+          <title>The Page Title</title>
+          <briefdescription><para>Some brief description.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about the index.</para></detaileddescription>
+        </compounddef>
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="deprecated" kind="page">
+          <compoundname>deprecated</compoundname>
+          <title>Deprecated List</title>
+          <briefdescription><para>Some brief description.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about the index.</para></detaileddescription>
+        </compounddef>
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="secretmanager_v1_1_1SecretManagerServiceClient-endpoint-snippet" kind="page">
+          <compoundname>secretmanager_v1::SecretManagerServiceClient-endpoint-snippet</compoundname>
+          <title>Override secretmanager_v1::SecretManagerServiceClient Endpoint Configuration</title>
+          <briefdescription><para>Some brief description.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about the snippet.</para></detaileddescription>
+        </compounddef>
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="secretmanager_v1_1_1SecretManagerServiceClient-service-account-snippet" kind="page">
+          <compoundname>secretmanager_v1::SecretManagerServiceClient-service-account-snippet</compoundname>
+          <title>Override secretmanager_v1::SecretManagerServiceClient Authentication Default</title>
+          <briefdescription><para>Some brief description.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about the snippet.</para></detaileddescription>
+        </compounddef>
+      </doxygen>)xml";
+
+  auto constexpr kExpected = R"""(### YamlMime:TableOfContent
+name: cloud.google.com/cpp/cloud
+items:
+  - name: The Page Title
+    href: index.md
+    uid: indexpage
+  - name: In-Depth Topics
+    items:
+      - name: Error Handling
+        href: common-error-handling.md
+        uid: common-error-handling
+)""";
+
+  pugi::xml_document doc;
+  ASSERT_TRUE(doc.load_string(kXml));
+  auto const actual = Doxygen2Toc(Config{"unused", "cloud", ""}, doc);
+  EXPECT_EQ(actual, kExpected);
+}
+
+TEST(Doxygen2Toc, GroupsToc) {
+  auto constexpr kXml =
+      R"xml(<?xml version="1.0" standalone="yes"?><doxygen version="1.9.1" xml:lang="en-US">
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="group__g1" kind="group">
+          <compoundname>g1</compoundname>
+          <title>Group 1</title>
+          <briefdescription><para>The description for Group 1.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about Group 1.</para></detaileddescription>
+        </compounddef>
+        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="group__g2" kind="group">
+          <compoundname>g2</compoundname>
+          <title>Group 2</title>
+          <briefdescription><para>The description for Group 2.</para>
+          </briefdescription>
+          <detaileddescription><para>More details about Group 2.</para></detaileddescription>
+        </compounddef>
+      </doxygen>)xml";
+
+  auto constexpr kExpected = R"""(### YamlMime:TableOfContent
+name: cloud.google.com/cpp/cloud
+items:
+  - name: Modules
+    items:
+      - name: Group 1
+        href: group__g1.yml
+        uid: group__g1
+      - name: Group 2
+        href: group__g2.yml
+        uid: group__g2
+)""";
+
+  pugi::xml_document doc;
+  ASSERT_TRUE(doc.load_string(kXml));
+  auto const config = Config{"test-only-no-input-file", "cloud", "4.2"};
+  auto const actual = Doxygen2Toc(config, doc);
+
+  EXPECT_EQ(kExpected, actual);
+}
+
+TEST(Doxygen2Toc, CompoundToc) {
+  auto constexpr kDocXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle" kind="namespace" language="C++">
+        <compoundname>google</compoundname>
+        <innernamespace refid="namespacegoogle_1_1cloud">google::cloud</innernamespace>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud" kind="namespace" language="C++">
+        <compoundname>google::cloud</compoundname>
+        <innerclass refid="classgoogle_1_1cloud_1_1future">google::cloud::future</innerclass>
+        <memberdef kind="enum" id="namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c" prot="public" static="no" strong="yes">
+          <type/>
+          <name>Idempotency</name>
+          <qualifiedname>google::cloud::Idempotency</qualifiedname>
+          <enumvalue id="namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9caf8bb1d9c7cccc450ecd06167c7422bfa" prot="public">
+            <name>kIdempotent</name>
+            <briefdescription>
+              <para>The operation is idempotent and can be retried after a transient failure.</para>
+            </briefdescription>
+            <detaileddescription>
+            </detaileddescription>
+          </enumvalue>
+          <enumvalue id="namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9cae75d33e94f2dc4028d4d67bdaab75190" prot="public">
+            <name>kNonIdempotent</name>
+            <briefdescription>
+              <para>The operation is not idempotent and should <bold>not</bold> be retried after a transient failure.</para>
+            </briefdescription>
+            <detaileddescription>
+            </detaileddescription>
+          </enumvalue>
+          <briefdescription>
+            <para>Whether a request is <ulink url="https://en.wikipedia.org/wiki/Idempotence">idempotent</ulink>.</para>
+          </briefdescription>
+          <detaileddescription>
+            <para>When a RPC fails with a retryable error, the <computeroutput>google-cloud-cpp</computeroutput> client libraries automatically retry the RPC <bold>if</bold> the RPC is <ulink url="https://en.wikipedia.org/wiki/Idempotence">idempotent</ulink>. For each service, the library define a policy that determines whether a given request is idempotent. In many cases this can be determined statically, for example, read-only operations are always idempotent. In some cases, the contents of the request may need to be examined to determine if the operation is idempotent. For example, performing operations with pre-conditions, such that the pre-conditions change when the operation succeed, is typically idempotent.</para>
+            <para>Applications may override the default idempotency policy, though we anticipate that this would be needed only in very rare circumstances. A few examples include:</para>
+            <para><itemizedlist>
+            <listitem><para>In some services deleting "the most recent" entry may be idempotent if the system has been configured to keep no history or versions, as the deletion may succeed only once. In contrast, deleting "the most recent entry" is <bold>not</bold> idempotent if the system keeps multiple versions. Google Cloud Storage or Bigtable can be configured either way.</para>
+            </listitem><listitem><para>In some applications, creating a duplicate entry may be acceptable as the system will deduplicate them later. In such systems it may be preferable to retry the operation even though it is not idempotent. </para>
+            </listitem></itemizedlist>
+            </para>
+          </detaileddescription>
+          <inbodydescription>
+          </inbodydescription>
+          <location file="idempotency.h" line="55" column="1" bodyfile="idempotency.h" bodystart="55" bodyend="61"/>
+        </memberdef>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacestd" kind="namespace" language="Unknown">
+        <compoundname>std</compoundname>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classgoogle_1_1cloud_1_1future" kind="class" language="C++" prot="public" final="yes">
+        <compoundname>google::cloud::future</compoundname>
+        <basecompoundref prot="private" virt="non-virtual">internal::future_base&lt; T &gt;</basecompoundref>
+        <includes refid="future__generic_8h" local="no">google/cloud/future_generic.h</includes>
+        <templateparamlist>
+          <param>
+            <type>typename T</type>
+          </param>
+        </templateparamlist>
+      </compounddef>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"""(### YamlMime:TableOfContent
+name: cloud.google.com/cpp/cloud
+items:
+  - name: Namespaces
+    items:
+      - name: google::cloud
+        items:
+          - name: Overview
+            uid: namespacegoogle_1_1cloud
+          - name: Classes
+            items:
+              - name: google::cloud::future
+                items:
+                  - name: Overview
+                    uid: classgoogle_1_1cloud_1_1future
+          - name: Enums
+            items:
+              - name: google::cloud::Idempotency
+                items:
+                  - name: Overview
+                    uid: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c
+                  - name: kIdempotent
+                    uid: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9caf8bb1d9c7cccc450ecd06167c7422bfa
+                  - name: kNonIdempotent
+                    uid: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9cae75d33e94f2dc4028d4d67bdaab75190
+)""";
+
+  pugi::xml_document doc;
+  ASSERT_TRUE(doc.load_string(kDocXml));
+  auto const actual = Doxygen2Toc(Config{"unused", "cloud", ""}, doc);
+  EXPECT_EQ(actual, kExpected);
 }
 
 }  // namespace

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -122,25 +122,6 @@ void AppendDescription(YAML::Emitter& yaml, pugi::xml_node node) {
 
 }  // namespace
 
-std::vector<TocEntry> CompoundToc(Config const& cfg,
-                                  pugi::xml_document const& doc) {
-  std::vector<TocEntry> result;
-  // Insert only namespaces in the TOC. Other entities (functions, typedefs,
-  // classes, structs) are always part of a namespace and will appear in the
-  // references from them.
-  for (auto const& i : doc.select_nodes("//compounddef[@kind='namespace']")) {
-    auto const node = i.node();
-    if (!IncludeInPublicDocuments(cfg, node)) continue;
-    auto const id = std::string{node.attribute("id").as_string()};
-    auto const name =
-        std::string_view{node.child("compoundname").child_value()};
-    result.push_back(TocEntry{id, std::string(name), id + ".yml"});
-  }
-  std::sort(result.begin(), result.end(),
-            [](auto const& a, auto const& b) { return a.name < b.name; });
-  return result;
-}
-
 std::string Compound2Yaml(Config const& cfg, pugi::xml_node node) {
   YAML::Emitter yaml;
   YamlContext ctx;

--- a/docfx/doxygen2yaml.h
+++ b/docfx/doxygen2yaml.h
@@ -23,10 +23,6 @@
 
 namespace docfx {
 
-// Get the table of contents for `<compounddef>` nodes representing C++ types.
-std::vector<TocEntry> CompoundToc(Config const& cfg,
-                                  pugi::xml_document const& doc);
-
 // Generate the YAML file contents for `<compounddef>` nodes representing C++
 // types.
 std::string Compound2Yaml(Config const& cfg, pugi::xml_node node);

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -20,8 +20,6 @@
 namespace docfx {
 namespace {
 
-using ::testing::ElementsAre;
-
 auto constexpr kEnumXml = R"xml(<?xml version="1.0" standalone="yes"?>
     <doxygen version="1.9.1" xml:lang="en-US">
       <memberdef kind="enum" id="namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c" prot="public" static="no" strong="yes">

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -377,40 +377,6 @@ auto constexpr kClassXml = R"xml(xml(<?xml version="1.0" standalone="yes"?>
     </compounddef>
   </doxygen>)xml";
 
-TEST(Doxygen2Yaml, CompoundToc) {
-  auto constexpr kDocXml = R"xml(<?xml version="1.0" standalone="yes"?>
-    <doxygen version="1.9.1" xml:lang="en-US">
-      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle" kind="namespace" language="C++">
-        <compoundname>google</compoundname>
-        <innernamespace refid="namespacegoogle_1_1cloud">google::cloud</innernamespace>
-      </compounddef>
-      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud" kind="namespace" language="C++">
-        <compoundname>google::cloud</compoundname>
-      </compounddef>
-      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacestd" kind="namespace" language="Unknown">
-        <compoundname>std</compoundname>
-      </compounddef>
-      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classgoogle_1_1cloud_1_1future" kind="class" language="C++" prot="public" final="yes">
-        <compoundname>google::cloud::future</compoundname>
-        <basecompoundref prot="private" virt="non-virtual">internal::future_base&lt; T &gt;</basecompoundref>
-        <includes refid="future__generic_8h" local="no">google/cloud/future_generic.h</includes>
-        <templateparamlist>
-          <param>
-            <type>typename T</type>
-          </param>
-        </templateparamlist>
-      </compounddef>
-    </doxygen>)xml";
-
-  pugi::xml_document doc;
-  ASSERT_TRUE(doc.load_string(kDocXml));
-  auto const actual = CompoundToc(Config{"unused", "cloud", ""}, doc);
-
-  EXPECT_THAT(actual,
-              ElementsAre(TocEntry{"namespacegoogle_1_1cloud", "google::cloud",
-                                   "namespacegoogle_1_1cloud.yml"}));
-}
-
 void TestPre(YAML::Emitter& yaml) {
   yaml << YAML::BeginMap << YAML::Key << "items" << YAML::Value
        << YAML::BeginSeq;

--- a/docfx/doxygen_groups.cc
+++ b/docfx/doxygen_groups.cc
@@ -47,23 +47,6 @@ void AppendReferences(YAML::Emitter& yaml, pugi::xml_node node) {
 
 }  // namespace
 
-std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc) {
-  std::vector<TocEntry> result;
-  auto nodes = doc.select_nodes("//*[@kind='group']");
-  std::transform(nodes.begin(), nodes.end(), std::back_inserter(result),
-                 [](auto const& i) {
-                   auto const group = i.node();
-                   auto const id =
-                       std::string{group.attribute("id").as_string()};
-                   std::ostringstream title;
-                   AppendTitle(title, MarkdownContext{}, group);
-                   return TocEntry{id, title.str(), id + ".yml"};
-                 });
-  std::sort(result.begin(), result.end(),
-            [](auto const& a, auto const& b) { return a.name < b.name; });
-  return result;
-}
-
 std::string Group2Yaml(pugi::xml_node node) {
   auto const id = std::string{node.attribute("id").as_string()};
   auto const title = [&] {

--- a/docfx/doxygen_groups.h
+++ b/docfx/doxygen_groups.h
@@ -23,9 +23,6 @@
 
 namespace docfx {
 
-/// Get the table of contents for groups.
-std::vector<TocEntry> GroupsToc(pugi::xml_document const& doc);
-
 /// Generates the YAML contents for a given group node.
 std::string Group2Yaml(pugi::xml_node node);
 

--- a/docfx/doxygen_groups_test.cc
+++ b/docfx/doxygen_groups_test.cc
@@ -18,9 +18,6 @@
 namespace docfx {
 namespace {
 
-using ::testing::ElementsAre;
-using ::testing::FieldsAre;
-
 TEST(DoxygenGroups, CommonPage) {
   auto constexpr kXml =
       R"xml(<?xml version="1.0" standalone="yes"?><doxygen version="1.9.1" xml:lang="en-US">

--- a/docfx/doxygen_groups_test.cc
+++ b/docfx/doxygen_groups_test.cc
@@ -74,33 +74,5 @@ items:
   EXPECT_EQ(kExpected, actual);
 }
 
-TEST(DoxygenGroups, GroupsToc) {
-  auto constexpr kXml =
-      R"xml(<?xml version="1.0" standalone="yes"?><doxygen version="1.9.1" xml:lang="en-US">
-        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="group__g1" kind="group">
-          <compoundname>g1</compoundname>
-          <title>Group 1</title>
-          <briefdescription><para>The description for Group 1.</para>
-          </briefdescription>
-          <detaileddescription><para>More details about Group 1.</para></detaileddescription>
-        </compounddef>
-        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="group__g2" kind="group">
-          <compoundname>g2</compoundname>
-          <title>Group 2</title>
-          <briefdescription><para>The description for Group 2.</para>
-          </briefdescription>
-          <detaileddescription><para>More details about Group 2.</para></detaileddescription>
-        </compounddef>
-      </doxygen>)xml";
-
-  pugi::xml_document doc;
-  ASSERT_TRUE(doc.load_string(kXml));
-  auto const actual = GroupsToc(doc);
-
-  EXPECT_THAT(actual,
-              ElementsAre(FieldsAre("group__g1", "Group 1", "group__g1.yml"),
-                          FieldsAre("group__g2", "Group 2", "group__g2.yml")));
-}
-
 }  // namespace
 }  // namespace docfx

--- a/docfx/doxygen_pages.cc
+++ b/docfx/doxygen_pages.cc
@@ -117,32 +117,4 @@ std::string Page2Markdown(pugi::xml_node node) {
   return std::move(os).str();
 }
 
-std::vector<TocEntry> PagesToc(Config const& cfg,
-                               pugi::xml_document const& doc) {
-  auto nodes = doc.select_nodes("//*[@kind='page']");
-  std::vector<TocEntry> result;
-  result.reserve(nodes.size());
-  for (auto const& i : nodes) {
-    auto const page = i.node();
-    if (!IncludeInPublicDocuments(cfg, page)) continue;
-    auto const id = std::string_view{page.attribute("id").as_string()};
-    // Skip endpoint and authorization override snippets.
-    if (id.find("-endpoint-snippet") != std::string_view::npos) continue;
-    if (id.find("-account-snippet") != std::string_view::npos) continue;
-    std::ostringstream title;
-    AppendTitle(title, MarkdownContext{}, page);
-    auto filename =
-        std::string(id == "indexpage" ? std::string_view{"index"} : id) + ".md";
-    result.push_back({std::string{id}, title.str(), std::move(filename)});
-  };
-  std::sort(result.begin(), result.end(), [](auto const& a, auto const& b) {
-    // If there is an `indexpage` element (aka `index.md`) it should be the
-    // first entry.
-    if (b.uid == "indexpage") return false;
-    if (a.uid == "indexpage") return true;
-    return a.uid < b.uid;
-  });
-  return result;
-}
-
 }  // namespace docfx

--- a/docfx/doxygen_pages.h
+++ b/docfx/doxygen_pages.h
@@ -30,10 +30,6 @@ namespace docfx {
  */
 std::string Page2Markdown(pugi::xml_node node);
 
-// Get the table of contents for pages.
-std::vector<TocEntry> PagesToc(Config const& cfg,
-                               pugi::xml_document const& doc);
-
 }  // namespace docfx
 
 #endif  // GOOGLE_CLOUD_CPP_DOCFX_DOXYGEN_PAGES_H

--- a/docfx/doxygen_pages_test.cc
+++ b/docfx/doxygen_pages_test.cc
@@ -100,56 +100,5 @@ This library contains common components shared by all the Google Cloud C++ Clien
   EXPECT_EQ(kExpected, actual);
 }
 
-TEST(DoxygenPages, PagesToc) {
-  auto constexpr kXml =
-      R"xml(<?xml version="1.0" standalone="yes"?><doxygen version="1.9.1" xml:lang="en-US">
-        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="common-error-handling" kind="page">
-          <compoundname>common-error-handling</compoundname>
-          <title>Error Handling</title>
-          <briefdescription><para>An overview of error handling in the Google Cloud C++ client libraries.</para>
-          </briefdescription>
-          <detaileddescription><para>More details about error handling.</para></detaileddescription>
-        </compounddef>
-        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="indexpage" kind="page">
-          <compoundname>index</compoundname>
-          <title>The Page Title</title>
-          <briefdescription><para>Some brief description.</para>
-          </briefdescription>
-          <detaileddescription><para>More details about the index.</para></detaileddescription>
-        </compounddef>
-        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="deprecated" kind="page">
-          <compoundname>deprecated</compoundname>
-          <title>Deprecated List</title>
-          <briefdescription><para>Some brief description.</para>
-          </briefdescription>
-          <detaileddescription><para>More details about the index.</para></detaileddescription>
-        </compounddef>
-        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="secretmanager_v1_1_1SecretManagerServiceClient-endpoint-snippet" kind="page">
-          <compoundname>secretmanager_v1::SecretManagerServiceClient-endpoint-snippet</compoundname>
-          <title>Override secretmanager_v1::SecretManagerServiceClient Endpoint Configuration</title>
-          <briefdescription><para>Some brief description.</para>
-          </briefdescription>
-          <detaileddescription><para>More details about the snippet.</para></detaileddescription>
-        </compounddef>
-        <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="secretmanager_v1_1_1SecretManagerServiceClient-service-account-snippet" kind="page">
-          <compoundname>secretmanager_v1::SecretManagerServiceClient-service-account-snippet</compoundname>
-          <title>Override secretmanager_v1::SecretManagerServiceClient Authentication Default</title>
-          <briefdescription><para>Some brief description.</para>
-          </briefdescription>
-          <detaileddescription><para>More details about the snippet.</para></detaileddescription>
-        </compounddef>
-      </doxygen>)xml";
-
-  pugi::xml_document doc;
-  ASSERT_TRUE(doc.load_string(kXml));
-  auto const actual = PagesToc(Config{"unused", "cloud", "unused"}, doc);
-
-  // The order matters, we want `indexpage` to be the first page.
-  EXPECT_THAT(actual,
-              ElementsAre(FieldsAre("indexpage", "The Page Title", "index.md"),
-                          FieldsAre("common-error-handling", "Error Handling",
-                                    "common-error-handling.md")));
-}
-
 }  // namespace
 }  // namespace docfx

--- a/docfx/doxygen_pages_test.cc
+++ b/docfx/doxygen_pages_test.cc
@@ -18,9 +18,6 @@
 namespace docfx {
 namespace {
 
-using ::testing::ElementsAre;
-using ::testing::FieldsAre;
-
 TEST(DoxygenPages, CommonPage) {
   auto constexpr kXml =
       R"xml(<?xml version="1.0" standalone="yes"?><doxygen version="1.9.1" xml:lang="en-US">

--- a/docfx/toc_entry.cc
+++ b/docfx/toc_entry.cc
@@ -13,12 +13,33 @@
 // limitations under the License.
 
 #include "docfx/toc_entry.h"
+#include <algorithm>
 #include <iostream>
 
 namespace docfx {
 
+bool operator==(TocEntry const& lhs, TocEntry const& rhs) {
+  if (lhs.name != rhs.name || lhs.attr != rhs.attr) return false;
+  return std::equal(lhs.items.begin(), lhs.items.end(), rhs.items.begin(),
+                    rhs.items.end(),
+                    [](auto const& a, auto const& b) { return *a == *b; });
+}
+
 std::ostream& operator<<(std::ostream& os, TocEntry const& entry) {
-  return os << "filename=" << entry.filename << ", name=" << entry.name;
+  os << "{name=" << entry.name << ", attr={";
+  auto sep = std::string_view{", attr={"};
+  for (auto const& [key, value] : entry.attr) {
+    os << sep << key << "=" << value;
+    sep = ", ";
+  }
+  if (!entry.attr.empty()) os << "}";
+  sep = ", items=[";
+  for (auto const& item : entry.items) {
+    os << sep << *item;
+    sep = ", ";
+  }
+  if (!entry.items.empty()) os << "]";
+  return os << "}";
 }
 
 }  // namespace docfx

--- a/docfx/toc_entry.cc
+++ b/docfx/toc_entry.cc
@@ -19,9 +19,9 @@
 namespace docfx {
 
 bool operator==(TocEntry const& lhs, TocEntry const& rhs) {
-  if (lhs.name != rhs.name || lhs.attr != rhs.attr) return false;
-  return std::equal(lhs.items.begin(), lhs.items.end(), rhs.items.begin(),
-                    rhs.items.end(),
+  return lhs.name == rhs.name && lhs.attr == rhs.attr &&
+         std::equal(lhs.items.begin(), lhs.items.end(),  //
+                    rhs.items.begin(), rhs.items.end(),  //
                     [](auto const& a, auto const& b) { return *a == *b; });
 }
 

--- a/docfx/toc_entry.h
+++ b/docfx/toc_entry.h
@@ -15,26 +15,43 @@
 #ifndef GOOGLE_CLOUD_CPP_DOCFX_TOC_ENTRY_H
 #define GOOGLE_CLOUD_CPP_DOCFX_TOC_ENTRY_H
 
+#include <pugixml.hpp>
 #include <iosfwd>
+#include <list>
+#include <map>
+#include <memory>
 #include <string>
 
 namespace docfx {
 
-/// An entry in table of contents
+struct TocEntry;
+using TocItems = std::list<std::shared_ptr<TocEntry>>;
+
+/**
+ * An entry in the Table of Contents.
+ *
+ * The table of contents is a hierarchical data structure. Each node contains
+ * a name, an optional set of attributes and then a list of nodes.
+ *
+ * The attributes are optional, but the following values are common:
+ * - `href`: the name of a file that the node links to.
+ * - `uid`: the uid of the documented element.
+ */
 struct TocEntry {
-  std::string uid;
   std::string name;
-  std::string filename;
+  std::map<std::string, std::string> attr;
+  TocItems items;
 };
 
-inline bool operator==(TocEntry const& lhs, TocEntry const& rhs) {
-  return lhs.filename == rhs.filename && lhs.name == rhs.name;
-}
+/// Compare two ToC entries, used in unit tests.
+bool operator==(TocEntry const& lhs, TocEntry const& rhs);
 
+/// Compare two ToC entries, used in unit tests.
 inline bool operator!=(TocEntry const& lhs, TocEntry const& rhs) {
   return !(lhs == rhs);
 }
 
+/// Print out the tree, mostly for troubleshooting.
 std::ostream& operator<<(std::ostream& os, TocEntry const& entry);
 
 }  // namespace docfx


### PR DESCRIPTION
Change the table of contents generation to include namespaces, classes, structs, functions, enums, typedefs, etc. Group elements by "type", so structs appear together. The grouping matches the groups in the right-side navigation for a namespace or class. Compound elements (namespaces, classes, structs) have an 'Overview' link to point to the element description. There is no way to have a grouping that is also a link, that is, a group for "all the stuff in class Foo that also links to Foo" is not a thing.

Links to enums and typedefs are not pointing anywhere at the moment, that will be fixed in separate PRs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11493)
<!-- Reviewable:end -->
