### PR TITLE
impl(otel): `AsyncStreamingReadRpcTracing`

### DIFF
--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -43,6 +43,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/async_streaming_read_rpc_auth.h",
     "internal/async_streaming_read_rpc_impl.h",
     "internal/async_streaming_read_rpc_logging.h",
+    "internal/async_streaming_read_rpc_tracing.h",
     "internal/async_streaming_write_rpc.h",
     "internal/async_streaming_write_rpc_auth.h",
     "internal/async_streaming_write_rpc_impl.h",

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -49,6 +49,7 @@ add_library(
     internal/async_streaming_read_rpc_auth.h
     internal/async_streaming_read_rpc_impl.h
     internal/async_streaming_read_rpc_logging.h
+    internal/async_streaming_read_rpc_tracing.h
     internal/async_streaming_write_rpc.h
     internal/async_streaming_write_rpc_auth.h
     internal/async_streaming_write_rpc_impl.h
@@ -243,6 +244,7 @@ if (BUILD_TESTING)
         internal/async_streaming_read_rpc_auth_test.cc
         internal/async_streaming_read_rpc_impl_test.cc
         internal/async_streaming_read_rpc_logging_test.cc
+        internal/async_streaming_read_rpc_tracing_test.cc
         internal/async_streaming_write_rpc_auth_test.cc
         internal/async_streaming_write_rpc_impl_test.cc
         internal/async_streaming_write_rpc_logging_test.cc

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -32,6 +32,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/async_streaming_read_rpc_auth_test.cc",
     "internal/async_streaming_read_rpc_impl_test.cc",
     "internal/async_streaming_read_rpc_logging_test.cc",
+    "internal/async_streaming_read_rpc_tracing_test.cc",
     "internal/async_streaming_write_rpc_auth_test.cc",
     "internal/async_streaming_write_rpc_impl_test.cc",
     "internal/async_streaming_write_rpc_logging_test.cc",

--- a/google/cloud/internal/async_streaming_read_rpc_tracing.h
+++ b/google/cloud/internal/async_streaming_read_rpc_tracing.h
@@ -1,0 +1,91 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_STREAMING_READ_RPC_TRACING_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_STREAMING_READ_RPC_TRACING_H
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/async_streaming_read_rpc.h"
+#include "google/cloud/internal/grpc_opentelemetry.h"
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+template <typename Response>
+class AsyncStreamingReadRpcTracing : public AsyncStreamingReadRpc<Response> {
+ public:
+  AsyncStreamingReadRpcTracing(
+      std::shared_ptr<grpc::ClientContext> context,
+      std::unique_ptr<AsyncStreamingReadRpc<Response>> impl,
+      opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span)
+      : context_(std::move(context)),
+        impl_(std::move(impl)),
+        span_(std::move(span)) {}
+  ~AsyncStreamingReadRpcTracing() override { (void)End(Status()); }
+
+  void Cancel() override {
+    span_->AddEvent("cancel");
+    impl_->Cancel();
+  }
+
+  future<bool> Start() override {
+    return impl_->Start().then([this](future<bool> f) {
+      auto started = f.get();
+      span_->SetAttribute("gcloud.stream_started", started);
+      return started;
+    });
+  }
+
+  future<absl::optional<Response>> Read() override {
+    return impl_->Read().then([this](future<absl::optional<Response>> f) {
+      auto r = f.get();
+      if (r.has_value()) {
+        span_->AddEvent("message", {{"message.type", "RECEIVED"},
+                                    {"message.id", ++read_count_}});
+      }
+      return r;
+    });
+  }
+
+  future<Status> Finish() override {
+    return impl_->Finish().then(
+        [this](future<Status> f) { return End(f.get()); });
+  }
+
+  StreamingRpcMetadata GetRequestMetadata() const override {
+    return impl_->GetRequestMetadata();
+  }
+
+ private:
+  Status End(Status status) {
+    if (!context_) return status;
+    return EndSpan(*std::move(context_), *std::move(span_), std::move(status));
+  }
+
+  std::shared_ptr<grpc::ClientContext> context_;
+  std::unique_ptr<AsyncStreamingReadRpc<Response>> impl_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span_;
+  int read_count_ = 0;
+};
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_STREAMING_READ_RPC_TRACING_H

--- a/google/cloud/internal/async_streaming_read_rpc_tracing_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_tracing_test.cc
@@ -1,0 +1,204 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/async_streaming_read_rpc_tracing.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::EventNamed;
+using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::SpanEventAttributesAre;
+using ::google::cloud::testing_util::SpanHasAttributes;
+using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::SpanWithStatus;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Optional;
+using ::testing::Pair;
+using ::testing::Return;
+
+template <typename Response>
+class MockAsyncStreamingReadRpc : public AsyncStreamingReadRpc<Response> {
+ public:
+  ~MockAsyncStreamingReadRpc() override = default;
+
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<Response>>, Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
+  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+};
+
+using MockStream = MockAsyncStreamingReadRpc<int>;
+using TestedStream = AsyncStreamingReadRpcTracing<int>;
+
+TEST(AsyncStreamingReadRpcTracing, Cancel) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Cancel).WillOnce([span] {
+    // Verify that our "cancel" event is added before calling `TryCancel()` on
+    // the underlying stream.
+    span->AddEvent("test-only: underlying stream cancel");
+  });
+  EXPECT_CALL(*mock, Finish)
+      .WillOnce(
+          Return(make_ready_future(internal::CancelledError("cancelled"))));
+
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  stream.Cancel();
+  (void)stream.Finish().get();
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanNamed("span"),
+          SpanEventsAre(EventNamed("cancel"),
+                        EventNamed("test-only: underlying stream cancel")))));
+}
+
+TEST(AsyncStreamingReadRpcTracing, Start) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Start).WillOnce([] { return make_ready_future(true); });
+  EXPECT_CALL(*mock, Finish)
+      .WillOnce(Return(make_ready_future(internal::AbortedError("fail"))));
+
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  EXPECT_TRUE(stream.Start().get());
+  (void)stream.Finish().get();
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, ElementsAre(AllOf(SpanNamed("span"),
+                                       SpanHasAttributes(SpanAttribute<bool>(
+                                           "gcloud.stream_started", true)))));
+}
+
+TEST(AsyncStreamingReadRpcTracing, Read) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Read)
+      .WillOnce([] { return make_ready_future(absl::make_optional(100)); })
+      .WillOnce([] { return make_ready_future(absl::make_optional(200)); })
+      .WillOnce([] { return make_ready_future(absl::make_optional(300)); })
+      .WillOnce(
+          [] { return make_ready_future<absl::optional<int>>(absl::nullopt); });
+  EXPECT_CALL(*mock, Finish)
+      .WillOnce(Return(make_ready_future(internal::AbortedError("fail"))));
+
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  EXPECT_THAT(stream.Read().get(), Optional(100));
+  EXPECT_THAT(stream.Read().get(), Optional(200));
+  EXPECT_THAT(stream.Read().get(), Optional(300));
+  EXPECT_FALSE(stream.Read().get().has_value());
+  (void)stream.Finish().get();
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanNamed("span"),
+          SpanEventsAre(
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "RECEIVED"),
+                        SpanAttribute<int>("message.id", 1))),
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "RECEIVED"),
+                        SpanAttribute<int>("message.id", 2))),
+              AllOf(EventNamed("message"),
+                    SpanEventAttributesAre(
+                        SpanAttribute<std::string>("message.type", "RECEIVED"),
+                        SpanAttribute<int>("message.id", 3)))))));
+}
+
+TEST(AsyncStreamingReadRpcTracing, Finish) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto span = MakeSpan("span");
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Finish)
+      .WillOnce(Return(make_ready_future(internal::AbortedError("fail"))));
+
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  EXPECT_THAT(stream.Finish().get(), StatusIs(StatusCode::kAborted, "fail"));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanNamed("span"),
+          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)),
+          SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"))));
+}
+
+TEST(AsyncStreamingReadRpcTracing, GetRequestMetadata) {
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, GetRequestMetadata)
+      .WillOnce(Return(StreamingRpcMetadata{{"key", "value"}}));
+
+  auto span = MakeSpan("span");
+  TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
+                      span);
+  auto md = stream.GetRequestMetadata();
+  EXPECT_THAT(md, ElementsAre(Pair("key", "value")));
+}
+
+TEST(AsyncStreamingReadRpcTracing, SpanEndsOnDestruction) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  {
+    auto mock = std::make_unique<MockStream>();
+    auto span = MakeSpan("span");
+    TestedStream stream(std::make_shared<grpc::ClientContext>(),
+                        std::move(mock), span);
+
+    auto spans = span_catcher->GetSpans();
+    EXPECT_THAT(spans, IsEmpty());
+  }
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, ElementsAre(SpanNamed("span")));
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY


### PR DESCRIPTION
Part of the work for #10619 

Eventually becomes things like this:
![image](https://github.com/googleapis/google-cloud-cpp/assets/23088558/511202ba-4466-4406-a768-e61692423086)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11564)
<!-- Reviewable:end -->
