### PR TITLE
impl(generator): improved resource and path handling

### DIFF
--- a/generator/internal/discovery_file_test.cc
+++ b/generator/internal/discovery_file_test.cc
@@ -106,7 +106,8 @@ auto constexpr kDoFooRequestTypeJson = R"""({
       "description": "Description for fooId."
     },
     "my_foo_resource": {
-      "$ref": "Foo"
+      "$ref": "Foo",
+      "is_resource": true
     }
   },
   "request_resource_field_name": "my_foo_resource"
@@ -163,7 +164,7 @@ service MyResources {
 
   rpc DoFoo(DoFooRequest) returns (other.package.Operation) {
     option (google.api.http) = {
-      post: "my/service/projects/{project}/zones/{zone}/myResources/{foo_id}/doFoo"
+      post: "my/service/projects/{project=project}/zones/{zone=zone}/myResources/{foo_id=foo_id}/doFoo"
       body: "my_foo_resource"
     };
     option (google.api.method_signature) = "project,zone,foo_id,my_foo_resource";
@@ -173,7 +174,7 @@ service MyResources {
   // Description for the get method.
   rpc GetMyResources(GetMyResourcesRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      get: "my/service/projects/{project}/regions/{region}/myResources/{foo}"
+      get: "my/service/projects/{project=project}/regions/{region=region}/myResources/{foo=foo}"
     };
     option (google.api.method_signature) = "project,region,foo";
   }
@@ -183,7 +184,7 @@ message DoFooRequest {
   // Description for fooId.
   optional string foo_id = 1;
 
-  optional Foo my_foo_resource = 2;
+  optional Foo my_foo_resource = 2 [json_name="resource"];
 
   // Description for project.
   optional string project = 3;
@@ -264,7 +265,7 @@ service MyResources {
 
   rpc DoFoo(DoFooRequest) returns (other.package.Operation) {
     option (google.api.http) = {
-      post: "my/service/projects/{project}/zones/{zone}/myResources/{foo_id}/doFoo"
+      post: "my/service/projects/{project=project}/zones/{zone=zone}/myResources/{foo_id=foo_id}/doFoo"
       body: "my_foo_resource"
     };
     option (google.api.method_signature) = "project,zone,foo_id,my_foo_resource";
@@ -274,7 +275,7 @@ service MyResources {
   // Description for the get method.
   rpc GetMyResources(GetMyResourcesRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      get: "my/service/projects/{project}/regions/{region}/myResources/{foo}"
+      get: "my/service/projects/{project=project}/regions/{region=region}/myResources/{foo=foo}"
     };
     option (google.api.method_signature) = "project,region,foo";
   }
@@ -284,7 +285,7 @@ message DoFooRequest {
   // Description for fooId.
   optional string foo_id = 1;
 
-  optional Foo my_foo_resource = 2;
+  optional Foo my_foo_resource = 2 [json_name="resource"];
 
   // Description for project.
   optional string project = 3;
@@ -359,7 +360,7 @@ message DoFooRequest {
   // Description for fooId.
   optional string foo_id = 1;
 
-  optional Foo my_foo_resource = 2;
+  optional Foo my_foo_resource = 2 [json_name="resource"];
 
   // Description for project.
   optional string project = 3;

--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -68,7 +68,8 @@ std::string DiscoveryResource::FormatUrlPath(std::string const& path) {
     current = open + 1;
     auto close = path.find('}', current);
     absl::StrAppend(
-        &output, CamelCaseToSnakeCase(path.substr(current, close - current)));
+        &output, CamelCaseToSnakeCase(path.substr(current, close - current)),
+        "=", CamelCaseToSnakeCase(path.substr(current, close - current)));
     current = close;
   }
   absl::StrAppend(&output, path.substr(current));

--- a/generator/internal/discovery_resource_test.cc
+++ b/generator/internal/discovery_resource_test.cc
@@ -59,14 +59,17 @@ TEST(DiscoveryResourceTest, FormatUrlPath) {
               Eq("base/path/test"));
   EXPECT_THAT(DiscoveryResource::FormatUrlPath(
                   "projects/{project}/zones/{zone}/myTests/{foo}/method1"),
-              Eq("projects/{project}/zones/{zone}/myTests/{foo}/method1"));
+              Eq("projects/{project=project}/zones/{zone=zone}/myTests/"
+                 "{foo=foo}/method1"));
   EXPECT_THAT(DiscoveryResource::FormatUrlPath(
                   "projects/{project}/zones/{zone}/myTests/{fooId}/method1"),
-              Eq("projects/{project}/zones/{zone}/myTests/{foo_id}/method1"));
+              Eq("projects/{project=project}/zones/{zone=zone}/myTests/"
+                 "{foo_id=foo_id}/method1"));
   EXPECT_THAT(
       DiscoveryResource::FormatUrlPath(
           "projects/{project}/zones/{zoneName}/myTests/{fooId}:method1"),
-      Eq("projects/{project}/zones/{zone_name}/myTests/{foo_id}:method1"));
+      Eq("projects/{project=project}/zones/{zone_name=zone_name}/myTests/"
+         "{foo_id=foo_id}:method1"));
 }
 
 TEST(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
@@ -82,7 +85,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      get: "base/path/projects/{project}/regions/{region}/myTests/{foo}"
+      get: "base/path/projects/{project=project}/regions/{region=region}/myTests/{foo=foo}"
     };
     option (google.api.method_signature) = "project,region,foo";)""";
   auto method_json = nlohmann::json::parse(kMethodJson, nullptr, false);
