### PR TITLE
fix(GCS+gRPC): remove erroneous dereference of StatusOr value

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1239,7 +1239,7 @@ StatusOr<google::storage::v2::Bucket> GrpcClient::ModifyDefaultAccessControl(
         "retrying BucketAccessControl change due to conflict, bucket=" +
             request.bucket_name());
   }
-  return *patch;
+  return patch;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Fixes #11135.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11506)
<!-- Reviewable:end -->
