### PR TITLE
impl(bigquery): minor cleanup logging decorators

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/dataset_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_logging_test.cc
@@ -73,9 +73,14 @@ TEST(DatasetLoggingClientTest, GetDataset) {
   auto actual_lines = log.ExtractLines();
 
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetDatasetRequest)")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(project_id: "p-id")")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(dataset_id: "d-id")")));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(project_id: "p-id")")).Times(2));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(dataset_id: "d-id")")).Times(2));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetDatasetResponse)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "d-id")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "d-kind")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(etag: "d-tag")")));
 }
 
 TEST(DatasetLoggingClientTest, ListDatasets) {
@@ -89,9 +94,8 @@ TEST(DatasetLoggingClientTest, ListDatasets) {
           "datasets": [
               {
                 "id": "1",
-                "kind": "kind-2",
+                "kind": "kind-1",
                 "dataset_reference": {"project_id": "p123", "dataset_id": "d123"},
-
                 "friendly_name": "friendly-name",
                 "location": "location",
                 "type": "DEFAULT"
@@ -118,11 +122,14 @@ TEST(DatasetLoggingClientTest, ListDatasets) {
   auto actual_lines = log.ExtractLines();
 
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(ListDatasetsRequest)")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(project_id: "p123")")));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(project_id: "p123")")).Times(2));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(all_datasets: false)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(max_results: 0)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(ListDatasetsResponse)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(dataset_id: "d123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "kind-1")")));
   EXPECT_THAT(actual_lines,
               Contains(HasSubstr(R"(next_page_token: "npt-123")")));
 }

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
@@ -76,11 +76,14 @@ TEST(JobLoggingClientTest, GetJob) {
 
   EXPECT_THAT(actual_lines, Contains(HasSubstr(" << ")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetJobRequest)")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(job_id: "j123")")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(project_id: "p123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(job_id: "j123")")).Times(2));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(project_id: "p123")")).Times(2));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetJobResponse)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(status: "DONE")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "j123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "jkind")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(etag: "jtag")")));
 }
 
 TEST(JobLoggingClientTest, ListJobs) {
@@ -94,7 +97,7 @@ TEST(JobLoggingClientTest, ListJobs) {
           "jobs": [
               {
                 "id": "1",
-                "kind": "kind-2",
+                "kind": "kind-1",
                 "reference": {"project_id": "p123", "job_id": "j123"},
                 "state": "DONE",
                 "configuration": {
@@ -128,11 +131,14 @@ TEST(JobLoggingClientTest, ListJobs) {
 
   EXPECT_THAT(actual_lines, Contains(HasSubstr(" << ")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(ListJobsRequest)")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(project_id: "p123")")));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(project_id: "p123")")).Times(2));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(all_users: false)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(max_results: 0)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(ListJobsResponse)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "kind-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(job_id: "j123")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(state: "DONE")")));
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/project_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_logging_test.cc
@@ -70,6 +70,9 @@ TEST(ProjectLoggingClientTest, ListProjects) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(max_results: 10)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(page_token: "pt-123")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(ListProjectsResponse)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "p-id")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "kind-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(etag: "tag-1")")));
   EXPECT_THAT(actual_lines,
               Contains(HasSubstr(R"(project_id: "p-project-id")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(total_items: 1)")));

--- a/google/cloud/bigquery/v2/minimal/internal/table_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_logging_test.cc
@@ -67,10 +67,15 @@ TEST(TableLoggingClientTest, GetTable) {
   auto actual_lines = log.ExtractLines();
 
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetTableRequest)")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(project_id: "t-123")")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(dataset_id: "t-123")")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(table_id: "t-123")")));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(project_id: "t-123")")).Times(2));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(dataset_id: "t-123")")).Times(2));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(table_id: "t-123")")).Times(2));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetTableResponse)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "t-id")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "t-kind")")));
 }
 
 TEST(TableLoggingClientTest, ListTables) {
@@ -100,11 +105,15 @@ TEST(TableLoggingClientTest, ListTables) {
   auto actual_lines = log.ExtractLines();
 
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(ListTablesRequest)")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(project_id: "t-123")")));
-  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(dataset_id: "t-123")")));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(project_id: "t-123")")).Times(2));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(dataset_id: "t-123")")).Times(2));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(max_results: 10)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(page_token: "123")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(ListTablesResponse)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "t-id")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "t-kind")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(table_id: "t-123")")));
   EXPECT_THAT(actual_lines,
               Contains(HasSubstr(R"(next_page_token: "npt-123")")));


### PR DESCRIPTION
This PR addresses code review feedback by Bradley [here](https://github.com/googleapis/google-cloud-cpp/pull/11643#pullrequestreview-1433049852) regarding the logging test expectations to make them more meaningful.

Changes in the PR include:

1) Adding `Contains(e).Times(n)` where applicable

2) Adding expectations for some additional required members that should be logged.

Bradley, when you get a chance can you take a look?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11659)
<!-- Reviewable:end -->
