### PR TITLE
impl(generator): provide the correct proto for the payload

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -559,6 +559,17 @@ std::string FormatAdditionalPbHeaderPaths(VarsDictionary& vars) {
   return absl::StrJoin(additional_pb_header_paths, ",");
 }
 
+std::string FormatResourceAccessor(
+    google::protobuf::Descriptor const& request) {
+  for (int i = 0; i < request.field_count(); ++i) {
+    auto const* field = request.field(i);
+    if (field->has_json_name() && field->json_name() == "resource") {
+      return absl::StrCat(".", field->name(), "()");
+    }
+  }
+  return {};
+}
+
 }  // namespace
 
 std::string FormatDoxygenLink(
@@ -922,6 +933,8 @@ std::map<std::string, VarsDictionary> CreateMethodVars(
     method_vars["method_name_snake"] = CamelCaseToSnakeCase(method.name());
     method_vars["request_type"] =
         ProtoNameToCppName(method.input_type()->full_name());
+    method_vars["request_resource_field_name_accessor"] =
+        FormatResourceAccessor(*method.input_type());
     method_vars["response_message_type"] = method.output_type()->full_name();
     method_vars["response_type"] =
         ProtoNameToCppName(method.output_type()->full_name());

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -561,13 +561,13 @@ std::string FormatAdditionalPbHeaderPaths(VarsDictionary& vars) {
 
 std::string FormatResourceAccessor(
     google::protobuf::Descriptor const& request) {
-  for (int i = 0; i < request.field_count(); ++i) {
+  for (int i = 0; i != request.field_count(); ++i) {
     auto const* field = request.field(i);
     if (field->has_json_name() && field->json_name() == "resource") {
-      return absl::StrCat(".", field->name(), "()");
+      return absl::StrCat("request.", field->name(), "()");
     }
   }
-  return {};
+  return "request";
 }
 
 }  // namespace
@@ -931,10 +931,10 @@ std::map<std::string, VarsDictionary> CreateMethodVars(
     }
     method_vars["method_name"] = method.name();
     method_vars["method_name_snake"] = CamelCaseToSnakeCase(method.name());
+    method_vars["request_resource"] =
+        FormatResourceAccessor(*method.input_type());
     method_vars["request_type"] =
         ProtoNameToCppName(method.input_type()->full_name());
-    method_vars["request_resource_field_name_accessor"] =
-        FormatResourceAccessor(*method.input_type());
     method_vars["response_message_type"] = method.output_type()->full_name();
     method_vars["response_type"] =
         ProtoNameToCppName(method.output_type()->full_name());

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -934,7 +934,7 @@ INSTANTIATE_TEST_SUITE_P(
                              "method_request_param_value",
                              "namespace_().name()"),
         MethodVarsTestValues("google.protobuf.Service.Method8",
-                             "request_resource_field_name_accessor", ""),
+                             "request_resource", "request"),
         MethodVarsTestValues(
             "google.protobuf.Service.Method8", "method_rest_path",
             "absl::StrCat(\"/v1/\", request.namespace_().name(), \"\")"),
@@ -947,8 +947,8 @@ INSTANTIATE_TEST_SUITE_P(
        std::make_pair("name", request.name())})"""),
         // Method11
         MethodVarsTestValues("google.protobuf.Service.Method11",
-                             "request_resource_field_name_accessor",
-                             ".foo_resource()"),
+                             "request_resource",
+                             "request.foo_resource()"),
         // IAM idempotency defaults
         MethodVarsTestValues("google.protobuf.Service.GetIamPolicy",
                              "idempotency", "kIdempotent"),

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -947,8 +947,7 @@ INSTANTIATE_TEST_SUITE_P(
        std::make_pair("name", request.name())})"""),
         // Method11
         MethodVarsTestValues("google.protobuf.Service.Method11",
-                             "request_resource",
-                             "request.foo_resource()"),
+                             "request_resource", "request.foo_resource()"),
         // IAM idempotency defaults
         MethodVarsTestValues("google.protobuf.Service.GetIamPolicy",
                              "idempotency", "kIdempotent"),

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -442,6 +442,12 @@ char const* const kServiceProto =
     "  // namespace $field comment.\n"
     "  Namespace namespace = 1;\n"
     "}\n"
+    "// Leading comments about message Baz.\n"
+    "message Baz {\n"
+    "  string project = 1;\n"
+    "  string instance = 2;\n"
+    "  Foo foo_resource = 3 [json_name=\"resource\"];\n"
+    "}\n"
     "// Leading comments about service Service.\n"
     "service Service {\n"
     "  // Leading comments about rpc Method0$.\n"
@@ -536,6 +542,15 @@ char const* const kServiceProto =
     "    option (google.api.method_signature) = \"parent\";\n"
     "    option (google.api.method_signature) = \"name,parent,number\";\n"
     "    option (google.api.method_signature) = \"name,title,number\";\n"
+    "  }\n"
+    "  // Leading comments about rpc Method11.\n"
+    "  rpc Method11(Baz) returns (Empty) {\n"
+    "    option (google.api.http) = {\n"
+    "       post: "
+    "\"/v1/projects/{project=project}/instances/{instance=instance}/"
+    "databases\"\n"
+    "       body: \"*\"\n"
+    "    };\n"
     "  }\n"
     "  // Test that the method defaults to kIdempotent.\n"
     "  rpc GetIamPolicy(google.iam.v1.GetIamPolicyRequest)\n"
@@ -918,6 +933,8 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method8",
                              "method_request_param_value",
                              "namespace_().name()"),
+        MethodVarsTestValues("google.protobuf.Service.Method8",
+                             "request_resource_field_name_accessor", ""),
         MethodVarsTestValues(
             "google.protobuf.Service.Method8", "method_rest_path",
             "absl::StrCat(\"/v1/\", request.namespace_().name(), \"\")"),
@@ -928,6 +945,10 @@ INSTANTIATE_TEST_SUITE_P(
       {std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("name", request.name())})"""),
+        // Method11
+        MethodVarsTestValues("google.protobuf.Service.Method11",
+                             "request_resource_field_name_accessor",
+                             ".foo_resource()"),
         // IAM idempotency defaults
         MethodVarsTestValues("google.protobuf.Service.GetIamPolicy",
                              "idempotency", "kIdempotent"),

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -329,7 +329,7 @@ Default$stub_rest_class_name$::$method_name$(
       google::cloud::rest_internal::RestContext& rest_context,
       $request_type$ const& request) {
   return rest_internal::$method_http_verb$<$response_type$>(
-      *service_, rest_context, request,
+      *service_, rest_context, request$request_resource_field_name_accessor$,
       $method_rest_path$$method_http_query_parameters$);
 }
 )""");

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -329,7 +329,7 @@ Default$stub_rest_class_name$::$method_name$(
       google::cloud::rest_internal::RestContext& rest_context,
       $request_type$ const& request) {
   return rest_internal::$method_http_verb$<$response_type$>(
-      *service_, rest_context, request$request_resource_field_name_accessor$,
+      *service_, rest_context, $request_resource$,
       $method_rest_path$$method_http_query_parameters$);
 }
 )""");


### PR DESCRIPTION
part of the work for #10980 

For rest json payloads, if the request contains a field annotated with `json_name="resource"`, only convert the contents of that field, not the entire request, into the json payload.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11501)
<!-- Reviewable:end -->
