### PR TITLE
ci: timeout Linux GCS cache download

### DIFF
--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -138,7 +138,7 @@ function restore_cache() {
   for url in "${urls[@]}"; do
     if gsutil stat "${url}"; then
       io::log "Fetching cache url ${url}"
-      (gcloud --quiet storage cp "${url}" "${tmpf}" && tar -zxf "${tmpf}") || continue
+      (timeout -s SIGKILL 2m gcloud --quiet storage cp "${url}" "${tmpf}" && tar -zxf "${tmpf}") || continue
       break
     fi
   done


### PR DESCRIPTION
Motivated by #10031

I think this command takes ~4s normally. So 2m should be generous enough. Anything seems better than this command struggling for 3.5 hours.

The comments say this is not necessary that downloading the cache is not necessary for running the build, so we just continue on timeout.

We could implement a retry loop (with timeouts) instead.... thoughts?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11604)
<!-- Reviewable:end -->
