### PR TITLE
impl(docfx): fix table of contents for mocks

### DIFF
--- a/docfx/.clang-tidy
+++ b/docfx/.clang-tidy
@@ -3,4 +3,5 @@ InheritParentConfig: true
 
 Checks: >
   -misc-no-recursion,
-  -abseil-string-find-str-contains
+  -abseil-string-find-str-contains,
+  -abseil-string-find-startswith

--- a/docfx/doxygen2references.cc
+++ b/docfx/doxygen2references.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "docfx/doxygen2references.h"
+#include "docfx/node_name.h"
 #include "docfx/public_docs.h"
 #include "docfx/yaml_emit.h"
 #include <iterator>

--- a/docfx/doxygen2toc.cc
+++ b/docfx/doxygen2toc.cc
@@ -22,7 +22,6 @@
 #include "docfx/public_docs.h"
 #include <yaml-cpp/yaml.h>
 #include <functional>
-#include <iostream>
 #include <map>
 #include <sstream>
 
@@ -44,11 +43,16 @@ std::shared_ptr<TocEntry> CompoundEntry(pugi::xml_node node) {
   return entry;
 }
 
-std::shared_ptr<TocEntry> MemberEntry(pugi::xml_node node) {
-  auto const id = std::string_view{node.attribute("id").as_string()};
-  auto entry = NamedEntry(NodeName(node));
+TocItems MemberEntry(YamlContext const& ctx, pugi::xml_node node) {
+  // Skip MOCK_METHOD() functions.
+  auto const name = NodeName(node);
+  if (name.rfind("MOCK_METHOD", 0) == 0) return {};
+
+  auto actual = MockingNode(ctx, node);
+  auto const id = std::string_view{actual.attribute("id").as_string()};
+  auto entry = NamedEntry(name);
   entry->attr.emplace("uid", id);
-  return entry;
+  return {entry};
 }
 
 std::shared_ptr<TocEntry> EnumValueEntry(pugi::xml_node node) {
@@ -78,23 +82,23 @@ bool IsTypedef(pugi::xml_node node) {
   return std::string_view{node.attribute("kind").as_string()} == "typedef";
 }
 
-TocItems NamespaceToc(Config const& cfg, pugi::xml_document const& doc,
+TocItems NamespaceToc(YamlContext const& ctx, pugi::xml_document const& doc,
                       pugi::xml_node node);
-TocItems ClassToc(Config const& cfg, pugi::xml_document const& doc,
+TocItems ClassToc(YamlContext const& ctx, pugi::xml_document const& doc,
                   pugi::xml_node node);
-TocItems EnumToc(Config const& cfg, pugi::xml_document const& doc,
+TocItems EnumToc(YamlContext const& ctx, pugi::xml_document const& doc,
                  pugi::xml_node node);
 
 // Generate ToC entries for any elements
-TocItems GenericToc(Config const& cfg, pugi::xml_document const& doc,
+TocItems GenericToc(YamlContext const& ctx, pugi::xml_document const& doc,
                     pugi::xml_node node) {
-  if (!IncludeInPublicDocuments(cfg, node)) return {};
-  if (IsClass(node)) return ClassToc(cfg, doc, node);
-  if (IsStruct(node)) return ClassToc(cfg, doc, node);
-  if (IsEnum(node)) return EnumToc(cfg, doc, node);
-  if (IsNamespace(node)) return NamespaceToc(cfg, doc, node);
+  if (!IncludeInPublicDocuments(ctx.config, node)) return {};
+  if (IsClass(node)) return ClassToc(ctx, doc, node);
+  if (IsStruct(node)) return ClassToc(ctx, doc, node);
+  if (IsEnum(node)) return EnumToc(ctx, doc, node);
+  if (IsNamespace(node)) return NamespaceToc(ctx, doc, node);
   auto const element = std::string_view{node.name()};
-  if (element == "memberdef") return {MemberEntry(node)};
+  if (element == "memberdef") return MemberEntry(ctx, node);
   if (element == "enumvalue") return {EnumValueEntry(node)};
   return {};
 }
@@ -106,20 +110,21 @@ TocItems GenericToc(Config const& cfg, pugi::xml_document const& doc,
 // e.g. all the "Constructors" are grouped. The filtering does not recurse
 // for things like "classes" we want to list all the attributes of the matching
 // classes.
-template <typename Predicate>
-TocItems Recurse(Config const& cfg, pugi::xml_document const& doc,
-                 pugi::xml_node node, Predicate&& pred) {
-  if (!IncludeInPublicDocuments(cfg, node)) return {};
+using Predicate = std::function<bool(pugi::xml_node node)>;
+
+TocItems Recurse(YamlContext const& ctx, pugi::xml_document const& doc,
+                 pugi::xml_node node, Predicate const& pred) {
+  if (!IncludeInPublicDocuments(ctx.config, node)) return {};
   TocItems items;
   for (auto const child : node) {
-    if (!IncludeInPublicDocuments(cfg, child)) continue;
+    if (!IncludeInPublicDocuments(ctx.config, child)) continue;
     auto const element = std::string_view{child.name()};
     // A <sectiondef> element defines groups of members, such as, "public
     // functions", or "private member variables". They currently do not get
     // a representation in the ToC.
     if (element == "sectiondef") {
       items.splice(items.end(),
-                   Recurse(cfg, doc, child, std::forward<Predicate>(pred)));
+                   Recurse(NestedYamlContext(ctx, node), doc, child, pred));
       continue;
     }
     // In the Doxygen XML file classes are referenced, but not defined, as
@@ -145,32 +150,32 @@ TocItems Recurse(Config const& cfg, pugi::xml_document const& doc,
       auto child = doc.select_node(query);
       // Skip the referenced element if it does not match the predicate.
       if (!child || !pred(child.node())) continue;
-      items.splice(items.end(), GenericToc(cfg, doc, child.node()));
+      items.splice(items.end(), GenericToc(ctx, doc, child.node()));
       continue;
     }
     // Skip the element if it does not match the predicate.
     if (!pred(child)) continue;
-    items.splice(items.end(), GenericToc(cfg, doc, child));
+    items.splice(items.end(), GenericToc(ctx, doc, child));
   }
   return items;
 }
 
 using TocItemsProducer = std::function<TocItems()>;
 
-TocItems NamespaceToc(Config const& cfg, pugi::xml_document const& doc,
+TocItems NamespaceToc(YamlContext const& ctx, pugi::xml_document const& doc,
                       pugi::xml_node node) {
-  if (!IncludeInPublicDocuments(cfg, node)) return {};
+  if (!IncludeInPublicDocuments(ctx.config, node)) return {};
   auto entry = CompoundEntry(node);
   struct Node {
     std::string_view name;
     TocItemsProducer producer;
   } nodes[] = {
-      {"Classes", [&] { return Recurse(cfg, doc, node, IsClass); }},
-      {"Structs", [&] { return Recurse(cfg, doc, node, IsStruct); }},
-      {"Functions", [&] { return Recurse(cfg, doc, node, IsPlainFunction); }},
-      {"Operators", [&] { return Recurse(cfg, doc, node, IsOperator); }},
-      {"Enums", [&] { return Recurse(cfg, doc, node, IsEnum); }},
-      {"Types", [&] { return Recurse(cfg, doc, node, IsTypedef); }},
+      {"Classes", [&] { return Recurse(ctx, doc, node, IsClass); }},
+      {"Structs", [&] { return Recurse(ctx, doc, node, IsStruct); }},
+      {"Functions", [&] { return Recurse(ctx, doc, node, IsPlainFunction); }},
+      {"Operators", [&] { return Recurse(ctx, doc, node, IsOperator); }},
+      {"Enums", [&] { return Recurse(ctx, doc, node, IsEnum); }},
+      {"Types", [&] { return Recurse(ctx, doc, node, IsTypedef); }},
   };
   for (auto const& [name, generator] : nodes) {
     auto items = generator();
@@ -182,19 +187,22 @@ TocItems NamespaceToc(Config const& cfg, pugi::xml_document const& doc,
   return {std::move(entry)};
 }
 
-TocItems ClassToc(Config const& cfg, pugi::xml_document const& doc,
+TocItems ClassToc(YamlContext const& ctx, pugi::xml_document const& doc,
                   pugi::xml_node node) {
-  if (!IncludeInPublicDocuments(cfg, node)) return {};
+  if (!IncludeInPublicDocuments(ctx.config, node)) return {};
+  auto const nested = NestedYamlContext(ctx, node);
   auto entry = CompoundEntry(node);
   struct Node {
     std::string_view name;
     TocItemsProducer producer;
   } nodes[] = {
-      {"Types", [&] { return Recurse(cfg, doc, node, IsTypedef); }},
-      {"Constructors", [&] { return Recurse(cfg, doc, node, IsConstructor); }},
-      {"Operators", [&] { return Recurse(cfg, doc, node, IsOperator); }},
-      {"Functions", [&] { return Recurse(cfg, doc, node, IsPlainFunction); }},
-      {"Enums", [&] { return Recurse(cfg, doc, node, IsEnum); }},
+      {"Types", [&] { return Recurse(nested, doc, node, IsTypedef); }},
+      {"Constructors",
+       [&] { return Recurse(nested, doc, node, IsConstructor); }},
+      {"Operators", [&] { return Recurse(nested, doc, node, IsOperator); }},
+      {"Functions",
+       [&] { return Recurse(nested, doc, node, IsPlainFunction); }},
+      {"Enums", [&] { return Recurse(nested, doc, node, IsEnum); }},
       // Skip these. They also appear as `<innerclass>` elements in the
       // namespace.
       // {"Classes", [&] { return Recurse(cfg, doc, node, IsClass); }},
@@ -210,19 +218,20 @@ TocItems ClassToc(Config const& cfg, pugi::xml_document const& doc,
   return {std::move(entry)};
 }
 
-TocItems EnumToc(Config const& cfg, pugi::xml_document const& doc,
+TocItems EnumToc(YamlContext const& ctx, pugi::xml_document const& doc,
                  pugi::xml_node node) {
-  if (!IncludeInPublicDocuments(cfg, node)) return {};
+  if (!IncludeInPublicDocuments(ctx.config, node)) return {};
+  auto const nested = NestedYamlContext(ctx, node);
   auto const id = std::string_view{node.attribute("id").as_string()};
   auto entry = NamedEntry(NodeName(node));
   auto overview = NamedEntry("Overview");
   overview->attr.emplace("uid", id);
   entry->items.push_back(std::move(overview));
   for (auto const child : node) {
-    if (!IncludeInPublicDocuments(cfg, child)) continue;
+    if (!IncludeInPublicDocuments(ctx.config, child)) continue;
     auto const element = std::string_view{child.name()};
     if (element == "enumvalue") {
-      entry->items.splice(entry->items.end(), GenericToc(cfg, doc, child));
+      entry->items.splice(entry->items.end(), GenericToc(nested, doc, child));
       continue;
     }
   }
@@ -280,10 +289,12 @@ TocItems Groups(Config const& /*config*/, pugi::xml_document const& doc) {
 }
 
 TocItems Namespaces(Config const& config, pugi::xml_document const& doc) {
+  YamlContext ctx;
+  ctx.config = config;
   TocItems items;
   for (auto const& i : doc.select_nodes("//compounddef[@kind='namespace']")) {
     if (!IncludeInPublicDocuments(config, i.node())) continue;
-    items.splice(items.end(), NamespaceToc(config, doc, i.node()));
+    items.splice(items.end(), NamespaceToc(ctx, doc, i.node()));
   }
   return items;
 }

--- a/docfx/yaml_context.cc
+++ b/docfx/yaml_context.cc
@@ -60,10 +60,10 @@ std::unordered_map<std::string, std::string> MockingFunctions(
   return mocked;
 }
 
-std::unordered_set<std::string> MockedIds(
+std::unordered_map<std::string, std::string> MockedIds(
     std::unordered_map<std::string, std::string> const& mocked_functions,
     Config const& config, pugi::xml_node node) {
-  std::unordered_set<std::string> mocked;
+  std::unordered_map<std::string, std::string> mocked;
   for (auto const child : node.children("sectiondef")) {
     if (!IncludeInPublicDocuments(config, node)) continue;
     auto more = MockedIds(mocked_functions, config, child);
@@ -77,7 +77,7 @@ std::unordered_set<std::string> MockedIds(
     auto const member_name = std::string{child.child_value("name")};
     auto const it = mocked_functions.find(member_name);
     if (it == mocked_functions.end()) continue;
-    mocked.emplace(id);
+    mocked.emplace(id, it->second);
   }
   return mocked;
 }
@@ -112,6 +112,19 @@ bool IsSkippedChild(YamlContext const& ctx, pugi::xml_node node) {
   // compatibility. Skip them as there is no need to document those.
   auto const m = ctx.mocking_functions_by_id.find(id);
   return m == ctx.mocking_functions_by_id.end();
+}
+
+pugi::xml_node MockingNode(YamlContext const& ctx, pugi::xml_node node) {
+  auto const id = std::string{node.attribute("id").as_string()};
+  auto const m = ctx.mocked_ids.find(id);
+  if (m == ctx.mocked_ids.end()) return node;
+  pugi::xpath_variable_set vars;
+  vars.add("id", pugi::xpath_type_string);
+  vars.set("id", m->second.c_str());
+  auto found = node.select_node(
+      pugi::xpath_query("//memberdef[@id = string($id)]", &vars));
+  if (!found) return node;
+  return found.node();
 }
 
 }  // namespace docfx

--- a/docfx/yaml_context.h
+++ b/docfx/yaml_context.h
@@ -19,7 +19,6 @@
 #include <pugixml.hpp>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 
 namespace docfx {
 
@@ -31,16 +30,20 @@ struct YamlContext {
   std::unordered_map<std::string, std::string> mocking_functions;
   // Mocking functions (the `MOCK_METHOD()` elements), indexed by their id.
   std::unordered_map<std::string, std::string> mocking_functions_by_id;
-  // The id of inherited functions mocked via `MOCK_METHOD()`.
-  std::unordered_set<std::string> mocked_ids;
+  // Mocked functions (indexed by their id) pointing to the corresponding
+  // `MOCK_METHOD()`'s id.
+  std::unordered_map<std::string, std::string> mocked_ids;
 };
 
 /// Creates a new context to recurse over @p node
 YamlContext NestedYamlContext(YamlContext const& ctx, pugi::xml_node node);
 
 /// Returns true if a <memberdef> element should be skipped from the
-/// children and references lists.
+/// children and references lists. We always skip mocked functions.
 bool IsSkippedChild(YamlContext const& ctx, pugi::xml_node node);
+
+/// If @p node is mocked, returns the mocking node. Otherwise return @p node.
+pugi::xml_node MockingNode(YamlContext const& ctx, pugi::xml_node node);
 
 }  // namespace docfx
 

--- a/docfx/yaml_context_test.cc
+++ b/docfx/yaml_context_test.cc
@@ -55,11 +55,18 @@ TEST(YamlContextTest, MockedFunctions) {
                                 "ListCryptoKeys")));
   EXPECT_THAT(
       actual.mocked_ids,
-      UnorderedElementsAre(
-          "classgoogle_1_1cloud_1_1kms__inventory__v1_1_"
-          "1KeyDashboardServiceConnection_1a922ac7ae75f6939947a07d843e863845",
-          "classgoogle_1_1cloud_1_1kms__inventory__v1_1_"
-          "1KeyDashboardServiceConnection_1a2518e5014c3adbc16e83281bd2a596a8"));
+      UnorderedElementsAre(Pair("classgoogle_1_1cloud_1_1kms__inventory__v1_1_"
+                                "1KeyDashboardServiceConnection_"
+                                "1a922ac7ae75f6939947a07d843e863845",
+                                "classgoogle_1_1cloud_1_1kms__inventory__v1__"
+                                "mocks_1_1MockKeyDashboardServiceConnection_"
+                                "1a2bf84b7b96702bc1622f0e6c9f0babc4"),
+                           Pair("classgoogle_1_1cloud_1_1kms__inventory__v1_1_"
+                                "1KeyDashboardServiceConnection_"
+                                "1a2518e5014c3adbc16e83281bd2a596a8",
+                                "classgoogle_1_1cloud_1_1kms__inventory__v1__"
+                                "mocks_1_1MockKeyDashboardServiceConnection_"
+                                "1a789db998d71abf9016b64832d0c7a99e")));
 }
 
 }  // namespace


### PR DESCRIPTION
Use the name of the mocked function, but link to the mocking function.

Part of the work for #11428

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11661)
<!-- Reviewable:end -->
