### PR TITLE
impl(bigquery): Logging Tests cleanup

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/dataset_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_logging_test.cc
@@ -67,6 +67,8 @@ TEST(DatasetLoggingClientTest, GetDataset) {
   auto client = CreateMockDatasetLogging(std::move(mock_stub));
   GetDatasetRequest request("p-id", "d-id");
   rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
 
   client->GetDataset(context, request);
 
@@ -81,6 +83,11 @@ TEST(DatasetLoggingClientTest, GetDataset) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "d-id")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "d-kind")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(etag: "d-tag")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
 }
 
 TEST(DatasetLoggingClientTest, ListDatasets) {
@@ -116,6 +123,8 @@ TEST(DatasetLoggingClientTest, ListDatasets) {
   auto client = CreateMockDatasetLogging(std::move(mock_stub));
   ListDatasetsRequest request("p123");
   rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
 
   client->ListDatasets(context, request);
 
@@ -132,6 +141,11 @@ TEST(DatasetLoggingClientTest, ListDatasets) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "kind-1")")));
   EXPECT_THAT(actual_lines,
               Contains(HasSubstr(R"(next_page_token: "npt-123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
@@ -69,6 +69,8 @@ TEST(JobLoggingClientTest, GetJob) {
   auto client = CreateMockJobLogging(std::move(mock_stub));
   GetJobRequest request("p123", "j123");
   rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
 
   client->GetJob(context, request);
 
@@ -84,6 +86,11 @@ TEST(JobLoggingClientTest, GetJob) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "j123")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "jkind")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(etag: "jtag")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
 }
 
 TEST(JobLoggingClientTest, ListJobs) {
@@ -124,6 +131,8 @@ TEST(JobLoggingClientTest, ListJobs) {
   auto client = CreateMockJobLogging(std::move(mock_stub));
   ListJobsRequest request("p123");
   rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
 
   client->ListJobs(context, request);
 
@@ -140,6 +149,11 @@ TEST(JobLoggingClientTest, ListJobs) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "kind-1")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(job_id: "j123")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(state: "DONE")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/project_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_logging_test.cc
@@ -61,6 +61,8 @@ TEST(ProjectLoggingClientTest, ListProjects) {
   ListProjectsRequest request;
   request.set_max_results(10).set_page_token("pt-123");
   rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
 
   client->ListProjects(context, request);
 
@@ -78,6 +80,11 @@ TEST(ProjectLoggingClientTest, ListProjects) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(total_items: 1)")));
   EXPECT_THAT(actual_lines,
               Contains(HasSubstr(R"(next_page_token: "npt-123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/table_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_logging_test.cc
@@ -61,6 +61,8 @@ TEST(TableLoggingClientTest, GetTable) {
   auto client = CreateMockTableLogging(std::move(mock_stub));
   GetTableRequest request = bigquery_v2_minimal_testing::MakeGetTableRequest();
   rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
 
   client->GetTable(context, request);
 
@@ -76,6 +78,11 @@ TEST(TableLoggingClientTest, GetTable) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetTableResponse)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "t-id")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "t-kind")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
 }
 
 TEST(TableLoggingClientTest, ListTables) {
@@ -98,7 +105,10 @@ TEST(TableLoggingClientTest, ListTables) {
   auto client = CreateMockTableLogging(std::move(mock_stub));
   ListTablesRequest request =
       bigquery_v2_minimal_testing::MakeListTablesRequest();
+
   rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
 
   client->ListTables(context, request);
 
@@ -117,6 +127,11 @@ TEST(TableLoggingClientTest, ListTables) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(table_id: "t-123")")));
   EXPECT_THAT(actual_lines,
               Contains(HasSubstr(R"(next_page_token: "npt-123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Addressing some more test cleanup for read-only apis before I start on the mutating apis for V2 resources next week.

This PR adds the expectations for context headers and ensures they are getting logged along with request and response logging. These were missed in initial tests.

Thanks in advance for the review!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11667)
<!-- Reviewable:end -->
