### PR TITLE
doc(otel): add main.dox

### DIFF
--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -21,7 +21,7 @@ set(DOXYGEN_PROJECT_BRIEF
     "Provides exporters for sending telemetry to Google Cloud services in C++.")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "otel_internal")
-set(DOXYGEN_EXAMPLE_PATH "")
+set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
 
 include(GoogleCloudCppDoxygen)
 google_cloud_cpp_doxygen_targets("opentelemetry" DEPENDS cloud-docs

--- a/google/cloud/opentelemetry/README.md
+++ b/google/cloud/opentelemetry/README.md
@@ -1,8 +1,8 @@
 # Google Cloud C++ OpenTelemetry Exporters
 
-This directory contains the [OpenTelemetry] [trace exporter] for [Cloud Trace].
-It also contains helpers to install the Cloud Trace exporter with reasonable
-defaults.
+This directory contains the [OpenTelemetry] [trace exporter][trace-exporter] for
+[Cloud Trace][cloud-trace]. It also contains helpers to install the Cloud Trace
+exporter with reasonable defaults.
 
 :construction:
 
@@ -97,9 +97,9 @@ int main(int argc, char* argv[]) {
 - [Reference doxygen documentation][doxygen-link] for each release of this library
 - Detailed header comments in our [public `.h`][source-link] files
 
-[cloud trace]: https://cloud.google.com/trace
+[cloud-trace]: https://cloud.google.com/trace
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-opentelemetry/latest/
 [howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
 [opentelemetry]: https://opentelemetry.io/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/opentelemetry
-[trace exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters
+[trace-exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters

--- a/google/cloud/opentelemetry/README.md
+++ b/google/cloud/opentelemetry/README.md
@@ -1,8 +1,14 @@
 # Google Cloud C++ OpenTelemetry Exporters
 
-This directory contains the [OpenTelemetry] [trace exporter][trace-exporter] for
-[Cloud Trace][cloud-trace]. It also contains helpers to install the Cloud Trace
-exporter with reasonable defaults.
+This directory contains components to export [traces] captured with
+[OpenTelemetry] to [Cloud Trace]. Traces are a form of telemetry where
+calls across multiple distributed systems can be collected in a centralized
+view, showing the sequence of calls and their latency. Cloud Trace can provide
+such views of your system calls.
+
+The C++ client libraries are already instrumented to collect traces. You can
+enable the collection and export of traces with minimal changes to your
+application. It is not necessary to instrument your application too.
 
 :construction:
 
@@ -11,9 +17,8 @@ This library is **experimental**. Its APIs are subject to change without notice.
 ## Quickstart
 
 The [quickstart/](quickstart/README.md) directory contains a minimal environment
-to get started using this client library in a larger project. The following
-"Hello World" program is used in this quickstart, and should give you a taste of
-this library.
+to get started exporting traces from the C++ client libraries. The following
+program is used in this quickstart.
 
 <!-- inject-quickstart-start -->
 
@@ -73,33 +78,19 @@ int main(int argc, char* argv[]) {
 
 <!-- inject-quickstart-end -->
 
-## Build and Install
-
-- Packaging maintainers or developers who prefer to install the library in a
-  fixed directory (such as `/usr/local` or `/opt`) should consult the
-  [packaging guide](/doc/packaging.md).
-- Developers who prefer using a package manager such as
-  [vcpkg](https://vcpkg.io), or [Conda](https://conda.io), should follow the
-  instructions for their package manager.
-- Developers wanting to use the libraries as part of a larger CMake or Bazel
-  project should consult the [quickstart guides](#quickstart) for the library
-  or libraries they want to use.
-- Developers wanting to compile the library just to run some examples or
-  tests should read the project's top-level
-  [README](/README.md#building-and-installing).
-- Contributors and developers to `google-cloud-cpp` should consult the guide to
-  [set up a development workstation][howto-setup-dev-workstation].
-
 ## More Information
 
 - If you want to learn more about the [OpenTelemetry] for C++ SDKs, consult
   their [online documentation](https://opentelemetry-cpp.readthedocs.io/).
 - [Reference doxygen documentation][doxygen-link] for each release of this library
 - Detailed header comments in our [public `.h`][source-link] files
+- The [Setting up your development environment] guide describes how to set up
+  a C++ development environment in various platforms, including the Google Cloud
+  C++ client libraries.
 
-[cloud-trace]: https://cloud.google.com/trace
+[cloud trace]: https://cloud.google.com/trace
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-opentelemetry/latest/
-[howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
 [opentelemetry]: https://opentelemetry.io/
+[setting up your development environment]: https://cloud.google.com/cpp/docs/setup
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/opentelemetry
-[trace-exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters
+[traces]: https://opentelemetry.io/docs/concepts/observability-primer/#distributed-traces

--- a/google/cloud/opentelemetry/README.md
+++ b/google/cloud/opentelemetry/README.md
@@ -1,4 +1,8 @@
-# C++ OpenTelemetry Exporters for Google Cloud Platform services.
+# Google Cloud C++ OpenTelemetry Exporters
+
+This directory contains the [OpenTelemetry] [trace exporter] for [Cloud Trace].
+It also contains helpers to install the Cloud Trace exporter with reasonable
+defaults.
 
 :construction:
 
@@ -90,10 +94,12 @@ int main(int argc, char* argv[]) {
 
 - If you want to learn more about the [OpenTelemetry] for C++ SDKs, consult
   their [online documentation](https://opentelemetry-cpp.readthedocs.io/).
-- [Reference doxygen documentation][doxygen-link] for each release of this client library
+- [Reference doxygen documentation][doxygen-link] for each release of this library
 - Detailed header comments in our [public `.h`][source-link] files
 
-[doxygen-link]: https://googleapis.dev/cpp/google-cloud-storage/latest/
+[cloud trace]: https://cloud.google.com/trace
+[doxygen-link]: https://googleapis.dev/cpp/google-cloud-opentelemetry/latest/
 [howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
 [opentelemetry]: https://opentelemetry.io/
-[source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage
+[source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/opentelemetry
+[trace exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters

--- a/google/cloud/opentelemetry/doc/main.dox
+++ b/google/cloud/opentelemetry/doc/main.dox
@@ -1,0 +1,28 @@
+/*!
+
+@mainpage Google Cloud C++ OpenTelemetry Exporters
+
+This directory contains the [OpenTelemetry] [trace exporter] for [Cloud Trace].
+It also contains helpers to install the Cloud Trace exporter with reasonable
+defaults.
+
+This library is **experimental**. Its APIs are subject to change without notice.
+
+Please note Google Cloud C++ client libraries do **not** follow
+[Semantic Versioning](https://semver.org/).
+
+@tableofcontents{HTML:2}
+
+## Quickstart
+
+The following shows the code that you'll run in the
+`google/cloud/opentelemetry/quickstart/` directory, which demonstrates how to
+enable tracing in the Google Cloud client libraries.
+
+@snippet quickstart.cc all
+
+*/
+
+[cloud trace]: https://cloud.google.com/trace
+[opentelemetry]: https://opentelemetry.io/
+[trace exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters

--- a/google/cloud/opentelemetry/doc/main.dox
+++ b/google/cloud/opentelemetry/doc/main.dox
@@ -2,9 +2,15 @@
 
 @mainpage Google Cloud C++ OpenTelemetry Exporters
 
-This directory contains the [OpenTelemetry] [trace exporter][trace-exporter] for
-[Cloud Trace][cloud-trace]. It also contains helpers to install the Cloud Trace
-exporter with reasonable defaults.
+This directory contains components to export [traces] captured with
+[OpenTelemetry] to [Cloud Trace]. Traces are a form of telemetry where
+calls across multiple distributed systems can be collected in a centralized
+view, showing the sequence of calls and their latency. Cloud Trace can provide
+such views of your system calls.
+
+The C++ client libraries are already instrumented to collect traces. You can
+enable the collection and export of traces with minimal changes to your
+application. It is not necessary to instrument your application too.
 
 This library is **experimental**. Its APIs are subject to change without notice.
 
@@ -21,8 +27,15 @@ enable tracing in the Google Cloud client libraries.
 
 @snippet quickstart.cc all
 
-[cloud-trace]: https://cloud.google.com/trace
+## More Information
+
+- The [Setting up your development environment] guide describes how to set up
+  a C++ development environment in various platforms, including the Google Cloud
+  C++ client libraries.
+
+[cloud trace]: https://cloud.google.com/trace
 [opentelemetry]: https://opentelemetry.io/
-[trace-exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters
+[setting up your development environment]: https://cloud.google.com/cpp/docs/setup
+[traces]: https://opentelemetry.io/docs/concepts/observability-primer/#distributed-traces
 
 */

--- a/google/cloud/opentelemetry/doc/main.dox
+++ b/google/cloud/opentelemetry/doc/main.dox
@@ -2,9 +2,9 @@
 
 @mainpage Google Cloud C++ OpenTelemetry Exporters
 
-This directory contains the [OpenTelemetry] [trace exporter] for [Cloud Trace].
-It also contains helpers to install the Cloud Trace exporter with reasonable
-defaults.
+This directory contains the [OpenTelemetry] [trace exporter][trace-exporter] for
+[Cloud Trace][cloud-trace]. It also contains helpers to install the Cloud Trace
+exporter with reasonable defaults.
 
 This library is **experimental**. Its APIs are subject to change without notice.
 
@@ -21,8 +21,8 @@ enable tracing in the Google Cloud client libraries.
 
 @snippet quickstart.cc all
 
-*/
-
-[cloud trace]: https://cloud.google.com/trace
+[cloud-trace]: https://cloud.google.com/trace
 [opentelemetry]: https://opentelemetry.io/
-[trace exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters
+[trace-exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters
+
+*/


### PR DESCRIPTION
Part of the work for #11156 

- Add a main page for `google/cloud/opentelemetry`
- Link to it from the README
- Add a brief description to the README

I want to get this in place before we add samples. (so we can reference those samples from the index page)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11692)
<!-- Reviewable:end -->
