### PR TITLE
cleanup: re-enable google/cloud/storagetransfer on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,11 @@ the APIs in these libraries are stable, and are ready for production use.
 
 - [Cloud Support API](/google/cloud/support/README.md)
 
+### [Storage Transfer Service](/google/cloud/storagetransfer/README.md)
+
+The library has been re-enabled on macOS. See
+[#8785](https://github.com/googleapis/google-cloud-cpp/issues/8785) for details.
+
 ## v2.10.0 - 2023-05
 
 ### New Libraries

--- a/ci/kokoro/windows/builds/quickstart-bazel.ps1
+++ b/ci/kokoro/windows/builds/quickstart-bazel.ps1
@@ -45,9 +45,8 @@ function Get-Released-Quickstarts {
         # The following quickstarts have problems building on Windows:
         #   TODO(#8145) - asset (TRUE/FALSE macros)
         #   TODO(#8125) - channel (DOMAIN macro)
-        #   TODO(#8785) - storagetransfer (UID_MAX/GID_MAX macros)
         #   TODO(#10737) - dialogflow_es triggers bug in Bazel 6.0.0
-        Where-Object { -not ("asset", "channel", "dialogflow_es", "storagetransfer" -contains $_) } |
+        Where-Object { -not ("asset", "channel", "dialogflow_es" -contains $_) } |
         # TODO(#9923) - compiling all quickstarts on Windows is too slow
         Get-Random -Count 10
     Pop-Location

--- a/ci/kokoro/windows/builds/quickstart-cmake.ps1
+++ b/ci/kokoro/windows/builds/quickstart-cmake.ps1
@@ -50,9 +50,7 @@ function Get-Vcpkg-Features {
             # TODO(#8145) - does not compile on Windows.
             "asset",
             # TODO(#8125) - does not compile on Windows.
-            "channel",
-            # TODO(#8785) - does not compile on Windows.
-            "storagetransfer" -contains $_) } |
+            "channel" -contains $_) } |
         # These are convenience features to refactor dependencies; they do not have quickstarts.
         Where-Object { -not ("googleapis", "grpc-common", "grafeas" -contains $_) }
 }

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -42,11 +42,6 @@ cc_library(
     name = "google_cloud_cpp_storagetransfer",
     srcs = [":srcs"],
     hdrs = [":hdrs"],
-    # TODO(#8785): Enable on macOS.
-    target_compatible_with = select({
-        "@platforms//os:macos": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -14,16 +14,6 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#8785): Enable on macOS.
-if (APPLE)
-    message(
-        WARNING
-            "Cannot build google/cloud/storagetransfer on Apple platforms."
-            " More details at https://github.com/googleapis/google-cloud-cpp/issues/8785 ."
-    )
-    return()
-endif ()
-
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Storage Transfer API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Storage Transfer API")


### PR DESCRIPTION
Reverse #8789 now that we have a new protobuf release that avoids the macOS `UID_MAX`/`GID_MAX` issue.

Fixes #8785.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11672)
<!-- Reviewable:end -->
