### PR TITLE
doc: restore environment variable documentation

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -712,6 +712,8 @@ can override the default policies.
   endpoint.
 - @ref $library$-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref $library$-env - describes environment variables that can configure the
+  behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/$site_root$
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -42,13 +42,8 @@ can override the default policies.
   endpoint.
 - @ref accessapproval-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref accessapproval-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
-[gcs-quickstart]: https://cloud.google.com/cloud-provider-access-management/access-approval/docs/quickstart 'Quickstarts'
-[resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
-- @ref accessapproval-env - describes environment variables that can configure the behavior of the library.
-[billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
-[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
-[gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
 
 */

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -46,6 +46,7 @@ can override the default policies.
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 [gcs-quickstart]: https://cloud.google.com/cloud-provider-access-management/access-approval/docs/quickstart 'Quickstarts'
 [resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
+- @ref accessapproval-env - describes environment variables that can configure the behavior of the library.
 [billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
 [authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
 [gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts

--- a/google/cloud/accesscontextmanager/doc/main.dox
+++ b/google/cloud/accesscontextmanager/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref accesscontextmanager-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref accesscontextmanager-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/access-context-manager
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/advisorynotifications/doc/main.dox
+++ b/google/cloud/advisorynotifications/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref advisorynotifications-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref advisorynotifications-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/advisory-notifications
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/alloydb/doc/main.dox
+++ b/google/cloud/alloydb/doc/main.dox
@@ -53,6 +53,7 @@ can override the default policies.
   endpoint.
 - @ref alloydb-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref alloydb-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/alloydb
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/apigateway/doc/main.dox
+++ b/google/cloud/apigateway/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref apigateway-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref apigateway-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/api-gateway
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/apigeeconnect/doc/main.dox
+++ b/google/cloud/apigeeconnect/doc/main.dox
@@ -45,6 +45,7 @@ can override the default policies.
   endpoint.
 - @ref apigeeconnect-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref apigeeconnect-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/apigee/docs/hybrid/
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/apikeys/doc/main.dox
+++ b/google/cloud/apikeys/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref apikeys-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref apikeys-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/api-keys
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/appengine/doc/main.dox
+++ b/google/cloud/appengine/doc/main.dox
@@ -53,6 +53,7 @@ can override the default policies.
   endpoint.
 - @ref appengine-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref appengine-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/appengine/docs/admin-api
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/artifactregistry/doc/main.dox
+++ b/google/cloud/artifactregistry/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref artifactregistry-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref artifactregistry-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/artifact-registry
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/asset/doc/main.dox
+++ b/google/cloud/asset/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref asset-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref asset-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/asset-inventory
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
 - @ref assuredworkloads-override-endpoint - describes how to override the default
   endpoint.
 - @ref assuredworkloads-override-authentication - describes how to change the
+- @ref assuredworkloads-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -42,8 +42,8 @@ can override the default policies.
 - @ref assuredworkloads-override-endpoint - describes how to override the default
   endpoint.
 - @ref assuredworkloads-override-authentication - describes how to change the
-- @ref assuredworkloads-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref assuredworkloads-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -48,6 +48,7 @@ can override the default policies.
   endpoint.
 - @ref automl-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref automl-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/automl
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/baremetalsolution/doc/main.dox
+++ b/google/cloud/baremetalsolution/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref baremetalsolution-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref baremetalsolution-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/bare-metal
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/batch/doc/main.dox
+++ b/google/cloud/batch/doc/main.dox
@@ -40,6 +40,7 @@ can override the default policies.
   endpoint.
 - @ref batch-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref batch-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/batch
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/beyondcorp/doc/main.dox
+++ b/google/cloud/beyondcorp/doc/main.dox
@@ -53,6 +53,7 @@ can override the default policies.
   endpoint.
 - @ref beyondcorp-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref beyondcorp-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/beyondcorp
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/bigquery/doc/main.dox
+++ b/google/cloud/bigquery/doc/main.dox
@@ -82,6 +82,7 @@ when testing your application.
 [concepts-link]: https://cloud.google.com/bigquery/docs/concepts 'BigQuery Concepts'
 [authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
 [gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
+- @ref bigquery-env - describes environment variables that can configure the behavior of the library.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 [quickstart-link]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/bigquery/quickstart
 [status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h

--- a/google/cloud/bigquery/doc/main.dox
+++ b/google/cloud/bigquery/doc/main.dox
@@ -75,16 +75,18 @@ when testing your application.
 
 ## Next Steps
 
-* @ref bigquery-read-mock
+- @ref common-error-handling - describes how the library reports errors.
+- @ref bigquery-override-endpoint - describes how to override the default
+  endpoint.
+- @ref bigquery-override-authentication - describes how to change the
+  authentication credentials used by the library.
+- @ref bigquery-env - describes environment variables that can configure the behavior of the library.
+- @ref bigquery-read-mock
 
 [resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
 [billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
 [concepts-link]: https://cloud.google.com/bigquery/docs/concepts 'BigQuery Concepts'
-[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
-[gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
-- @ref bigquery-env - describes environment variables that can configure the behavior of the library.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 [quickstart-link]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/bigquery/quickstart
-[status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
 
 */

--- a/google/cloud/bigtable/doc/bigtable-main.dox
+++ b/google/cloud/bigtable/doc/bigtable-main.dox
@@ -141,6 +141,7 @@ guide for more details.
 
 @snippet google/cloud/bigtable/admin/samples/bigtable_instance_admin_client_samples.cc set-client-endpoint
 */
+- @ref bigtable-env - describes environment variables that can configure the behavior of the library.
 
 /*! @page BigtableInstanceAdminClient-with-service-account-snippet Override @c BigtableInstanceAdminClient Default Authentication
 

--- a/google/cloud/bigtable/doc/bigtable-main.dox
+++ b/google/cloud/bigtable/doc/bigtable-main.dox
@@ -141,7 +141,6 @@ guide for more details.
 
 @snippet google/cloud/bigtable/admin/samples/bigtable_instance_admin_client_samples.cc set-client-endpoint
 */
-- @ref bigtable-env - describes environment variables that can configure the behavior of the library.
 
 /*! @page BigtableInstanceAdminClient-with-service-account-snippet Override @c BigtableInstanceAdminClient Default Authentication
 

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -48,8 +48,8 @@ can override the default policies.
 - @ref billing-override-endpoint - describes how to override the default
   endpoint.
 - @ref billing-override-authentication - describes how to change the
-- @ref billing-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref billing-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -48,6 +48,7 @@ can override the default policies.
 - @ref billing-override-endpoint - describes how to override the default
   endpoint.
 - @ref billing-override-authentication - describes how to change the
+- @ref billing-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/binaryauthorization/doc/main.dox
+++ b/google/cloud/binaryauthorization/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref binaryauthorization-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref binaryauthorization-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/binary-authorization
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/certificatemanager/doc/main.dox
+++ b/google/cloud/certificatemanager/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref certificatemanager-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref certificatemanager-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/certificate-manager
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/channel/doc/main.dox
+++ b/google/cloud/channel/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref channel-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref channel-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/channel
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/cloudbuild/doc/main.dox
+++ b/google/cloud/cloudbuild/doc/main.dox
@@ -47,6 +47,7 @@ can override the default policies.
   endpoint.
 - @ref cloudbuild-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref cloudbuild-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/build
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/composer/doc/main.dox
+++ b/google/cloud/composer/doc/main.dox
@@ -47,6 +47,7 @@ can override the default policies.
   endpoint.
 - @ref composer-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref composer-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/composer
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/confidentialcomputing/doc/main.dox
+++ b/google/cloud/confidentialcomputing/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref confidentialcomputing-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref confidentialcomputing-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/confidential-computing
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/connectors/doc/main.dox
+++ b/google/cloud/connectors/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref connectors-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref connectors-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/apigee/docs/api-platform/connectors/about-connectors
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/contactcenterinsights/doc/main.dox
+++ b/google/cloud/contactcenterinsights/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref contactcenterinsights-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref contactcenterinsights-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/contact-center/insights/docs
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/container/doc/main.dox
+++ b/google/cloud/container/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref container-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref container-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/kubernetes-engine/docs/
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/containeranalysis/doc/main.dox
+++ b/google/cloud/containeranalysis/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref containeranalysis-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref containeranalysis-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/container-analysis
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/datacatalog/doc/main.dox
+++ b/google/cloud/datacatalog/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref datacatalog-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref datacatalog-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/data-catalog
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/datamigration/doc/main.dox
+++ b/google/cloud/datamigration/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref datamigration-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref datamigration-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/database-migration
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/dataplex/doc/main.dox
+++ b/google/cloud/dataplex/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref dataplex-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref dataplex-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/dataplex
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -53,6 +53,7 @@ can override the default policies.
   endpoint.
 - @ref dataproc-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref dataproc-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/dataproc
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/datastream/doc/main.dox
+++ b/google/cloud/datastream/doc/main.dox
@@ -44,6 +44,7 @@ can override the default policies.
   endpoint.
 - @ref datastream-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref datastream-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/datastream
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/debugger/doc/main.dox
+++ b/google/cloud/debugger/doc/main.dox
@@ -48,6 +48,7 @@ can override the default policies.
   endpoint.
 - @ref debugger-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref debugger-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/debugger
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/deploy/doc/main.dox
+++ b/google/cloud/deploy/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref deploy-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref deploy-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/deploy
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -64,6 +64,7 @@ can override the default policies.
   endpoint.
 - @ref dialogflow_cx-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref dialogflow_cx-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/dialogflow/cx/docs
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -65,6 +65,7 @@ can override the default policies.
   endpoint.
 - @ref dialogflow_es-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref dialogflow_es-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/dialogflow/es/docs
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/dlp/doc/main.dox
+++ b/google/cloud/dlp/doc/main.dox
@@ -44,6 +44,7 @@ can override the default policies.
   endpoint.
 - @ref dlp-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref dlp-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/dlp/docs/
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/doc/common-main.dox
+++ b/google/cloud/doc/common-main.dox
@@ -42,7 +42,6 @@ These namespaces include:
   run-time errors and how you can handle them.
 - @ref options for information about configuring the client libraries at
   runtime.
-- @ref cloud-env - describes environment variables that can configure the behavior of the library.
 - @ref guac for more details about how to configure authentication in the client
   libraries.
 - @ref logging for information about enabling logging to the console in the

--- a/google/cloud/doc/common-main.dox
+++ b/google/cloud/doc/common-main.dox
@@ -42,6 +42,7 @@ These namespaces include:
   run-time errors and how you can handle them.
 - @ref options for information about configuring the client libraries at
   runtime.
+- @ref cloud-env - describes environment variables that can configure the behavior of the library.
 - @ref guac for more details about how to configure authentication in the client
   libraries.
 - @ref logging for information about enabling logging to the console in the

--- a/google/cloud/documentai/doc/main.dox
+++ b/google/cloud/documentai/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref documentai-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref documentai-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/document-ai
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/edgecontainer/doc/main.dox
+++ b/google/cloud/edgecontainer/doc/main.dox
@@ -44,6 +44,7 @@ can override the default policies.
   endpoint.
 - @ref edgecontainer-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref edgecontainer-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/distributed-cloud/edge/latest/docs
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -47,6 +47,7 @@ can override the default policies.
   endpoint.
 - @ref eventarc-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref eventarc-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/eventarc
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/filestore/doc/main.dox
+++ b/google/cloud/filestore/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref filestore-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref filestore-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/filestore
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/functions/doc/main.dox
+++ b/google/cloud/functions/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref functions-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref functions-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/functions
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/gameservices/doc/main.dox
+++ b/google/cloud/gameservices/doc/main.dox
@@ -50,6 +50,7 @@ can override the default policies.
   endpoint.
 - @ref gameservices-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref gameservices-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/game-servers/docs/
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/gkehub/doc/main.dox
+++ b/google/cloud/gkehub/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref gkehub-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref gkehub-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/anthos
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/gkemulticloud/doc/main.dox
+++ b/google/cloud/gkemulticloud/doc/main.dox
@@ -55,6 +55,7 @@ can override the default policies.
   endpoint.
 - @ref gkemulticloud-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref gkemulticloud-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/anthos/clusters/docs/multi-cloud
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/iam/doc/main.dox
+++ b/google/cloud/iam/doc/main.dox
@@ -71,17 +71,19 @@ when testing your application.
 
 ## Next Steps
 
-* @ref iam-mock
-* @ref iam-credentials-mock
+- @ref common-error-handling - describes how the library reports errors.
+- @ref iam-override-endpoint - describes how to override the default
+  endpoint.
+- @ref iam-override-authentication - describes how to change the
+  authentication credentials used by the library.
+- @ref iam-env - describes environment variables that can configure the behavior of the library.
+- @ref iam-mock
+- @ref iam-credentials-mock
 
 [resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
 [billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
 [concepts-link]: https://cloud.google.com/iam/docs/concepts 'IAM Concepts'
-[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
-[gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
-- @ref iam-env - describes environment variables that can configure the behavior of the library.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 [quickstart-link]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/iam/quickstart
-[status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
 
 */

--- a/google/cloud/iam/doc/main.dox
+++ b/google/cloud/iam/doc/main.dox
@@ -79,6 +79,7 @@ when testing your application.
 [concepts-link]: https://cloud.google.com/iam/docs/concepts 'IAM Concepts'
 [authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
 [gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
+- @ref iam-env - describes environment variables that can configure the behavior of the library.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 [quickstart-link]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/iam/quickstart
 [status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h

--- a/google/cloud/iap/doc/main.dox
+++ b/google/cloud/iap/doc/main.dox
@@ -47,6 +47,7 @@ can override the default policies.
   endpoint.
 - @ref iap-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref iap-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/iap
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/ids/doc/main.dox
+++ b/google/cloud/ids/doc/main.dox
@@ -46,6 +46,7 @@ can override the default policies.
   endpoint.
 - @ref ids-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref ids-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/ids
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/iot/doc/main.dox
+++ b/google/cloud/iot/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref iot-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref iot-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/iot
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -50,8 +50,8 @@ can override the default policies.
 - @ref kms-override-endpoint - describes how to override the default
   endpoint.
 - @ref kms-override-authentication - describes how to change the
-- @ref kms-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref kms-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -50,6 +50,7 @@ can override the default policies.
 - @ref kms-override-endpoint - describes how to override the default
   endpoint.
 - @ref kms-override-authentication - describes how to change the
+- @ref kms-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/language/doc/main.dox
+++ b/google/cloud/language/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref language-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref language-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/natural-language
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
 - @ref logging-override-endpoint - describes how to override the default
   endpoint.
 - @ref logging-override-authentication - describes how to change the
+- @ref logging-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -41,8 +41,8 @@ can override the default policies.
 - @ref logging-override-endpoint - describes how to override the default
   endpoint.
 - @ref logging-override-authentication - describes how to change the
-- @ref logging-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref logging-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/managedidentities/doc/main.dox
+++ b/google/cloud/managedidentities/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref managedidentities-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref managedidentities-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/managed-microsoft-ad
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/memcache/doc/main.dox
+++ b/google/cloud/memcache/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref memcache-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref memcache-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/memorystore/docs/memcached
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -57,6 +57,7 @@ can override the default policies.
   endpoint.
 - @ref monitoring-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref monitoring-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/monitoring
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/networkconnectivity/doc/main.dox
+++ b/google/cloud/networkconnectivity/doc/main.dox
@@ -44,6 +44,7 @@ can override the default policies.
   endpoint.
 - @ref networkconnectivity-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref networkconnectivity-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/network-connectivity/docs
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/networkmanagement/doc/main.dox
+++ b/google/cloud/networkmanagement/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref networkmanagement-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref networkmanagement-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/concepts/overview
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -48,8 +48,8 @@ can override the default policies.
   endpoint.
 - @ref notebooks-override-authentication - describes how to change the
   authentication credentials used by the library.
-
 - @ref notebooks-env - describes environment variables that can configure the behavior of the library.
+
 [cloud-service-docs]: https://cloud.google.com/vertex-ai/docs/workbench
 [Vertex AI Workbench]: https://cloud.google.com/vertex-ai-workbench
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
 - @ref notebooks-override-authentication - describes how to change the
   authentication credentials used by the library.
 
+- @ref notebooks-env - describes environment variables that can configure the behavior of the library.
 [cloud-service-docs]: https://cloud.google.com/vertex-ai/docs/workbench
 [Vertex AI Workbench]: https://cloud.google.com/vertex-ai-workbench
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/optimization/doc/main.dox
+++ b/google/cloud/optimization/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref optimization-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref optimization-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/optimization
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/orgpolicy/doc/main.dox
+++ b/google/cloud/orgpolicy/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref orgpolicy-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref orgpolicy-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/resource-manager/docs/organization-policy/overview
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -48,6 +48,7 @@ can override the default policies.
   endpoint.
 - @ref osconfig-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref osconfig-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/compute/docs/os-configuration-management
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/oslogin/doc/main.dox
+++ b/google/cloud/oslogin/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref oslogin-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref oslogin-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/compute/docs/oslogin
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/policytroubleshooter/doc/main.dox
+++ b/google/cloud/policytroubleshooter/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref policytroubleshooter-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref policytroubleshooter-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/iam/docs/troubleshooting-access
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/privateca/doc/main.dox
+++ b/google/cloud/privateca/doc/main.dox
@@ -44,6 +44,7 @@ can override the default policies.
   endpoint.
 - @ref privateca-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref privateca-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/certificate-authority-service/docs
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/profiler/doc/main.dox
+++ b/google/cloud/profiler/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref profiler-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref profiler-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/profiler
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/pubsub/doc/pubsub-main.dox
+++ b/google/cloud/pubsub/doc/pubsub-main.dox
@@ -176,7 +176,6 @@ Follow these links for additional examples
 
 */
 
-- @ref pubsub-env - describes environment variables that can configure the behavior of the library.
 /*! @page SchemaServiceClient-service-account-snippet Override @c SchemaServiceClient Default Authentication
 
 @snippet google/cloud/pubsub/samples/schema_client_samples.cc with-service-account

--- a/google/cloud/pubsub/doc/pubsub-main.dox
+++ b/google/cloud/pubsub/doc/pubsub-main.dox
@@ -176,6 +176,7 @@ Follow these links for additional examples
 
 */
 
+- @ref pubsub-env - describes environment variables that can configure the behavior of the library.
 /*! @page SchemaServiceClient-service-account-snippet Override @c SchemaServiceClient Default Authentication
 
 @snippet google/cloud/pubsub/samples/schema_client_samples.cc with-service-account

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -48,8 +48,8 @@ can override the default policies.
 - @ref pubsublite-override-endpoint - describes how to override the default
   endpoint.
 - @ref pubsublite-override-authentication - describes how to change the
-- @ref pubsublite-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref pubsublite-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -48,6 +48,7 @@ can override the default policies.
 - @ref pubsublite-override-endpoint - describes how to override the default
   endpoint.
 - @ref pubsublite-override-authentication - describes how to change the
+- @ref pubsublite-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/recommender/doc/main.dox
+++ b/google/cloud/recommender/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref recommender-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref recommender-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/recommender
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/redis/doc/main.dox
+++ b/google/cloud/redis/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref redis-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref redis-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/memorystore/docs/redis
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref resourcemanager-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref resourcemanager-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-product]: https://cloud.google.com/resource-manager
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/resourcesettings/doc/main.dox
+++ b/google/cloud/resourcesettings/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref resourcesettings-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref resourcesettings-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/resource-manager/docs/resource-settings/overview
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -53,6 +53,7 @@ can override the default policies.
   endpoint.
 - @ref retail-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref retail-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/retail/docs
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/run/doc/main.dox
+++ b/google/cloud/run/doc/main.dox
@@ -56,6 +56,7 @@ can override the default policies.
   endpoint.
 - @ref run-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref run-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/run
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -41,8 +41,8 @@ can override the default policies.
 - @ref scheduler-override-endpoint - describes how to override the default
   endpoint.
 - @ref scheduler-override-authentication - describes how to change the
-- @ref scheduler-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref scheduler-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
 - @ref scheduler-override-endpoint - describes how to override the default
   endpoint.
 - @ref scheduler-override-authentication - describes how to change the
+- @ref scheduler-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
 - @ref secretmanager-override-endpoint - describes how to override the default
   endpoint.
 - @ref secretmanager-override-authentication - describes how to change the
+- @ref secretmanager-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -42,8 +42,8 @@ can override the default policies.
 - @ref secretmanager-override-endpoint - describes how to override the default
   endpoint.
 - @ref secretmanager-override-authentication - describes how to change the
-- @ref secretmanager-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref secretmanager-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/securitycenter/doc/main.dox
+++ b/google/cloud/securitycenter/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref securitycenter-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref securitycenter-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/security-command-center
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/servicecontrol/doc/main.dox
+++ b/google/cloud/servicecontrol/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref servicecontrol-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref servicecontrol-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/service-control
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/servicedirectory/doc/main.dox
+++ b/google/cloud/servicedirectory/doc/main.dox
@@ -48,6 +48,7 @@ can override the default policies.
   endpoint.
 - @ref servicedirectory-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref servicedirectory-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service]: https://cloud.google.com/service-directory
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/servicemanagement/doc/main.dox
+++ b/google/cloud/servicemanagement/doc/main.dox
@@ -40,6 +40,7 @@ can override the default policies.
   endpoint.
 - @ref servicemanagement-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref servicemanagement-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/service-management
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/serviceusage/doc/main.dox
+++ b/google/cloud/serviceusage/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref serviceusage-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref serviceusage-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service]: https://cloud.google.com/service-usage
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/shell/doc/main.dox
+++ b/google/cloud/shell/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref shell-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref shell-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/shell
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -130,7 +130,6 @@ period between retries.
 
 */
 
-- @ref spanner-env - describes environment variables that can configure the behavior of the library.
 /*! @page InstanceAdminClient-with-service-account-snippet Override InstanceAdminClient Default Authentication
 
 @snippet google/cloud/spanner/admin/samples/instance_admin_client_samples.cc with-service-account

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -130,6 +130,7 @@ period between retries.
 
 */
 
+- @ref spanner-env - describes environment variables that can configure the behavior of the library.
 /*! @page InstanceAdminClient-with-service-account-snippet Override InstanceAdminClient Default Authentication
 
 @snippet google/cloud/spanner/admin/samples/instance_admin_client_samples.cc with-service-account

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -47,6 +47,7 @@ can override the default policies.
   endpoint.
 - @ref speech-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref speech-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/speech
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/sql/doc/main.dox
+++ b/google/cloud/sql/doc/main.dox
@@ -57,6 +57,7 @@ can override the default policies.
   endpoint.
 - @ref sql-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref sql-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/sql
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -136,7 +136,6 @@ more conservative approach:
 @see [ExponentialBackoffPolicy](@ref google::cloud::storage::ExponentialBackoffPolicy)
    to configure different parameters for the exponential backoff policy.
 
-- @ref storage-env - describes environment variables that can configure the behavior of the library.
 @see [AlwaysRetryIdempotencyPolicy](@ref google::cloud::storage::AlwaysRetryIdempotencyPolicy)
    and [StrictIdempotencyPolicy](@ref google::cloud::storage::StrictIdempotencyPolicy)
    for alternative idempotency policies.

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -136,6 +136,7 @@ more conservative approach:
 @see [ExponentialBackoffPolicy](@ref google::cloud::storage::ExponentialBackoffPolicy)
    to configure different parameters for the exponential backoff policy.
 
+- @ref storage-env - describes environment variables that can configure the behavior of the library.
 @see [AlwaysRetryIdempotencyPolicy](@ref google::cloud::storage::AlwaysRetryIdempotencyPolicy)
    and [StrictIdempotencyPolicy](@ref google::cloud::storage::StrictIdempotencyPolicy)
    for alternative idempotency policies.

--- a/google/cloud/storageinsights/doc/main.dox
+++ b/google/cloud/storageinsights/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref storageinsights-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref storageinsights-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/storage/docs/insights/inventory-reports
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/storagetransfer/doc/main.dox
+++ b/google/cloud/storagetransfer/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref storagetransfer-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref storagetransfer-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/storage-transfer
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/support/doc/main.dox
+++ b/google/cloud/support/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref support-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref support-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/support
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/talent/doc/main.dox
+++ b/google/cloud/talent/doc/main.dox
@@ -51,6 +51,7 @@ can override the default policies.
   endpoint.
 - @ref talent-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref talent-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/solutions/talent-solution
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
 - @ref tasks-override-endpoint - describes how to override the default
   endpoint.
 - @ref tasks-override-authentication - describes how to change the
+- @ref tasks-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -42,8 +42,8 @@ can override the default policies.
 - @ref tasks-override-endpoint - describes how to override the default
   endpoint.
 - @ref tasks-override-authentication - describes how to change the
-- @ref tasks-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref tasks-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/texttospeech/doc/main.dox
+++ b/google/cloud/texttospeech/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref texttospeech-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref texttospeech-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/text-to-speech
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -48,6 +48,7 @@ can override the default policies.
   endpoint.
 - @ref tpu-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref tpu-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service]: https://cloud.google.com/tpu
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/trace/doc/main.dox
+++ b/google/cloud/trace/doc/main.dox
@@ -50,6 +50,7 @@ can override the default policies.
   endpoint.
 - @ref trace-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref trace-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/trace
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/translate/doc/main.dox
+++ b/google/cloud/translate/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref translate-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref translate-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/translate
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/video/doc/main.dox
+++ b/google/cloud/video/doc/main.dox
@@ -57,6 +57,7 @@ can override the default policies.
   authentication credentials used by the library.
 
 [livestream-service-docs]: https://cloud.google.com/livestream
+- @ref video-env - describes environment variables that can configure the behavior of the library.
 [transcoder-service-docs]: https://cloud.google.com/transcoder
 [stitcher-service-docs]: https://cloud.google.com/video-stitcher
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/video/doc/main.dox
+++ b/google/cloud/video/doc/main.dox
@@ -55,9 +55,9 @@ can override the default policies.
   endpoint.
 - @ref video-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref video-env - describes environment variables that can configure the behavior of the library.
 
 [livestream-service-docs]: https://cloud.google.com/livestream
-- @ref video-env - describes environment variables that can configure the behavior of the library.
 [transcoder-service-docs]: https://cloud.google.com/transcoder
 [stitcher-service-docs]: https://cloud.google.com/video-stitcher
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/videointelligence/doc/main.dox
+++ b/google/cloud/videointelligence/doc/main.dox
@@ -43,6 +43,7 @@ can override the default policies.
   endpoint.
 - @ref videointelligence-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref videointelligence-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/videointelligence
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -49,6 +49,7 @@ can override the default policies.
   endpoint.
 - @ref vision-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref vision-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/vision
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/vmmigration/doc/main.dox
+++ b/google/cloud/vmmigration/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref vmmigration-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref vmmigration-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/migrate/compute-engine
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/vmwareengine/doc/main.dox
+++ b/google/cloud/vmwareengine/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
   endpoint.
 - @ref vmwareengine-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref vmwareengine-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/vmware-engine
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/vpcaccess/doc/main.dox
+++ b/google/cloud/vpcaccess/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
   endpoint.
 - @ref vpcaccess-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref vpcaccess-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/vpc/docs/serverless-vpc-access
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -41,6 +41,7 @@ can override the default policies.
 - @ref webrisk-override-endpoint - describes how to override the default
   endpoint.
 - @ref webrisk-override-authentication - describes how to change the
+- @ref webrisk-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -41,8 +41,8 @@ can override the default policies.
 - @ref webrisk-override-endpoint - describes how to override the default
   endpoint.
 - @ref webrisk-override-authentication - describes how to change the
-- @ref webrisk-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref webrisk-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -42,6 +42,7 @@ can override the default policies.
 - @ref websecurityscanner-override-endpoint - describes how to override the default
   endpoint.
 - @ref websecurityscanner-override-authentication - describes how to change the
+- @ref websecurityscanner-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -42,8 +42,8 @@ can override the default policies.
 - @ref websecurityscanner-override-endpoint - describes how to override the default
   endpoint.
 - @ref websecurityscanner-override-authentication - describes how to change the
-- @ref websecurityscanner-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref websecurityscanner-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -47,8 +47,8 @@ can override the default policies.
 - @ref workflows-override-endpoint - describes how to override the default
   endpoint.
 - @ref workflows-override-authentication - describes how to change the
-- @ref workflows-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
+- @ref workflows-env - describes environment variables that can configure the behavior of the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -47,6 +47,7 @@ can override the default policies.
 - @ref workflows-override-endpoint - describes how to override the default
   endpoint.
 - @ref workflows-override-authentication - describes how to change the
+- @ref workflows-env - describes environment variables that can configure the behavior of the library.
   authentication credentials used by the library.
 
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/google/cloud/workstations/doc/main.dox
+++ b/google/cloud/workstations/doc/main.dox
@@ -44,6 +44,7 @@ can override the default policies.
   endpoint.
 - @ref workstations-override-authentication - describes how to change the
   authentication credentials used by the library.
+- @ref workstations-env - describes environment variables that can configure the behavior of the library.
 
 [cloud-service-docs]: https://cloud.google.com/workstations
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff


### PR DESCRIPTION
We factored these out in #11381 and forgot to readd them. hehehe.

Also adds all the other ref pages for `bigquery` and `iam`.

---

My methodology was basically:
```sh
files=$(git ls-files -- *main.dox)
for file in ${files[@]}; do
  library=$(basename $(dirname $(dirname $file)))
  line=$(($(wc -l < $file)-4))
  text="- @ref ${library}-env - describes environment variables that can configure the behavior of the library."
  sed -i "${line}i${text}" $file
done
```

Assuming these always go 4 lines up from the bottom of the dox was not a great assumption. Many things were wrong.

I then manually looked through the diff and fixed the errors I saw.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11577)
<!-- Reviewable:end -->