@@ -115,7 +118,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPatchZone) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      patch: "base/path/projects/{project}/zones/{zone}/myTests/{foo_id}/method1"
+      patch: "base/path/projects/{project=project}/zones/{zone=zone}/myTests/{foo_id=foo_id}/method1"
       body: "my_request_resource"
     };
     option (google.api.method_signature) = "project,zone,foo_id,my_request_resource";
@@ -150,7 +153,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegion) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      put: "base/path/projects/{project}/regions/{region}/myTests/{foo_id}/method1"
+      put: "base/path/projects/{project=project}/regions/{region=region}/myTests/{foo_id=foo_id}/method1"
       body: "my_request_resource"
     };
     option (google.api.method_signature) = "project,region,foo_id,my_request_resource";
@@ -179,7 +182,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobal) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      post: "base/path/projects/{project}/global/myTests/{foo}:cancel"
+      post: "base/path/projects/{project=project}/global/myTests/{foo=foo}:cancel"
       body: "*"
     };
     option (google.api.method_signature) = "project,foo";)""";
@@ -210,7 +213,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationResponse) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      post: "base/path/projects/{project}/global/myTests/{foo}:cancel"
+      post: "base/path/projects/{project=project}/global/myTests/{foo=foo}:cancel"
       body: "*"
     };
     option (google.api.method_signature) = "project,foo";
@@ -461,7 +464,7 @@ service MyResources {
 
   rpc DoFoo(DoFooRequest) returns (other.package.Operation) {
     option (google.api.http) = {
-      post: "base/path/projects/{project}/zones/{zone}/myResources/{foo_id}/doFoo"
+      post: "base/path/projects/{project=project}/zones/{zone=zone}/myResources/{foo_id=foo_id}/doFoo"
       body: "my_foo_resource"
     };
     option (google.api.method_signature) = "project,zone,foo_id,my_foo_resource";
@@ -471,7 +474,7 @@ service MyResources {
   // Description for the get method.
   rpc GetMyResources(GetMyResourcesRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      get: "base/path/projects/{project}/regions/{region}/myResources/{foo}"
+      get: "base/path/projects/{project=project}/regions/{region=region}/myResources/{foo=foo}"
     };
     option (google.api.method_signature) = "project,region,foo";
   }

--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -208,6 +208,8 @@ StatusOr<DiscoveryTypeVertex> SynthesizeRequestType(
     synthesized_request["properties"][request_resource_field_name] =
         method_json["request"];
     synthesized_request["properties"][request_resource_field_name]
+                       ["is_resource"] = true;
+    synthesized_request["properties"][request_resource_field_name]
                        ["description"] = absl::StrFormat(
                            "The %s for this request.",
                            std::string((method_json["request"]["$ref"])));

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -299,7 +299,8 @@ TEST(SynthesizeRequestTypeTest, OperationResponseWithRefRequestField) {
   },
   "foo_resource":{
     "$ref":"Foo",
-    "description":"The Foo for this request."
+    "description":"The Foo for this request.",
+    "is_resource":true
   },
   "project":{
     "operation_request_field":true,
@@ -371,7 +372,8 @@ TEST(SynthesizeRequestTypeTest,
   },
   "foo_resource":{
     "$ref":"FooResource",
-    "description":"The FooResource for this request."
+    "description":"The FooResource for this request.",
+    "is_resource": true
   },
   "project":{
     "operation_request_field":true,

--- a/generator/internal/discovery_type_vertex.cc
+++ b/generator/internal/discovery_type_vertex.cc
@@ -272,11 +272,18 @@ std::string DiscoveryTypeVertex::FormatFieldOptions(
     field_options.emplace_back("google.cloud.operation_request_field",
                                absl::StrCat("\"", field_name, "\""));
   }
+  if (field_json.value("is_resource", false)) {
+    field_options.emplace_back("json_name", "resource");
+  }
 
   if (!field_options.empty()) {
     auto formatter = [](std::string* s,
                         std::pair<std::string, std::string> const& p) {
-      *s += absl::StrFormat("(%s) = %s", p.first, p.second);
+      if (p.first == "json_name") {
+        *s += absl::StrFormat("%s=\"%s\"", p.first, p.second);
+      } else {
+        *s += absl::StrFormat("(%s) = %s", p.first, p.second);
+      }
     };
     return absl::StrCat(" [", absl::StrJoin(field_options, ",", formatter),
                         "]");

--- a/generator/internal/discovery_type_vertex_test.cc
+++ b/generator/internal/discovery_type_vertex_test.cc
@@ -130,6 +130,22 @@ TEST(DiscoveryTypeVertexTest, FormatFieldOptionsRequiredOperationRequestField) {
          "REQUIRED,(google.cloud.operation_request_field) = \"test_field\"]"));
 }
 
+TEST(DiscoveryTypeVertexTest, FormatFieldOptionsRequiredIsResource) {
+  auto constexpr kRequiredIsResourceFieldJson = R"""(
+{
+  "type": "string",
+  "required": true,
+  "is_resource": true
+}
+)""";
+  auto json =
+      nlohmann::json::parse(kRequiredIsResourceFieldJson, nullptr, false);
+  ASSERT_TRUE(json.is_object());
+  EXPECT_THAT(
+      DiscoveryTypeVertex::FormatFieldOptions("test_field", json),
+      Eq(" [(google.api.field_behavior) = REQUIRED,json_name=\"resource\"]"));
+}
+
 struct DetermineTypesSuccess {
   std::string json;
   std::string expected_name;


### PR DESCRIPTION
part of the work for #10980 

Add variable substitution format in http paths such that the generator can parse them correctly.
Add `json_name="resource"` option for `$ref` types in requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11503)
<!-- Reviewable:end -->
