### PR TITLE
impl(bigtable): AsyncSampleRows traced backoffs

### DIFF
--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/row_key_sample.h"
 #include "google/cloud/bigtable/version.h"
+#include "google/cloud/internal/call_context.h"
 #include <atomic>
 #include <memory>
 #include <string>
@@ -63,7 +64,7 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   std::atomic<bool> keep_reading_{true};
   std::vector<bigtable::RowKeySample> samples_;
   promise<StatusOr<std::vector<bigtable::RowKeySample>>> promise_;
-  Options options_ = internal::CurrentOptions();
+  internal::CallContext call_context_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #11585

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11593)
<!-- Reviewable:end -->
