### PR TITLE
cleanup(ci): log cmake/ctest command lines

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++
@@ -30,15 +31,15 @@ readonly ENABLED_FEATURES="__ga_libraries__"
 # uninitialized values with GCC, so we disable that warning with
 # -Wno-maybe-uninitialized. See also:
 # https://github.com/googleapis/google-cloud-cpp/issues/6313
-cmake "${cmake_args[@]}" \
+io::run cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_BUILD_TYPE=Debug \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}" \
   -DCMAKE_CXX_FLAGS="-Og -Wno-maybe-uninitialized"
-cmake --build cmake-out
-cmake --install cmake-out >/dev/null
+io::run cmake --build cmake-out
+io::run cmake --install cmake-out >/dev/null
 
 mapfile -t ga_list < <(cmake -DCMAKE_MODULE_PATH="${PWD}/cmake" -P cmake/print-ga-libraries.cmake 2>&1)
 # These libraries are not "features", but they are part of the public API

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -17,9 +17,9 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module ci/lib/io.sh
-source module ci/cloudbuild/builds/lib/git.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/cloudbuild/builds/lib/git.sh
+source module ci/lib/io.sh
 
 # Runs sed expressions (specified after -e) over the given files, editing them
 # in place. This function is exported so it can be run in subshells, such as

--- a/ci/cloudbuild/builds/clang-60.sh
+++ b/ci/cloudbuild/builds/clang-60.sh
@@ -19,18 +19,19 @@ set -euo pipefail
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/lib/io.sh
 
 # We run this test in a Docker image that includes the oldest Clang that we
 # support, which happens to be 6.0 currently.
 export CC=clang
 export CXX=clang++
 
-cmake -GNinja -H. -Bcmake-out \
+io::run cmake -GNinja -H. -Bcmake-out \
   -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)" \
   -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON \
   -DBUILD_SHARED_LIBS=yes
-cmake --build cmake-out
+io::run cmake --build cmake-out
 
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out ctest "${ctest_args[@]}" -LE integration-test
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE integration-test

--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -20,6 +20,7 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
@@ -36,15 +37,15 @@ readonly ENABLED_FEATURES
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache
 # Note: we use C++14 for this build because we don't want tidy suggestions that
 # require a newer C++ standard.
-cmake "${cmake_args[@]}" \
+io::run cmake "${cmake_args[@]}" \
   -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
   -DCMAKE_CXX_STANDARD=14 \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}" \
   -DGOOGLE_CLOUD_CPP_INTERNAL_DOCFX=ON
-cmake --build cmake-out
+io::run cmake --build cmake-out
 
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out ctest "${ctest_args[@]}" -LE integration-test
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE integration-test
 
 integration::ctest_with_emulators "cmake-out"
 

--- a/ci/cloudbuild/builds/cmake-gcs-rest.sh
+++ b/ci/cloudbuild/builds/cmake-gcs-rest.sh
@@ -20,6 +20,7 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++
@@ -28,10 +29,10 @@ mapfile -t cmake_args < <(cmake::common_args)
 read -r ENABLED_FEATURES < <(features::always_build_cmake)
 readonly ENABLED_FEATURES
 
-cmake "${cmake_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
-cmake --build cmake-out
+io::run cmake "${cmake_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
+io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT=yes \
+io::run env -C cmake-out GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT=yes \
   ctest "${ctest_args[@]}" -LE "integration-test"
 
 GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT=yes \

--- a/ci/cloudbuild/builds/cmake-single-feature.sh
+++ b/ci/cloudbuild/builds/cmake-single-feature.sh
@@ -17,8 +17,8 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module ci/lib/io.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/lib/io.sh
 
 mapfile -t features < <(features::list_full)
 

--- a/ci/cloudbuild/builds/cxx14.sh
+++ b/ci/cloudbuild/builds/cxx14.sh
@@ -20,6 +20,7 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++
@@ -30,11 +31,11 @@ read -r ENABLED_FEATURES < <(features::always_build_cmake)
 ENABLED_FEATURES="${ENABLED_FEATURES},__ga_libraries__"
 readonly ENABLED_FEATURES
 
-cmake "${cmake_args[@]}" \
+io::run cmake "${cmake_args[@]}" \
   -DCMAKE_CXX_STANDARD=14 \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
-cmake --build cmake-out
+io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
 
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/cxx20.sh
+++ b/ci/cloudbuild/builds/cxx20.sh
@@ -20,6 +20,7 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++
@@ -30,11 +31,11 @@ read -r ENABLED_FEATURES < <(features::always_build_cmake)
 ENABLED_FEATURES="${ENABLED_FEATURES},__ga_libraries__"
 readonly ENABLED_FEATURES
 
-cmake "${cmake_args[@]}" \
+io::run cmake "${cmake_args[@]}" \
   -DCMAKE_CXX_STANDARD=20 \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
-cmake --build cmake-out
+io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
 
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/gcc-7.3.sh
+++ b/ci/cloudbuild/builds/gcc-7.3.sh
@@ -18,22 +18,23 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/lib/io.sh
 
 # We run this test in a docker image that includes the oldest GCC that we
 # support, which happens to be 7.3 currently.
 export CC=gcc
 export CXX=g++
 
-cmake -GNinja -H. -Bcmake-out \
+io::run cmake -GNinja -H. -Bcmake-out \
   -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)" \
   -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON \
   -DBUILD_SHARED_LIBS=yes
