### PR TITLE
cleanup(bigtable): fix CI table leaks

### DIFF
--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -388,7 +388,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning the AsyncReadModifyWrite() example" << std::endl;
   AsyncReadModifyWrite(table, {"read-modify-write-row-key"});
 
-  (void)admin.DeleteTable(table_id);
+  (void)admin.DeleteTable(table.table_name());
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
I noticed this call fails silently in Cloud Trace, lol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11563)
<!-- Reviewable:end -->
