### PR TITLE
impl(bigtable): correlate AsyncReadRows span with children

### DIFF
--- a/google/cloud/bigtable/internal/data_tracing_connection.cc
+++ b/google/cloud/bigtable/internal/data_tracing_connection.cc
@@ -172,9 +172,9 @@ class DataTracingConnection : public bigtable::DataConnection {
                      bigtable::RowSet row_set, std::int64_t rows_limit,
                      bigtable::Filter filter) override {
     auto span = internal::MakeSpan("bigtable::Table::AsyncReadRows");
-    auto traced_on_finish = [s = std::move(span),
-                             on_finish](Status const& status) {
-      return on_finish(internal::EndSpan(*s, status));
+    auto scope = opentelemetry::trace::Scope(span);
+    auto traced_on_finish = [span, on_finish](Status const& status) {
+      return on_finish(internal::EndSpan(*span, status));
     };
     child_->AsyncReadRows(table_name, std::move(on_row),
                           std::move(traced_on_finish), std::move(row_set),

--- a/google/cloud/bigtable/internal/data_tracing_connection_test.cc
+++ b/google/cloud/bigtable/internal/data_tracing_connection_test.cc
@@ -476,6 +476,7 @@ TEST(DataTracingConnection, AsyncReadRows) {
                    std::function<void(Status)> const& on_finish,
                    bigtable::RowSet const&, std::int64_t,
                    bigtable::Filter const&) {
+        EXPECT_TRUE(ThereIsAnActiveSpan());
         // Invoke the callbacks.
         on_row(bigtable::Row("r1", {})).get();
         on_row(bigtable::Row("r2", {})).get();


### PR DESCRIPTION
I missed this in: #11558 

We need to set the connection level span as active before we get to the stub layer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11572)
<!-- Reviewable:end -->
