### PR TITLE
impl(generator): tweak generation of PopulateCommonOptions() call

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.cc
@@ -36,7 +36,7 @@ Options GoldenKitchenSinkDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOLDEN_KITCHEN_SINK_ENDPOINT",
       "GOLDEN_KITCHEN_SINK_EMULATOR_HOST", "GOLDEN_KITCHEN_SINK_AUTHORITY",
-"goldenkitchensink.googleapis.com");
+      "goldenkitchensink.googleapis.com");
   options = google::cloud::internal::PopulateGrpcOptions(
       std::move(options), "GOLDEN_KITCHEN_SINK_EMULATOR_HOST");
   if (!options.has<golden_v1::GoldenKitchenSinkRetryPolicyOption>()) {

--- a/generator/integration_tests/golden/v1/internal/golden_rest_only_option_defaults.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_rest_only_option_defaults.cc
@@ -36,7 +36,7 @@ Options GoldenRestOnlyDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_GOLDEN_REST_ONLY_ENDPOINT",
       "", "GOOGLE_CLOUD_CPP_GOLDEN_REST_ONLY_AUTHORITY",
-"goldenrestonly.googleapis.com");
+      "goldenrestonly.googleapis.com");
   options = google::cloud::internal::PopulateGrpcOptions(
       std::move(options), "");
   if (!options.has<golden_v1::GoldenRestOnlyRetryPolicyOption>()) {

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_option_defaults.cc
@@ -36,7 +36,7 @@ Options GoldenThingAdminDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOLDEN_KITCHEN_SINK_ENDPOINT",
       "GOLDEN_KITCHEN_SINK_EMULATOR_HOST", "GOLDEN_KITCHEN_SINK_AUTHORITY",
-"test.googleapis.com");
+      "test.googleapis.com");
   options = google::cloud::internal::PopulateGrpcOptions(
       std::move(options), "GOLDEN_KITCHEN_SINK_EMULATOR_HOST");
   if (!options.has<golden_v1::GoldenThingAdminRetryPolicyOption>()) {

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -124,22 +124,22 @@ Status OptionDefaultsGenerator::GenerateCc() {
     default:
       break;
   }
-  CcPrint("Options options) {");
-  CcPrint(R"""(
-  options = google::cloud::internal::PopulateCommonOptions(
-      std::move(options), "$service_endpoint_env_var$",
-      "$emulator_endpoint_env_var$", "$service_authority_env_var$",
-      )""");
+  CcPrint(
+    "Options options) {\n"
+    "  options = google::cloud::internal::PopulateCommonOptions(\n"
+    "      std::move(options), \"$service_endpoint_env_var$\",\n"
+    "      \"$emulator_endpoint_env_var$\", \"$service_authority_env_var$\",\n"
+  );
   switch (endpoint_location_style) {
     case ServiceConfiguration::LOCATION_DEPENDENT:
-      CcPrint(R"""(absl::StrCat(location, "-", "$service_endpoint$"))""");
+      CcPrint(R"""(      absl::StrCat(location, "-", "$service_endpoint$"))""");
       break;
     case ServiceConfiguration::LOCATION_DEPENDENT_COMPAT:
-      CcPrint(R"""(absl::StrCat(location, )"""
+      CcPrint(R"""(      absl::StrCat(location, )"""
               R"""(location.empty() ? "" : "-", "$service_endpoint$"))""");
       break;
     default:
-      CcPrint(R"""("$service_endpoint$")""");
+      CcPrint(R"""(      "$service_endpoint$")""");
       break;
   }
   CcPrint({  // clang-format off


### PR DESCRIPTION
Adjust the generation of the call to `PopulateCommonOptions()` so that it is not affected by the recent "smart" indentation changes to `protobuf::io::Printer`.  This restores the (pre clang-format) shape of the generated code to what we had before the protobuf upgrade.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11673)
<!-- Reviewable:end -->
