### PR TITLE
cleanup(storage): use `Options` in implementation

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3357,7 +3357,7 @@ class Client {
     return UploadFileResumable(file_name, std::move(request));
   }
 
-  bool UseSimpleUpload(std::string const& file_name, std::size_t& size) const;
+  static bool UseSimpleUpload(std::string const& file_name, std::size_t& size);
 
   StatusOr<ObjectMetadata> UploadFileSimple(
       std::string const& file_name, std::size_t file_size,

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -97,7 +97,7 @@ StatusOr<ObjectWriteStream> ParallelUploadStateImpl::CreateStream(
       shared_from_this(), idx, std::move(raw_client), request,
       std::move(create->upload_id), create->committed_size,
       std::move(create->metadata),
-      raw_client->client_options().upload_buffer_size()));
+      raw_client->options().get<UploadBufferSizeOption>()));
 }
 
 std::string ParallelUploadPersistentState::ToString() const {

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -1118,8 +1118,8 @@ struct CreateParallelUploadShards {
     auto upload_buffer_size =
         google::cloud::storage::internal::ClientImplDetails::GetRawClient(
             client)
-            ->client_options()
-            .upload_buffer_size();
+            ->options()
+            .get<UploadBufferSizeOption>();
 
     file_split_points.emplace_back(file_size);
     assert(file_split_points.size() == state->shards().size());

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -220,8 +220,8 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteNotChunked) {
   auto constexpr kUploadQuantum = 256 * 1024;
   auto const payload = std::string(
       google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
-          ->client_options()
-          .upload_buffer_size(),
+          ->options()
+          .get<UploadBufferSizeOption>(),
       '*');
   auto const header = MakeRandomData(kUploadQuantum / 2);
 


### PR DESCRIPTION
A number of places still used `client_options()` or did not use `google::cloud::internal::CurrentOptions()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11686)
<!-- Reviewable:end -->
