### PR TITLE
chore: a kokoro job to store the commit hash of each release

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,3 @@
+enabled: true
+triggerWithoutPullRequest: true
+lang: c++

--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -1,0 +1,9 @@
+build_file: "google-cloud-cpp/.kokoro/release/publish.sh"
+
+# Record the the commit hash.
+action {
+  define_artifacts {
+    regex: "github/google-cloud-cpp/commit-hash.txt"
+    strip_prefix: "github/google-cloud-cpp"
+  }
+}

--- a/.kokoro/release/publish.sh
+++ b/.kokoro/release/publish.sh
@@ -1,0 +1,2 @@
+# Record the current commit hash.
+git -C github/google-cloud-cpp log -1 --format=%H > commit-hash.txt


### PR DESCRIPTION
See go/cpp-sbom for rationale.