### PR TITLE
docs: cleanup landing pages for docfx

### DIFF
--- a/google/cloud/bigtable/doc/bigtable-main.dox
+++ b/google/cloud/bigtable/doc/bigtable-main.dox
@@ -20,22 +20,7 @@ library.
 
 @snippet quickstart.cc all
 
-## Building and Installing
-
-- Packaging maintainers or developers who prefer to install the library in a
-  fixed directory (such as `/usr/local` or `/opt`) should consult the
-  [packaging guide].
-- Developers who prefer using a package manager such as
-  [vcpkg](https://vcpkg.io), or [Conda](https://conda.io), should follow the
-  instructions for their package manager.
-- Developers wanting to use the libraries as part of a larger CMake or Bazel
-  project should consult the [quickstart guide].
-- Developers wanting to compile the library just to run some examples or
-  tests should read the project's top-level [README][project-build].
-- Contributors and developers to [google-cloud-cpp] should consult
-  the guide to [set up a development workstation][howto-setup-dev-workstation].
-
-## Next Steps
+## More Information
 
 - Read more about [Cloud Bigtable](https://cloud.google.com/bigtable/docs/)
 - [Table::ReadRow()] - to read a single row from an existing Table
@@ -47,13 +32,15 @@ library.
 - @ref bigtable-hello-table-admin
 - @ref bigtable-hello-instance-admin
 - @ref bigtable-error-handling to learn how the library reports run-time errors.
-- @ref bigtable-env-logging enabling logging. This can be an effective approach
-  to diagnose many problems.
 - @ref bigtable-environment-variables for environment variables affecting the
-  library.
+  library.  Some of these environment variables enable logging to the console.
+  This can be an effective approach to diagnose runtime problems.
 - @ref bigtable-endpoint-example
 - @ref bigtable-auth-example
 - @ref bigtable-mocking "Mocking the Cloud Bigtable C++ client"
+- The [Setting up your development environment] guide describes how to set up
+  a C++ development environment in various platforms, including the Google Cloud
+  C++ client libraries.
 
 [Table::ReadRows()]: @ref google::cloud::bigtable::Table::ReadRows()
 [Table::ReadRow()]: @ref google::cloud::bigtable::Table::ReadRow()
@@ -69,6 +56,7 @@ library.
 [howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/contributor/howto-guide-setup-development-workstation.md
 [quickstart guide]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/bigtable/quickstart#readme
 [packaging guide]:  https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[Setting up your development environment]: https://cloud.google.com/cpp/docs/setup
 
 */
 
@@ -85,8 +73,8 @@ endpoint for `google::cloud::bigtable::Table`:
 Changing the default endpoint for other `*Client` classes is very similar, as
 shown in these examples:
 
-- [BigtableTableAdminClient](@ref BigtableTableAdminClient-set-endpoint-snippet)
-- [InstanceTableAdminClient](@ref BigtableInstanceAdminClient-set-endpoint-snippet)
+- [`BigtableTableAdminClient`](@ref BigtableTableAdminClient-set-endpoint-snippet)
+- [`InstanceTableAdminClient`](@ref BigtableInstanceAdminClient-set-endpoint-snippet)
 */
 
 /**
@@ -106,8 +94,8 @@ guide for more details.
 Changing the default authentication configuration for other `*Client` classes is
 very similar, as shown in these examples:
 
-- [BigtableTableAdminClient](@ref BigtableTableAdminClient-with-service-account-snippet)
-- [InstanceTableAdminClient](@ref BigtableInstanceAdminClient-with-service-account-snippet)
+- [`BigtableTableAdminClient`](@ref BigtableTableAdminClient-with-service-account-snippet)
+- [`InstanceTableAdminClient`](@ref BigtableInstanceAdminClient-with-service-account-snippet)
 
 Keep in mind that we chose this as an example because it is relatively easy to
 understand. Consult the [Best practices for managing service account keys]

--- a/google/cloud/pubsub/doc/pubsub-main.dox
+++ b/google/cloud/pubsub/doc/pubsub-main.dox
@@ -14,35 +14,23 @@ library.
 
 @snippet quickstart.cc all
 
-## Building and Installing
-
-- Packaging maintainers or developers who prefer to install the library in a
-  fixed directory (such as `/usr/local` or `/opt`) should consult the
-  [packaging guide].
-- Developers who prefer using a package manager such as
-  [vcpkg](https://vcpkg.io), or [Conda](https://conda.io), should follow the
-  instructions for their package manager.
-- Developers wanting to use the libraries as part of a larger CMake or Bazel
-  project should consult the [quickstart guide].
-- Developers wanting to compile the library just to run some examples or
-  tests should read the project's top-level [README][project-build].
-- Contributors and developers to [google-cloud-cpp][github-link] should consult
-  the guide to [set up a development workstation][howto-setup-dev-workstation].
-
-## Next Steps
+## More Information
 
 - [Publisher::Publish()] - to efficiently publish Pub/Sub messages.
 - [BlockingPublisher::Publish()] - to publish a single Pub/Sub messages.
 - [Subscriber::Subscribe()] - to asynchronous receive Pub/Sub messages.
 - [Subscriber::Pull()] - to receive a single Pub/Sub messages.
 - @ref pubsub-error-handling to learn how the library reports run-time errors.
-- @ref pubsub-env-logging enabling logging. This can be an effective approach to
-  diagnose many problems.
-- @ref pubsub-env for environment variables affecting the library.
+- @ref pubsub-env for environment variables affecting the library.  Some of
+  these environment variables enable logging to the console. This can be an
+  effective approach to diagnose runtime problems.
 - @ref pubsub-endpoint-example
 - @ref pubsub-auth-example
 - @ref publisher-mock shows how to write tests mocking [Publisher]
 - @ref subscriber-mock shows how to write tests mocking [Subscriber]
+- The [Setting up your development environment] guide describes how to set up
+  a C++ development environment in various platforms, including the Google Cloud
+  C++ client libraries.
 
 [Publisher]: @ref google::cloud::pubsub::Publisher
 [Subscriber]: @ref google::cloud::pubsub::Subscriber
@@ -57,6 +45,7 @@ library.
 [howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/contributor/howto-guide-setup-development-workstation.md
 [quickstart guide]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/pubsub/quickstart#readme
 [packaging guide]:  https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[Setting up your development environment]: https://cloud.google.com/cpp/docs/setup
 
 */
 
@@ -70,13 +59,14 @@ endpoint for `google::cloud::pubsub::Publisher`:
 
 @snippet client_samples.cc publisher-set-endpoint
 
-Follow these links for additional examples
- [Subscriber](@ref Subscriber-endpoint-snippet)
- [BlockingPublisher](@ref BlockingPublisher-endpoint-snippet)
- [TopicAdminClient](@ref TopicAdminClient-endpoint-snippet)
- [SubscriptionAdminClient](@ref SubscriptionAdminClient-endpoint-snippet)
- [SchemaServiceClient](@ref SchemaServiceClient-endpoint-snippet)
- [Publisher](@ref Publisher-endpoint-snippet)
+Follow these links to find examples for other `*Client` classes:
+
+- [`Subscriber`](@ref Subscriber-endpoint-snippet)
+- [`BlockingPublisher`](@ref BlockingPublisher-endpoint-snippet)
+- [`TopicAdminClient`](@ref TopicAdminClient-endpoint-snippet)
+- [`SubscriptionAdminClient`](@ref SubscriptionAdminClient-endpoint-snippet)
+- [`SchemaServiceClient`](@ref SchemaServiceClient-endpoint-snippet)
+- [`Publisher`](@ref Publisher-endpoint-snippet)
 */
 
 /**
@@ -96,13 +86,14 @@ guide for more details.
 @see @ref guac - for more information on the factory functions to create
 `google::cloud::Credentials` objects.
 
-Follow these links for additional examples
- [Subscriber](@ref Subscriber-service-account-snippet)
- [BlockingPublisher](@ref BlockingPublisher-service-account-snippet)
- [TopicAdminClient](@ref TopicAdminClient-service-account-snippet)
- [SubscriptionAdminClient](@ref SubscriptionAdminClient-service-account-snippet)
- [SchemaServiceClient](@ref SchemaServiceClient-service-account-snippet)
- [Publisher](@ref Publisher-service-account-snippet)
+Follow these links to find examples for other `*Client` classes:
+
+- [`Subscriber`](@ref Subscriber-service-account-snippet)
+- [`BlockingPublisher`](@ref BlockingPublisher-service-account-snippet)
+- [`TopicAdminClient`](@ref TopicAdminClient-service-account-snippet)
+- [`SubscriptionAdminClient`](@ref SubscriptionAdminClient-service-account-snippet)
+- [`SchemaServiceClient`](@ref SchemaServiceClient-service-account-snippet)
+- [`Publisher`](@ref Publisher-service-account-snippet)
 
 [Best practices for managing service account keys]: https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys
 [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -15,7 +15,7 @@ into your project.
 
 @snippet quickstart.cc all
 
-## Next Steps
+## More Information
 
 - Read more about [Cloud Spanner](https://cloud.google.com/spanner/docs/)
 - [Client::ExecuteQuery()](@ref google::cloud::spanner::Client::ExecuteQuery())
@@ -32,6 +32,9 @@ into your project.
 - @ref spanner-auth-example
 - @ref spanner-retry-example
 - @ref spanner-mocking
+- The [Setting up your development environment] guide describes how to set up
+  a C++ development environment in various platforms, including the Google Cloud
+  C++ client libraries.
 
 [google-cloud-cpp]: https://github.com/googleapis/google-cloud-cpp
 [project-readme]:   https://github.com/googleapis/google-cloud-cpp#readme
@@ -39,6 +42,7 @@ into your project.
 [howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/contributor/howto-guide-setup-development-workstation.md
 [quickstart guide]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/bigtable/quickstart#readme
 [packaging guide]:  https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[Setting up your development environment]: https://cloud.google.com/cpp/docs/setup
 
 */
 

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -21,35 +21,23 @@ project.
 
 @snippet quickstart.cc all
 
-## Building and Installing
-
-- Packaging maintainers or developers who prefer to install the library in a
-  fixed directory (such as `/usr/local` or `/opt`) should consult the
-  [packaging guide].
-- Developers who prefer using a package manager such as
-  [vcpkg](https://vcpkg.io), or [Conda](https://conda.io), should follow the
-  instructions for their package manager.
-- Developers wanting to use the libraries as part of a larger CMake or Bazel
-  project should consult the [quickstart guide].
-- Developers wanting to compile the library just to run some examples or
-  tests should read the project's top-level [README][project-build].
-- Contributors and developers to [google-cloud-cpp][github-link] should consult
-  the guide to [set up a development workstation][howto-setup-dev-workstation].
-
-## Next Steps
+## More Information
 
 - [ReadObject()] - the function to read object data.
 - [WriteObject()] - the function to write objects.
 - [InsertObject()] - the function to write small objects.
 - @ref storage-error to learn how the library reports run-time errors.
-- @ref storage-env-logging enabling logging. This can be an effective approach to
-  diagnose many problems.
-- @ref storage-env for environment variables affecting the library.
+- @ref storage-env for environment variables affecting the library.  Some of
+  these environment variables enable logging to the console.  This can be an
+  effective approach to diagnose runtime problems.
 - @ref storage-endpoint-example
 - @ref storage-auth-example
 - @ref storage-retry-examples
 - @ref storage-mocking shows how to write tests mocking the [Client] class
 <!-- @ref storage-grpc "Using the GCS+gRPC plugin" -->
+- The [Setting up your development environment] guide describes how to set up
+  a C++ development environment in various platforms, including the Google Cloud
+  C++ client libraries.
 
 [Client]: @ref google::cloud::storage::Client
 [ReadObject()]: @ref google::cloud::storage::Client::ReadObject()
@@ -72,6 +60,7 @@ project.
 [howto-setup-dev-workstation]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/contributor/howto-guide-setup-development-workstation.md
 [quickstart guide]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage/quickstart#readme
 [packaging guide]:  https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[Setting up your development environment]: https://cloud.google.com/cpp/docs/setup
 
 */
 


### PR DESCRIPTION
Remove the installation instructions and just link the common "set up" page.

Avoid deep links to the environment variables page as those do not work (yet) with docfx.

Avoid formatting problems with back-to-back links.

Motivated by #11430. Part of the work for #10157

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11654)
<!-- Reviewable:end -->
