### PR TITLE
impl(docfx): reset paragraph start after titles

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -958,6 +958,7 @@ bool AppendIfSimpleSect(std::ostream& os, MarkdownContext const& ctx,
     nested = ctx;
     os << "\n\n###### ";
     AppendTitle(os, nested, node);
+    nested.paragraph_start = "\n\n";
   } else if (kind == "note") {
     os << "\n";
     os << nested.paragraph_start << nested.paragraph_indent << "**Note:**";


### PR DESCRIPTION
When using the `@par` command with a title we need to reset the paragraph start to separate the title from the rest of the text.