### PR TITLE
docs: fix badly formatted links in `main.dox`

### DIFF
--- a/ci/generate-markdown/update-library-landing-dox.sh
+++ b/ci/generate-markdown/update-library-landing-dox.sh
@@ -98,10 +98,10 @@ done
     client_name="${clients[${sample_cc}]}"
     cat <<_EOF_
 The main class in this library is
-[\\c ${client_name}](@ref google::cloud::${client_name}).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\\c ${client_name}](@ref google::cloud::${client_name}) when testing your
+[\`${client_name}\`](@ref google::cloud::${client_name}). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[\`${client_name}\`](@ref google::cloud::${client_name}) when testing your
 application.
 _EOF_
   else
@@ -112,9 +112,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 _EOF_
     for sample_cc in "${samples_cc[@]}"; do

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Access Approval API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c accessapproval_v1::AccessApprovalClient](@ref google::cloud::accessapproval_v1::AccessApprovalClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c accessapproval_v1::AccessApprovalClient](@ref google::cloud::accessapproval_v1::AccessApprovalClient) when testing your
+[`accessapproval_v1::AccessApprovalClient`](@ref google::cloud::accessapproval_v1::AccessApprovalClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`accessapproval_v1::AccessApprovalClient`](@ref google::cloud::accessapproval_v1::AccessApprovalClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/accesscontextmanager/doc/main.dox
+++ b/google/cloud/accesscontextmanager/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the Access Context Manager API C++ client libra
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c accesscontextmanager_v1::AccessContextManagerClient](@ref google::cloud::accesscontextmanager_v1::AccessContextManagerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c accesscontextmanager_v1::AccessContextManagerClient](@ref google::cloud::accesscontextmanager_v1::AccessContextManagerClient) when testing your
+[`accesscontextmanager_v1::AccessContextManagerClient`](@ref google::cloud::accesscontextmanager_v1::AccessContextManagerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`accesscontextmanager_v1::AccessContextManagerClient`](@ref google::cloud::accesscontextmanager_v1::AccessContextManagerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/advisorynotifications/doc/main.dox
+++ b/google/cloud/advisorynotifications/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Advisory Notifications API C++ client libra
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c advisorynotifications_v1::AdvisoryNotificationsServiceClient](@ref google::cloud::advisorynotifications_v1::AdvisoryNotificationsServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c advisorynotifications_v1::AdvisoryNotificationsServiceClient](@ref google::cloud::advisorynotifications_v1::AdvisoryNotificationsServiceClient) when testing your
+[`advisorynotifications_v1::AdvisoryNotificationsServiceClient`](@ref google::cloud::advisorynotifications_v1::AdvisoryNotificationsServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`advisorynotifications_v1::AdvisoryNotificationsServiceClient`](@ref google::cloud::advisorynotifications_v1::AdvisoryNotificationsServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/alloydb/doc/main.dox
+++ b/google/cloud/alloydb/doc/main.dox
@@ -33,10 +33,10 @@ which should give you a taste of the AlloyDB API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c alloydb_v1::AlloyDBAdminClient](@ref google::cloud::alloydb_v1::AlloyDBAdminClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c alloydb_v1::AlloyDBAdminClient](@ref google::cloud::alloydb_v1::AlloyDBAdminClient) when testing your
+[`alloydb_v1::AlloyDBAdminClient`](@ref google::cloud::alloydb_v1::AlloyDBAdminClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`alloydb_v1::AlloyDBAdminClient`](@ref google::cloud::alloydb_v1::AlloyDBAdminClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/apigateway/doc/main.dox
+++ b/google/cloud/apigateway/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the API Gateway API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c apigateway_v1::ApiGatewayServiceClient](@ref google::cloud::apigateway_v1::ApiGatewayServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c apigateway_v1::ApiGatewayServiceClient](@ref google::cloud::apigateway_v1::ApiGatewayServiceClient) when testing your
+[`apigateway_v1::ApiGatewayServiceClient`](@ref google::cloud::apigateway_v1::ApiGatewayServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`apigateway_v1::ApiGatewayServiceClient`](@ref google::cloud::apigateway_v1::ApiGatewayServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/apigeeconnect/doc/main.dox
+++ b/google/cloud/apigeeconnect/doc/main.dox
@@ -25,10 +25,10 @@ which should give you a taste of the Apigee Connect API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c apigeeconnect_v1::ConnectionServiceClient](@ref google::cloud::apigeeconnect_v1::ConnectionServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c apigeeconnect_v1::ConnectionServiceClient](@ref google::cloud::apigeeconnect_v1::ConnectionServiceClient) when testing your
+[`apigeeconnect_v1::ConnectionServiceClient`](@ref google::cloud::apigeeconnect_v1::ConnectionServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`apigeeconnect_v1::ConnectionServiceClient`](@ref google::cloud::apigeeconnect_v1::ConnectionServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/apikeys/doc/main.dox
+++ b/google/cloud/apikeys/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the API Keys API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c apikeys_v2::ApiKeysClient](@ref google::cloud::apikeys_v2::ApiKeysClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c apikeys_v2::ApiKeysClient](@ref google::cloud::apikeys_v2::ApiKeysClient) when testing your
+[`apikeys_v2::ApiKeysClient`](@ref google::cloud::apikeys_v2::ApiKeysClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`apikeys_v2::ApiKeysClient`](@ref google::cloud::apikeys_v2::ApiKeysClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/appengine/doc/main.dox
+++ b/google/cloud/appengine/doc/main.dox
@@ -26,9 +26,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c appengine_v1::ApplicationsClient](@ref google::cloud::appengine_v1::ApplicationsClient)
 - [\c appengine_v1::AuthorizedCertificatesClient](@ref google::cloud::appengine_v1::AuthorizedCertificatesClient)

--- a/google/cloud/artifactregistry/doc/main.dox
+++ b/google/cloud/artifactregistry/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Artifact Registry API C++ client library AP
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c artifactregistry_v1::ArtifactRegistryClient](@ref google::cloud::artifactregistry_v1::ArtifactRegistryClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c artifactregistry_v1::ArtifactRegistryClient](@ref google::cloud::artifactregistry_v1::ArtifactRegistryClient) when testing your
+[`artifactregistry_v1::ArtifactRegistryClient`](@ref google::cloud::artifactregistry_v1::ArtifactRegistryClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`artifactregistry_v1::ArtifactRegistryClient`](@ref google::cloud::artifactregistry_v1::ArtifactRegistryClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/asset/doc/main.dox
+++ b/google/cloud/asset/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud Asset API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c asset_v1::AssetServiceClient](@ref google::cloud::asset_v1::AssetServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c asset_v1::AssetServiceClient](@ref google::cloud::asset_v1::AssetServiceClient) when testing your
+[`asset_v1::AssetServiceClient`](@ref google::cloud::asset_v1::AssetServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`asset_v1::AssetServiceClient`](@ref google::cloud::asset_v1::AssetServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Assured Workloads API C++ client library AP
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c assuredworkloads_v1::AssuredWorkloadsServiceClient](@ref google::cloud::assuredworkloads_v1::AssuredWorkloadsServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c assuredworkloads_v1::AssuredWorkloadsServiceClient](@ref google::cloud::assuredworkloads_v1::AssuredWorkloadsServiceClient) when testing your
+[`assuredworkloads_v1::AssuredWorkloadsServiceClient`](@ref google::cloud::assuredworkloads_v1::AssuredWorkloadsServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`assuredworkloads_v1::AssuredWorkloadsServiceClient`](@ref google::cloud::assuredworkloads_v1::AssuredWorkloadsServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c automl_v1::AutoMlClient](@ref google::cloud::automl_v1::AutoMlClient)
 - [\c automl_v1::PredictionServiceClient](@ref google::cloud::automl_v1::PredictionServiceClient)

--- a/google/cloud/baremetalsolution/doc/main.dox
+++ b/google/cloud/baremetalsolution/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Bare Metal Solution API C++ client library 
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c baremetalsolution_v2::BareMetalSolutionClient](@ref google::cloud::baremetalsolution_v2::BareMetalSolutionClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c baremetalsolution_v2::BareMetalSolutionClient](@ref google::cloud::baremetalsolution_v2::BareMetalSolutionClient) when testing your
+[`baremetalsolution_v2::BareMetalSolutionClient`](@ref google::cloud::baremetalsolution_v2::BareMetalSolutionClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`baremetalsolution_v2::BareMetalSolutionClient`](@ref google::cloud::baremetalsolution_v2::BareMetalSolutionClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/batch/doc/main.dox
+++ b/google/cloud/batch/doc/main.dox
@@ -20,10 +20,10 @@ which should give you a taste of the Batch API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c batch_v1::BatchServiceClient](@ref google::cloud::batch_v1::BatchServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c batch_v1::BatchServiceClient](@ref google::cloud::batch_v1::BatchServiceClient) when testing your
+[`batch_v1::BatchServiceClient`](@ref google::cloud::batch_v1::BatchServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`batch_v1::BatchServiceClient`](@ref google::cloud::batch_v1::BatchServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/beyondcorp/doc/main.dox
+++ b/google/cloud/beyondcorp/doc/main.dox
@@ -29,9 +29,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c beyondcorp_appconnections_v1::AppConnectionsServiceClient](@ref google::cloud::beyondcorp_appconnections_v1::AppConnectionsServiceClient)
 - [\c beyondcorp_appconnectors_v1::AppConnectorsServiceClient](@ref google::cloud::beyondcorp_appconnectors_v1::AppConnectorsServiceClient)

--- a/google/cloud/bigquery/doc/main.dox
+++ b/google/cloud/bigquery/doc/main.dox
@@ -59,9 +59,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c bigquery_analyticshub_v1::AnalyticsHubServiceClient](@ref google::cloud::bigquery_analyticshub_v1::AnalyticsHubServiceClient)
 - [\c bigquery_connection_v1::ConnectionServiceClient](@ref google::cloud::bigquery_connection_v1::ConnectionServiceClient)

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c billing_budgets_v1::BudgetServiceClient](@ref google::cloud::billing_budgets_v1::BudgetServiceClient)
 - [\c billing_v1::CloudBillingClient](@ref google::cloud::billing_v1::CloudBillingClient)

--- a/google/cloud/binaryauthorization/doc/main.dox
+++ b/google/cloud/binaryauthorization/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c binaryauthorization_v1::BinauthzManagementServiceV1Client](@ref google::cloud::binaryauthorization_v1::BinauthzManagementServiceV1Client)
 - [\c binaryauthorization_v1::SystemPolicyV1Client](@ref google::cloud::binaryauthorization_v1::SystemPolicyV1Client)

--- a/google/cloud/certificatemanager/doc/main.dox
+++ b/google/cloud/certificatemanager/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Certificate Manager API C++ client library 
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c certificatemanager_v1::CertificateManagerClient](@ref google::cloud::certificatemanager_v1::CertificateManagerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c certificatemanager_v1::CertificateManagerClient](@ref google::cloud::certificatemanager_v1::CertificateManagerClient) when testing your
+[`certificatemanager_v1::CertificateManagerClient`](@ref google::cloud::certificatemanager_v1::CertificateManagerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`certificatemanager_v1::CertificateManagerClient`](@ref google::cloud::certificatemanager_v1::CertificateManagerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/channel/doc/main.dox
+++ b/google/cloud/channel/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Cloud Channel API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c channel_v1::CloudChannelServiceClient](@ref google::cloud::channel_v1::CloudChannelServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c channel_v1::CloudChannelServiceClient](@ref google::cloud::channel_v1::CloudChannelServiceClient) when testing your
+[`channel_v1::CloudChannelServiceClient`](@ref google::cloud::channel_v1::CloudChannelServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`channel_v1::CloudChannelServiceClient`](@ref google::cloud::channel_v1::CloudChannelServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/cloudbuild/doc/main.dox
+++ b/google/cloud/cloudbuild/doc/main.dox
@@ -26,9 +26,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c cloudbuild_v1::CloudBuildClient](@ref google::cloud::cloudbuild_v1::CloudBuildClient)
 - [\c cloudbuild_v2::RepositoryManagerClient](@ref google::cloud::cloudbuild_v2::RepositoryManagerClient)

--- a/google/cloud/composer/doc/main.dox
+++ b/google/cloud/composer/doc/main.dox
@@ -26,9 +26,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c composer_v1::EnvironmentsClient](@ref google::cloud::composer_v1::EnvironmentsClient)
 - [\c composer_v1::ImageVersionsClient](@ref google::cloud::composer_v1::ImageVersionsClient)

--- a/google/cloud/confidentialcomputing/doc/main.dox
+++ b/google/cloud/confidentialcomputing/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Confidential Computing API C++ client libra
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c confidentialcomputing_v1::ConfidentialComputingClient](@ref google::cloud::confidentialcomputing_v1::ConfidentialComputingClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c confidentialcomputing_v1::ConfidentialComputingClient](@ref google::cloud::confidentialcomputing_v1::ConfidentialComputingClient) when testing your
+[`confidentialcomputing_v1::ConfidentialComputingClient`](@ref google::cloud::confidentialcomputing_v1::ConfidentialComputingClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`confidentialcomputing_v1::ConfidentialComputingClient`](@ref google::cloud::confidentialcomputing_v1::ConfidentialComputingClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/connectors/doc/main.dox
+++ b/google/cloud/connectors/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Connectors API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c connectors_v1::ConnectorsClient](@ref google::cloud::connectors_v1::ConnectorsClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c connectors_v1::ConnectorsClient](@ref google::cloud::connectors_v1::ConnectorsClient) when testing your
+[`connectors_v1::ConnectorsClient`](@ref google::cloud::connectors_v1::ConnectorsClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`connectors_v1::ConnectorsClient`](@ref google::cloud::connectors_v1::ConnectorsClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/contactcenterinsights/doc/main.dox
+++ b/google/cloud/contactcenterinsights/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Contact Center AI Insights API C++ client l
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c contactcenterinsights_v1::ContactCenterInsightsClient](@ref google::cloud::contactcenterinsights_v1::ContactCenterInsightsClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c contactcenterinsights_v1::ContactCenterInsightsClient](@ref google::cloud::contactcenterinsights_v1::ContactCenterInsightsClient) when testing your
+[`contactcenterinsights_v1::ContactCenterInsightsClient`](@ref google::cloud::contactcenterinsights_v1::ContactCenterInsightsClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`contactcenterinsights_v1::ContactCenterInsightsClient`](@ref google::cloud::contactcenterinsights_v1::ContactCenterInsightsClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/container/doc/main.dox
+++ b/google/cloud/container/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Kubernetes Engine API C++ client library AP
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c container_v1::ClusterManagerClient](@ref google::cloud::container_v1::ClusterManagerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c container_v1::ClusterManagerClient](@ref google::cloud::container_v1::ClusterManagerClient) when testing your
+[`container_v1::ClusterManagerClient`](@ref google::cloud::container_v1::ClusterManagerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`container_v1::ClusterManagerClient`](@ref google::cloud::container_v1::ClusterManagerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/containeranalysis/doc/main.dox
+++ b/google/cloud/containeranalysis/doc/main.dox
@@ -28,9 +28,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c containeranalysis_v1::ContainerAnalysisClient](@ref google::cloud::containeranalysis_v1::ContainerAnalysisClient)
 - [\c containeranalysis_v1::GrafeasClient](@ref google::cloud::containeranalysis_v1::GrafeasClient)

--- a/google/cloud/datacatalog/doc/main.dox
+++ b/google/cloud/datacatalog/doc/main.dox
@@ -26,9 +26,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c datacatalog_lineage_v1::LineageClient](@ref google::cloud::datacatalog_lineage_v1::LineageClient)
 - [\c datacatalog_v1::DataCatalogClient](@ref google::cloud::datacatalog_v1::DataCatalogClient)

--- a/google/cloud/datamigration/doc/main.dox
+++ b/google/cloud/datamigration/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the Database Migration API C++ client library A
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c datamigration_v1::DataMigrationServiceClient](@ref google::cloud::datamigration_v1::DataMigrationServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c datamigration_v1::DataMigrationServiceClient](@ref google::cloud::datamigration_v1::DataMigrationServiceClient) when testing your
+[`datamigration_v1::DataMigrationServiceClient`](@ref google::cloud::datamigration_v1::DataMigrationServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`datamigration_v1::DataMigrationServiceClient`](@ref google::cloud::datamigration_v1::DataMigrationServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/dataplex/doc/main.dox
+++ b/google/cloud/dataplex/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c dataplex_v1::ContentServiceClient](@ref google::cloud::dataplex_v1::ContentServiceClient)
 - [\c dataplex_v1::DataplexServiceClient](@ref google::cloud::dataplex_v1::DataplexServiceClient)

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -29,9 +29,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c dataproc_v1::AutoscalingPolicyServiceClient](@ref google::cloud::dataproc_v1::AutoscalingPolicyServiceClient)
 - [\c dataproc_v1::BatchControllerClient](@ref google::cloud::dataproc_v1::BatchControllerClient)

--- a/google/cloud/datastream/doc/main.dox
+++ b/google/cloud/datastream/doc/main.dox
@@ -24,10 +24,10 @@ which should give you a taste of the Datastream API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c datastream_v1::DatastreamClient](@ref google::cloud::datastream_v1::DatastreamClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c datastream_v1::DatastreamClient](@ref google::cloud::datastream_v1::DatastreamClient) when testing your
+[`datastream_v1::DatastreamClient`](@ref google::cloud::datastream_v1::DatastreamClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`datastream_v1::DatastreamClient`](@ref google::cloud::datastream_v1::DatastreamClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/debugger/doc/main.dox
+++ b/google/cloud/debugger/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c debugger_v2::Controller2Client](@ref google::cloud::debugger_v2::Controller2Client)
 - [\c debugger_v2::Debugger2Client](@ref google::cloud::debugger_v2::Debugger2Client)

--- a/google/cloud/deploy/doc/main.dox
+++ b/google/cloud/deploy/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Google Cloud Deploy API C++ client library 
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c deploy_v1::CloudDeployClient](@ref google::cloud::deploy_v1::CloudDeployClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c deploy_v1::CloudDeployClient](@ref google::cloud::deploy_v1::CloudDeployClient) when testing your
+[`deploy_v1::CloudDeployClient`](@ref google::cloud::deploy_v1::CloudDeployClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`deploy_v1::CloudDeployClient`](@ref google::cloud::deploy_v1::CloudDeployClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -29,9 +29,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c dialogflow_cx::AgentsClient](@ref google::cloud::dialogflow_cx::AgentsClient)
 - [\c dialogflow_cx::ChangelogsClient](@ref google::cloud::dialogflow_cx::ChangelogsClient)

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -29,9 +29,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c dialogflow_es::AgentsClient](@ref google::cloud::dialogflow_es::AgentsClient)
 - [\c dialogflow_es::AnswerRecordsClient](@ref google::cloud::dialogflow_es::AnswerRecordsClient)

--- a/google/cloud/dlp/doc/main.dox
+++ b/google/cloud/dlp/doc/main.dox
@@ -24,10 +24,10 @@ which should give you a taste of the Cloud Data Loss Prevention (DLP) API C++ cl
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c dlp_v2::DlpServiceClient](@ref google::cloud::dlp_v2::DlpServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c dlp_v2::DlpServiceClient](@ref google::cloud::dlp_v2::DlpServiceClient) when testing your
+[`dlp_v2::DlpServiceClient`](@ref google::cloud::dlp_v2::DlpServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`dlp_v2::DlpServiceClient`](@ref google::cloud::dlp_v2::DlpServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/documentai/doc/main.dox
+++ b/google/cloud/documentai/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud Document AI API C++ client library AP
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c documentai_v1::DocumentProcessorServiceClient](@ref google::cloud::documentai_v1::DocumentProcessorServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c documentai_v1::DocumentProcessorServiceClient](@ref google::cloud::documentai_v1::DocumentProcessorServiceClient) when testing your
+[`documentai_v1::DocumentProcessorServiceClient`](@ref google::cloud::documentai_v1::DocumentProcessorServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`documentai_v1::DocumentProcessorServiceClient`](@ref google::cloud::documentai_v1::DocumentProcessorServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/edgecontainer/doc/main.dox
+++ b/google/cloud/edgecontainer/doc/main.dox
@@ -24,10 +24,10 @@ which should give you a taste of the Distributed Cloud Edge Container API C++ cl
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c edgecontainer_v1::EdgeContainerClient](@ref google::cloud::edgecontainer_v1::EdgeContainerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c edgecontainer_v1::EdgeContainerClient](@ref google::cloud::edgecontainer_v1::EdgeContainerClient) when testing your
+[`edgecontainer_v1::EdgeContainerClient`](@ref google::cloud::edgecontainer_v1::EdgeContainerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`edgecontainer_v1::EdgeContainerClient`](@ref google::cloud::edgecontainer_v1::EdgeContainerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -26,9 +26,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c eventarc_publishing_v1::PublisherClient](@ref google::cloud::eventarc_publishing_v1::PublisherClient)
 - [\c eventarc_v1::EventarcClient](@ref google::cloud::eventarc_v1::EventarcClient)

--- a/google/cloud/filestore/doc/main.dox
+++ b/google/cloud/filestore/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the Cloud Filestore API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c filestore_v1::CloudFilestoreManagerClient](@ref google::cloud::filestore_v1::CloudFilestoreManagerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c filestore_v1::CloudFilestoreManagerClient](@ref google::cloud::filestore_v1::CloudFilestoreManagerClient) when testing your
+[`filestore_v1::CloudFilestoreManagerClient`](@ref google::cloud::filestore_v1::CloudFilestoreManagerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`filestore_v1::CloudFilestoreManagerClient`](@ref google::cloud::filestore_v1::CloudFilestoreManagerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/functions/doc/main.dox
+++ b/google/cloud/functions/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Cloud Functions API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c functions_v1::CloudFunctionsServiceClient](@ref google::cloud::functions_v1::CloudFunctionsServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c functions_v1::CloudFunctionsServiceClient](@ref google::cloud::functions_v1::CloudFunctionsServiceClient) when testing your
+[`functions_v1::CloudFunctionsServiceClient`](@ref google::cloud::functions_v1::CloudFunctionsServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`functions_v1::CloudFunctionsServiceClient`](@ref google::cloud::functions_v1::CloudFunctionsServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/gameservices/doc/main.dox
+++ b/google/cloud/gameservices/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c gameservices_v1::GameServerClustersServiceClient](@ref google::cloud::gameservices_v1::GameServerClustersServiceClient)
 - [\c gameservices_v1::GameServerConfigsServiceClient](@ref google::cloud::gameservices_v1::GameServerConfigsServiceClient)

--- a/google/cloud/gkehub/doc/main.dox
+++ b/google/cloud/gkehub/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the GKE Hub C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c gkehub_v1::GkeHubClient](@ref google::cloud::gkehub_v1::GkeHubClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c gkehub_v1::GkeHubClient](@ref google::cloud::gkehub_v1::GkeHubClient) when testing your
+[`gkehub_v1::GkeHubClient`](@ref google::cloud::gkehub_v1::GkeHubClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`gkehub_v1::GkeHubClient`](@ref google::cloud::gkehub_v1::GkeHubClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/gkemulticloud/doc/main.dox
+++ b/google/cloud/gkemulticloud/doc/main.dox
@@ -33,9 +33,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c gkemulticloud_v1::AttachedClustersClient](@ref google::cloud::gkemulticloud_v1::AttachedClustersClient)
 - [\c gkemulticloud_v1::AwsClustersClient](@ref google::cloud::gkemulticloud_v1::AwsClustersClient)

--- a/google/cloud/iam/doc/main.dox
+++ b/google/cloud/iam/doc/main.dox
@@ -59,9 +59,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c iam_admin_v1::IAMClient](@ref google::cloud::iam_admin_v1::IAMClient)
 - [\c iam_credentials_v1::IAMCredentialsClient](@ref google::cloud::iam_credentials_v1::IAMCredentialsClient)

--- a/google/cloud/iap/doc/main.dox
+++ b/google/cloud/iap/doc/main.dox
@@ -26,9 +26,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c iap_v1::IdentityAwareProxyAdminServiceClient](@ref google::cloud::iap_v1::IdentityAwareProxyAdminServiceClient)
 - [\c iap_v1::IdentityAwareProxyOAuthServiceClient](@ref google::cloud::iap_v1::IdentityAwareProxyOAuthServiceClient)

--- a/google/cloud/ids/doc/main.dox
+++ b/google/cloud/ids/doc/main.dox
@@ -26,10 +26,10 @@ which should give you a taste of the Cloud IDS API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c ids_v1::IDSClient](@ref google::cloud::ids_v1::IDSClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c ids_v1::IDSClient](@ref google::cloud::ids_v1::IDSClient) when testing your
+[`ids_v1::IDSClient`](@ref google::cloud::ids_v1::IDSClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`ids_v1::IDSClient`](@ref google::cloud::ids_v1::IDSClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/iot/doc/main.dox
+++ b/google/cloud/iot/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud IoT API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c iot_v1::DeviceManagerClient](@ref google::cloud::iot_v1::DeviceManagerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c iot_v1::DeviceManagerClient](@ref google::cloud::iot_v1::DeviceManagerClient) when testing your
+[`iot_v1::DeviceManagerClient`](@ref google::cloud::iot_v1::DeviceManagerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`iot_v1::DeviceManagerClient`](@ref google::cloud::iot_v1::DeviceManagerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -28,9 +28,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c kms_inventory_v1::KeyDashboardServiceClient](@ref google::cloud::kms_inventory_v1::KeyDashboardServiceClient)
 - [\c kms_inventory_v1::KeyTrackingServiceClient](@ref google::cloud::kms_inventory_v1::KeyTrackingServiceClient)

--- a/google/cloud/language/doc/main.dox
+++ b/google/cloud/language/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Cloud Natural Language API C++ client libra
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c language_v1::LanguageServiceClient](@ref google::cloud::language_v1::LanguageServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c language_v1::LanguageServiceClient](@ref google::cloud::language_v1::LanguageServiceClient) when testing your
+[`language_v1::LanguageServiceClient`](@ref google::cloud::language_v1::LanguageServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`language_v1::LanguageServiceClient`](@ref google::cloud::language_v1::LanguageServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud Logging API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c logging_v2::LoggingServiceV2Client](@ref google::cloud::logging_v2::LoggingServiceV2Client).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c logging_v2::LoggingServiceV2Client](@ref google::cloud::logging_v2::LoggingServiceV2Client) when testing your
+[`logging_v2::LoggingServiceV2Client`](@ref google::cloud::logging_v2::LoggingServiceV2Client). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`logging_v2::LoggingServiceV2Client`](@ref google::cloud::logging_v2::LoggingServiceV2Client) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/managedidentities/doc/main.dox
+++ b/google/cloud/managedidentities/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Managed Service for Microsoft Active Direct
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c managedidentities_v1::ManagedIdentitiesServiceClient](@ref google::cloud::managedidentities_v1::ManagedIdentitiesServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c managedidentities_v1::ManagedIdentitiesServiceClient](@ref google::cloud::managedidentities_v1::ManagedIdentitiesServiceClient) when testing your
+[`managedidentities_v1::ManagedIdentitiesServiceClient`](@ref google::cloud::managedidentities_v1::ManagedIdentitiesServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`managedidentities_v1::ManagedIdentitiesServiceClient`](@ref google::cloud::managedidentities_v1::ManagedIdentitiesServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/memcache/doc/main.dox
+++ b/google/cloud/memcache/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud Memorystore for Memcached API C++ cli
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c memcache_v1::CloudMemcacheClient](@ref google::cloud::memcache_v1::CloudMemcacheClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c memcache_v1::CloudMemcacheClient](@ref google::cloud::memcache_v1::CloudMemcacheClient) when testing your
+[`memcache_v1::CloudMemcacheClient`](@ref google::cloud::memcache_v1::CloudMemcacheClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`memcache_v1::CloudMemcacheClient`](@ref google::cloud::memcache_v1::CloudMemcacheClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -29,9 +29,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c monitoring_dashboard_v1::DashboardsServiceClient](@ref google::cloud::monitoring_dashboard_v1::DashboardsServiceClient)
 - [\c monitoring_metricsscope_v1::MetricsScopesClient](@ref google::cloud::monitoring_metricsscope_v1::MetricsScopesClient)

--- a/google/cloud/networkconnectivity/doc/main.dox
+++ b/google/cloud/networkconnectivity/doc/main.dox
@@ -24,10 +24,10 @@ which should give you a taste of the Network Connectivity API C++ client library
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c networkconnectivity_v1::HubServiceClient](@ref google::cloud::networkconnectivity_v1::HubServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c networkconnectivity_v1::HubServiceClient](@ref google::cloud::networkconnectivity_v1::HubServiceClient) when testing your
+[`networkconnectivity_v1::HubServiceClient`](@ref google::cloud::networkconnectivity_v1::HubServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`networkconnectivity_v1::HubServiceClient`](@ref google::cloud::networkconnectivity_v1::HubServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/networkmanagement/doc/main.dox
+++ b/google/cloud/networkmanagement/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Network Management API C++ client library A
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c networkmanagement_v1::ReachabilityServiceClient](@ref google::cloud::networkmanagement_v1::ReachabilityServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c networkmanagement_v1::ReachabilityServiceClient](@ref google::cloud::networkmanagement_v1::ReachabilityServiceClient) when testing your
+[`networkmanagement_v1::ReachabilityServiceClient`](@ref google::cloud::networkmanagement_v1::ReachabilityServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`networkmanagement_v1::ReachabilityServiceClient`](@ref google::cloud::networkmanagement_v1::ReachabilityServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c notebooks_v1::ManagedNotebookServiceClient](@ref google::cloud::notebooks_v1::ManagedNotebookServiceClient)
 - [\c notebooks_v1::NotebookServiceClient](@ref google::cloud::notebooks_v1::NotebookServiceClient)

--- a/google/cloud/optimization/doc/main.dox
+++ b/google/cloud/optimization/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud Optimization API C++ client library A
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c optimization_v1::FleetRoutingClient](@ref google::cloud::optimization_v1::FleetRoutingClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c optimization_v1::FleetRoutingClient](@ref google::cloud::optimization_v1::FleetRoutingClient) when testing your
+[`optimization_v1::FleetRoutingClient`](@ref google::cloud::optimization_v1::FleetRoutingClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`optimization_v1::FleetRoutingClient`](@ref google::cloud::optimization_v1::FleetRoutingClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/orgpolicy/doc/main.dox
+++ b/google/cloud/orgpolicy/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the Organization Policy API C++ client library 
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c orgpolicy_v2::OrgPolicyClient](@ref google::cloud::orgpolicy_v2::OrgPolicyClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c orgpolicy_v2::OrgPolicyClient](@ref google::cloud::orgpolicy_v2::OrgPolicyClient) when testing your
+[`orgpolicy_v2::OrgPolicyClient`](@ref google::cloud::orgpolicy_v2::OrgPolicyClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`orgpolicy_v2::OrgPolicyClient`](@ref google::cloud::orgpolicy_v2::OrgPolicyClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c osconfig_agentendpoint_v1::AgentEndpointServiceClient](@ref google::cloud::osconfig_agentendpoint_v1::AgentEndpointServiceClient)
 - [\c osconfig_v1::OsConfigServiceClient](@ref google::cloud::osconfig_v1::OsConfigServiceClient)

--- a/google/cloud/oslogin/doc/main.dox
+++ b/google/cloud/oslogin/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud OS Login API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c oslogin_v1::OsLoginServiceClient](@ref google::cloud::oslogin_v1::OsLoginServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c oslogin_v1::OsLoginServiceClient](@ref google::cloud::oslogin_v1::OsLoginServiceClient) when testing your
+[`oslogin_v1::OsLoginServiceClient`](@ref google::cloud::oslogin_v1::OsLoginServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`oslogin_v1::OsLoginServiceClient`](@ref google::cloud::oslogin_v1::OsLoginServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/policytroubleshooter/doc/main.dox
+++ b/google/cloud/policytroubleshooter/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Policy Troubleshooter API C++ client librar
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c policytroubleshooter_v1::IamCheckerClient](@ref google::cloud::policytroubleshooter_v1::IamCheckerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c policytroubleshooter_v1::IamCheckerClient](@ref google::cloud::policytroubleshooter_v1::IamCheckerClient) when testing your
+[`policytroubleshooter_v1::IamCheckerClient`](@ref google::cloud::policytroubleshooter_v1::IamCheckerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`policytroubleshooter_v1::IamCheckerClient`](@ref google::cloud::policytroubleshooter_v1::IamCheckerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/privateca/doc/main.dox
+++ b/google/cloud/privateca/doc/main.dox
@@ -24,10 +24,10 @@ which should give you a taste of the Certificate Authority API C++ client librar
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c privateca_v1::CertificateAuthorityServiceClient](@ref google::cloud::privateca_v1::CertificateAuthorityServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c privateca_v1::CertificateAuthorityServiceClient](@ref google::cloud::privateca_v1::CertificateAuthorityServiceClient) when testing your
+[`privateca_v1::CertificateAuthorityServiceClient`](@ref google::cloud::privateca_v1::CertificateAuthorityServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`privateca_v1::CertificateAuthorityServiceClient`](@ref google::cloud::privateca_v1::CertificateAuthorityServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/profiler/doc/main.dox
+++ b/google/cloud/profiler/doc/main.dox
@@ -29,10 +29,10 @@ which should give you a taste of the Cloud Profiler API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c profiler_v2::ProfilerServiceClient](@ref google::cloud::profiler_v2::ProfilerServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c profiler_v2::ProfilerServiceClient](@ref google::cloud::profiler_v2::ProfilerServiceClient) when testing your
+[`profiler_v2::ProfilerServiceClient`](@ref google::cloud::profiler_v2::ProfilerServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`profiler_v2::ProfilerServiceClient`](@ref google::cloud::profiler_v2::ProfilerServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -28,9 +28,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c pubsublite::AdminServiceClient](@ref google::cloud::pubsublite::AdminServiceClient)
 - [\c pubsublite::TopicStatsServiceClient](@ref google::cloud::pubsublite::TopicStatsServiceClient)

--- a/google/cloud/recommender/doc/main.dox
+++ b/google/cloud/recommender/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Recommender C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c recommender_v1::RecommenderClient](@ref google::cloud::recommender_v1::RecommenderClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c recommender_v1::RecommenderClient](@ref google::cloud::recommender_v1::RecommenderClient) when testing your
+[`recommender_v1::RecommenderClient`](@ref google::cloud::recommender_v1::RecommenderClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`recommender_v1::RecommenderClient`](@ref google::cloud::recommender_v1::RecommenderClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/redis/doc/main.dox
+++ b/google/cloud/redis/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Google Cloud Memorystore for Redis API C++ 
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c redis_v1::CloudRedisClient](@ref google::cloud::redis_v1::CloudRedisClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c redis_v1::CloudRedisClient](@ref google::cloud::redis_v1::CloudRedisClient) when testing your
+[`redis_v1::CloudRedisClient`](@ref google::cloud::redis_v1::CloudRedisClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`redis_v1::CloudRedisClient`](@ref google::cloud::redis_v1::CloudRedisClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c resourcemanager_v3::FoldersClient](@ref google::cloud::resourcemanager_v3::FoldersClient)
 - [\c resourcemanager_v3::OrganizationsClient](@ref google::cloud::resourcemanager_v3::OrganizationsClient)

--- a/google/cloud/resourcesettings/doc/main.dox
+++ b/google/cloud/resourcesettings/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Resource Settings API C++ client library AP
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c resourcesettings_v1::ResourceSettingsServiceClient](@ref google::cloud::resourcesettings_v1::ResourceSettingsServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c resourcesettings_v1::ResourceSettingsServiceClient](@ref google::cloud::resourcesettings_v1::ResourceSettingsServiceClient) when testing your
+[`resourcesettings_v1::ResourceSettingsServiceClient`](@ref google::cloud::resourcesettings_v1::ResourceSettingsServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`resourcesettings_v1::ResourceSettingsServiceClient`](@ref google::cloud::resourcesettings_v1::ResourceSettingsServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -28,9 +28,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c retail_v2::CatalogServiceClient](@ref google::cloud::retail_v2::CatalogServiceClient)
 - [\c retail_v2::CompletionServiceClient](@ref google::cloud::retail_v2::CompletionServiceClient)

--- a/google/cloud/run/doc/main.dox
+++ b/google/cloud/run/doc/main.dox
@@ -35,9 +35,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c run_v2::RevisionsClient](@ref google::cloud::run_v2::RevisionsClient)
 - [\c run_v2::ServicesClient](@ref google::cloud::run_v2::ServicesClient)

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud Scheduler API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c scheduler_v1::CloudSchedulerClient](@ref google::cloud::scheduler_v1::CloudSchedulerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c scheduler_v1::CloudSchedulerClient](@ref google::cloud::scheduler_v1::CloudSchedulerClient) when testing your
+[`scheduler_v1::CloudSchedulerClient`](@ref google::cloud::scheduler_v1::CloudSchedulerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`scheduler_v1::CloudSchedulerClient`](@ref google::cloud::scheduler_v1::CloudSchedulerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Secret Manager API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c secretmanager_v1::SecretManagerServiceClient](@ref google::cloud::secretmanager_v1::SecretManagerServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c secretmanager_v1::SecretManagerServiceClient](@ref google::cloud::secretmanager_v1::SecretManagerServiceClient) when testing your
+[`secretmanager_v1::SecretManagerServiceClient`](@ref google::cloud::secretmanager_v1::SecretManagerServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`secretmanager_v1::SecretManagerServiceClient`](@ref google::cloud::secretmanager_v1::SecretManagerServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/securitycenter/doc/main.dox
+++ b/google/cloud/securitycenter/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the Security Command Center API C++ client libr
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c securitycenter_v1::SecurityCenterClient](@ref google::cloud::securitycenter_v1::SecurityCenterClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c securitycenter_v1::SecurityCenterClient](@ref google::cloud::securitycenter_v1::SecurityCenterClient) when testing your
+[`securitycenter_v1::SecurityCenterClient`](@ref google::cloud::securitycenter_v1::SecurityCenterClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`securitycenter_v1::SecurityCenterClient`](@ref google::cloud::securitycenter_v1::SecurityCenterClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/servicecontrol/doc/main.dox
+++ b/google/cloud/servicecontrol/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c servicecontrol_v1::QuotaControllerClient](@ref google::cloud::servicecontrol_v1::QuotaControllerClient)
 - [\c servicecontrol_v1::ServiceControllerClient](@ref google::cloud::servicecontrol_v1::ServiceControllerClient)

--- a/google/cloud/servicedirectory/doc/main.dox
+++ b/google/cloud/servicedirectory/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c servicedirectory_v1::LookupServiceClient](@ref google::cloud::servicedirectory_v1::LookupServiceClient)
 - [\c servicedirectory_v1::RegistrationServiceClient](@ref google::cloud::servicedirectory_v1::RegistrationServiceClient)

--- a/google/cloud/servicemanagement/doc/main.dox
+++ b/google/cloud/servicemanagement/doc/main.dox
@@ -20,10 +20,10 @@ which should give you a taste of the Service Management API C++ client library A
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c servicemanagement_v1::ServiceManagerClient](@ref google::cloud::servicemanagement_v1::ServiceManagerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c servicemanagement_v1::ServiceManagerClient](@ref google::cloud::servicemanagement_v1::ServiceManagerClient) when testing your
+[`servicemanagement_v1::ServiceManagerClient`](@ref google::cloud::servicemanagement_v1::ServiceManagerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`servicemanagement_v1::ServiceManagerClient`](@ref google::cloud::servicemanagement_v1::ServiceManagerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/serviceusage/doc/main.dox
+++ b/google/cloud/serviceusage/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Service Usage API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c serviceusage_v1::ServiceUsageClient](@ref google::cloud::serviceusage_v1::ServiceUsageClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c serviceusage_v1::ServiceUsageClient](@ref google::cloud::serviceusage_v1::ServiceUsageClient) when testing your
+[`serviceusage_v1::ServiceUsageClient`](@ref google::cloud::serviceusage_v1::ServiceUsageClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`serviceusage_v1::ServiceUsageClient`](@ref google::cloud::serviceusage_v1::ServiceUsageClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/shell/doc/main.dox
+++ b/google/cloud/shell/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud Shell API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c shell_v1::CloudShellServiceClient](@ref google::cloud::shell_v1::CloudShellServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c shell_v1::CloudShellServiceClient](@ref google::cloud::shell_v1::CloudShellServiceClient) when testing your
+[`shell_v1::CloudShellServiceClient`](@ref google::cloud::shell_v1::CloudShellServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`shell_v1::CloudShellServiceClient`](@ref google::cloud::shell_v1::CloudShellServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -26,9 +26,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c speech_v1::SpeechClient](@ref google::cloud::speech_v1::SpeechClient)
 - [\c speech_v2::SpeechClient](@ref google::cloud::speech_v2::SpeechClient)

--- a/google/cloud/sql/doc/main.dox
+++ b/google/cloud/sql/doc/main.dox
@@ -29,9 +29,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c sql_v1::SqlBackupRunsServiceClient](@ref google::cloud::sql_v1::SqlBackupRunsServiceClient)
 - [\c sql_v1::SqlConnectServiceClient](@ref google::cloud::sql_v1::SqlConnectServiceClient)

--- a/google/cloud/storageinsights/doc/main.dox
+++ b/google/cloud/storageinsights/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Storage Insights API C++ client library API
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c storageinsights_v1::StorageInsightsClient](@ref google::cloud::storageinsights_v1::StorageInsightsClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c storageinsights_v1::StorageInsightsClient](@ref google::cloud::storageinsights_v1::StorageInsightsClient) when testing your
+[`storageinsights_v1::StorageInsightsClient`](@ref google::cloud::storageinsights_v1::StorageInsightsClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`storageinsights_v1::StorageInsightsClient`](@ref google::cloud::storageinsights_v1::StorageInsightsClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/storagetransfer/doc/main.dox
+++ b/google/cloud/storagetransfer/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Storage Transfer API C++ client library API
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c storagetransfer_v1::StorageTransferServiceClient](@ref google::cloud::storagetransfer_v1::StorageTransferServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c storagetransfer_v1::StorageTransferServiceClient](@ref google::cloud::storagetransfer_v1::StorageTransferServiceClient) when testing your
+[`storagetransfer_v1::StorageTransferServiceClient`](@ref google::cloud::storagetransfer_v1::StorageTransferServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`storagetransfer_v1::StorageTransferServiceClient`](@ref google::cloud::storagetransfer_v1::StorageTransferServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/support/doc/main.dox
+++ b/google/cloud/support/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c support_v2::CaseAttachmentServiceClient](@ref google::cloud::support_v2::CaseAttachmentServiceClient)
 - [\c support_v2::CaseServiceClient](@ref google::cloud::support_v2::CaseServiceClient)

--- a/google/cloud/talent/doc/main.dox
+++ b/google/cloud/talent/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c talent_v4::CompanyServiceClient](@ref google::cloud::talent_v4::CompanyServiceClient)
 - [\c talent_v4::CompletionClient](@ref google::cloud::talent_v4::CompletionClient)

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Cloud Tasks API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c tasks_v2::CloudTasksClient](@ref google::cloud::tasks_v2::CloudTasksClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c tasks_v2::CloudTasksClient](@ref google::cloud::tasks_v2::CloudTasksClient) when testing your
+[`tasks_v2::CloudTasksClient`](@ref google::cloud::tasks_v2::CloudTasksClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`tasks_v2::CloudTasksClient`](@ref google::cloud::tasks_v2::CloudTasksClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/texttospeech/doc/main.dox
+++ b/google/cloud/texttospeech/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Cloud Text-to-Speech API C++ client library
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c texttospeech_v1::TextToSpeechClient](@ref google::cloud::texttospeech_v1::TextToSpeechClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c texttospeech_v1::TextToSpeechClient](@ref google::cloud::texttospeech_v1::TextToSpeechClient) when testing your
+[`texttospeech_v1::TextToSpeechClient`](@ref google::cloud::texttospeech_v1::TextToSpeechClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`texttospeech_v1::TextToSpeechClient`](@ref google::cloud::texttospeech_v1::TextToSpeechClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c tpu_v1::TpuClient](@ref google::cloud::tpu_v1::TpuClient)
 - [\c tpu_v2::TpuClient](@ref google::cloud::tpu_v2::TpuClient)

--- a/google/cloud/trace/doc/main.dox
+++ b/google/cloud/trace/doc/main.dox
@@ -29,9 +29,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c trace_v1::TraceServiceClient](@ref google::cloud::trace_v1::TraceServiceClient)
 - [\c trace_v2::TraceServiceClient](@ref google::cloud::trace_v2::TraceServiceClient)

--- a/google/cloud/translate/doc/main.dox
+++ b/google/cloud/translate/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the Cloud Translation API C++ client library AP
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c translate_v3::TranslationServiceClient](@ref google::cloud::translate_v3::TranslationServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c translate_v3::TranslationServiceClient](@ref google::cloud::translate_v3::TranslationServiceClient) when testing your
+[`translate_v3::TranslationServiceClient`](@ref google::cloud::translate_v3::TranslationServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`translate_v3::TranslationServiceClient`](@ref google::cloud::translate_v3::TranslationServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/video/doc/main.dox
+++ b/google/cloud/video/doc/main.dox
@@ -33,9 +33,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c video_livestream_v1::LivestreamServiceClient](@ref google::cloud::video_livestream_v1::LivestreamServiceClient)
 - [\c video_stitcher_v1::VideoStitcherServiceClient](@ref google::cloud::video_stitcher_v1::VideoStitcherServiceClient)

--- a/google/cloud/videointelligence/doc/main.dox
+++ b/google/cloud/videointelligence/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Cloud Video Intelligence API C++ client lib
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c videointelligence_v1::VideoIntelligenceServiceClient](@ref google::cloud::videointelligence_v1::VideoIntelligenceServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c videointelligence_v1::VideoIntelligenceServiceClient](@ref google::cloud::videointelligence_v1::VideoIntelligenceServiceClient) when testing your
+[`videointelligence_v1::VideoIntelligenceServiceClient`](@ref google::cloud::videointelligence_v1::VideoIntelligenceServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`videointelligence_v1::VideoIntelligenceServiceClient`](@ref google::cloud::videointelligence_v1::VideoIntelligenceServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -28,9 +28,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c vision_v1::ImageAnnotatorClient](@ref google::cloud::vision_v1::ImageAnnotatorClient)
 - [\c vision_v1::ProductSearchClient](@ref google::cloud::vision_v1::ProductSearchClient)

--- a/google/cloud/vmmigration/doc/main.dox
+++ b/google/cloud/vmmigration/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the VM Migration API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c vmmigration_v1::VmMigrationClient](@ref google::cloud::vmmigration_v1::VmMigrationClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c vmmigration_v1::VmMigrationClient](@ref google::cloud::vmmigration_v1::VmMigrationClient) when testing your
+[`vmmigration_v1::VmMigrationClient`](@ref google::cloud::vmmigration_v1::VmMigrationClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`vmmigration_v1::VmMigrationClient`](@ref google::cloud::vmmigration_v1::VmMigrationClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/vmwareengine/doc/main.dox
+++ b/google/cloud/vmwareengine/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the VMware Engine API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c vmwareengine_v1::VmwareEngineClient](@ref google::cloud::vmwareengine_v1::VmwareEngineClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c vmwareengine_v1::VmwareEngineClient](@ref google::cloud::vmwareengine_v1::VmwareEngineClient) when testing your
+[`vmwareengine_v1::VmwareEngineClient`](@ref google::cloud::vmwareengine_v1::VmwareEngineClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`vmwareengine_v1::VmwareEngineClient`](@ref google::cloud::vmwareengine_v1::VmwareEngineClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/vpcaccess/doc/main.dox
+++ b/google/cloud/vpcaccess/doc/main.dox
@@ -21,10 +21,10 @@ which should give you a taste of the Serverless VPC Access API C++ client librar
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c vpcaccess_v1::VpcAccessServiceClient](@ref google::cloud::vpcaccess_v1::VpcAccessServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c vpcaccess_v1::VpcAccessServiceClient](@ref google::cloud::vpcaccess_v1::VpcAccessServiceClient) when testing your
+[`vpcaccess_v1::VpcAccessServiceClient`](@ref google::cloud::vpcaccess_v1::VpcAccessServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`vpcaccess_v1::VpcAccessServiceClient`](@ref google::cloud::vpcaccess_v1::VpcAccessServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -22,10 +22,10 @@ which should give you a taste of the Web Risk API C++ client library API.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c webrisk_v1::WebRiskServiceClient](@ref google::cloud::webrisk_v1::WebRiskServiceClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c webrisk_v1::WebRiskServiceClient](@ref google::cloud::webrisk_v1::WebRiskServiceClient) when testing your
+[`webrisk_v1::WebRiskServiceClient`](@ref google::cloud::webrisk_v1::WebRiskServiceClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`webrisk_v1::WebRiskServiceClient`](@ref google::cloud::webrisk_v1::WebRiskServiceClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -23,10 +23,10 @@ which should give you a taste of the Web Security Scanner API C++ client library
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c websecurityscanner_v1::WebSecurityScannerClient](@ref google::cloud::websecurityscanner_v1::WebSecurityScannerClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c websecurityscanner_v1::WebSecurityScannerClient](@ref google::cloud::websecurityscanner_v1::WebSecurityScannerClient) when testing your
+[`websecurityscanner_v1::WebSecurityScannerClient`](@ref google::cloud::websecurityscanner_v1::WebSecurityScannerClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`websecurityscanner_v1::WebSecurityScannerClient`](@ref google::cloud::websecurityscanner_v1::WebSecurityScannerClient) when testing your
 application.
 <!-- inject-client-list-end -->
 

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -27,9 +27,9 @@ functions of the class. This library groups multiple gRPC services because they
 are part of the same product or are often used together. A typical example may
 be the administrative and data plane operations for a single product.
 
-The library also has other classes that provide helpers, retry policies,
-configuration parameters, and infrastructure to mock the `*Client` classes
-when testing your application.
+The library also has other classes that provide helpers, configuration
+parameters, and infrastructure to mock the `*Client` classes when testing your
+application.
 
 - [\c workflows_executions_v1::ExecutionsClient](@ref google::cloud::workflows_executions_v1::ExecutionsClient)
 - [\c workflows_v1::WorkflowsClient](@ref google::cloud::workflows_v1::WorkflowsClient)

--- a/google/cloud/workstations/doc/main.dox
+++ b/google/cloud/workstations/doc/main.dox
@@ -24,10 +24,10 @@ which should give you a taste of the Cloud Workstations API C++ client library.
 
 <!-- inject-client-list-start -->
 The main class in this library is
-[\c workstations_v1::WorkstationsClient](@ref google::cloud::workstations_v1::WorkstationsClient).
-All RPCs are exposed as member functions of this class. Other classes provide
-helpers, retry policies, configuration parameters, and infrastructure to mock
-[\c workstations_v1::WorkstationsClient](@ref google::cloud::workstations_v1::WorkstationsClient) when testing your
+[`workstations_v1::WorkstationsClient`](@ref google::cloud::workstations_v1::WorkstationsClient). All RPCs are exposed
+as member functions of this class. Other classes provide helpers, configuration
+parameters, and infrastructure to mock
+[`workstations_v1::WorkstationsClient`](@ref google::cloud::workstations_v1::WorkstationsClient) when testing your
 application.
 <!-- inject-client-list-end -->
 


### PR DESCRIPTION
With the previous formatting Doxygen generated the following XML structure:

```
<ref><computeroutput>...Client</computeroutput>when testing your</ref>application
```

Note how the text following the link was included in the link body, and some spacing was dropped.

Part of the work for #11428

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11602)
<!-- Reviewable:end -->
