### PR TITLE
cleanup(storage): gRPC plugin usings in benchmarks

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -35,7 +35,6 @@
 #include <vector>
 
 namespace {
-using ::google::cloud::storage_experimental::DefaultGrpcClient;
 using ::google::cloud::testing_util::FormatSize;
 using ::google::cloud::testing_util::Timer;
 namespace gcs = ::google::cloud::storage;
@@ -123,8 +122,9 @@ class Iteration {
 gcs::Client MakeClient(AggregateDownloadThroughputOptions const& options) {
   auto opts = options.client_options;
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+  namespace gcs_ex = ::google::cloud::storage_experimental;
   if (options.api == "GRPC") {
-    return DefaultGrpcClient(
+    return gcs_ex::DefaultGrpcClient(
         std::move(opts).set<gcs_ex::GrpcPluginOption>("media"));
   }
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
@@ -28,11 +28,9 @@
 #include "absl/time/time.h"
 
 namespace {
-using ::google::cloud::storage_experimental::DefaultGrpcClient;
 using ::google::cloud::testing_util::FormatSize;
 using ::google::cloud::testing_util::Timer;
 namespace gcs = ::google::cloud::storage;
-namespace gcs_ex = ::google::cloud::storage_experimental;
 namespace gcs_bm = ::google::cloud::storage_benchmarks;
 using gcs_bm::AggregateUploadThroughputOptions;
 using gcs_bm::FormatBandwidthGbPerSecond;
@@ -116,8 +114,9 @@ gcs::Client MakeClient(AggregateUploadThroughputOptions const& options) {
                   // on almost all `.write()` requests.
                   .set<gcs::UploadBufferSizeOption>(256 * gcs_bm::kKiB);
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+  namespace gcs_ex = ::google::cloud::storage_experimental;
   if (options.api == "GRPC") {
-    return DefaultGrpcClient(
+    return gcs_ex::DefaultGrpcClient(
         std::move(opts).set<gcs_ex::GrpcPluginOption>("media"));
   }
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -32,7 +32,6 @@
 
 namespace {
 namespace gcs = ::google::cloud::storage;
-namespace gcs_ex = ::google::cloud::storage_experimental;
 namespace gcs_bm = ::google::cloud::storage_benchmarks;
 using gcs_bm::ExperimentLibrary;
 using gcs_bm::ExperimentTransport;
@@ -291,18 +290,18 @@ gcs_bm::ClientProvider BaseProvider(ThroughputOptions const& options) {
     auto opts = google::cloud::Options{options.client_options}
                     .set<gcs::ProjectIdOption>(options.project_id);
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
-    using ::google::cloud::storage_experimental::DefaultGrpcClient;
+    namespace gcs_ex = ::google::cloud::storage_experimental;
     if (t == ExperimentTransport::kDirectPath) {
       opts = google::cloud::internal::MergeOptions(options.direct_path_options,
                                                    std::move(opts));
       opts.set<gcs_ex::GrpcPluginOption>("media");
-      return DefaultGrpcClient(std::move(opts));
+      return gcs_ex::DefaultGrpcClient(std::move(opts));
     }
     if (t == ExperimentTransport::kGrpc) {
       opts = google::cloud::internal::MergeOptions(options.grpc_options,
                                                    std::move(opts));
       opts.set<gcs_ex::GrpcPluginOption>("media");
-      return DefaultGrpcClient(std::move(opts));
+      return gcs_ex::DefaultGrpcClient(std::move(opts));
     }
 #else
     (void)t;  // disable unused parameter warning


### PR DESCRIPTION
Move directives inside the `#ifdef`s