### PR TITLE
impl(common): support extracting a typed option from an Options

### DIFF
--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -329,7 +329,7 @@ Options MergeOptions(Options preferred, Options alternatives);
  * Extracts and returns the value for `T` from @p opts, or nullopt if `T` was
  * not set.  This is intended for code paths that want to consume an option,
  * for example, a client call that passes the option's value via conventional
- * mechanisms, rather than though an OptionsSpan.
+ * mechanisms, rather than through an OptionsSpan.
  */
 template <typename T>
 absl::optional<typename T::Type> ExtractOption(Options& opts) {

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -26,6 +26,8 @@ namespace {
 using ::testing::AllOf;
 using ::testing::Contains;
 using ::testing::ContainsRegex;
+using ::testing::Optional;
+using ::testing::StrEq;
 using ::testing::UnorderedElementsAre;
 
 struct IntOption {
@@ -283,15 +285,13 @@ TEST(ExtractOption, Basics) {
   EXPECT_FALSE(opts.has<BoolOption>());
   EXPECT_FALSE(opts.has<IntOption>());
   EXPECT_TRUE(opts.has<StringOption>());
-  ASSERT_TRUE(i.has_value());
-  EXPECT_EQ(*i, 42);
+  EXPECT_THAT(i, Optional(42));
 
   auto s = internal::ExtractOption<StringOption>(opts);
   EXPECT_FALSE(opts.has<BoolOption>());
   EXPECT_FALSE(opts.has<IntOption>());
   EXPECT_FALSE(opts.has<StringOption>());
-  ASSERT_TRUE(s.has_value());
-  EXPECT_EQ(*s, "foo");
+  EXPECT_THAT(s, Optional(StrEq("foo")));
 }
 
 TEST(OptionsSpan, Basics) {

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -270,6 +270,30 @@ TEST(MergeOptions, Basics) {
   EXPECT_EQ(a.get<IntOption>(), 42);           // From a
 }
 
+TEST(ExtractOption, Basics) {
+  auto opts = Options{}.set<StringOption>("foo").set<IntOption>(42);
+
+  auto b = internal::ExtractOption<BoolOption>(opts);
+  EXPECT_FALSE(opts.has<BoolOption>());
+  EXPECT_TRUE(opts.has<IntOption>());
+  EXPECT_TRUE(opts.has<StringOption>());
+  EXPECT_FALSE(b.has_value());
+
+  auto i = internal::ExtractOption<IntOption>(opts);
+  EXPECT_FALSE(opts.has<BoolOption>());
+  EXPECT_FALSE(opts.has<IntOption>());
+  EXPECT_TRUE(opts.has<StringOption>());
+  ASSERT_TRUE(i.has_value());
+  EXPECT_EQ(*i, 42);
+
+  auto s = internal::ExtractOption<StringOption>(opts);
+  EXPECT_FALSE(opts.has<BoolOption>());
+  EXPECT_FALSE(opts.has<IntOption>());
+  EXPECT_FALSE(opts.has<StringOption>());
+  ASSERT_TRUE(s.has_value());
+  EXPECT_EQ(*s, "foo");
+}
+
 TEST(OptionsSpan, Basics) {
   EXPECT_FALSE(internal::CurrentOptions().has<IntOption>());
   {


### PR DESCRIPTION
```
absl::optional<typename T::Type> internal::ExtractOption<T>(Options&);
```
Extracts and returns the value for `T` from the options, or nullopt if `T` was not set.

This is intended for code paths that want to consume an option, for example in a client call that passes the option's value via conventional mechanisms, rather than through an `OptionsSpan`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11576)
<!-- Reviewable:end -->
