### PR TITLE
feat(generator): link more enum values

### DIFF
--- a/generator/internal/resolve_comment_references_test.cc
+++ b/generator/internal/resolve_comment_references_test.cc
@@ -132,6 +132,43 @@ service Service {
                                            "test/v1/service.proto"))));
 }
 
+TEST_F(ResolveCommentsReferenceTest, EnumValueInMessage) {
+  auto constexpr kContents = R"""(
+syntax = "proto3";
+import "test/v1/common.proto";
+package test.v1;
+
+message Container {
+  enum State {
+    STATE_0 = 0;
+    STATE_1 = 1;
+  }
+
+  // The current state
+  State state  = 1;
+}
+
+// Test service.
+service Service {
+    rpc Unary(Request) returns (Response) {}
+}
+)""";
+
+  auto constexpr kComment = R"""(// Test comment.
+// Reference a enum value [STATE_0][test.v1.Container.State.STATE_0]
+  )""";
+
+  ASSERT_THAT(FindFile("test/v1/common.proto"), NotNull());
+  ASSERT_TRUE(AddProtoFile("test/v1/service.proto", kContents));
+
+  auto const actual = ResolveCommentReferences(kComment, pool());
+  EXPECT_THAT(
+      actual,
+      UnorderedElementsAre(Pair(
+          "test.v1.Container.State.STATE_0",
+          Field(&ProtoDefinitionLocation::filename, "test/v1/service.proto"))));
+}
+
 TEST_F(ResolveCommentsReferenceTest, Field) {
   auto constexpr kContents = R"""(
 syntax = "proto3";

--- a/google/cloud/kms/v1/key_management_client.h
+++ b/google/cloud/kms/v1/key_management_client.h
@@ -626,6 +626,8 @@ class KeyManagementServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L90}
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L83}
   /// [google.cloud.kms.v1.CryptoKey.purpose]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L119}
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
   /// [google.cloud.kms.v1.GetPublicKeyRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L649}
@@ -664,6 +666,8 @@ class KeyManagementServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L90}
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L83}
   /// [google.cloud.kms.v1.CryptoKey.purpose]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L119}
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
   /// [google.cloud.kms.v1.GetPublicKeyRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L649}
@@ -911,6 +915,7 @@ class KeyManagementServiceClient {
   /// [google.cloud.kms.v1.CreateCryptoKeyVersionRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L728}
   /// [google.cloud.kms.v1.CryptoKey]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L58}
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L445}
   /// [google.cloud.kms.v1.CryptoKeyVersion.state]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L527}
   ///
   // clang-format on
@@ -951,6 +956,7 @@ class KeyManagementServiceClient {
   /// [google.cloud.kms.v1.CreateCryptoKeyVersionRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L728}
   /// [google.cloud.kms.v1.CryptoKey]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L58}
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L445}
   /// [google.cloud.kms.v1.CryptoKeyVersion.state]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L527}
   ///
   // clang-format on
@@ -1168,6 +1174,8 @@ class KeyManagementServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L451}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L445}
   /// [google.cloud.kms.v1.CryptoKeyVersion.state]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L527}
   /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L269}
   /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L287}
@@ -1214,6 +1222,8 @@ class KeyManagementServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L451}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L445}
   /// [google.cloud.kms.v1.CryptoKeyVersion.state]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L527}
   /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L269}
   /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L287}
@@ -1252,6 +1262,7 @@ class KeyManagementServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.kms.v1.CryptoKey]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L58}
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L76}
   /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L300}
   /// [google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L901}
   ///
@@ -1290,6 +1301,7 @@ class KeyManagementServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.kms.v1.CryptoKey]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L58}
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L76}
   /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L300}
   /// [google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L901}
   ///
@@ -1341,6 +1353,8 @@ class KeyManagementServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.kms.v1.CryptoKey.destroy_scheduled_duration]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L181}
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L460}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L468}
   /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L566}
   /// [google.cloud.kms.v1.CryptoKeyVersion.state]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L527}
   /// [google.cloud.kms.v1.DestroyCryptoKeyVersionRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L918}
@@ -1396,6 +1410,8 @@ class KeyManagementServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.kms.v1.CryptoKey.destroy_scheduled_duration]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L181}
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L460}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L468}
   /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L566}
   /// [google.cloud.kms.v1.CryptoKeyVersion.state]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L527}
   /// [google.cloud.kms.v1.DestroyCryptoKeyVersionRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L918}
@@ -1435,6 +1451,8 @@ class KeyManagementServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L468}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L451}
   /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L566}
   /// [google.cloud.kms.v1.CryptoKeyVersion.state]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L527}
   /// [google.cloud.kms.v1.RestoreCryptoKeyVersionRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L931}
@@ -1476,6 +1494,8 @@ class KeyManagementServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.kms.v1.CryptoKeyVersion]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L284}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L468}
+  /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L451}
   /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L566}
   /// [google.cloud.kms.v1.CryptoKeyVersion.state]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L527}
   /// [google.cloud.kms.v1.RestoreCryptoKeyVersionRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L931}
@@ -1522,6 +1542,7 @@ class KeyManagementServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L76}
   /// [google.cloud.kms.v1.CryptoKey.purpose]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L119}
   /// [google.cloud.kms.v1.EncryptRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L944}
   /// [google.cloud.kms.v1.EncryptResponse]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1332}
@@ -1558,6 +1579,7 @@ class KeyManagementServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L76}
   /// [google.cloud.kms.v1.CryptoKey.purpose]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L119}
   /// [google.cloud.kms.v1.EncryptRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L944}
   /// [google.cloud.kms.v1.EncryptResponse]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1332}
@@ -1593,6 +1615,7 @@ class KeyManagementServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L76}
   /// [google.cloud.kms.v1.CryptoKey.purpose]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L119}
   /// [google.cloud.kms.v1.DecryptRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1033}
   /// [google.cloud.kms.v1.DecryptResponse]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1397}
@@ -1630,6 +1653,7 @@ class KeyManagementServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
+  /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L76}
   /// [google.cloud.kms.v1.CryptoKey.purpose]: @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L119}
   /// [google.cloud.kms.v1.DecryptRequest]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1033}
   /// [google.cloud.kms.v1.DecryptResponse]: @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1397}

--- a/google/cloud/privateca/v1/certificate_authority_client.h
+++ b/google/cloud/privateca/v1/certificate_authority_client.h
@@ -485,6 +485,8 @@ class CertificateAuthorityServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.security.privateca.v1.ActivateCertificateAuthorityRequest]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L621}
   /// [google.cloud.security.privateca.v1.CertificateAuthority]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L40}
+  /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L95}
+  /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L59}
   /// [google.cloud.security.privateca.v1.CertificateAuthorityService.FetchCertificateAuthorityCsr]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L175}
   ///
   // clang-format on
@@ -532,6 +534,8 @@ class CertificateAuthorityServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.security.privateca.v1.ActivateCertificateAuthorityRequest]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L621}
   /// [google.cloud.security.privateca.v1.CertificateAuthority]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L40}
+  /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L95}
+  /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L59}
   /// [google.cloud.security.privateca.v1.CertificateAuthorityService.FetchCertificateAuthorityCsr]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L175}
   ///
   // clang-format on
@@ -813,6 +817,8 @@ class CertificateAuthorityServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.security.privateca.v1.CertificateAuthority]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L40}
+  /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L95}
+  /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L59}
   /// [google.cloud.security.privateca.v1.CertificateAuthorityService.ActivateCertificateAuthority]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L104}
   /// [google.cloud.security.privateca.v1.FetchCertificateAuthorityCsrRequest]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L763}
   /// [google.cloud.security.privateca.v1.FetchCertificateAuthorityCsrResponse]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L777}
@@ -857,6 +863,8 @@ class CertificateAuthorityServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.security.privateca.v1.CertificateAuthority]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L40}
+  /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L95}
+  /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L59}
   /// [google.cloud.security.privateca.v1.CertificateAuthorityService.ActivateCertificateAuthority]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L104}
   /// [google.cloud.security.privateca.v1.FetchCertificateAuthorityCsrRequest]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L763}
   /// [google.cloud.security.privateca.v1.FetchCertificateAuthorityCsrResponse]: @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L777}

--- a/google/cloud/resourcemanager/v3/folders_client.h
+++ b/google/cloud/resourcemanager/v3/folders_client.h
@@ -737,6 +737,8 @@ class FoldersClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.resourcemanager.v3.DeleteFolderRequest]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L517}
   /// [google.cloud.resourcemanager.v3.Folder]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L273}
+  /// [google.cloud.resourcemanager.v3.Folder.State.ACTIVE]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L286}
+  /// [google.cloud.resourcemanager.v3.Folder.State.DELETE_REQUESTED]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L289}
   ///
   // clang-format on
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> DeleteFolder(
@@ -784,6 +786,8 @@ class FoldersClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.resourcemanager.v3.DeleteFolderRequest]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L517}
   /// [google.cloud.resourcemanager.v3.Folder]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L273}
+  /// [google.cloud.resourcemanager.v3.Folder.State.ACTIVE]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L286}
+  /// [google.cloud.resourcemanager.v3.Folder.State.DELETE_REQUESTED]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L289}
   ///
   // clang-format on
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> DeleteFolder(
@@ -827,6 +831,7 @@ class FoldersClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.resourcemanager.v3.Folder]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L273}
+  /// [google.cloud.resourcemanager.v3.Folder.State.ACTIVE]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L286}
   /// [google.cloud.resourcemanager.v3.Folders.CreateFolder]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L112}
   /// [google.cloud.resourcemanager.v3.UndeleteFolderRequest]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L533}
   ///
@@ -875,6 +880,7 @@ class FoldersClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.resourcemanager.v3.Folder]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L273}
+  /// [google.cloud.resourcemanager.v3.Folder.State.ACTIVE]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L286}
   /// [google.cloud.resourcemanager.v3.Folders.CreateFolder]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L112}
   /// [google.cloud.resourcemanager.v3.UndeleteFolderRequest]: @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L533}
   ///

--- a/google/cloud/resourcemanager/v3/projects_client.h
+++ b/google/cloud/resourcemanager/v3/projects_client.h
@@ -691,6 +691,8 @@ class ProjectsClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.resourcemanager.v3.DeleteProjectRequest]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L607}
   /// [google.cloud.resourcemanager.v3.Project]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L295}
+  /// [google.cloud.resourcemanager.v3.Project.State.ACTIVE]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L309}
+  /// [google.cloud.resourcemanager.v3.Project.State.DELETE_REQUESTED]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L317}
   /// [google.cloud.resourcemanager.v3.Projects.SearchProjects]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L79}
   ///
   // clang-format on
@@ -761,6 +763,8 @@ class ProjectsClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.resourcemanager.v3.DeleteProjectRequest]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L607}
   /// [google.cloud.resourcemanager.v3.Project]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L295}
+  /// [google.cloud.resourcemanager.v3.Project.State.ACTIVE]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L309}
+  /// [google.cloud.resourcemanager.v3.Project.State.DELETE_REQUESTED]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L317}
   /// [google.cloud.resourcemanager.v3.Projects.SearchProjects]: @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L79}
   ///
   // clang-format on

--- a/google/cloud/scheduler/v1/cloud_scheduler_client.h
+++ b/google/cloud/scheduler/v1/cloud_scheduler_client.h
@@ -319,6 +319,7 @@ class CloudSchedulerClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.scheduler.v1.Job]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L32}
+  /// [google.cloud.scheduler.v1.Job.State.UPDATE_FAILED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L60}
   /// [google.cloud.scheduler.v1.UpdateJobRequest]: @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L225}
   ///
   // clang-format on
@@ -360,6 +361,7 @@ class CloudSchedulerClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.scheduler.v1.Job]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L32}
+  /// [google.cloud.scheduler.v1.Job.State.UPDATE_FAILED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L60}
   /// [google.cloud.scheduler.v1.UpdateJobRequest]: @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L225}
   ///
   // clang-format on
@@ -450,6 +452,8 @@ class CloudSchedulerClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.scheduler.v1.CloudScheduler.ResumeJob]: @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L118}
   /// [google.cloud.scheduler.v1.Job]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L32}
+  /// [google.cloud.scheduler.v1.Job.State.ENABLED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L44}
+  /// [google.cloud.scheduler.v1.Job.State.PAUSED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L49}
   /// [google.cloud.scheduler.v1.Job.state]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L147}
   /// [google.cloud.scheduler.v1.PauseJobRequest]: @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L252}
   ///
@@ -492,6 +496,8 @@ class CloudSchedulerClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.scheduler.v1.CloudScheduler.ResumeJob]: @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L118}
   /// [google.cloud.scheduler.v1.Job]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L32}
+  /// [google.cloud.scheduler.v1.Job.State.ENABLED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L44}
+  /// [google.cloud.scheduler.v1.Job.State.PAUSED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L49}
   /// [google.cloud.scheduler.v1.Job.state]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L147}
   /// [google.cloud.scheduler.v1.PauseJobRequest]: @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L252}
   ///
@@ -529,6 +535,8 @@ class CloudSchedulerClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.scheduler.v1.Job]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L32}
+  /// [google.cloud.scheduler.v1.Job.State.ENABLED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L44}
+  /// [google.cloud.scheduler.v1.Job.State.PAUSED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L49}
   /// [google.cloud.scheduler.v1.Job.state]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L147}
   /// [google.cloud.scheduler.v1.ResumeJobRequest]: @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L265}
   ///
@@ -569,6 +577,8 @@ class CloudSchedulerClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.scheduler.v1.Job]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L32}
+  /// [google.cloud.scheduler.v1.Job.State.ENABLED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L44}
+  /// [google.cloud.scheduler.v1.Job.State.PAUSED]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L49}
   /// [google.cloud.scheduler.v1.Job.state]: @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L147}
   /// [google.cloud.scheduler.v1.ResumeJobRequest]: @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L265}
   ///

--- a/google/cloud/secretmanager/v1/secret_manager_client.h
+++ b/google/cloud/secretmanager/v1/secret_manager_client.h
@@ -725,6 +725,7 @@ class SecretManagerServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.secretmanager.v1.DisableSecretVersionRequest]: @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L407}
   /// [google.cloud.secretmanager.v1.SecretVersion]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L144}
+  /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L166}
   /// [google.cloud.secretmanager.v1.SecretVersion.state]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L198}
   ///
   // clang-format on
@@ -760,6 +761,7 @@ class SecretManagerServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.secretmanager.v1.DisableSecretVersionRequest]: @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L407}
   /// [google.cloud.secretmanager.v1.SecretVersion]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L144}
+  /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L166}
   /// [google.cloud.secretmanager.v1.SecretVersion.state]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L198}
   ///
   // clang-format on
@@ -794,6 +796,7 @@ class SecretManagerServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.secretmanager.v1.EnableSecretVersionRequest]: @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L424}
   /// [google.cloud.secretmanager.v1.SecretVersion]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L144}
+  /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L159}
   /// [google.cloud.secretmanager.v1.SecretVersion.state]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L198}
   ///
   // clang-format on
@@ -829,6 +832,7 @@ class SecretManagerServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.secretmanager.v1.EnableSecretVersionRequest]: @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L424}
   /// [google.cloud.secretmanager.v1.SecretVersion]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L144}
+  /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L159}
   /// [google.cloud.secretmanager.v1.SecretVersion.state]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L198}
   ///
   // clang-format on
@@ -863,6 +867,7 @@ class SecretManagerServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.secretmanager.v1.DestroySecretVersionRequest]: @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L441}
   /// [google.cloud.secretmanager.v1.SecretVersion]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L144}
+  /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L171}
   /// [google.cloud.secretmanager.v1.SecretVersion.state]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L198}
   ///
   // clang-format on
@@ -899,6 +904,7 @@ class SecretManagerServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.secretmanager.v1.DestroySecretVersionRequest]: @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L441}
   /// [google.cloud.secretmanager.v1.SecretVersion]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L144}
+  /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L171}
   /// [google.cloud.secretmanager.v1.SecretVersion.state]: @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L198}
   ///
   // clang-format on

--- a/google/cloud/storagetransfer/v1/storage_transfer_client.h
+++ b/google/cloud/storagetransfer/v1/storage_transfer_client.h
@@ -195,6 +195,9 @@ class StorageTransferServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.storagetransfer.v1.TransferJob]: @googleapis_reference_link{google/storagetransfer/v1/transfer_types.proto#L842}
+  /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: @googleapis_reference_link{google/storagetransfer/v1/transfer_types.proto#L858}
+  /// [google.storagetransfer.v1.TransferJob.Status.DISABLED]: @googleapis_reference_link{google/storagetransfer/v1/transfer_types.proto#L852}
+  /// [google.storagetransfer.v1.TransferJob.Status.ENABLED]: @googleapis_reference_link{google/storagetransfer/v1/transfer_types.proto#L849}
   /// [google.storagetransfer.v1.TransferJob.status]: @googleapis_reference_link{google/storagetransfer/v1/transfer_types.proto#L919}
   /// [google.storagetransfer.v1.UpdateTransferJobRequest]: @googleapis_reference_link{google/storagetransfer/v1/transfer.proto#L188}
   ///
@@ -400,6 +403,7 @@ class StorageTransferServiceClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.storagetransfer.v1.DeleteTransferJobRequest]: @googleapis_reference_link{google/storagetransfer/v1/transfer.proto#L232}
+  /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: @googleapis_reference_link{google/storagetransfer/v1/transfer_types.proto#L858}
   ///
   // clang-format on
   Status DeleteTransferJob(

--- a/google/cloud/tasks/v2/cloud_tasks_client.h
+++ b/google/cloud/tasks/v2/cloud_tasks_client.h
@@ -577,6 +577,7 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.CloudTasks.ResumeQueue]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L166}
   /// [google.cloud.tasks.v2.PauseQueueRequest]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L443}
   /// [google.cloud.tasks.v2.Queue]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L33}
+  /// [google.cloud.tasks.v2.Queue.State.PAUSED]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L57}
   /// [google.cloud.tasks.v2.Queue.state]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L161}
   ///
   // clang-format on
@@ -616,6 +617,7 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.CloudTasks.ResumeQueue]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L166}
   /// [google.cloud.tasks.v2.PauseQueueRequest]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L443}
   /// [google.cloud.tasks.v2.Queue]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L33}
+  /// [google.cloud.tasks.v2.Queue.State.PAUSED]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L57}
   /// [google.cloud.tasks.v2.Queue.state]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L161}
   ///
   // clang-format on
@@ -656,6 +658,9 @@ class CloudTasksClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.tasks.v2.Queue]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L33}
+  /// [google.cloud.tasks.v2.Queue.State.DISABLED]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L73}
+  /// [google.cloud.tasks.v2.Queue.State.PAUSED]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L57}
+  /// [google.cloud.tasks.v2.Queue.State.RUNNING]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L52}
   /// [google.cloud.tasks.v2.Queue.state]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L161}
   /// [google.cloud.tasks.v2.ResumeQueueRequest]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L455}
   ///
@@ -700,6 +705,9 @@ class CloudTasksClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.tasks.v2.Queue]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L33}
+  /// [google.cloud.tasks.v2.Queue.State.DISABLED]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L73}
+  /// [google.cloud.tasks.v2.Queue.State.PAUSED]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L57}
+  /// [google.cloud.tasks.v2.Queue.State.RUNNING]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L52}
   /// [google.cloud.tasks.v2.Queue.state]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L161}
   /// [google.cloud.tasks.v2.ResumeQueueRequest]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L455}
   ///
@@ -1011,6 +1019,7 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.ListTasksRequest]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L467}
   /// [google.cloud.tasks.v2.ListTasksRequest.response_view]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L489}
   /// [google.cloud.tasks.v2.Task]: @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L32}
+  /// [google.cloud.tasks.v2.Task.View.BASIC]: @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L58}
   ///
   // clang-format on
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
@@ -1060,6 +1069,7 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.ListTasksRequest]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L467}
   /// [google.cloud.tasks.v2.ListTasksRequest.response_view]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L489}
   /// [google.cloud.tasks.v2.Task]: @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L32}
+  /// [google.cloud.tasks.v2.Task.View.BASIC]: @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L58}
   ///
   // clang-format on
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
@@ -1324,6 +1334,7 @@ class CloudTasksClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.tasks.v2.CloudTasks.RunTask]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L298}
+  /// [google.cloud.tasks.v2.Queue.State.PAUSED]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L57}
   /// [google.cloud.tasks.v2.RateLimits]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L191}
   /// [google.cloud.tasks.v2.RetryConfig]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L261}
   /// [google.cloud.tasks.v2.RunTaskRequest]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L632}
@@ -1382,6 +1393,7 @@ class CloudTasksClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.tasks.v2.CloudTasks.RunTask]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L298}
+  /// [google.cloud.tasks.v2.Queue.State.PAUSED]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L57}
   /// [google.cloud.tasks.v2.RateLimits]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L191}
   /// [google.cloud.tasks.v2.RetryConfig]: @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L261}
   /// [google.cloud.tasks.v2.RunTaskRequest]: @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L632}


### PR DESCRIPTION
Sometimes the comments reference enum values using
`foo.bar.Baz.EnumName.VALUE` while the Protobuf library only finds
`foo.bar.Baz.VALUE`.

Fixes #11675 