### PR TITLE
impl(generator): handle http path with multiple substitutions

### DIFF
--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -31,12 +31,8 @@ struct HttpSimpleInfo {
 };
 
 struct HttpExtensionInfo {
-  struct RestPathPiece {
-    RestPathPiece(std::string piece, bool format_as_accessor)
-        : piece(std::move(piece)), format_as_accessor(format_as_accessor) {}
-    std::string piece;
-    bool format_as_accessor;
-  };
+  using RestPathPiece =
+      std::function<std::string(google::protobuf::MethodDescriptor const&)>;
   std::string http_verb;
   std::string url_path;
   std::string request_field_name;

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -31,6 +31,12 @@ struct HttpSimpleInfo {
 };
 
 struct HttpExtensionInfo {
+  struct RestPathPiece {
+    RestPathPiece(std::string piece, bool format_as_accessor)
+        : piece(std::move(piece)), format_as_accessor(format_as_accessor) {}
+    std::string piece;
+    bool format_as_accessor;
+  };
   std::string http_verb;
   std::string url_path;
   std::string request_field_name;
@@ -38,6 +44,7 @@ struct HttpExtensionInfo {
   std::string body;
   std::string path_prefix;
   std::string path_suffix;
+  std::vector<RestPathPiece> rest_path;
 };
 
 /**

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -367,9 +367,9 @@ TEST_F(HttpOptionUtilsTest,
                  "databases"));
   EXPECT_THAT(vars.at("method_request_body"), Eq("*"));
   EXPECT_THAT(vars.at("method_http_verb"), Eq("Post"));
-  EXPECT_THAT(vars.at("method_rest_path"),
-              Eq("absl::StrCat(\"/v1/projects/\", request.project(), "
-                 "\"/instances/\", request.instance(), \"/databases\")"));
+  auto const* expected_rest_path =
+      R"""(absl::StrCat("/v1/projects/", request.project(), "/instances/", request.instance(), "/databases"))""";
+  EXPECT_THAT(vars.at("method_rest_path"), Eq(expected_rest_path));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersNonGet) {


### PR DESCRIPTION
part of the work for #10980 

When dealing with protos generated from discovery documents, we can encounter http paths with multiple substitutions, i.e. multiple pairs of `{}`. We need to parse this and then reassemble it with the string literals pieces and appropriate request accessor calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11502)
<!-- Reviewable:end -->
