### PR TITLE
impl(docfx): fallback to sectiondef descriptions

### DIFF
--- a/docfx/doxygen2yaml.cc
+++ b/docfx/doxygen2yaml.cc
@@ -85,39 +85,47 @@ void CompoundRecurse(YAML::Emitter& yaml, YamlContext const& ctx,
   }
 }
 
-std::string Summary(pugi::xml_node node) {
+std::string Summary(YamlContext const& ctx, pugi::xml_node node) {
   std::ostringstream os;
-  MarkdownContext ctx;
-  ctx.paragraph_start = "";
+  MarkdownContext mdctx;
+  mdctx.paragraph_start = "";
   auto brief = node.child("briefdescription");
-  if (!brief.empty()) {
-    AppendIfBriefDescription(os, ctx, brief);
-    ctx = MarkdownContext{};
+  if (!brief.children().empty()) {
+    AppendIfBriefDescription(os, mdctx, brief);
+  } else {
+    os << ctx.fallback_description_brief;
   }
   return std::move(os).str();
 }
 
-std::string Conceptual(pugi::xml_node node, bool skip_xrefsect = false) {
+std::string Conceptual(YamlContext const& ctx, pugi::xml_node node,
+                       bool skip_xrefsect = false) {
   std::ostringstream os;
-  MarkdownContext ctx;
-  ctx.paragraph_start = "";
-  ctx.skip_xrefsect = skip_xrefsect;
+  MarkdownContext mdctx;
+  mdctx.paragraph_start = "";
+  mdctx.skip_xrefsect = skip_xrefsect;
   auto description = node.child("description");
-  if (!description.empty()) {
-    AppendDescriptionType(os, ctx, description);
-    ctx = MarkdownContext{};
+  if (!description.children().empty()) {
+    AppendDescriptionType(os, mdctx, description);
+    mdctx = MarkdownContext{};
   }
   auto detailed = node.child("detaileddescription");
-  if (!detailed.empty()) AppendIfDetailedDescription(os, ctx, detailed);
+  if (!detailed.children().empty()) {
+    AppendIfDetailedDescription(os, mdctx, detailed);
+  }
+  if (description.children().empty() && detailed.children().empty()) {
+    os << ctx.fallback_description_detailed;
+  }
   return std::move(os).str();
 }
 
-void AppendDescription(YAML::Emitter& yaml, pugi::xml_node node) {
-  auto const summary = Summary(node);
+void AppendDescription(YAML::Emitter& yaml, YamlContext const& ctx,
+                       pugi::xml_node node) {
+  auto const summary = Summary(ctx, node);
   if (!summary.empty()) {
     yaml << YAML::Key << "summary" << YAML::Value << YAML::Literal << summary;
   }
-  auto const conceptual = Conceptual(node);
+  auto const conceptual = Conceptual(ctx, node);
   if (!conceptual.empty()) {
     yaml << YAML::Key << "conceptual" << YAML::Value << YAML::Literal
          << conceptual;
@@ -167,7 +175,7 @@ bool AppendIfEnumValue(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "parent" << YAML::Value << ctx.parent_id     //
        << YAML::Key << "type" << YAML::Value << "enumvalue"         //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;
-  AppendDescription(yaml, node);
+  AppendDescription(yaml, ctx, node);
   yaml << YAML::EndMap;
   return true;
 }
@@ -190,7 +198,7 @@ bool AppendIfEnum(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "type" << YAML::Value << "enum"                      //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendEnumSyntax(yaml, ctx, node);
-  AppendDescription(yaml, node);
+  AppendDescription(yaml, ctx, node);
   auto const children = Children(ctx, node);
   if (!children.empty()) {
     yaml << YAML::Key << "children" << YAML::Value << children;
@@ -221,7 +229,7 @@ bool AppendIfTypedef(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "type" << YAML::Value << "typealias"                 //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendTypedefSyntax(yaml, ctx, node);
-  AppendDescription(yaml, node);
+  AppendDescription(yaml, ctx, node);
   yaml << YAML::EndMap;
   return true;
 }
@@ -243,7 +251,7 @@ bool AppendIfFriend(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "type" << YAML::Value << "friend"                    //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendFriendSyntax(yaml, ctx, node);
-  AppendDescription(yaml, node);
+  AppendDescription(yaml, ctx, node);
   yaml << YAML::EndMap;
   return true;
 }
@@ -265,7 +273,7 @@ bool AppendIfVariable(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "type" << YAML::Value << "variable"                  //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendVariableSyntax(yaml, ctx, node);
-  AppendDescription(yaml, node);
+  AppendDescription(yaml, ctx, node);
   yaml << YAML::EndMap;
   return true;
 }
@@ -300,11 +308,11 @@ bool AppendIfFunction(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "type" << YAML::Value << type                        //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendFunctionSyntax(yaml, ctx, node);
-  auto const summary = Summary(node);
+  auto const summary = Summary(ctx, node);
   if (!summary.empty()) {
     yaml << YAML::Key << "summary" << YAML::Value << YAML::Literal << summary;
   }
-  auto conceptual = Conceptual(node);
+  auto conceptual = Conceptual(ctx, node);
   if (!conceptual.empty() || is_mocked) {
     auto constexpr kMockedSummary =
         R"md(This function is implemented using [gMock]'s `MOCK_METHOD()`.
@@ -326,7 +334,13 @@ Consult the gMock documentation to use this mock in your tests.
 bool AppendIfSectionDef(YAML::Emitter& yaml, YamlContext const& ctx,
                         pugi::xml_node node) {
   if (std::string_view{node.name()} != "sectiondef") return false;
-  CompoundRecurse(yaml, ctx, node);
+  auto nested = ctx;
+  nested.fallback_description_brief = Summary(ctx, node);
+  if (nested.fallback_description_brief.empty()) {
+    nested.fallback_description_brief = node.child_value("header");
+  }
+  nested.fallback_description_detailed = Conceptual(ctx, node);
+  CompoundRecurse(yaml, nested, node);
   return true;
 }
 
@@ -344,11 +358,11 @@ bool AppendIfNamespace(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendNamespaceSyntax(yaml, ctx, node);
   // Deprecated namespaces need special treatment
-  auto const summary = Summary(node);
+  auto const summary = Summary(ctx, node);
   if (!summary.empty()) {
     yaml << YAML::Key << "summary" << YAML::Value << YAML::Literal << summary;
   }
-  auto conceptual = Conceptual(node, true);
+  auto conceptual = Conceptual(ctx, node, true);
   // Discover all the `xrefsect` descendants that document this is a deprecated
   // namespace and list the alternatives.
   std::map<std::string, std::string> deprecated;
@@ -403,7 +417,7 @@ bool AppendIfClass(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "type" << YAML::Value << "class"                     //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendClassSyntax(yaml, ctx, node);
-  AppendDescription(yaml, node);
+  AppendDescription(yaml, ctx, node);
   auto const children = Children(ctx, node);
   if (!children.empty()) {
     yaml << YAML::Key << "children" << YAML::Value << children;
@@ -426,7 +440,7 @@ bool AppendIfStruct(YAML::Emitter& yaml, YamlContext const& ctx,
        << YAML::Key << "type" << YAML::Value << "struct"                    //
        << YAML::Key << "langs" << YAML::BeginSeq << "cpp" << YAML::EndSeq;  //
   AppendStructSyntax(yaml, ctx, node);
-  AppendDescription(yaml, node);
+  AppendDescription(yaml, ctx, node);
   auto const children = Children(ctx, node);
   if (!children.empty()) {
     yaml << YAML::Key << "children" << YAML::Value << children;

--- a/docfx/doxygen2yaml_test.cc
+++ b/docfx/doxygen2yaml_test.cc
@@ -779,6 +779,97 @@ items:
   EXPECT_EQ(actual, kExpected);
 }
 
+TEST(Doxygen2Yaml, InheritSectionDefSummary) {
+  auto constexpr kXml = R"xml(xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+      <compounddef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classgoogle_1_1cloud_1_1StatusOr" kind="class" language="C++" prot="public" final="yes">
+        <compoundname>google::cloud::StatusOr</compoundname>
+        <includes refid="status__or_8h" local="no">google/cloud/status_or.h</includes>
+        <templateparamlist>
+          <param>
+            <type>typename T</type>
+          </param>
+        </templateparamlist>
+        <sectiondef kind="user-defined">
+          <header>Dereference operators.</header>
+            <memberdef kind="function" id="classgoogle_1_1cloud_1_1StatusOr_1a95250d82418ed95673d41377347a3dbd" prot="public" static="no" const="no" explicit="no" inline="yes" refqual="lvalue" virt="non-virtual">
+              <type>T &amp;</type>
+              <definition>T &amp; google::cloud::StatusOr&lt; T &gt;::operator*</definition>
+              <argsstring>() &amp;</argsstring>
+              <name>operator*</name>
+              <qualifiedname>google::cloud::StatusOr::operator*</qualifiedname>
+              <briefdescription>
+              </briefdescription>
+              <detaileddescription>
+              </detaileddescription>
+              <inbodydescription>
+              </inbodydescription>
+              <location file="status_or.h" line="208" column="5" bodyfile="status_or.h" bodystart="208" bodyend="208"/>
+            </memberdef>
+        </sectiondef>
+      </compounddef>
+    </doxygen>)xml";
+
+  auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
+items:
+  - uid: classgoogle_1_1cloud_1_1StatusOr
+    name: "StatusOr<T>"
+    id: classgoogle_1_1cloud_1_1StatusOr
+    parent: test-only-parent-id
+    type: class
+    langs:
+      - cpp
+    syntax:
+      contents: |
+        // Found in #include <google/cloud/status_or.h>
+        template <
+            typename T>
+        class google::cloud::StatusOr { ... };
+    children:
+      - classgoogle_1_1cloud_1_1StatusOr_1a95250d82418ed95673d41377347a3dbd
+  - uid: classgoogle_1_1cloud_1_1StatusOr_1a95250d82418ed95673d41377347a3dbd
+    name: "operator*() &"
+    fullName: |
+      google::cloud::StatusOr::operator*
+    id: classgoogle_1_1cloud_1_1StatusOr_1a95250d82418ed95673d41377347a3dbd
+    parent: classgoogle_1_1cloud_1_1StatusOr
+    type: operator
+    langs:
+      - cpp
+    syntax:
+      contents: |
+        T &
+        google::cloud::StatusOr::operator* ()
+      return:
+        type:
+          - "T &"
+      source:
+        id: operator*
+        path: google/cloud/status_or.h
+        startLine: 208
+        remote:
+          repo: https://github.com/googleapis/google-cloud-cpp/
+          branch: main
+          path: google/cloud/status_or.h
+    summary: |
+      Dereference operators.
+)yml";
+
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected =
+      doc.select_node("//*[@id='classgoogle_1_1cloud_1_1StatusOr']");
+  ASSERT_TRUE(selected);
+  YAML::Emitter yaml;
+  TestPre(yaml);
+  YamlContext ctx;
+  ctx.parent_id = "test-only-parent-id";
+  ASSERT_TRUE(AppendIfClass(yaml, ctx, selected.node()));
+  TestPost(yaml);
+  auto const actual = EndDocFxYaml(yaml);
+  EXPECT_EQ(actual, kExpected);
+}
+
 TEST(Doxygen2Yaml, MockedFunction) {
   auto constexpr kExpected = R"yml(### YamlMime:UniversalReference
 items:

--- a/docfx/yaml_context.h
+++ b/docfx/yaml_context.h
@@ -33,6 +33,9 @@ struct YamlContext {
   // Mocked functions (indexed by their id) pointing to the corresponding
   // `MOCK_METHOD()`'s id.
   std::unordered_map<std::string, std::string> mocked_ids;
+  // Fallback brief and detailed description.
+  std::string fallback_description_brief;
+  std::string fallback_description_detailed;
 };
 
 /// Creates a new context to recurse over @p node


### PR DESCRIPTION
Many of our functions share a brief (and rarely a longer) description in a custom group (the things that start with `///@{`. These become `<sectiondef>` elements in the XML representation. With this change we use their description, or their header, as a fallback to the member descriptions.

Fixes #11496

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11668)
<!-- Reviewable:end -->
