### PR TITLE
refactor(otel): prepare for noexcept handling

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -139,6 +139,16 @@ class Recordable final : public opentelemetry::sdk::trace::Recordable {
           instrumentation_scope) noexcept override;
 
  private:
+  void SetIdentityImpl(opentelemetry::trace::SpanContext const& span_context,
+                       opentelemetry::trace::SpanId parent_span_id);
+  void AddEventImpl(opentelemetry::nostd::string_view name,
+                    opentelemetry::common::SystemTimestamp timestamp,
+                    opentelemetry::common::KeyValueIterable const& attributes);
+  void AddLinkImpl(opentelemetry::trace::SpanContext const& span_context,
+                   opentelemetry::common::KeyValueIterable const& attributes);
+  void SetStatusImpl(opentelemetry::trace::StatusCode code,
+                     opentelemetry::nostd::string_view description);
+
   Project project_;
   google::devtools::cloudtrace::v2::Span span_;
 };

--- a/google/cloud/opentelemetry/trace_exporter.cc
+++ b/google/cloud/opentelemetry/trace_exporter.cc
@@ -37,6 +37,16 @@ class TraceExporter final : public opentelemetry::sdk::trace::SpanExporter {
       opentelemetry::nostd::span<
           std::unique_ptr<opentelemetry::sdk::trace::Recordable>> const&
           spans) noexcept override {
+    return ExportImpl(spans);
+  }
+
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+
+ private:
+  opentelemetry::sdk::common::ExportResult ExportImpl(
+      opentelemetry::nostd::span<
+          std::unique_ptr<opentelemetry::sdk::trace::Recordable>> const&
+          spans) {
     google::devtools::cloudtrace::v2::BatchWriteSpansRequest request;
     request.set_name(project_.FullName());
     for (auto& recordable : spans) {
@@ -52,9 +62,6 @@ class TraceExporter final : public opentelemetry::sdk::trace::SpanExporter {
     return opentelemetry::sdk::common::ExportResult::kFailure;
   }
 
-  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
-
- private:
   Project project_;
   trace_v2::TraceServiceClient client_;
 };


### PR DESCRIPTION
Motivated by #11669 

Factor out the longer, more involved implementations in the exporter classes. They will be wrapped in a `NoExceptAction(...)` in a follow up PR.

I had planned to do the refactor and `noexcept` handling as two commits in the same PR, but this diff is sufficiently ugly. So I am splitting it up into separate PRs.

No, I don't really care that `Foo() noexcept` is calling `FooImpl()` (which could throw). If the compilers yell at me, I will do something about it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11676)
<!-- Reviewable:end -->
