### PR TITLE
docs(storage): fix snippet reference

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,4 +47,4 @@ RawStringFormats:
   - 'proto'
   BasedOnStyle: Google
 
-CommentPragmas: '(@copydoc|@copybrief|@see|@overload)'
+CommentPragmas: '(@copydoc|@copybrief|@see|@overload|@snippet)'

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2472,8 +2472,7 @@ class Client {
    * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
-   * @snippet storage_default_object_acl_samples.cc patch default object acl
-   * no-read
+   * @snippet storage_default_object_acl_samples.cc patch no-read
    *
    * @see
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -133,7 +133,7 @@ void PatchDefaultObjectAcl(google::cloud::storage::Client client,
 
 void PatchDefaultObjectAclNoRead(google::cloud::storage::Client client,
                                  std::vector<std::string> const& argv) {
-  //! [patch default object acl no-read]
+  //! [patch no-read]
   namespace gcs = ::google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
@@ -148,7 +148,7 @@ void PatchDefaultObjectAclNoRead(google::cloud::storage::Client client,
               << " in bucket " << patched_acl->bucket() << " is now "
               << *patched_acl << "\n";
   }
-  //! [patch default object acl no-read]
+  //! [patch no-read]
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 


### PR DESCRIPTION
`clang-format` broke a reference to a snippet because the name was too long.  Fixed the reference and configure `clang-format` to avoid this problem in the future.

Part of the work for #11428

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11678)
<!-- Reviewable:end -->
