### PR TITLE
cleanup(ci): disentangle cmake::common_args from GOOGLE_CLOUD_CPP_ENABLE

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -21,9 +21,11 @@ source module ci/cloudbuild/builds/lib/cmake.sh
 
 export CC=gcc
 export CXX=g++
-mapfile -t cmake_args < <(cmake::common_args)
 
-INSTALL_PREFIX=/var/tmp/google-cloud-cpp
+mapfile -t cmake_args < <(cmake::common_args)
+readonly INSTALL_PREFIX=/var/tmp/google-cloud-cpp
+readonly ENABLED_FEATURES="__ga_libraries__"
+
 # abi-dumper wants us to use -Og, but that causes bogus warnings about
 # uninitialized values with GCC, so we disable that warning with
 # -Wno-maybe-uninitialized. See also:
@@ -33,7 +35,7 @@ cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_BUILD_TYPE=Debug \
-  -DGOOGLE_CLOUD_CPP_ENABLE="__ga_libraries__" \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}" \
   -DCMAKE_CXX_FLAGS="-Og -Wno-maybe-uninitialized"
 cmake --build cmake-out
 cmake --install cmake-out >/dev/null

--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -18,20 +18,20 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
-source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=clang
 export CXX=clang++
 export CTCACHE_DIR=~/.cache/ctcache
+
+mapfile -t cmake_args < <(cmake::common_args)
 read -r ENABLED_FEATURES < <(features::always_build_cmake)
 # Add some features that we don't always build, but we want to run clang-tidy
 # over them.
 ENABLED_FEATURES="${ENABLED_FEATURES},experimental-storage-grpc"
 ENABLED_FEATURES="${ENABLED_FEATURES},generator"
 readonly ENABLED_FEATURES
-
-mapfile -t cmake_args < <(cmake::common_args)
 
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache
 # Note: we use C++14 for this build because we don't want tidy suggestions that

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -18,18 +18,18 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
-source module ci/cloudbuild/builds/lib/quickstart.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/cloudbuild/builds/lib/quickstart.sh
 source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
 
+mapfile -t cmake_args < <(cmake::common_args)
 INSTALL_PREFIX="$(mktemp -d)"
 readonly INSTALL_PREFIX
-
 read -r ENABLED_FEATURES < <(features::list_full_cmake)
-mapfile -t cmake_args < <(cmake::common_args)
+readonly ENABLED_FEATURES
 
 # Compiles and installs all libraries and headers.
 cmake "${cmake_args[@]}" \

--- a/ci/cloudbuild/builds/cxx14.sh
+++ b/ci/cloudbuild/builds/cxx14.sh
@@ -23,15 +23,16 @@ source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=gcc
 export CXX=g++
-mapfile -t cmake_args < <(cmake::common_args)
-cmake_args+=(
-  # This is the build to test with C++14
-  -DCMAKE_CXX_STANDARD=14
-  # We should test all the GA libraries
-  -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake),__ga_libraries__"
-)
 
-cmake "${cmake_args[@]}"
+mapfile -t cmake_args < <(cmake::common_args)
+read -r ENABLED_FEATURES < <(features::always_build_cmake)
+# We should test all the GA libraries
+ENABLED_FEATURES="${ENABLED_FEATURES},__ga_libraries__"
+readonly ENABLED_FEATURES
+
+cmake "${cmake_args[@]}" \
+  -DCMAKE_CXX_STANDARD=14 \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
 env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"

--- a/ci/cloudbuild/builds/cxx20.sh
+++ b/ci/cloudbuild/builds/cxx20.sh
@@ -23,15 +23,16 @@ source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=gcc
 export CXX=g++
-mapfile -t cmake_args < <(cmake::common_args)
-cmake_args+=(
-  # This is the build to test with C++20
-  -DCMAKE_CXX_STANDARD=20
-  # We should test all the GA libraries
-  -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake),__ga_libraries__"
-)
 
-cmake "${cmake_args[@]}"
+mapfile -t cmake_args < <(cmake::common_args)
+read -r ENABLED_FEATURES < <(features::always_build_cmake)
+# We should test all the GA libraries
+ENABLED_FEATURES="${ENABLED_FEATURES},__ga_libraries__"
+readonly ENABLED_FEATURES
+
+cmake "${cmake_args[@]}" \
+  -DCMAKE_CXX_STANDARD=20 \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
 env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"

