### PR TITLE
test(bigtable): relax backup expiration time checks

### DIFF
--- a/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
@@ -20,8 +20,8 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/chrono_literals.h"
+#include "google/cloud/testing_util/chrono_output.h"
 #include "google/cloud/testing_util/contains_once.h"
-#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/util/time_util.h>
 #include <gmock/gmock.h>
@@ -34,10 +34,13 @@ namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::internal::ToChronoTimePoint;
 using ::google::cloud::internal::ToProtoTimestamp;
 using ::google::cloud::testing_util::ContainsOnce;
-using ::google::cloud::testing_util::IsProtoEqual;
+using ::testing::AllOf;
 using ::testing::Contains;
+using ::testing::Ge;
+using ::testing::Le;
 using ::testing::Not;
 namespace btadmin = ::google::bigtable::admin::v2;
 
@@ -129,8 +132,11 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   backup = client_.GetBackup(backup_name);
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
-  EXPECT_THAT(backup->expire_time(),
-              IsProtoEqual(ToProtoTimestamp(expire_time)));
+  // The proto documentation says backup expiration times are in "microsecond
+  // granularity"
+  auto const delta = expire_time - ToChronoTimePoint(backup->expire_time());
+  EXPECT_THAT(delta, AllOf(Le(std::chrono::microseconds(1)),
+                           Ge(-std::chrono::microseconds(1))));
 
   // Delete table
   EXPECT_STATUS_OK(client_.DeleteTable(table_name));

--- a/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
@@ -20,8 +20,8 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/chrono_literals.h"
-#include "google/cloud/testing_util/chrono_output.h"
 #include "google/cloud/testing_util/contains_once.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/util/time_util.h>
 #include <gmock/gmock.h>
@@ -34,13 +34,10 @@ namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::ToChronoTimePoint;
 using ::google::cloud::internal::ToProtoTimestamp;
 using ::google::cloud::testing_util::ContainsOnce;
-using ::testing::AllOf;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::testing::Contains;
-using ::testing::Ge;
-using ::testing::Le;
 using ::testing::Not;
 namespace btadmin = ::google::bigtable::admin::v2;
 
@@ -102,7 +99,11 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   auto const backup_name = cluster_name + "/backups/" + backup_id;
 
   // Create backup
-  auto expire_time = std::chrono::system_clock::now() + std::chrono::hours(12);
+  // The proto documentation says backup expiration times are in "microseconds
+  // granularity":
+  //   https://cloud.google.com/bigtable/docs/reference/admin/rpc/google.bigtable.admin.v2#google.bigtable.admin.v2.Backup
+  auto expire_time = std::chrono::time_point_cast<std::chrono::microseconds>(
+      std::chrono::system_clock::now() + std::chrono::hours(12));
 
   btadmin::Backup b;
   b.set_source_table(table_name);
@@ -132,12 +133,8 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   backup = client_.GetBackup(backup_name);
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
-  // The proto documentation says backup expiration times are in "microseconds
-  // granularity":
-  //   https://cloud.google.com/bigtable/docs/reference/admin/rpc/google.bigtable.admin.v2#google.bigtable.admin.v2.Backup
-  auto const delta = expire_time - ToChronoTimePoint(backup->expire_time());
-  EXPECT_THAT(delta, AllOf(Le(std::chrono::microseconds(1)),
-                           Ge(-std::chrono::microseconds(1))));
+  EXPECT_THAT(backup->expire_time(),
+              IsProtoEqual(ToProtoTimestamp(expire_time)));
 
   // Delete table
   EXPECT_STATUS_OK(client_.DeleteTable(table_name));

--- a/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
@@ -132,8 +132,9 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   backup = client_.GetBackup(backup_name);
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
-  // The proto documentation says backup expiration times are in "microsecond
-  // granularity"
+  // The proto documentation says backup expiration times are in "microseconds
+  // granularity":
+  //   https://cloud.google.com/bigtable/docs/reference/admin/rpc/google.bigtable.admin.v2#google.bigtable.admin.v2.Backup
   auto const delta = expire_time - ToChronoTimePoint(backup->expire_time());
   EXPECT_THAT(delta, AllOf(Le(std::chrono::microseconds(1)),
                            Ge(-std::chrono::microseconds(1))));

--- a/google/cloud/bigtable/tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_backup_integration_test.cc
@@ -107,8 +107,9 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   backup = table_admin_->GetBackup(cluster_id, backup_id);
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
-  // The proto documentation says backup expiration times are in "microsecond
-  // granularity"
+  // The proto documentation says backup expiration times are in "microseconds
+  // granularity":
+  //   https://cloud.google.com/bigtable/docs/reference/admin/rpc/google.bigtable.admin.v2#google.bigtable.admin.v2.Backup
   auto const delta = expire_time - ToChronoTimePoint(backup->expire_time());
   EXPECT_THAT(delta, AllOf(Le(std::chrono::microseconds(1)),
                            Ge(-std::chrono::microseconds(1))));

--- a/google/cloud/bigtable/tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_backup_integration_test.cc
@@ -23,7 +23,6 @@
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
-#include <algorithm>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Bigtable stores the backup expiration time in microsecond granularity, don't expect that full nanosecond is preserved (or whatever the `std::chrono::time_point` granularity happens to be).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11524)
<!-- Reviewable:end -->
