### PR TITLE
test(spanner): avoid "europe-west9" in CreateInstanceConfig() tests

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -241,6 +241,10 @@ TEST_F(InstanceAdminClientTest, InstanceConfigUserManaged) {
   auto base_config_name = spanner_testing::PickInstanceConfig(
       project, generator_,
       [](google::spanner::admin::instance::v1::InstanceConfig const& config) {
+        // TODO(#11346): Remove once the incident clears out
+        for (auto const& replica_info : config.optional_replicas()) {
+          if (replica_info.location() == "europe-west9") return false;
+        }
         return !config.optional_replicas().empty();
       });
   ASSERT_THAT(base_config_name, Not(IsEmpty()));

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -4243,7 +4243,13 @@ void RunAllSlowInstanceTests(
         Basename(google::cloud::spanner_testing::PickInstanceConfig(
             google::cloud::Project(project_id), generator,
             [](google::spanner::admin::instance::v1::InstanceConfig const&
-                   config) { return !config.optional_replicas().empty(); }));
+                   config) {
+              // TODO(#11346): Remove once the incident clears out
+              for (auto const& replica_info : config.optional_replicas()) {
+                if (replica_info.location() == "europe-west9") return false;
+              }
+              return !config.optional_replicas().empty();
+            }));
     if (base_config_id.empty()) {
       throw std::runtime_error("Failed to pick a base config");
     }

--- a/google/cloud/spanner/testing/pick_instance_config.cc
+++ b/google/cloud/spanner/testing/pick_instance_config.cc
@@ -36,8 +36,6 @@ std::string PickInstanceConfig(
       if (!instance_config->base_config().empty()) {
         continue;  // skip non-base configurations
       }
-      // TODO(#11346) - remove once the incident clears out
-      if (absl::StrContains(instance_config->name(), "europe-west9")) continue;
       if (instance_config_name.empty()) {
         // The fallback for when nothing satisfies the predicate, which is
         // only really useful for the emulator, which has a single config.


### PR DESCRIPTION
Followup to #11461, but skipping instance configs that have an optional replica in location "europe-west9" ("regional-us-central1") rather than ones whose names include "europe-west9" ("regional-europe-west9").

Part of #11346.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11516)
<!-- Reviewable:end -->