--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -51,11 +51,12 @@ fi
 function cmake::common_args() {
   local args
   args=(
-    -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)"
     -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON
     -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON
+    -GNinja
+    -S .
+    -B cmake-out
   )
-  args+=(-GNinja -S . -B cmake-out)
   printf "%s\n" "${args[@]}"
 }
 

--- a/ci/cloudbuild/builds/m32.sh
+++ b/ci/cloudbuild/builds/m32.sh
@@ -17,7 +17,6 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module ci/lib/io.sh
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
@@ -26,15 +25,17 @@ export CC=gcc
 export CXX=g++
 
 mapfile -t cmake_args < <(cmake::common_args)
-cmake_args+=(
-  # This is the build to test with -m32, which requires a toolchain file.
-  "--toolchain" "${PROJECT_ROOT}/ci/etc/m32-toolchain.cmake"
-  # We should test all the GA libraries
-  "-DGOOGLE_CLOUD_CPP_ENABLE=$(features::always_build_cmake),__ga_libraries__"
-)
+read -r ENABLED_FEATURES < <(features::always_build_cmake)
+# We should test all the GA libraries
+ENABLED_FEATURES="${ENABLED_FEATURES},__ga_libraries__"
+readonly ENABLED_FEATURES
 
-io::run cmake "${cmake_args[@]}"
+# This is the build to test with -m32, which requires a toolchain file.
+cmake "${cmake_args[@]}" \
+  "--toolchain" "${PROJECT_ROOT}/ci/etc/m32-toolchain.cmake" \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
 env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/noex.sh
+++ b/ci/cloudbuild/builds/noex.sh
@@ -18,13 +18,19 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=gcc
 export CXX=g++
-mapfile -t cmake_args < <(cmake::common_args)
 
-cmake "${cmake_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=NO
+mapfile -t cmake_args < <(cmake::common_args)
+read -r ENABLED_FEATURES < <(features::always_build_cmake)
+readonly ENABLED_FEATURES
+
+cmake "${cmake_args[@]}" \
+  -DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=NO \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
 env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"

--- a/ci/cloudbuild/builds/quickstart-production.sh
+++ b/ci/cloudbuild/builds/quickstart-production.sh
@@ -18,16 +18,17 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
-source module ci/cloudbuild/builds/lib/quickstart.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/cloudbuild/builds/lib/quickstart.sh
 
 export CC=gcc
 export CXX=g++
 
-read -r ENABLED_FEATURES < <(features::list_full_cmake)
 mapfile -t cmake_args < <(cmake::common_args)
+readonly INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
+read -r ENABLED_FEATURES < <(features::list_full_cmake)
+readonly ENABLED_FEATURES
 
-INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
 cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \

--- a/ci/cloudbuild/builds/scan-build.sh
+++ b/ci/cloudbuild/builds/scan-build.sh
@@ -22,15 +22,20 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/features.sh
 
 export CC=clang
 export CXX=clang++
+
 mapfile -t cmake_args < <(cmake::common_args)
+read -r ENABLED_FEATURES < <(features::always_build_cmake)
+readonly ENABLED_FEATURES
 
 scan_build=(
   "scan-build"
   "-o"
   "${HOME}/scan-build"
 )
-"${scan_build[@]}" cmake "${cmake_args[@]}"
+"${scan_build[@]}" cmake "${cmake_args[@]}" \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 "${scan_build[@]}" cmake --build cmake-out

--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -18,16 +18,17 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
-source module ci/cloudbuild/builds/lib/quickstart.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/cloudbuild/builds/lib/quickstart.sh
 
 export CC=gcc
 export CXX=g++
 
-read -r ENABLED_FEATURES < <(features::list_full_cmake)
 mapfile -t cmake_args < <(cmake::common_args)
+readonly INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
+read -r ENABLED_FEATURES < <(features::list_full_cmake)
+readonly ENABLED_FEATURES
 
-INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
 cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \


### PR DESCRIPTION
The enabled features aren't really a "common argument" as more often than not we override them with an extra `-DGOOGLE_CLOUD_CPP_ENABLE` setting. So, stop adding a setting in `cmake::common_args`, and instead have each build script specify its own (typically starting from a `features::*` call).  This makes what we're building much clearer in the scripts, and when looking at an executed CMake command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11515)
<!-- Reviewable:end -->
