### PR TITLE
impl(docfx): skip duplicate `deprecated` sections

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -176,8 +176,13 @@ bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
 bool AppendIfXRefSect(std::ostream& os, MarkdownContext const& ctx,
                       pugi::xml_node node) {
   if (std::string_view{node.name()} != "xrefsect") return false;
-  // Add the title in bold, then some
-  os << "**" << node.child_value("xreftitle") << "**";
+  auto const id = std::string_view{node.attribute("id").as_string()};
+  // Sometimes the "deprecated" notice appears twice.
+  if (id.rfind("deprecated_") == 0 && id != "deprecated_1_deprecated000001") {
+    return true;
+  }
+  // Add the title in bold, then the description.
+  os << "**" << node.child_value("xreftitle") << "**\n\n";
   AppendDescriptionType(os, ctx, node.child("xrefdescription"));
   return true;
 }

--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -176,11 +176,7 @@ bool AppendIfSect1(std::ostream& os, MarkdownContext const& ctx,
 bool AppendIfXRefSect(std::ostream& os, MarkdownContext const& ctx,
                       pugi::xml_node node) {
   if (std::string_view{node.name()} != "xrefsect") return false;
-  auto const id = std::string_view{node.attribute("id").as_string()};
-  // Sometimes the "deprecated" notice appears twice.
-  if (id.rfind("deprecated_") == 0 && id != "deprecated_1_deprecated000001") {
-    return true;
-  }
+  if (ctx.skip_xrefsect) return true;
   // Add the title in bold, then the description.
   os << "**" << node.child_value("xreftitle") << "**\n\n";
   AppendDescriptionType(os, ctx, node.child("xrefdescription"));

--- a/docfx/doxygen2markdown.h
+++ b/docfx/doxygen2markdown.h
@@ -34,6 +34,7 @@ struct MarkdownContext {
   std::string paragraph_indent;
   std::string item_prefix;
   std::vector<std::string> decorators;
+  bool skip_xrefsect = false;
 };
 
 /// Handles a sect4 node.

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -235,6 +235,38 @@ Second paragraph (4).)md";
   EXPECT_EQ(kExpected, os.str());
 }
 
+TEST(Doxygen2Markdown, DetailedDescriptionXrefSectDeprecatedTwice) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud_1_1kms" kind="namespace" language="C++">
+          <compoundname>google::cloud::kms</compoundname>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+            <para><xrefsect id="deprecated_1_deprecated000001"><xreftitle>Deprecated</xreftitle><xrefdescription><para>This namespace exists for backwards compatibility. Use the types defined in <ref refid="namespacegoogle_1_1cloud_1_1kms__v1" kindref="compound">kms_v1</ref> instead of the aliases defined in this namespace.</para>
+            </xrefdescription></xrefsect></para>
+            <para><xrefsect id="deprecated_1_deprecated000014"><xreftitle>Deprecated</xreftitle><xrefdescription><para>This namespace exists for backwards compatibility. Use the types defined in <ref refid="namespacegoogle_1_1cloud_1_1kms__v1" kindref="compound">kms_v1</ref> instead of the aliases defined in this namespace.</para>
+            </xrefdescription></xrefsect></para>
+          </detaileddescription>
+      </compounddef>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"md(**Deprecated**
+
+This namespace exists for backwards compatibility. Use the types defined in [kms_v1](xref:namespacegoogle_1_1cloud_1_1kms__v1) instead of the aliases defined in this namespace.
+
+)md";
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//detaileddescription");
+  ASSERT_TRUE(selected);
+  std::ostringstream os;
+  MarkdownContext ctx;
+  ctx.paragraph_start = "";
+  EXPECT_TRUE(AppendIfDetailedDescription(os, ctx, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
+}
+
 TEST(Doxygen2Markdown, BriefDescription) {
   auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
     <doxygen version="1.9.1" xml:lang="en-US">
@@ -744,7 +776,7 @@ TEST(Doxygen2Markdown, ParagraphXrefSect) {
   auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
     <doxygen version="1.9.1" xml:lang="en-US">
       <para id='tested-node'>
-        <xrefsect id="deprecated_1_deprecated000007">
+        <xrefsect id="deprecated_1_deprecated000001">
           <xreftitle>Deprecated</xreftitle>
           <xrefdescription>
             <para>Use <computeroutput><ref refid="classgoogle_1_1cloud_1_1Options" kindref="compound">Options</ref></computeroutput> and <computeroutput><ref refid="structgoogle_1_1cloud_1_1EndpointOption" kindref="compound">EndpointOption</ref></computeroutput>.</para>
@@ -753,9 +785,7 @@ TEST(Doxygen2Markdown, ParagraphXrefSect) {
       </para>
     </doxygen>)xml";
 
-  auto constexpr kExpected = R"md(
-
-**Deprecated**
+  auto constexpr kExpected = R"md(**Deprecated**
 
 Use [`Options`](xref:classgoogle_1_1cloud_1_1Options) and [`EndpointOption`](xref:structgoogle_1_1cloud_1_1EndpointOption).)md";
   pugi::xml_document doc;
@@ -763,7 +793,9 @@ Use [`Options`](xref:classgoogle_1_1cloud_1_1Options) and [`EndpointOption`](xre
   auto selected = doc.select_node("//*[@id='tested-node']");
   ASSERT_TRUE(selected);
   std::ostringstream os;
-  ASSERT_TRUE(AppendIfParagraph(os, {}, selected.node()));
+  MarkdownContext ctx;
+  ctx.paragraph_start = "";
+  ASSERT_TRUE(AppendIfParagraph(os, ctx, selected.node()));
   EXPECT_EQ(kExpected, os.str());
 }
 

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -235,7 +235,7 @@ Second paragraph (4).)md";
   EXPECT_EQ(kExpected, os.str());
 }
 