-cmake --build cmake-out
+io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
 # Cannot use `env -C` as the version of env on Ubuntu:16.04 this does not
 # support it
 (
   cd cmake-out
-  ctest "${ctest_args[@]}" -LE "integration-test"
+  io::run ctest "${ctest_args[@]}" -LE "integration-test"
 )

--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -22,8 +22,8 @@ if ((CI_CLOUDBUILD_BUILDS_LIB_CMAKE_SH__++ != 0)); then
   return 0
 fi # include guard
 
-source module ci/lib/io.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/lib/io.sh
 
 io::log "Using CMake version"
 cmake --version

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -23,8 +23,8 @@ if ((CI_CLOUDBUILD_BUILDS_LIB_INTEGRATION_SH__++ != 0)); then
 fi # include guard
 
 source module ci/etc/integration-tests-config.sh
-source module ci/lib/io.sh
 source module ci/cloudbuild/builds/lib/git.sh
+source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"

--- a/ci/cloudbuild/builds/m32.sh
+++ b/ci/cloudbuild/builds/m32.sh
@@ -20,6 +20,7 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++
@@ -31,11 +32,11 @@ ENABLED_FEATURES="${ENABLED_FEATURES},__ga_libraries__"
 readonly ENABLED_FEATURES
 
 # This is the build to test with -m32, which requires a toolchain file.
-cmake "${cmake_args[@]}" \
+io::run cmake "${cmake_args[@]}" \
   "--toolchain" "${PROJECT_ROOT}/ci/etc/m32-toolchain.cmake" \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
-cmake --build cmake-out
+io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
 
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/noex.sh
+++ b/ci/cloudbuild/builds/noex.sh
@@ -20,6 +20,7 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++
@@ -28,11 +29,11 @@ mapfile -t cmake_args < <(cmake::common_args)
 read -r ENABLED_FEATURES < <(features::always_build_cmake)
 readonly ENABLED_FEATURES
 
-cmake "${cmake_args[@]}" \
+io::run cmake "${cmake_args[@]}" \
   -DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=NO \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
-cmake --build cmake-out
+io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
 
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/lib/io.sh
 
 mapfile -t FEATURE_LIST < <(features::list_full)
 read -r ENABLED_FEATURES < <(features::list_full_cmake)
@@ -64,13 +65,13 @@ fi
 
 export CC=clang
 export CXX=clang++
-cmake -GNinja "${doc_args[@]}" -S . -B cmake-out
+io::run cmake -GNinja "${doc_args[@]}" -S . -B cmake-out
 # Doxygen needs the proto-generated headers, but there are race conditions
 # between CMake generating these files and doxygen scanning for them. We could
 # fix this by avoiding parallelism with `-j 1`, or as we do here, we'll
 # pre-generate all the proto headers, then call doxygen.
-cmake --build cmake-out --target google-cloud-cpp-protos
-cmake --build cmake-out --target doxygen-docs all-docfx
+io::run cmake --build cmake-out --target google-cloud-cpp-protos
+io::run cmake --build cmake-out --target doxygen-docs all-docfx
 
 if [[ "${PROJECT_ID:-}" != "cloud-cpp-testing-resources" ]]; then
   io::log_h2 "Skipping upload of docs," \

--- a/ci/cloudbuild/builds/quickstart-production.sh
+++ b/ci/cloudbuild/builds/quickstart-production.sh
@@ -20,6 +20,7 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/quickstart.sh
+source module ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++
@@ -29,17 +30,17 @@ readonly INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
 read -r ENABLED_FEATURES < <(features::list_full_cmake)
 readonly ENABLED_FEATURES
 
-cmake "${cmake_args[@]}" \
+io::run cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_SHARED_LIBS=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
-cmake --build cmake-out
+io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
 
 # Verify the quickstart programs for generated libraries run. Note
 # that most of these run against production, and are therefore
 # integration tests with the usual flakiness issues.
 io::log_h2 "Running all other quickstart programs"
-env -C cmake-out ctest "${ctest_args[@]}" -L "quickstart"
+io::run env -C cmake-out ctest "${ctest_args[@]}" -L "quickstart"

--- a/ci/cloudbuild/builds/scan-build.sh
+++ b/ci/cloudbuild/builds/scan-build.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
+source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
@@ -36,6 +37,6 @@ scan_build=(
   "-o"
   "${HOME}/scan-build"
 )
-"${scan_build[@]}" cmake "${cmake_args[@]}" \
+io::run "${scan_build[@]}" cmake "${cmake_args[@]}" \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
-"${scan_build[@]}" cmake --build cmake-out
+io::run "${scan_build[@]}" cmake --build cmake-out

--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -20,6 +20,7 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/quickstart.sh
+source module ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++
@@ -29,15 +30,15 @@ readonly INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
 read -r ENABLED_FEATURES < <(features::list_full_cmake)
 readonly ENABLED_FEATURES
 
-cmake "${cmake_args[@]}" \
+io::run cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_SHARED_LIBS=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
-cmake --build cmake-out
+io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
-env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
-cmake --install cmake-out
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+io::run cmake --install cmake-out
 
 # Tests the installed artifacts by building and running the quickstarts.
 quickstart::build_cmake_and_make "${INSTALL_PREFIX}"


### PR DESCRIPTION
In #11515 I removed `io::run` from the cmake command in the "m32" build, in the interests of consistency with the other cmake builds, which don't use logging.

Here, we still maintain consistency but by adding `io::run` to all the other cmake/ctest commands instead (well, at least those in the top-level build scripts).  This makes the build output easier to follow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11523)
<!-- Reviewable:end -->
