### PR TITLE
impl: prefer Protobuf config vs. module in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,14 @@ add_custom_target(all-docfx)
 find_package(absl CONFIG REQUIRED)
 if (${GOOGLE_CLOUD_CPP_ENABLE_GRPC})
     find_package(gRPC REQUIRED QUIET)
-    find_package(Protobuf REQUIRED QUIET)
+    set(GOOGLE_CLOUD_CPP_FIND_DEPENDENCY_PROTOBUF
+        "find_dependency(Protobuf CONFIG)")
+    find_package(Protobuf CONFIG QUIET)
+    if (NOT Protobuf_FOUND)
+        set(GOOGLE_CLOUD_CPP_FIND_DEPENDENCY_PROTOBUF
+            "find_dependency(Protobuf)")
+        find_package(Protobuf REQUIRED)
+    endif ()
     add_subdirectory(external/googleapis)
 endif ()
 

--- a/cmake/FindgRPC.cmake
+++ b/cmake/FindgRPC.cmake
@@ -69,7 +69,10 @@ find_package(Threads REQUIRED)
 # `find_package()` because we (have to) install this module in non-standard
 # locations.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-find_package(Protobuf)
+find_package(Protobuf CONFIG QUIET)
+if (NOT Protobuf_FOUND)
+    find_package(Protobuf)
+endif ()
 
 # The gRPC::grpc_cpp_plugin target is sometimes defined, but without a
 # IMPORTED_LOCATION

--- a/external/googleapis/config.cmake.in
+++ b/external/googleapis/config.cmake.in
@@ -15,7 +15,7 @@
 # ~~~
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-find_dependency(Protobuf)
+@GOOGLE_CLOUD_CPP_FIND_DEPENDENCY_PROTOBUF@
 find_dependency(gRPC)
 
 include("${CMAKE_CURRENT_LIST_DIR}/googleapis-targets.cmake")

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -18,7 +18,10 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "generator_internal")
 set(DOXYGEN_EXAMPLE_PATH "")
 
 include(GoogleCloudCppCommon)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG QUIET)
+if (NOT Protobuf_FOUND)
+    find_package(Protobuf REQUIRED)
+endif ()
 include(IncludeNlohmannJson)
 
 add_library(
@@ -149,8 +152,17 @@ target_link_libraries(
     protobuf::libprotoc ${Protobuf_LIBRARIES})
 
 # Generate protobuf code and library
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS generator_config.proto)
-add_library(google_cloud_cpp_generator_config ${PROTO_HDRS} ${PROTO_SRCS})
+if (COMMAND protobuf_generate)
+    set(protobuf_PROTOC_EXE $<TARGET_FILE:protobuf::protoc>)
+    add_library(google_cloud_cpp_generator_config)
+    protobuf_generate(LANGUAGE cpp TARGET google_cloud_cpp_generator_config
+                      PROTOS generator_config.proto)
+elseif (COMMAND protobuf_generate_cpp)
+    protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS generator_config.proto)
+    add_library(google_cloud_cpp_generator_config ${PROTO_HDRS} ${PROTO_SRCS})
+else ()
+    message(FATAL_ERROR "Missing protobuf_generate_cpp and protobuf_generate")
+endif ()
 target_link_libraries(google_cloud_cpp_generator_config
                       PUBLIC protobuf::libprotobuf)
 set_target_properties(google_cloud_cpp_generator_config

--- a/google/cloud/config-rest-protobuf.cmake.in
+++ b/google/cloud/config-rest-protobuf.cmake.in
@@ -17,6 +17,6 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(google_cloud_cpp_rest_internal)
 find_dependency(google_cloud_cpp_common)
 find_dependency(absl)
-find_dependency(protobuf)
+@GOOGLE_CLOUD_CPP_FIND_DEPENDENCY_PROTOBUF@
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_rest_protobuf_internal-targets.cmake")

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -39,10 +39,6 @@ include(GoogleCloudCppDoxygen)
 google_cloud_cpp_doxygen_targets("dataproc" DEPENDS cloud-docs
                                  google-cloud-cpp::dataproc_protos)
 
-find_package(gRPC REQUIRED)
-find_package(Protobuf REQUIRED)
-find_package(absl CONFIG REQUIRED)
-
 include(GoogleCloudCppCommon)
 
 include(CompileProtos)

--- a/google/cloud/resourcesettings/CMakeLists.txt
+++ b/google/cloud/resourcesettings/CMakeLists.txt
@@ -39,10 +39,6 @@ include(GoogleCloudCppDoxygen)
 google_cloud_cpp_doxygen_targets("resourcesettings" DEPENDS cloud-docs
                                  google-cloud-cpp::resourcesettings_protos)
 
-find_package(gRPC REQUIRED)
-find_package(Protobuf REQUIRED)
-find_package(absl CONFIG REQUIRED)
-
 include(GoogleCloudCppCommon)
 
 include(CompileProtos)


### PR DESCRIPTION
CMake ships with a `FindProtobuf` module, when one types:

```
find_package(Protobuf)
```

CMake uses that module to find protobuf and add the necessary compile and link-time flags. The next release of Protobuf adds dependencies that the module does not know about. Fortunately the next release also install the CMake support files, which can be used if one types:

```
find_package(Protobuf CONFIG)
```

Because we need to support older versions of Protobuf, we first try with the `CONFIG` flag, and then fallback to the module instead.

We install our own CMake configuration files, which need to use `find_dependency()` to find Protobuf. `find_dependency()` is a thin wrapper around `find_package()`, and it needs to use the same strategy that we know worked for building `google-cloud-cpp`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11517)
<!-- Reviewable:end -->
