### PR TITLE
docs: exclude some implementation details

### DIFF
--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -89,14 +89,19 @@ using CellValueType = std::decay<
  */
 class Cell {
  public:
-  /// Create a Cell and fill it with data.
+  /**
+   * Creates a Cell and fill it with data.
+   *
+   * This function does not participate in overload resolution if @p ValueType
+   * is not an integral type. The case for integral types is handled by a
+   * separate overload.
+   */
   template <typename KeyType, typename ColumnType, typename ValueType,
-            // This function does not participate in overload resolution if
-            // ValueType is not an integral type. The case for integral types is
-            // handled by the next overload, where the value is stored as a Big
-            // Endian number.
+            /// @cond implementation_details
             typename std::enable_if<!std::is_integral<ValueType>::value,
-                                    int>::type = 0>
+                                    int>::type = 0
+            /// @endcond
+            >
   Cell(KeyType&& row_key, std::string family_name,
        ColumnType&& column_qualifier, std::int64_t timestamp, ValueType&& value,
        std::vector<std::string> labels)

--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -296,10 +296,12 @@ Mutation DeleteFromRow();
 class SingleRowMutation {
  public:
   /// Create an empty mutation.
-  template <
-      typename RowKey,
-      typename std::enable_if<std::is_constructible<RowKeyType, RowKey>::value,
-                              int>::type = 0>
+  template <typename RowKey,
+            /// @cond implementation_details
+            typename std::enable_if<
+                std::is_constructible<RowKeyType, RowKey>::value, int>::type = 0
+            /// @endcond
+            >
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   explicit SingleRowMutation(RowKey&& row_key) {
     request_.set_row_key(RowKeyType(std::forward<RowKey>(row_key)));
@@ -315,10 +317,12 @@ class SingleRowMutation {
   }
 
   /// Create a single-row multiple-cell mutation from a variadic list.
-  template <
-      typename RowKey, typename... M,
-      typename std::enable_if<std::is_constructible<RowKeyType, RowKey>::value,
-                              int>::type = 0>
+  template <typename RowKey, typename... M,
+            /// @cond implementation_details
+            typename std::enable_if<
+                std::is_constructible<RowKeyType, RowKey>::value, int>::type = 0
+            /// @endcond
+            >
   explicit SingleRowMutation(RowKey&& row_key, M&&... m) {
     static_assert(
         absl::conjunction<std::is_convertible<M, Mutation>...>::value,
@@ -518,9 +522,12 @@ class BulkMutation {
 
   /// Create a multi-row mutation from a variadic list.
   template <typename... M,
+            /// @cond implementation_details
             typename std::enable_if<absl::conjunction<std::is_convertible<
                                         M, SingleRowMutation>...>::value,
-                                    int>::type = 0>
+                                    int>::type = 0
+            /// @endcond
+            >
   // NOLINTNEXTLINE(google-explicit-constructor)
   BulkMutation(M&&... m) : BulkMutation() {
     emplace_many(std::forward<M>(m)...);

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -951,7 +951,10 @@ class Table {
    */
   template <
       typename... Policies,
-      typename std::enable_if<ValidPolicies<Policies...>::value, int>::type = 0>
+      /// @cond implementation_details
+      typename std::enable_if<ValidPolicies<Policies...>::value, int>::type = 0
+      /// @endcond
+      >
   Table(std::shared_ptr<DataClient> client, std::string const& table_id,
         Policies&&... policies)
       : Table(std::move(client), table_id) {
@@ -1012,7 +1015,10 @@ class Table {
    */
   template <
       typename... Policies,
-      typename std::enable_if<ValidPolicies<Policies...>::value, int>::type = 0>
+      /// @cond implementation_details
+      typename std::enable_if<ValidPolicies<Policies...>::value, int>::type = 0
+      /// @endcond
+      >
   Table(std::shared_ptr<DataClient> client, std::string app_profile_id,
         std::string const& table_id, Policies&&... policies)
       : Table(std::move(client), std::move(app_profile_id), table_id) {

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -110,7 +110,7 @@ class CompletionQueue {
   /**
    * Make an asynchronous unary RPC.
    *
-   * @deprecated Applications should have not need to call this function. The
+   * @deprecated Applications should have no need to call this function. The
    *     libraries provide `Async*()` member functions in the generated (or)
    *     hand-crafted `*Client` classes for the same purpose.
    *
@@ -157,7 +157,7 @@ class CompletionQueue {
    * by any thread blocked on this object's Run() member function. However, only
    * one callback in the handler is called at a time.
    *
-   * @deprecated Applications should have not need to call this function. The
+   * @deprecated Applications should have no need to call this function. The
    *     libraries provide `Async*()` member functions in the generated (or)
    *     hand-crafted `*Client` classes for the same purpose.
    *

--- a/google/cloud/spanner/numeric.h
+++ b/google/cloud/spanner/numeric.h
@@ -257,7 +257,11 @@ StatusOr<Decimal<Mode>> MakeDecimal(double d) {
  */
 template <
     typename T, DecimalMode Mode,
-    typename std::enable_if<std::numeric_limits<T>::is_integer, int>::type = 0>
+    /// @cond implementation_details
+    typename std::enable_if<std::numeric_limits<T>::is_integer, int>::type = 0
+    /// @endcond
+
+    >
 StatusOr<Decimal<Mode>> MakeDecimal(T i, int exponent = 0) {
   return spanner_internal::MakeDecimal<Mode>(spanner_internal::ToString(i),
                                              exponent);
@@ -293,9 +297,12 @@ double ToDouble(Decimal<Mode> const& d) {
  */
 ///@{
 template <typename T, DecimalMode Mode,
+          /// @cond implementation_details
           typename std::enable_if<std::numeric_limits<T>::is_integer &&
                                       !std::numeric_limits<T>::is_signed,
-                                  int>::type = 0>
+                                  int>::type = 0
+          /// @endcond
+          >
 StatusOr<T> ToInteger(  // NOLINT(misc-no-recursion)
     Decimal<Mode> const& d, int exponent = 0) {
   std::string const& rep = d.ToString();
@@ -330,9 +337,12 @@ StatusOr<T> ToInteger(  // NOLINT(misc-no-recursion)
   return v;
 }
 template <typename T, DecimalMode Mode,
+          /// @cond implementation_details
           typename std::enable_if<std::numeric_limits<T>::is_integer &&
                                       std::numeric_limits<T>::is_signed,
-                                  int>::type = 0>
+                                  int>::type = 0
+          /// @endcond
+          >
 StatusOr<T> ToInteger(  // NOLINT(misc-no-recursion)
     Decimal<Mode> const& d, int exponent = 0) {
   std::string const& rep = d.ToString();
@@ -400,8 +410,12 @@ inline StatusOr<Numeric> MakeNumeric(std::string s) {
 inline StatusOr<Numeric> MakeNumeric(double d) {
   return MakeDecimal<DecimalMode::kGoogleSQL>(d);
 }
-template <typename T, typename std::enable_if<
-                          std::numeric_limits<T>::is_integer, int>::type = 0>
+template <
+    typename T,
+    /// @cond implementation_details
+    typename std::enable_if<std::numeric_limits<T>::is_integer, int>::type = 0
+    /// @endcond
+    >
 StatusOr<Numeric> MakeNumeric(T i, int exponent = 0) {
   return MakeDecimal<T, DecimalMode::kGoogleSQL>(i, exponent);
 }
@@ -417,8 +431,12 @@ inline StatusOr<PgNumeric> MakePgNumeric(std::string s) {
 inline StatusOr<PgNumeric> MakePgNumeric(double d) {
   return MakeDecimal<DecimalMode::kPostgreSQL>(d);
 }
-template <typename T, typename std::enable_if<
-                          std::numeric_limits<T>::is_integer, int>::type = 0>
+template <
+    typename T,
+    /// @cond implementation_details
+    typename std::enable_if<std::numeric_limits<T>::is_integer, int>::type = 0
+    /// @endcond
+    >
 StatusOr<PgNumeric> MakePgNumeric(T i, int exponent = 0) {
   return MakeDecimal<T, DecimalMode::kPostgreSQL>(i, exponent);
 }

--- a/google/cloud/spanner/numeric.h
+++ b/google/cloud/spanner/numeric.h
@@ -260,7 +260,6 @@ template <
     /// @cond implementation_details
     typename std::enable_if<std::numeric_limits<T>::is_integer, int>::type = 0
     /// @endcond
-
     >
 StatusOr<Decimal<Mode>> MakeDecimal(T i, int exponent = 0) {
   return spanner_internal::MakeDecimal<Mode>(spanner_internal::ToString(i),

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -149,15 +149,19 @@ class StatusOr final {
   /**
    * Assign a `T` (or anything convertible to `T`) into the `StatusOr`.
    *
+   * This function does not participate in overload resolution if `U` is equal
+   * to `StatusOr<T>` (or to a cv-ref-qualified `StatusOr<T>`).
+   *
    * @return a reference to this object.
-   * @tparam U a type convertible to @p T
-   * @tparam Unspecified removes this function from overload resolution if
-   *   `U` is (a possibly cv-qualified version of) `StatusOr<T>`.
+   * @tparam U a type convertible to @p T.
    */
   template <typename U = T,
-            typename Unspecified = typename std::enable_if<
+            /// @cond implementation_details
+            typename std::enable_if<
                 !std::is_same<StatusOr, typename std::decay<U>::type>::value,
-                int>::type>
+                int>::type = 0
+            /// @endcond
+            >
   StatusOr& operator=(U&& rhs) {
     status_ = Status();
     value_ = std::forward<U>(rhs);


### PR DESCRIPTION
From time-to-time the template parameters of a function include implementation details to exclude the function from overload resolution, or to apply some template magic to deduce dependent types. These details do not need to be documented.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11645)
<!-- Reviewable:end -->
