### PR TITLE
impl(generator): add longrunning var support for compute operation types

### DIFF
--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
         "@com_google_googleapis//:googleapis_system_includes",
         "@com_google_googleapis//google/api:client_cc_proto",
         "@com_google_googleapis//google/api:routing_cc_proto",
+        "@com_google_googleapis//google/cloud:extended_operations_cc_proto",
         "@com_google_googleapis//google/longrunning:longrunning_cc_proto",
         "@com_google_protobuf//:protoc_lib",
     ],

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -135,6 +135,7 @@ target_link_libraries(
            nlohmann_json::nlohmann_json
            google-cloud-cpp::api_client_protos
            google-cloud-cpp::api_routing_protos
+           google-cloud-cpp::cloud_extended_operations_protos
            google-cloud-cpp::longrunning_operations_protos
            absl::str_format
            protobuf::libprotoc

--- a/generator/internal/longrunning.h
+++ b/generator/internal/longrunning.h
@@ -41,6 +41,20 @@ void SetLongrunningOperationMethodVars(
     google::protobuf::MethodDescriptor const& method,
     VarsDictionary& method_vars);
 
+/**
+ * Determines if the method uses `google::longrunning::Operation` types for
+ * long running operations.
+ */
+bool IsGRPCLongrunningOperation(
+    google::protobuf::MethodDescriptor const& method);
+
+/**
+ * Sets longrunning operation related key/value pairs in service_vars.
+ */
+void SetLongrunningOperationServiceVars(
+    google::protobuf::ServiceDescriptor const& service,
+    VarsDictionary& service_vars);
+
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -108,6 +108,13 @@ bool ServiceCodeGenerator::HasLongrunningMethod() const {
                      });
 }
 
+bool ServiceCodeGenerator::HasGRPCLongrunningOperation() const {
+  return std::any_of(methods_.begin(), methods_.end(),
+                     [](google::protobuf::MethodDescriptor const& m) {
+                       return IsGRPCLongrunningOperation(m);
+                     });
+}
+
 bool ServiceCodeGenerator::HasAsyncMethod() const {
   return !async_methods_.empty() || HasLongrunningMethod();
 }

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -112,10 +112,16 @@ class ServiceCodeGenerator : public GeneratorInterface {
   bool IsExperimental() const;
 
   /**
+   * Determines if the service contains at least one method that requires
+   * LRO handling. This could be AIP-151 compatible or something custom.
+   */
+  bool HasLongrunningMethod() const;
+
+  /**
    * Determines if the service contains at least one method that returns a
    * google::longrunning::Operation.
    */
-  bool HasLongrunningMethod() const;
+  bool HasGRPCLongrunningOperation() const;
 
   /**
    * Determines if any async methods are generated for the service.

--- a/generator/internal/service_code_generator_test.cc
+++ b/generator/internal/service_code_generator_test.cc
@@ -49,6 +49,7 @@ class TestGenerator : public ServiceCodeGenerator {
 
   using ServiceCodeGenerator::HasBidirStreamingMethod;
   using ServiceCodeGenerator::HasExplicitRoutingMethod;
+  using ServiceCodeGenerator::HasGRPCLongrunningOperation;
   using ServiceCodeGenerator::HasLongrunningMethod;
   using ServiceCodeGenerator::HasMessageWithMapField;
   using ServiceCodeGenerator::HasPaginatedMethod;
@@ -139,6 +140,7 @@ TEST(PredicateUtilsTest, HasLongRunningMethodNone) {
       .WillOnce(Return(output.release()));
   TestGenerator g(service_file_descriptor->service(0), generator_context.get());
   EXPECT_FALSE(g.HasLongrunningMethod());
+  EXPECT_FALSE(g.HasGRPCLongrunningOperation());
 }
 
 TEST(PredicateUtilsTest, HasLongRunningMethodOne) {
@@ -186,6 +188,7 @@ TEST(PredicateUtilsTest, HasLongRunningMethodOne) {
       .WillOnce(Return(output.release()));
   TestGenerator g(service_file_descriptor->service(0), generator_context.get());
   EXPECT_TRUE(g.HasLongrunningMethod());
+  EXPECT_TRUE(g.HasGRPCLongrunningOperation());
 }
 
 TEST(PredicateUtilsTest, HasLongRunningMethodMoreThanOne) {
@@ -238,6 +241,7 @@ TEST(PredicateUtilsTest, HasLongRunningMethodMoreThanOne) {
       .WillOnce(Return(output.release()));
   TestGenerator g(service_file_descriptor->service(0), generator_context.get());
   EXPECT_TRUE(g.HasLongrunningMethod());
+  EXPECT_TRUE(g.HasGRPCLongrunningOperation());
 }
 
 TEST(PredicateUtilsTest, HasPaginatedMethodTrue) {


### PR DESCRIPTION
part of the work for #11531 

We're currently hardcoding compute LRO values for many of these variables as that's all we need right now for non `google::longrunning::Operation` types. If in the future, we need support additional LRO mechanisms, we can figure out if we want to abstract the values out and inject them via the config textproto, or some additional branching in this code to handle additional LRO schemes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11653)
<!-- Reviewable:end -->
