### PR TITLE
impl(docfx): iterate on table-of-contents

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -34,4 +34,5 @@ extend-exclude = [
     # Input data for DocFX tests. It contains many long hex strings that confuse
     # the spell checker.
     "docfx/testing/inputs.cc",
+    "docfx/doxygen2toc_test.cc",
 ]

--- a/.typos.toml
+++ b/.typos.toml
@@ -34,5 +34,6 @@ extend-exclude = [
     # Input data for DocFX tests. It contains many long hex strings that confuse
     # the spell checker.
     "docfx/testing/inputs.cc",
+    # Some of the tests also contain the same long hex strings.
     "docfx/doxygen2toc_test.cc",
 ]

--- a/docfx/doxygen2toc.cc
+++ b/docfx/doxygen2toc.cc
@@ -46,11 +46,9 @@ std::shared_ptr<TocEntry> CompoundEntry(pugi::xml_node node) {
 
 std::shared_ptr<TocEntry> MemberEntry(pugi::xml_node node) {
   auto const id = std::string_view{node.attribute("id").as_string()};
-  auto const name = std::string_view{node.child("qualifiedname").child_value()};
-  auto overview = NamedEntry("Overview");
-  overview->attr.emplace("uid", id);
+  auto const name = std::string_view{node.child("name").child_value()};
   auto entry = NamedEntry(name);
-  entry->items.push_back(std::move(overview));
+  entry->attr.emplace("uid", id);
   return entry;
 }
 
@@ -217,7 +215,12 @@ TocItems ClassToc(Config const& cfg, pugi::xml_document const& doc,
 TocItems EnumToc(Config const& cfg, pugi::xml_document const& doc,
                  pugi::xml_node node) {
   if (!IncludeInPublicDocuments(cfg, node)) return {};
-  auto entry = MemberEntry(node);
+  auto const id = std::string_view{node.attribute("id").as_string()};
+  auto const name = std::string_view{node.child("name").child_value()};
+  auto entry = NamedEntry(name);
+  auto overview = NamedEntry("Overview");
+  overview->attr.emplace("uid", id);
+  entry->items.push_back(std::move(overview));
   for (auto const child : node) {
     if (!IncludeInPublicDocuments(cfg, child)) continue;
     auto const element = std::string_view{child.name()};

--- a/docfx/doxygen2toc_test.cc
+++ b/docfx/doxygen2toc_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "docfx/doxygen2toc.h"
+#include "docfx/testing/inputs.h"
 #include <gmock/gmock.h>
 
 namespace docfx {
@@ -261,7 +262,7 @@ items:
                     uid: classgoogle_1_1cloud_1_1future
           - name: Enums
             items:
-              - name: google::cloud::Idempotency
+              - name: Idempotency
                 items:
                   - name: Overview
                     uid: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c
@@ -273,6 +274,62 @@ items:
 
   pugi::xml_document doc;
   ASSERT_TRUE(doc.load_string(kDocXml));
+  auto const actual = Doxygen2Toc(Config{"unused", "cloud", ""}, doc);
+  EXPECT_EQ(actual, kExpected);
+}
+
+TEST(Doxygen2Toc, ClassToc) {
+  auto constexpr kExpected = R"""(### YamlMime:TableOfContent
+name: cloud.google.com/cpp/cloud
+items:
+  - name: Namespaces
+    items:
+      - name: google::cloud
+        items:
+          - name: Overview
+            uid: namespacegoogle_1_1cloud
+          - name: Classes
+            items:
+              - name: google::cloud::Status
+                items:
+                  - name: Overview
+                    uid: classgoogle_1_1cloud_1_1Status
+                  - name: Constructors
+                    items:
+                      - name: Status
+                        uid: classgoogle_1_1cloud_1_1Status_1aa3656155ad44d8bd75d92cd797123f4d
+                      - name: Status
+                        uid: classgoogle_1_1cloud_1_1Status_1afd186465a07fa176c10d437c1240f2de
+                      - name: Status
+                        uid: classgoogle_1_1cloud_1_1Status_1af3de0fb0dee8fb557e693195a812987f
+                      - name: ~Status
+                        uid: classgoogle_1_1cloud_1_1Status_1a739165d43975222a55f064dd87db5e1f
+                      - name: Status
+                        uid: classgoogle_1_1cloud_1_1Status_1af927a89141bbcf10f0e02d789ebade94
+                  - name: Operators
+                    items:
+                      - name: operator=
+                        uid: classgoogle_1_1cloud_1_1Status_1a675be7e53ab9b27d69ba776a3c1ca7bf
+                      - name: operator=
+                        uid: classgoogle_1_1cloud_1_1Status_1a23aaae701351564b3a17f47d5cb4e7cb
+                      - name: operator==
+                        uid: classgoogle_1_1cloud_1_1Status_1a8c00daab4bca2eeb428f816fabf59492
+                      - name: operator!=
+                        uid: classgoogle_1_1cloud_1_1Status_1a3624db9be409bca17dc8940db074ddff
+                  - name: Functions
+                    items:
+                      - name: ok
+                        uid: classgoogle_1_1cloud_1_1Status_1a18952043ffe5a4f74911c8146e8bb504
+                      - name: code
+                        uid: classgoogle_1_1cloud_1_1Status_1ac18337d2ceb00ca007725d21f2c63f9f
+                      - name: message
+                        uid: classgoogle_1_1cloud_1_1Status_1aaa8dea39008758d8494f29b12b92be02
+                      - name: error_info
+                        uid: classgoogle_1_1cloud_1_1Status_1a172e846ab5623d78d49e2ed128f49583
+)""";
+
+  pugi::xml_document doc;
+  ASSERT_TRUE(doc.load_string(docfx_testing::StatusClassXml().c_str()));
   auto const actual = Doxygen2Toc(Config{"unused", "cloud", ""}, doc);
   EXPECT_EQ(actual, kExpected);
 }

--- a/docfx/testing/inputs.cc
+++ b/docfx/testing/inputs.cc
@@ -234,6 +234,14 @@ std::string FunctionXmlId() {
 std::string StatusClassXml() {
   return R"""(<?xml version='1.0' encoding='UTF-8' standalone='no'?>
     <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.9.5" xml:lang="en-US">
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle" kind="namespace" language="C++">
+        <compoundname>google</compoundname>
+        <innernamespace refid="namespacegoogle_1_1cloud">google::cloud</innernamespace>
+      </compounddef>
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud" kind="namespace" language="C++">
+        <compoundname>google::cloud</compoundname>
+        <innerclass refid="classgoogle_1_1cloud_1_1Status">google::cloud::Status</innerclass>
+      </compounddef>
       <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classgoogle_1_1cloud_1_1Status" kind="class" language="C++" prot="public">
           <compoundname>google::cloud::Status</compoundname>
           <includes refid="status_8h" local="no">google/cloud/status.h</includes>


### PR DESCRIPTION
For functions and enums (and in general for `<memberdef>` elements) we do not want to use the fully-qualified name, it is just too cumbersome. Likewise, items in the table of contents without subitems (like functions, enum values, and typedefs) we don't need to create an `Overview` section, just use the item as its own link.

Part of the work for #11428

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11495)
<!-- Reviewable:end -->
