### PR TITLE
impl(docfx): generate separate file for enums

### DIFF
--- a/docfx/doxygen2docfx.cc
+++ b/docfx/doxygen2docfx.cc
@@ -50,6 +50,15 @@ int main(int argc, char* argv[]) try {
     std::ofstream(id + ".yml") << docfx::Compound2Yaml(config, node);
   }
 
+  // Enums need to be generated in their own file or DocFX cannot create links
+  // to them.
+  for (auto const& i : doc.select_nodes("//memberdef[@kind='enum']")) {
+    auto const node = i.node();
+    if (!docfx::IncludeInPublicDocuments(config, node)) continue;
+    auto const id = std::string{node.attribute("id").as_string()};
+    std::ofstream(id + ".yml") << docfx::Compound2Yaml(config, node);
+  }
+
   return 0;
 } catch (std::exception const& ex) {
   std::cerr << "Standard exception thrown: " << ex.what() << "\n";

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -68,8 +68,7 @@ void CompoundRecurse(YAML::Emitter& yaml, YamlContext const& ctx,
   for (auto const child : node) {
     if (!IncludeInPublicDocuments(ctx.config, child)) continue;
     if (IgnoreForRecurse(child)) continue;
-    // Enums need to get their own files, never recurse in them.
-    // if (AppendIfEnum(yaml, ctx, child)) continue;
+    // Enums need to get their own files, so never recurse in them:
     if (kind(child) == "enum") continue;
     if (AppendIfSectionDef(yaml, ctx, child)) continue;
     if (AppendIfNamespace(yaml, ctx, child)) continue;

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -70,7 +70,7 @@ void CompoundRecurse(YAML::Emitter& yaml, YamlContext const& ctx,
     if (IgnoreForRecurse(child)) continue;
     // Enums need to get their own files, never recurse in them.
     // if (AppendIfEnum(yaml, ctx, child)) continue;
-    if (kind(node) == "enum") continue;
+    if (kind(child) == "enum") continue;
     if (AppendIfSectionDef(yaml, ctx, child)) continue;
     if (AppendIfNamespace(yaml, ctx, child)) continue;
     if (AppendIfClass(yaml, ctx, child)) continue;

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -68,12 +68,14 @@ void CompoundRecurse(YAML::Emitter& yaml, YamlContext const& ctx,
   for (auto const child : node) {
     if (!IncludeInPublicDocuments(ctx.config, child)) continue;
     if (IgnoreForRecurse(child)) continue;
+    // Enums need to get their own files, never recurse in them.
+    // if (AppendIfEnum(yaml, ctx, child)) continue;
+    if (kind(node) == "enum") continue;
     if (AppendIfSectionDef(yaml, ctx, child)) continue;
     if (AppendIfNamespace(yaml, ctx, child)) continue;
     if (AppendIfClass(yaml, ctx, child)) continue;
     if (AppendIfStruct(yaml, ctx, child)) continue;
     if (AppendIfEnumValue(yaml, ctx, child)) continue;
-    if (AppendIfEnum(yaml, ctx, child)) continue;
     if (AppendIfTypedef(yaml, ctx, child)) continue;
     if (AppendIfFriend(yaml, ctx, child)) continue;
     if (AppendIfVariable(yaml, ctx, child)) continue;
@@ -157,12 +159,12 @@ bool AppendIfEnumValue(YAML::Emitter& yaml, YamlContext const& ctx,
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto const name = std::string_view{node.child("name").child_value()};
 
-  yaml << YAML::BeginMap                                               //
-       << YAML::Key << "uid" << YAML::Value << id                      //
-       << YAML::Key << "name" << YAML::Value << YAML::Literal << name  //
-       << YAML::Key << "id" << YAML::Value << id                       //
-       << YAML::Key << "parent" << YAML::Value << ctx.parent_id        //
-       << YAML::Key << "type" << YAML::Value << "enumvalue"            //
+  yaml << YAML::BeginMap                                         //
+       << YAML::Key << "uid" << YAML::Value << id                //
+       << YAML::Key << "name" << YAML::Value << name             //
+       << YAML::Key << "id" << YAML::Value << id                 //
+       << YAML::Key << "parent" << YAML::Value << ctx.parent_id  //
+       << YAML::Key << "type" << YAML::Value << "enumvalue"      //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;
   AppendDescription(yaml, node);
   yaml << YAML::EndMap;
@@ -179,7 +181,7 @@ bool AppendIfEnum(YAML::Emitter& yaml, YamlContext const& ctx,
       std::string_view{node.child("qualifiedname").child_value()};
   yaml << YAML::BeginMap                                                    //
        << YAML::Key << "uid" << YAML::Value << id                           //
-       << YAML::Key << "name" << YAML::Value << YAML::Literal << name       //
+       << YAML::Key << "name" << YAML::Value << name                        //
        << YAML::Key << "fullName"                                           //
        << YAML::Value << YAML::Literal << full_name                         //
        << YAML::Key << "id" << YAML::Value << id                            //
@@ -188,6 +190,10 @@ bool AppendIfEnum(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendEnumSyntax(yaml, ctx, node);
   AppendDescription(yaml, node);
+  auto const children = Children(ctx, node);
+  if (!children.empty()) {
+    yaml << YAML::Key << "children" << YAML::Value << children;
+  }
   yaml << YAML::EndMap;
   auto nested = ctx;
   nested.parent_id = id;

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -404,8 +404,7 @@ TEST(Doxygen2Yaml, EnumValue) {
   auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
 items:
   - uid: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9caf8bb1d9c7cccc450ecd06167c7422bfa
-    name: |
-      kIdempotent
+    name: kIdempotent
     id: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9caf8bb1d9c7cccc450ecd06167c7422bfa
     parent: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c
     type: enumvalue
@@ -436,8 +435,7 @@ TEST(Doxygen2Yaml, Enum) {
   auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
 items:
   - uid: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c
-    name: |
-      Idempotency
+    name: Idempotency
     fullName: |
       google::cloud::Idempotency
     id: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c
@@ -487,9 +485,11 @@ items:
       - In some applications, creating a duplicate entry may
       be acceptable as the system will deduplicate them later. In such systems it may
       be preferable to retry the operation even though it is not idempotent.
+    children:
+      - namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9caf8bb1d9c7cccc450ecd06167c7422bfa
+      - namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9cae75d33e94f2dc4028d4d67bdaab75190
   - uid: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9caf8bb1d9c7cccc450ecd06167c7422bfa
-    name: |
-      kIdempotent
+    name: kIdempotent
     id: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9caf8bb1d9c7cccc450ecd06167c7422bfa
     parent: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c
     type: enumvalue
@@ -498,8 +498,7 @@ items:
     summary: |
       The operation is idempotent and can be retried after a transient failure.
   - uid: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9cae75d33e94f2dc4028d4d67bdaab75190
-    name: |
-      kNonIdempotent
+    name: kNonIdempotent
     id: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9cae75d33e94f2dc4028d4d67bdaab75190
     parent: namespacegoogle_1_1cloud_1a7d65fd569564712b7cfe652613f30d9c
     type: enumvalue


### PR DESCRIPTION
The tooling at google expects enums to be generated as separate files. This adds a small loop in `main()` to generate the files. We need to remove the enum definitions from the previous yml files, or we get duplicate definitions. And to make the enumvalues visible we need to list them as children of the enum.

Part of the work for #11455

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11497)
<!-- Reviewable:end -->
