### PR TITLE
impl: prepare for next Protobuf release

### DIFF
--- a/google/cloud/bigtable/tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_backup_integration_test.cc
@@ -96,7 +96,7 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   EXPECT_EQ(backup->name(), backup_name);
 
   // Update backup
-  expire_time = expire_time + std::chrono::hours(12);
+  expire_time += std::chrono::hours(12);
   backup = table_admin_->UpdateBackup({cluster_id, backup_id, expire_time});
   ASSERT_STATUS_OK(backup);
 

--- a/google/cloud/bigtable/tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_backup_integration_test.cc
@@ -20,8 +20,8 @@
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/contains_once.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include <google/protobuf/util/time_util.h>
 #include <gmock/gmock.h>
 #include <string>
 #include <vector>
@@ -32,8 +32,9 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::internal::ToProtoTimestamp;
 using ::google::cloud::testing_util::ContainsOnce;
-using ::google::protobuf::util::TimeUtil;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::testing::Contains;
 using ::testing::Not;
 namespace btadmin = ::google::bigtable::admin::v2;
@@ -77,12 +78,10 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   auto const backup_name = cluster_name + "/backups/" + backup_id;
 
   // Create backup
-  google::protobuf::Timestamp expire_time =
-      TimeUtil::GetCurrentTime() + TimeUtil::HoursToDuration(12);
+  auto expire_time = std::chrono::system_clock::now() + std::chrono::hours(12);
 
   auto backup = table_admin_->CreateBackup(
-      {cluster_id, backup_id, table_id,
-       google::cloud::internal::ToChronoTimePoint(expire_time)});
+      {cluster_id, backup_id, table_id, expire_time});
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
 
@@ -97,17 +96,16 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   EXPECT_EQ(backup->name(), backup_name);
 
   // Update backup
-  expire_time = expire_time + TimeUtil::HoursToDuration(12);
-  backup = table_admin_->UpdateBackup(
-      {cluster_id, backup_id,
-       google::cloud::internal::ToChronoTimePoint(expire_time)});
+  expire_time = expire_time + std::chrono::hours(12);
+  backup = table_admin_->UpdateBackup({cluster_id, backup_id, expire_time});
   ASSERT_STATUS_OK(backup);
 
   // Verify the update
   backup = table_admin_->GetBackup(cluster_id, backup_id);
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
-  EXPECT_EQ(backup->expire_time(), expire_time);
+  EXPECT_THAT(backup->expire_time(),
+              IsProtoEqual(ToProtoTimestamp(expire_time)));
 
   // Delete table
   EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id));

--- a/google/cloud/servicecontrol/README.md
+++ b/google/cloud/servicecontrol/README.md
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) try {
     op.set_operation_id("TODO-use-UUID-4-or-UUID-5");
     op.set_operation_name("google.pubsub.v1.Publisher.Publish");
     op.set_consumer_id(project.FullName());
-    *op.mutable_start_time() = TimeUtil::GetCurrentTime();
+    *op.mutable_start_time() = (TimeUtil::GetCurrentTime)();
     return op;
   }();
 

--- a/google/cloud/servicecontrol/quickstart/quickstart.cc
+++ b/google/cloud/servicecontrol/quickstart/quickstart.cc
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) try {
     op.set_operation_id("TODO-use-UUID-4-or-UUID-5");
     op.set_operation_name("google.pubsub.v1.Publisher.Publish");
     op.set_consumer_id(project.FullName());
-    *op.mutable_start_time() = TimeUtil::GetCurrentTime();
+    *op.mutable_start_time() = (TimeUtil::GetCurrentTime)();
     return op;
   }();
 

--- a/google/cloud/trace/README.md
+++ b/google/cloud/trace/README.md
@@ -59,10 +59,10 @@ int main(int argc, char* argv[]) try {
   span.set_name(std::string{"projects/"} + argv[1] + "/traces/" +
                 RandomHexDigits(gen, 32) + "/spans/" + span_id);
   span.set_span_id(std::move(span_id));
-  *span.mutable_start_time() = TimeUtil::GetCurrentTime();
+  *span.mutable_start_time() = (TimeUtil::GetCurrentTime)();
   // Simulate a call using a small sleep
   std::this_thread::sleep_for(std::chrono::milliseconds(2));
-  *span.mutable_end_time() = TimeUtil::GetCurrentTime();
+  *span.mutable_end_time() = (TimeUtil::GetCurrentTime)();
 
   auto response = client.CreateSpan(span);
   if (!response) throw std::move(response).status();

--- a/google/cloud/trace/quickstart/quickstart.cc
+++ b/google/cloud/trace/quickstart/quickstart.cc
@@ -49,10 +49,10 @@ int main(int argc, char* argv[]) try {
   span.set_name(std::string{"projects/"} + argv[1] + "/traces/" +
                 RandomHexDigits(gen, 32) + "/spans/" + span_id);
   span.set_span_id(std::move(span_id));
-  *span.mutable_start_time() = TimeUtil::GetCurrentTime();
+  *span.mutable_start_time() = (TimeUtil::GetCurrentTime)();
   // Simulate a call using a small sleep
   std::this_thread::sleep_for(std::chrono::milliseconds(2));
-  *span.mutable_end_time() = TimeUtil::GetCurrentTime();
+  *span.mutable_end_time() = (TimeUtil::GetCurrentTime)();
 
   auto response = client.CreateSpan(span);
   if (!response) throw std::move(response).status();


### PR DESCRIPTION
On Windows, `GetCurrentTime()` is a macro. The current and previous releases of Protobuf undefine this macro in one of its headers.  That was probably a bug in Protobuf.  We use `TimeUtil::GetCurrentTime()`. With the next release of Protobuf that will expand the macro. We either need to prevent the macro expansion, using something like `(TimeUtil::GetCurrentTime)()`, or we need to avoid the function altogether.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11518)
<!-- Reviewable:end -->