-TEST(Doxygen2Markdown, DetailedDescriptionXrefSectDeprecatedTwice) {
+TEST(Doxygen2Markdown, DetailedDescriptionNotSkipped) {
   auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
     <doxygen version="1.9.1" xml:lang="en-US">
       <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud_1_1kms" kind="namespace" language="C++">
@@ -255,6 +255,40 @@ TEST(Doxygen2Markdown, DetailedDescriptionXrefSectDeprecatedTwice) {
 
 This namespace exists for backwards compatibility. Use the types defined in [kms_v1](xref:namespacegoogle_1_1cloud_1_1kms__v1) instead of the aliases defined in this namespace.
 
+**Deprecated**
+
+
+
+This namespace exists for backwards compatibility. Use the types defined in [kms_v1](xref:namespacegoogle_1_1cloud_1_1kms__v1) instead of the aliases defined in this namespace.)md";
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//detaileddescription");
+  ASSERT_TRUE(selected);
+  std::ostringstream os;
+  MarkdownContext ctx;
+  ctx.paragraph_start = "";
+  EXPECT_TRUE(AppendIfDetailedDescription(os, ctx, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
+}
+
+TEST(Doxygen2Markdown, DetailedDescriptionSkipped) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud_1_1kms" kind="namespace" language="C++">
+          <compoundname>google::cloud::kms</compoundname>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+            <para><xrefsect id="deprecated_1_deprecated000001"><xreftitle>Deprecated</xreftitle><xrefdescription><para>This namespace exists for backwards compatibility. Use the types defined in <ref refid="namespacegoogle_1_1cloud_1_1kms__v1" kindref="compound">kms_v1</ref> instead of the aliases defined in this namespace.</para>
+</xrefdescription></xrefsect></para>
+            <para><xrefsect id="deprecated_1_deprecated000014"><xreftitle>Deprecated</xreftitle><xrefdescription><para>This namespace exists for backwards compatibility. Use the types defined in <ref refid="namespacegoogle_1_1cloud_1_1kms__v1" kindref="compound">kms_v1</ref> instead of the aliases defined in this namespace.</para>
+</xrefdescription></xrefsect></para>
+          </detaileddescription>
+      </compounddef>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"md(
+
 )md";
   pugi::xml_document doc;
   doc.load_string(kXml);
@@ -263,6 +297,7 @@ This namespace exists for backwards compatibility. Use the types defined in [kms
   std::ostringstream os;
   MarkdownContext ctx;
   ctx.paragraph_start = "";
+  ctx.skip_xrefsect = true;
   EXPECT_TRUE(AppendIfDetailedDescription(os, ctx, selected.node()));
   EXPECT_EQ(kExpected, os.str());
 }

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -920,6 +920,70 @@ items:
   EXPECT_EQ(actual, kExpected);
 }
 
+TEST(Doxygen2Yaml, NamespaceDeprecated) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="namespacegoogle_1_1cloud_1_1kms" kind="namespace" language="C++">
+        <compoundname>google::cloud::kms</compoundname>
+          <sectiondef kind="func">
+          </sectiondef>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+<para><xrefsect id="deprecated_1_deprecated000001"><xreftitle>Deprecated</xreftitle><xrefdescription><para>This namespace exists for backwards compatibility. Use the types defined in <ref refid="namespacegoogle_1_1cloud_1_1kms__v1" kindref="compound">kms_v1</ref> instead of the aliases defined in this namespace. </para>
+</xrefdescription></xrefsect></para>
+<para><xrefsect id="deprecated_1_deprecated000014"><xreftitle>Deprecated</xreftitle><xrefdescription><para>This namespace exists for backwards compatibility. Use the types defined in <ref refid="namespacegoogle_1_1cloud_1_1kms__v1" kindref="compound">kms_v1</ref> instead of the aliases defined in this namespace. </para>
+</xrefdescription></xrefsect></para>
+        </detaileddescription>
+        <location file="ekm_client.h" line="30" column="1"/>
+      </compounddef>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
+items:
+  - uid: namespacegoogle_1_1cloud_1_1kms
+    name: "google::cloud::kms"
+    id: namespacegoogle_1_1cloud_1_1kms
+    parent: test-only-parent-id
+    type: namespace
+    langs:
+      - cpp
+    syntax:
+      contents: |
+        namespace google::cloud::kms { ... };
+      source:
+        id: google::cloud::kms
+        path: google/cloud/kms/ekm_client.h
+        startLine: 30
+        remote:
+          repo: https://github.com/googleapis/google-cloud-cpp/
+          branch: main
+          path: google/cloud/kms/ekm_client.h
+    conceptual: |
+
+
+
+
+      <aside class="deprecated">
+          <b>Deprecated:</b> This namespace is deprecated, prefer the types defined in [`kms_v1`](xref:namespacegoogle_1_1cloud_1_1kms__v1).
+      </aside>
+)yml";
+
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//*[@id='namespacegoogle_1_1cloud_1_1kms']");
+  ASSERT_TRUE(selected);
+  YAML::Emitter yaml;
+  TestPre(yaml);
+  YamlContext ctx;
+  ctx.parent_id = "test-only-parent-id";
+  ctx.library_root = "google/cloud/kms/";
+  ASSERT_TRUE(AppendIfNamespace(yaml, ctx, selected.node()));
+  TestPost(yaml);
+  auto const actual = EndDocFxYaml(yaml);
+  EXPECT_EQ(actual, kExpected);
+}
+
 TEST(Doxygen2Yaml, Class) {
   auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
 items:


### PR DESCRIPTION
Namespaces can have multiple `xrefsect` marking them as deprecated. This skips all but the first such section.

Fixes #11614

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11615)
<!-- Reviewable:end -->
