### PR TITLE
cleanup(bigtable): reduce test logs

### DIFF
--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -67,13 +67,13 @@ class SampleRowsIntegrationTest
     : public ::google::cloud::testing_util::IntegrationTest {
  public:
   static void SetUpTestSuite() {
-    // Create kBatchSize * kBatchCount rows. Use a special client with tracing
+    // Create kBatchSize * kBatchCount rows. Use a special client with logging
     // disabled because it simply generates too much data.
-    auto table = Table(
-        MakeDataConnection(Options{}.set<TracingComponentsOption>({"rpc"})),
-        TableResource(TableTestEnvironment::project_id(),
-                      TableTestEnvironment::instance_id(),
-                      TableTestEnvironment::table_id()));
+    auto table =
+        Table(MakeDataConnection(Options{}.set<TracingComponentsOption>({})),
+              TableResource(TableTestEnvironment::project_id(),
+                            TableTestEnvironment::instance_id(),
+                            TableTestEnvironment::table_id()));
 
     int constexpr kBatchCount = 10;
     int constexpr kBatchSize = 5000;

--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -70,7 +70,10 @@ class SampleRowsIntegrationTest
     // Create kBatchSize * kBatchCount rows. Use a special client with logging
     // disabled because it simply generates too much data.
     auto table =
-        Table(MakeDataConnection(Options{}.set<TracingComponentsOption>({})),
+        Table(MakeDataConnection(
+                  Options{}
+                      .set<TracingComponentsOption>({"rpc"})
+                      .set<GrpcTracingOptionsOption>(TracingOptions())),
               TableResource(TableTestEnvironment::project_id(),
                             TableTestEnvironment::instance_id(),
                             TableTestEnvironment::table_id()));


### PR DESCRIPTION
* GCB: https://console.cloud.google.com/cloud-build/builds;region=us-east1/eb9fbf8a-9bca-4c32-a422-35df84ecbfb2;tab=detail?project=cloud-cpp-testing-resources
* Raw: https://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/main/0669593d4b1a72eed9c16f828ca7c1d4f76aef6e/fedora-m32-m32/log-eb9fbf8a-9bca-4c32-a422-35df84ecbfb2.txt

This build flaked and there was too much noise in the log to see why. We had enabled logging for `"rpc"` , but not `"rpc-streams"`. That will still dump the request, which in this case, is too big:
https://github.com/googleapis/google-cloud-cpp/blob/b89901f7c51ffcc1a2cfba35631ba6a26a428663/google/cloud/internal/log_wrapper.h#L114-L117

So just turn off all logging for the set up. That will at least tell us if it is the set up that is failing or the actual test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11603)
<!-- Reviewable:end -->
