### PR TITLE
impl(docfx): support odd mocks in pubsub library

### DIFF
--- a/docfx/doxygen2children.cc
+++ b/docfx/doxygen2children.cc
@@ -40,9 +40,8 @@ std::vector<std::string> Children(YamlContext const& ctx, pugi::xml_node node) {
   }
   for (auto const child : node.children("memberdef")) {
     if (!IncludeInPublicDocuments(nested.config, child)) continue;
+    if (IsSkippedChild(nested, child)) continue;
     auto id = std::string{child.attribute("id").as_string()};
-    // Mocked functions are not children.
-    if (nested.mocked_ids.count(id) != 0) continue;
     if (!id.empty()) children.push_back(std::move(id));
   }
   for (auto const child : node.children("enumvalue")) {

--- a/docfx/doxygen2references.cc
+++ b/docfx/doxygen2references.cc
@@ -69,6 +69,7 @@ std::list<Reference> ExtractReferences(YamlContext const& ctx,
     return recurse;
   }
   if (name == "memberdef") {
+    if (IsSkippedChild(ctx, node)) return {};
     auto const uid = std::string{node.attribute("id").as_string()};
     if (ctx.mocked_ids.count(uid) != 0) return {};
     auto const name = [&] {

--- a/docfx/yaml_context.cc
+++ b/docfx/yaml_context.cc
@@ -97,4 +97,21 @@ YamlContext NestedYamlContext(YamlContext const& ctx, pugi::xml_node node) {
   return nested;
 }
 
+bool IsSkippedChild(YamlContext const& ctx, pugi::xml_node node) {
+  // Mocked functions are not children.
+  auto id = std::string{node.attribute("id").as_string()};
+  if (ctx.mocked_ids.count(id) != 0) return true;
+
+  // Things that are not MOCK_METHOD() are always present
+  auto qname = std::string_view{node.child("qualifiedname").child_value()};
+  auto const p = qname.find("::MOCK_METHOD");
+  if (p == std::string_view::npos) return false;
+
+  // In a few places we kept a MOCK_METHOD() definition for a function that
+  // does not exist in the base class.  These only exist for backwards
+  // compatibility. Skip them is no need to document those.
+  auto const m = ctx.mocking_functions_by_id.find(id);
+  return m == ctx.mocking_functions_by_id.end();
+}
+
 }  // namespace docfx

--- a/docfx/yaml_context.h
+++ b/docfx/yaml_context.h
@@ -38,6 +38,10 @@ struct YamlContext {
 /// Creates a new context to recurse over @p node
 YamlContext NestedYamlContext(YamlContext const& ctx, pugi::xml_node node);
 
+/// Returns true if a <memberdef> element should be skipped from the
+/// children and references lists.
+bool IsSkippedChild(YamlContext const& ctx, pugi::xml_node node);
+
 }  // namespace docfx
 
 #endif  // GOOGLE_CLOUD_CPP_DOCFX_YAML_CONTEXT_H


### PR DESCRIPTION
The Pub/Sub library has a few mocks that don't mock anything. We kept the `MOCK_METHOD(..., ack_id...)` definitions for backwards compatibility, but the base class has no `ack_id()` to mock. Skip these in the documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11648)
<!-- Reviewable:end -->
