### PR TITLE
impl(docfx): use `typealias` for typedefs

### DIFF
--- a/docfx/doxygen2syntax.cc
+++ b/docfx/doxygen2syntax.cc
@@ -308,7 +308,9 @@ void AppendTypedefSyntax(YAML::Emitter& yaml, YamlContext const& ctx,
   yaml << YAML::Key << "syntax" << YAML::Value                     //
        << YAML::BeginMap                                           //
        << YAML::Key << "contents" << YAML::Value << YAML::Literal  //
-       << TypedefSyntaxContent(node);
+       << TypedefSyntaxContent(node)                               //
+       << YAML::Key << "aliasof" << YAML::Value << YAML::DoubleQuoted
+       << HtmlEscape(LinkedTextType(node.child("type")));
   AppendLocation(yaml, ctx, node, "name");
   yaml << YAML::EndMap;
 }

--- a/docfx/doxygen2syntax_test.cc
+++ b/docfx/doxygen2syntax_test.cc
@@ -547,6 +547,7 @@ TEST(Doxygen2Syntax, Typedef) {
   contents: |
     using google::cloud::BackgroundThreadsFactory =
       std::function< std::unique_ptr< BackgroundThreads >()>;
+  aliasof: "std::function&lt; std::unique_ptr&lt; BackgroundThreads &gt;()&gt;"
   source:
     id: BackgroundThreadsFactory
     path: google/cloud/grpc_options.h

--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -211,12 +211,12 @@ bool AppendIfTypedef(YAML::Emitter& yaml, YamlContext const& ctx,
       std::string_view{node.child("qualifiedname").child_value()};
   yaml << YAML::BeginMap                                                    //
        << YAML::Key << "uid" << YAML::Value << id                           //
-       << YAML::Key << "name" << YAML::Value << YAML::Literal << name       //
+       << YAML::Key << "name" << YAML::Value << YAML::DoubleQuoted << name  //
        << YAML::Key << "fullName"                                           //
-       << YAML::Value << YAML::Literal << full_name                         //
+       << YAML::Value << YAML::DoubleQuoted << full_name                    //
        << YAML::Key << "id" << YAML::Value << id                            //
        << YAML::Key << "parent" << YAML::Value << ctx.parent_id             //
-       << YAML::Key << "type" << YAML::Value << "typedef"                   //
+       << YAML::Key << "type" << YAML::Value << "typealias"                 //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendTypedefSyntax(yaml, ctx, node);
   AppendDescription(yaml, node);

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -551,19 +551,18 @@ TEST(Doxygen2Yaml, Typedef) {
   auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
 items:
   - uid: namespacegoogle_1_1cloud_1a1498c1ea55d81842f37bbc42d003df1f
-    name: |
-      BackgroundThreadsFactory
-    fullName: |
-      google::cloud::BackgroundThreadsFactory
+    name: "BackgroundThreadsFactory"
+    fullName: "google::cloud::BackgroundThreadsFactory"
     id: namespacegoogle_1_1cloud_1a1498c1ea55d81842f37bbc42d003df1f
     parent: test-only-parent-id
-    type: typedef
+    type: typealias
     langs:
       - cpp
     syntax:
       contents: |
         using google::cloud::BackgroundThreadsFactory =
           std::function< std::unique_ptr< BackgroundThreads >()>;
+      aliasof: "std::function&lt; std::unique_ptr&lt; BackgroundThreads &gt;()&gt;"
       source:
         id: BackgroundThreadsFactory
         path: google/cloud/grpc_options.h
@@ -842,19 +841,18 @@ TEST(Doxygen2Yaml, SectionDef) {
   auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
 items:
   - uid: structgoogle_1_1cloud_1_1AccessTokenLifetimeOption_1ad6b8a4672f1c196926849229f62d0de2
-    name: |
-      Type
-    fullName: |
-      google::cloud::AccessTokenLifetimeOption::Type
+    name: "Type"
+    fullName: "google::cloud::AccessTokenLifetimeOption::Type"
     id: structgoogle_1_1cloud_1_1AccessTokenLifetimeOption_1ad6b8a4672f1c196926849229f62d0de2
     parent: test-only-parent-id
-    type: typedef
+    type: typealias
     langs:
       - cpp
     syntax:
       contents: |
         using google::cloud::AccessTokenLifetimeOption::Type =
           std::chrono::seconds;
+      aliasof: "std::chrono::seconds"
       source:
         id: Type
         path: google/cloud/credentials.h


### PR DESCRIPTION
DocFX recognizes `typealias` as, well, aliases for types. A separate PR tweaks it to support typealiases in namespaces, but these changes make the aliases visible in the generated documentation.

Part of the work for #11456

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11541)
<!-- Reviewable:end -->
