### PR TITLE
refactor(bigtable): move test

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -341,6 +341,7 @@ if (BUILD_TESTING)
         cluster_config_test.cc
         column_family_test.cc
         data_client_test.cc
+        data_connection_test.cc
         expr_test.cc
         filters_test.cc
         force_sanitizer_failures_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -26,6 +26,7 @@ bigtable_client_unit_tests = [
     "cluster_config_test.cc",
     "column_family_test.cc",
     "data_client_test.cc",
+    "data_connection_test.cc",
     "expr_test.cc",
     "filters_test.cc",
     "force_sanitizer_failures_test.cc",

--- a/google/cloud/bigtable/data_connection_test.cc
+++ b/google/cloud/bigtable/data_connection_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
+#include <chrono>
 
 namespace google {
 namespace cloud {
@@ -24,8 +25,10 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::ScopedEnvironment;
+using ms = std::chrono::milliseconds;
+
 TEST(MakeDataConnection, DefaultsOptions) {
-  using ::google::cloud::testing_util::ScopedEnvironment;
   ScopedEnvironment emulator_host("BIGTABLE_EMULATOR_HOST", "localhost:1");
 
   auto conn = MakeDataConnection(

--- a/google/cloud/bigtable/data_connection_test.cc
+++ b/google/cloud/bigtable/data_connection_test.cc
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/data_connection.h"
+#include "google/cloud/bigtable/options.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+TEST(MakeDataConnection, DefaultsOptions) {
+  using ::google::cloud::testing_util::ScopedEnvironment;
+  ScopedEnvironment emulator_host("BIGTABLE_EMULATOR_HOST", "localhost:1");
+
+  auto conn = MakeDataConnection(
+      Options{}
+          .set<AppProfileIdOption>("user-supplied")
+          // Disable channel refreshing, which is not under test.
+          .set<MaxConnectionRefreshOption>(ms(0))
+          // Create the minimum number of stubs.
+          .set<GrpcNumChannelsOption>(1));
+  auto options = conn->options();
+  EXPECT_TRUE(options.has<DataRetryPolicyOption>())
+      << "Options are not defaulted in MakeDataConnection()";
+  EXPECT_EQ(options.get<AppProfileIdOption>(), "user-supplied")
+      << "User supplied Options are overridden in MakeDataConnection()";
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -22,7 +22,6 @@
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/async_streaming_read_rpc_impl.h"
 #include "google/cloud/testing_util/mock_backoff_policy.h"
-#include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -1547,24 +1546,6 @@ TEST(DataConnectionTest, AsyncReadRowFailure) {
   internal::OptionsSpan span(CallOptions());
   auto resp = conn->AsyncReadRow(kTableName, "row", TestFilter()).get();
   EXPECT_THAT(resp, StatusIs(StatusCode::kPermissionDenied));
-}
-
-TEST(MakeDataConnection, DefaultsOptions) {
-  using ::google::cloud::testing_util::ScopedEnvironment;
-  ScopedEnvironment emulator_host("BIGTABLE_EMULATOR_HOST", "localhost:1");
-
-  auto conn = bigtable::MakeDataConnection(
-      Options{}
-          .set<bigtable::AppProfileIdOption>("user-supplied")
-          // Disable channel refreshing, which is not under test.
-          .set<bigtable::MaxConnectionRefreshOption>(ms(0))
-          // Create the minimum number of stubs.
-          .set<GrpcNumChannelsOption>(1));
-  auto options = conn->options();
-  EXPECT_TRUE(options.has<bigtable::DataRetryPolicyOption>())
-      << "Options are not defaulted in MakeDataConnection()";
-  EXPECT_EQ(options.get<bigtable::AppProfileIdOption>(), "user-supplied")
-      << "User supplied Options are overridden in MakeDataConnection()";
 }
 
 }  // namespace


### PR DESCRIPTION
This is testing a function from `data_connection.h` so it should be in `data_connection_test.cc`.

I was probably too lazy to create a new test file at the time it was added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11521)
<!-- Reviewable:end -->
