### PR TITLE
feat(generator): preserve linebreaks in param comments 

### DIFF
--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
@@ -127,6 +127,7 @@ class GoldenKitchenSinkClient {
   ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
   ///  on the service account that is specified in the `name` field of the
   ///  request.
+  ///  @n
   ///  The delegates must have the following format:
   ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
   ///  character is required; replacing it with a project ID is invalid.
@@ -205,6 +206,7 @@ class GoldenKitchenSinkClient {
   ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
   ///  on the service account that is specified in the `name` field of the
   ///  request.
+  ///  @n
   ///  The delegates must have the following format:
   ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
   ///  character is required; replacing it with a project ID is invalid.
@@ -276,13 +278,17 @@ class GoldenKitchenSinkClient {
   ///
   /// @param log_name  Optional. A default log resource name that is assigned to all log entries
   ///  in `entries` that do not specify a value for `log_name`:
+  ///  @n
   ///      "projects/[PROJECT_ID]/logs/[LOG_ID]"
   ///      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
   ///      "folders/[FOLDER_ID]/logs/[LOG_ID]"
+  ///  @n
   ///  `[LOG_ID]` must be URL-encoded. For example:
+  ///  @n
   ///      "projects/my-project-id/logs/syslog"
   ///      "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+  ///  @n
   ///  The permission `logging.logEntries.create` is needed on each project,
   ///  organization, billing account, or folder that is receiving new log
   ///  entries, whether the resource is specified in `logName` or in an
@@ -355,6 +361,7 @@ class GoldenKitchenSinkClient {
   /// Only logs that have entries are listed.
   ///
   /// @param parent  Required. The resource name that owns the logs:
+  ///  @n
   ///      "projects/[PROJECT_ID]"
   ///      "organizations/[ORGANIZATION_ID]"
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
@@ -431,6 +438,7 @@ class GoldenKitchenSinkClient {
   ///
   /// @param name  Required. The resource name of the service account in the following format:
   ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  @n
   ///  Using `-` as a wildcard for the `PROJECT_ID`, will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -444,7 +444,7 @@ std::string FormatApiMethodSignatureParameters(
     }
     absl::StrReplaceAll(
         {
-            {"\n\n", "\n  /// "},
+            {"\n\n", "\n  ///  @n\n  /// "},
             {"\n", "\n  /// "},
         },
         &comment);

--- a/google/cloud/accessapproval/v1/access_approval_client.h
+++ b/google/cloud/accessapproval/v1/access_approval_client.h
@@ -456,6 +456,7 @@ class AccessApprovalClient {
   ///  supported. For each field, if it is included, the currently stored value
   ///  will be entirely overwritten with the value of the field passed in this
   ///  request.
+  ///  @n
   ///  For the `FieldMask` definition, see
   ///  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
   ///  If this field is left unset, only the notification_emails field will be

--- a/google/cloud/accesscontextmanager/v1/access_context_manager_client.h
+++ b/google/cloud/accesscontextmanager/v1/access_context_manager_client.h
@@ -148,6 +148,7 @@ class AccessContextManagerClient {
   /// [google.identity.accesscontextmanager.v1.AccessPolicy] based on the name.
   ///
   /// @param name  Required. Resource name for the access policy to get.
+  ///  @n
   ///  Format `accessPolicies/{policy_id}`
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -340,6 +341,7 @@ class AccessContextManagerClient {
   /// is removed from long-lasting storage.
   ///
   /// @param name  Required. Resource name for the access policy to delete.
+  ///  @n
   ///  Format `accessPolicies/{policy_id}`
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -421,6 +423,7 @@ class AccessContextManagerClient {
   ///
   /// @param parent  Required. Resource name for the access policy to list [Access Levels]
   ///  [google.identity.accesscontextmanager.v1.AccessLevel] from.
+  ///  @n
   ///  Format:
   ///  `accessPolicies/{policy_id}`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -506,6 +509,7 @@ class AccessContextManagerClient {
   ///
   /// @param name  Required. Resource name for the [Access Level]
   ///  [google.identity.accesscontextmanager.v1.AccessLevel].
+  ///  @n
   ///  Format:
   ///  `accessPolicies/{policy_id}/accessLevels/{access_level_id}`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -577,6 +581,7 @@ class AccessContextManagerClient {
   ///
   /// @param parent  Required. Resource name for the access policy which owns this [Access
   ///  Level] [google.identity.accesscontextmanager.v1.AccessLevel].
+  ///  @n
   ///  Format: `accessPolicies/{policy_id}`
   /// @param access_level  Required. The [Access Level]
   ///  [google.identity.accesscontextmanager.v1.AccessLevel] to create.
@@ -763,6 +768,7 @@ class AccessContextManagerClient {
   ///
   /// @param name  Required. Resource name for the [Access Level]
   ///  [google.identity.accesscontextmanager.v1.AccessLevel].
+  ///  @n
   ///  Format:
   ///  `accessPolicies/{policy_id}/accessLevels/{access_level_id}`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -902,6 +908,7 @@ class AccessContextManagerClient {
   ///
   /// @param parent  Required. Resource name for the access policy to list [Service Perimeters]
   ///  [google.identity.accesscontextmanager.v1.ServicePerimeter] from.
+  ///  @n
   ///  Format:
   ///  `accessPolicies/{policy_id}`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -987,6 +994,7 @@ class AccessContextManagerClient {
   ///
   /// @param name  Required. Resource name for the [Service Perimeter]
   ///  [google.identity.accesscontextmanager.v1.ServicePerimeter].
+  ///  @n
   ///  Format:
   ///  `accessPolicies/{policy_id}/servicePerimeters/{service_perimeters_id}`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1058,6 +1066,7 @@ class AccessContextManagerClient {
   ///
   /// @param parent  Required. Resource name for the access policy which owns this [Service
   ///  Perimeter] [google.identity.accesscontextmanager.v1.ServicePerimeter].
+  ///  @n
   ///  Format: `accessPolicies/{policy_id}`
   /// @param service_perimeter  Required. The [Service Perimeter]
   ///  [google.identity.accesscontextmanager.v1.ServicePerimeter] to create.
@@ -1242,6 +1251,7 @@ class AccessContextManagerClient {
   ///
   /// @param name  Required. Resource name for the [Service Perimeter]
   ///  [google.identity.accesscontextmanager.v1.ServicePerimeter].
+  ///  @n
   ///  Format:
   ///  `accessPolicies/{policy_id}/servicePerimeters/{service_perimeter_id}`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1678,6 +1688,7 @@ class AccessContextManagerClient {
   ///  [google.identity.accesscontextmanager.v1.GcpUserAccessBinding]
   /// @param update_mask  Required. Only the fields specified in this mask are updated. Because name and
   ///  group_key cannot be changed, update_mask is required and must always be:
+  ///  @n
   ///  update_mask {
   ///  paths: "access_levels"
   ///  }

--- a/google/cloud/alloydb/v1/alloy_db_admin_client.h
+++ b/google/cloud/alloydb/v1/alloy_db_admin_client.h
@@ -1406,6 +1406,7 @@ class AlloyDBAdminClient {
   ///
   /// @param parent  Required. The name of the parent resource. The required format is:
   ///   * projects/{project}/locations/{location}
+  ///  @n
   ///  Regardless of the parent specified here, as long it is contains a valid
   ///  project and location, the service will return a static list of supported
   ///  flags resources. Note that we do not yet support region-specific

--- a/google/cloud/apikeys/v2/api_keys_client.h
+++ b/google/cloud/apikeys/v2/api_keys_client.h
@@ -97,10 +97,12 @@ class ApiKeysClient {
   ///  `annotations` fields.
   /// @param key_id  User specified key id (optional). If specified, it will become the final
   ///  component of the key resource name.
+  ///  @n
   ///  The id must be unique within the project, must conform with RFC-1034,
   ///  is restricted to lower-cased letters, and has a maximum length of 63
   ///  characters. In another word, the id must match the regular
   ///  expression: `[a-z]([a-z0-9-]{0,61}[a-z0-9])?`.
+  ///  @n
   ///  The id must NOT be a UUID-like string.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/asset/v1/asset_client.h
+++ b/google/cloud/asset/v1/asset_client.h
@@ -568,7 +568,9 @@ class AssetServiceClient {
   ///  granted the
   ///  [`cloudasset.assets.searchAllResources`](https://cloud.google.com/asset-inventory/docs/access-control#required_permissions)
   ///  permission on the desired scope.
+  ///  @n
   ///  The allowed values are:
+  ///  @n
   ///  * projects/{PROJECT_ID} (e.g., "projects/foo-bar")
   ///  * projects/{PROJECT_NUMBER} (e.g., "projects/12345678")
   ///  * folders/{FOLDER_NUMBER} (e.g., "folders/1234567")
@@ -577,7 +579,9 @@ class AssetServiceClient {
   ///  query](https://cloud.google.com/asset-inventory/docs/searching-resources#how_to_construct_a_query)
   ///  for more information. If not specified or empty, it will search all the
   ///  resources within the specified `scope`.
+  ///  @n
   ///  Examples:
+  ///  @n
   ///  * `name:Important` to find Google Cloud resources whose name contains
   ///    "Important" as a word.
   ///  * `name=Important` to find the Google Cloud resource whose name is exactly
@@ -626,11 +630,14 @@ class AssetServiceClient {
   /// @param asset_types  Optional. A list of asset types that this request searches for. If empty,
   ///  it will search all the [searchable asset
   ///  types](https://cloud.google.com/asset-inventory/docs/supported-asset-types#searchable_asset_types).
+  ///  @n
   ///  Regular expressions are also supported. For example:
+  ///  @n
   ///  * "compute.googleapis.com.*" snapshots resources whose asset type starts
   ///  with "compute.googleapis.com".
   ///  * ".*Instance" snapshots resources whose asset type ends with "Instance".
   ///  * ".*Instance.*" snapshots resources whose asset type contains "Instance".
+  ///  @n
   ///  See [RE2](https://github.com/google/re2/wiki/Syntax) for all supported
   ///  regular expression syntax. If the regular expression does not match any
   ///  supported asset type, an INVALID_ARGUMENT error will be returned.
@@ -723,7 +730,9 @@ class AssetServiceClient {
   ///  be granted the
   ///  [`cloudasset.assets.searchAllIamPolicies`](https://cloud.google.com/asset-inventory/docs/access-control#required_permissions)
   ///  permission on the desired scope.
+  ///  @n
   ///  The allowed values are:
+  ///  @n
   ///  * projects/{PROJECT_ID} (e.g., "projects/foo-bar")
   ///  * projects/{PROJECT_NUMBER} (e.g., "projects/12345678")
   ///  * folders/{FOLDER_NUMBER} (e.g., "folders/1234567")
@@ -737,7 +746,9 @@ class AssetServiceClient {
   ///  contain the bindings that match your query. To learn more about the IAM
   ///  policy structure, see the [IAM policy
   ///  documentation](https://cloud.google.com/iam/help/allow-policies/structure).
+  ///  @n
   ///  Examples:
+  ///  @n
   ///  * `policy:amy@gmail.com` to find IAM policy bindings that specify user
   ///    "amy@gmail.com".
   ///  * `policy:roles/compute.admin` to find IAM policy bindings that specify
@@ -1024,8 +1035,10 @@ class AssetServiceClient {
   /// @param saved_query_id  Required. The ID to use for the saved query, which must be unique in the
   ///  specified parent. It will become the final component of the saved query's
   ///  resource name.
+  ///  @n
   ///  This value should be 4-63 characters, and valid characters
   ///  are `[a-z][0-9]-`.
+  ///  @n
   ///  Notice that this field is required in the saved query creation, and the
   ///  `name` field of the `saved_query` will be ignored.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1088,6 +1101,7 @@ class AssetServiceClient {
   /// Gets details about a saved query.
   ///
   /// @param name  Required. The name of the saved query and it must be in the format of:
+  ///  @n
   ///  * projects/project_number/savedQueries/saved_query_id
   ///  * folders/folder_number/savedQueries/saved_query_id
   ///  * organizations/organization_number/savedQueries/saved_query_id
@@ -1227,8 +1241,10 @@ class AssetServiceClient {
   /// Updates a saved query.
   ///
   /// @param saved_query  Required. The saved query to update.
+  ///  @n
   ///  The saved query's `name` field is used to identify the one to update,
   ///  which has format as below:
+  ///  @n
   ///  * projects/project_number/savedQueries/saved_query_id
   ///  * folders/folder_number/savedQueries/saved_query_id
   ///  * organizations/organization_number/savedQueries/saved_query_id
@@ -1293,6 +1309,7 @@ class AssetServiceClient {
   ///
   /// @param name  Required. The name of the saved query to delete. It must be in the format
   ///  of:
+  ///  @n
   ///  * projects/project_number/savedQueries/saved_query_id
   ///  * folders/folder_number/savedQueries/saved_query_id
   ///  * organizations/organization_number/savedQueries/saved_query_id
@@ -1382,6 +1399,7 @@ class AssetServiceClient {
   ///
   /// @param scope  Required. The organization to scope the request. Only organization
   ///  policies within the scope will be analyzed.
+  ///  @n
   ///  * organizations/{ORGANIZATION_NUMBER} (e.g., "organizations/123456")
   /// @param constraint  Required. The name of the constraint to analyze organization policies for.
   ///  The response only contains analyzed organization policies for the provided
@@ -1390,6 +1408,7 @@ class AssetServiceClient {
   ///  [AnalyzeOrgPoliciesResponse.org_policy_results][google.cloud.asset.v1.AnalyzeOrgPoliciesResponse.org_policy_results].
   ///  The only supported field is `consolidated_policy.attached_resource`, and
   ///  the only supported operator is `=`.
+  ///  @n
   ///  Example:
   ///  consolidated_policy.attached_resource="//cloudresourcemanager.googleapis.com/folders/001"
   ///  will return the org policy results of"folders/001".
@@ -1477,6 +1496,7 @@ class AssetServiceClient {
   ///  policies within the scope will be analyzed. The output containers will
   ///  also be limited to the ones governed by those in-scope organization
   ///  policies.
+  ///  @n
   ///  * organizations/{ORGANIZATION_NUMBER} (e.g., "organizations/123456")
   /// @param constraint  Required. The name of the constraint to analyze governed containers for.
   ///  The analysis only contains organization policies for the provided
@@ -1484,6 +1504,7 @@ class AssetServiceClient {
   /// @param filter  The expression to filter the governed containers in result.
   ///  The only supported field is `parent`, and the only supported operator is
   ///  `=`.
+  ///  @n
   ///  Example:
   ///  parent="//cloudresourcemanager.googleapis.com/folders/001" will return all
   ///  containers under "folders/001".
@@ -1592,6 +1613,7 @@ class AssetServiceClient {
   ///  policies within the scope will be analyzed. The output assets will
   ///  also be limited to the ones governed by those in-scope organization
   ///  policies.
+  ///  @n
   ///  * organizations/{ORGANIZATION_NUMBER} (e.g., "organizations/123456")
   /// @param constraint  Required. The name of the constraint to analyze governed assets for. The
   ///  analysis only contains analyzed organization policies for the provided
@@ -1601,9 +1623,11 @@ class AssetServiceClient {
   ///  `governed_resource.folders`. The only supported fields for governed iam
   ///  policies are `governed_iam_policy.project` and
   ///  `governed_iam_policy.folders`. The only supported operator is `=`.
+  ///  @n
   ///  Example 1: governed_resource.project="projects/12345678" filter will return
   ///  all governed resources under projects/12345678 including the project
   ///  ifself, if applicable.
+  ///  @n
   ///  Example 2: governed_iam_policy.folders="folders/12345678" filter will
   ///  return all governed iam policies under folders/12345678, if applicable.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/automl/v1/auto_ml_client.h
+++ b/google/cloud/automl/v1/auto_ml_client.h
@@ -1365,9 +1365,12 @@ class AutoMlClient {
   ///  If modelId is set as "-", this will list model evaluations from across all
   ///  models of the parent location.
   /// @param filter  Required. An expression for filtering the results of the request.
+  ///  @n
   ///    * `annotation_spec_id` - for =, !=  or existence. See example below for
   ///                           the last.
+  ///  @n
   ///  Some examples of using the filter are:
+  ///  @n
   ///    * `annotation_spec_id!=4` --> The model evaluation was done for
   ///                              annotation spec with ID different than 4.
   ///    * `NOT annotation_spec_id:*` --> The model evaluation was done for

--- a/google/cloud/automl/v1/prediction_client.h
+++ b/google/cloud/automl/v1/prediction_client.h
@@ -134,21 +134,28 @@ class PredictionServiceClient {
   ///  problem type that the model was trained to solve.
   /// @param params  Additional domain-specific parameters, any string must be up to 25000
   ///  characters long.
+  ///  @n
   ///  AutoML Vision Classification
+  ///  @n
   ///  `score_threshold`
   ///  : (float) A value from 0.0 to 1.0. When the model
   ///    makes predictions for an image, it will only produce results that have
   ///    at least this confidence score. The default is 0.5.
+  ///  @n
   ///  AutoML Vision Object Detection
+  ///  @n
   ///  `score_threshold`
   ///  : (float) When Model detects objects on the image,
   ///    it will only produce bounding boxes which have at least this
   ///    confidence score. Value in 0 to 1 range, default is 0.5.
+  ///  @n
   ///  `max_bounding_box_count`
   ///  : (int64) The maximum number of bounding
   ///    boxes returned. The default is 100. The
   ///    number of returned bounding boxes might be limited by the server.
+  ///  @n
   ///  AutoML Tables
+  ///  @n
   ///  `feature_importance`
   ///  : (boolean) Whether
   ///  [feature_importance][google.cloud.automl.v1.TablesModelColumnInfo.feature_importance]
@@ -269,37 +276,47 @@ class PredictionServiceClient {
   ///  be written.
   /// @param params  Additional domain-specific parameters for the predictions, any string must
   ///  be up to 25000 characters long.
+  ///  @n
   ///  AutoML Natural Language Classification
+  ///  @n
   ///  `score_threshold`
   ///  : (float) A value from 0.0 to 1.0. When the model
   ///    makes predictions for a text snippet, it will only produce results
   ///    that have at least this confidence score. The default is 0.5.
+  ///  @n
   ///
   ///  AutoML Vision Classification
+  ///  @n
   ///  `score_threshold`
   ///  : (float) A value from 0.0 to 1.0. When the model
   ///    makes predictions for an image, it will only produce results that
   ///    have at least this confidence score. The default is 0.5.
+  ///  @n
   ///  AutoML Vision Object Detection
+  ///  @n
   ///  `score_threshold`
   ///  : (float) When Model detects objects on the image,
   ///    it will only produce bounding boxes which have at least this
   ///    confidence score. Value in 0 to 1 range, default is 0.5.
+  ///  @n
   ///  `max_bounding_box_count`
   ///  : (int64) The maximum number of bounding
   ///    boxes returned per image. The default is 100, the
   ///    number of bounding boxes returned might be limited by the server.
   ///  AutoML Video Intelligence Classification
+  ///  @n
   ///  `score_threshold`
   ///  : (float) A value from 0.0 to 1.0. When the model
   ///    makes predictions for a video, it will only produce results that
   ///    have at least this confidence score. The default is 0.5.
+  ///  @n
   ///  `segment_classification`
   ///  : (boolean) Set to true to request
   ///    segment-level classification. AutoML Video Intelligence returns
   ///    labels and their confidence scores for the entire segment of the
   ///    video that user specified in the request configuration.
   ///    The default is true.
+  ///  @n
   ///  `shot_classification`
   ///  : (boolean) Set to true to request shot-level
   ///    classification. AutoML Video Intelligence determines the boundaries
@@ -308,27 +325,34 @@ class PredictionServiceClient {
   ///    then returns labels and their confidence scores for each detected
   ///    shot, along with the start and end time of the shot.
   ///    The default is false.
+  ///  @n
   ///    WARNING: Model evaluation is not done for this classification type,
   ///    the quality of it depends on training data, but there are no metrics
   ///    provided to describe that quality.
+  ///  @n
   ///  `1s_interval_classification`
   ///  : (boolean) Set to true to request
   ///    classification for a video at one-second intervals. AutoML Video
   ///    Intelligence returns labels and their confidence scores for each
   ///    second of the entire segment of the video that user specified in the
   ///    request configuration. The default is false.
+  ///  @n
   ///    WARNING: Model evaluation is not done for this classification
   ///    type, the quality of it depends on training data, but there are no
   ///    metrics provided to describe that quality.
+  ///  @n
   ///  AutoML Video Intelligence Object Tracking
+  ///  @n
   ///  `score_threshold`
   ///  : (float) When Model detects objects on video frames,
   ///    it will only produce bounding boxes which have at least this
   ///    confidence score. Value in 0 to 1 range, default is 0.5.
+  ///  @n
   ///  `max_bounding_box_count`
   ///  : (int64) The maximum number of bounding
   ///    boxes returned per image. The default is 100, the
   ///    number of bounding boxes returned might be limited by the server.
+  ///  @n
   ///  `min_bounding_box_size`
   ///  : (float) Only bounding boxes with shortest edge
   ///    at least that long as a relative value of video frame size are

--- a/google/cloud/baremetalsolution/v2/bare_metal_solution_client.h
+++ b/google/cloud/baremetalsolution/v2/bare_metal_solution_client.h
@@ -233,6 +233,7 @@ class BareMetalSolutionClient {
   /// Update details of a single server.
   ///
   /// @param instance  Required. The server to update.
+  ///  @n
   ///  The `name` field is used to identify the instance to update.
   ///  Format: projects/{project}/locations/{location}/instances/{instance}
   /// @param update_mask  The list of fields to update.
@@ -734,6 +735,7 @@ class BareMetalSolutionClient {
   /// Update details of a single storage volume.
   ///
   /// @param volume  Required. The volume to update.
+  ///  @n
   ///  The `name` field is used to identify the volume to update.
   ///  Format: projects/{project}/locations/{location}/volumes/{volume}
   /// @param update_mask  The list of fields to update.
@@ -1081,6 +1083,7 @@ class BareMetalSolutionClient {
   /// Update details of a single network.
   ///
   /// @param network  Required. The network to update.
+  ///  @n
   ///  The `name` field is used to identify the instance to update.
   ///  Format: projects/{project}/locations/{location}/networks/{network}
   /// @param update_mask  The list of fields to update.
@@ -1425,6 +1428,7 @@ class BareMetalSolutionClient {
   /// Update details of a single NFS share.
   ///
   /// @param nfs_share  Required. The NFS share to update.
+  ///  @n
   ///  The `name` field is used to identify the NFS share to update.
   ///  Format: projects/{project}/locations/{location}/nfsShares/{nfs_share}
   /// @param update_mask  The list of fields to update.

--- a/google/cloud/batch/v1/batch_client.h
+++ b/google/cloud/batch/v1/batch_client.h
@@ -101,6 +101,7 @@ class BatchServiceClient {
   ///  Only lowercase characters, numbers and '-' are accepted.
   ///  The '-' character cannot be the first or the last one.
   ///  A system generated ID will be used if the field is not set.
+  ///  @n
   ///  The job.name field in the request will be ignored and the created resource
   ///  name of the Job will be "{parent}/jobs/{job_id}".
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/beyondcorp/appconnectors/v1/app_connectors_client.h
+++ b/google/cloud/beyondcorp/appconnectors/v1/app_connectors_client.h
@@ -248,6 +248,7 @@ class AppConnectorsServiceClient {
   ///  form: `projects/{project_id}/locations/{location_id}`
   /// @param app_connector  Required. A BeyondCorp AppConnector resource.
   /// @param app_connector_id  Optional. User-settable AppConnector resource ID.
+  ///  @n
   ///   * Must start with a letter.
   ///   * Must contain between 4-63 characters from `/[a-z][0-9]-/`.
   ///   * Must end with a number or a letter.

--- a/google/cloud/beyondcorp/clientconnectorservices/v1/client_connector_services_client.h
+++ b/google/cloud/beyondcorp/clientconnectorservices/v1/client_connector_services_client.h
@@ -253,6 +253,7 @@ class ClientConnectorServicesServiceClient {
   ///   * Must start with a letter.
   ///   * Must contain between 4-63 characters from `/[a-z][0-9]-/`.
   ///   * Must end with a number or a letter.
+  ///  @n
   ///  A random system generated name will be assigned
   ///  if not specified by the user.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -338,6 +339,7 @@ class ClientConnectorServicesServiceClient {
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask. If the
   ///  user does not provide a mask then all fields will be overwritten.
+  ///  @n
   ///  Mutable fields: display_name.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/bigquery/datapolicies/v1/data_policy_client.h
+++ b/google/cloud/bigquery/datapolicies/v1/data_policy_client.h
@@ -159,12 +159,14 @@ class DataPolicyServiceClient {
   /// can be specified by the resource name.
   ///
   /// @param data_policy  Required. Update the data policy's metadata.
+  ///  @n
   ///  The target data policy is determined by the `name` field.
   ///  Other fields are updated to the specified values based on the field masks.
   /// @param update_mask  The update mask applies to the resource. For the `FieldMask` definition,
   ///  see
   ///  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
   ///  If not set, defaults to all of the fields that are allowed to update.
+  ///  @n
   ///  Updates to the `name` and `dataPolicyId` fields are not allowed.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/bigquery/reservation/v1/reservation_client.h
+++ b/google/cloud/bigquery/reservation/v1/reservation_client.h
@@ -1079,8 +1079,11 @@ class ReservationServiceClient {
   /// **Note** "-" cannot be used for projects nor locations.
   ///
   /// @param parent  Required. The parent resource name e.g.:
+  ///  @n
   ///  `projects/myproject/locations/US/reservations/team1-prod`
+  ///  @n
   ///  Or:
+  ///  @n
   ///  `projects/myproject/locations/US/reservations/-`
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1285,7 +1288,9 @@ class ReservationServiceClient {
   ///  location), e.g.:
   ///    `projects/myproject/locations/US`.
   /// @param query  Please specify resource name as assignee in the query.
+  ///  @n
   ///  Examples:
+  ///  @n
   ///  * `assignee=projects/myproject`
   ///  * `assignee=folders/123`
   ///  * `assignee=organizations/456`
@@ -1412,7 +1417,9 @@ class ReservationServiceClient {
   ///  wildcard '-'), e.g.:
   ///    `projects/-/locations/US`.
   /// @param query  Please specify resource name as assignee in the query.
+  ///  @n
   ///  Examples:
+  ///  @n
   ///  * `assignee=projects/myproject`
   ///  * `assignee=folders/123`
   ///  * `assignee=organizations/456`

--- a/google/cloud/bigquery/storage/v1/bigquery_read_client.h
+++ b/google/cloud/bigquery/storage/v1/bigquery_read_client.h
@@ -116,6 +116,7 @@ class BigQueryReadClient {
   ///  non-negative. The number of streams may be lower than the requested number,
   ///  depending on the amount parallelism that is reasonable for the table.
   ///  There is a default system max limit of 1,000.
+  ///  @n
   ///  This must be greater than or equal to preferred_min_stream_count.
   ///  Typically, clients should either leave this unset to let the system to
   ///  determine an upper bound OR set this a size for the maximum "units of work"

--- a/google/cloud/channel/v1/cloud_channel_client.h
+++ b/google/cloud/channel/v1/cloud_channel_client.h
@@ -3285,6 +3285,7 @@ class CloudChannelServiceClient {
   /// @param parent  Required. The resource name of the entitlement for which to list
   ///  entitlement changes. The `-` wildcard may be used to match entitlements
   ///  across a customer. Formats:
+  ///  @n
   ///    * accounts/{account_id}/customers/{customer_id}/entitlements/{entitlement_id}
   ///    * accounts/{account_id}/customers/{customer_id}/entitlements/-
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/cloudbuild/v1/cloud_build_client.h
+++ b/google/cloud/cloudbuild/v1/cloud_build_client.h
@@ -1039,6 +1039,7 @@ class CloudBuildClient {
   /// @param worker_pool  Required. `WorkerPool` resource to create.
   /// @param worker_pool_id  Required. Immutable. The ID to use for the `WorkerPool`, which will become
   ///  the final component of the resource name.
+  ///  @n
   ///  This value should be 1-63 characters, and valid characters
   ///  are /[a-z][0-9]-/.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1249,6 +1250,7 @@ class CloudBuildClient {
   /// Updates a `WorkerPool`.
   ///
   /// @param worker_pool  Required. The `WorkerPool` to update.
+  ///  @n
   ///  The `name` field is used to identify the `WorkerPool` to update.
   ///  Format: `projects/{project}/locations/{location}/workerPools/{workerPool}`.
   /// @param update_mask  A mask specifying which fields in `worker_pool` to update.

--- a/google/cloud/composer/v1/environments_client.h
+++ b/google/cloud/composer/v1/environments_client.h
@@ -319,6 +319,7 @@ class EnvironmentsClient {
   ///  `paths` values: "config.softwareConfig.pypiPackages.scikit-learn" and
   ///  "config.softwareConfig.pypiPackages.numpy". The included patch
   ///  environment would specify the scikit-learn version as follows:
+  ///  @n
   ///      {
   ///        "config":{
   ///          "softwareConfig":{
@@ -328,8 +329,10 @@ class EnvironmentsClient {
   ///          }
   ///        }
   ///      }
+  ///  @n
   ///  Note that in the above example, any existing PyPI packages
   ///  other than scikit-learn and numpy will be unaffected.
+  ///  @n
   ///  Only one update type may be included in a single request's `updateMask`.
   ///  For example, one cannot update both the PyPI packages and
   ///  labels in the same request. However, it is possible to update multiple
@@ -338,14 +341,17 @@ class EnvironmentsClient {
   ///  it already exists), one can
   ///  provide the paths "labels.label1", "labels.label2", and "labels.label3"
   ///  and populate the patch environment as follows:
+  ///  @n
   ///      {
   ///        "labels":{
   ///          "label1":"new-label1-value"
   ///          "label2":"new-label2-value"
   ///        }
   ///      }
+  ///  @n
   ///  Note that in the above example, any existing labels that are not
   ///  included in the `updateMask` will be unaffected.
+  ///  @n
   ///  It is also possible to replace an entire map field by providing the
   ///  map field's path in the `updateMask`. The new value of the field will
   ///  be that which is provided in the patch environment. For example, to
@@ -353,6 +359,7 @@ class EnvironmentsClient {
   ///  install botocore at version 1.7.14, the `updateMask` would contain
   ///  the path "config.softwareConfig.pypiPackages", and
   ///  the patch environment would be the following:
+  ///  @n
   ///      {
   ///        "config":{
   ///          "softwareConfig":{
@@ -362,7 +369,9 @@ class EnvironmentsClient {
   ///          }
   ///        }
   ///      }
+  ///  @n
   ///  **Note:** Only the following fields can be updated:
+  ///  @n
   ///  * `config.softwareConfig.pypiPackages`
   ///      * Replace all custom custom PyPI packages. If a replacement
   ///        package map is not included in `environment`, all custom

--- a/google/cloud/connectors/v1/connectors_client.h
+++ b/google/cloud/connectors/v1/connectors_client.h
@@ -302,10 +302,13 @@ class ConnectorsClient {
   ///
   /// @param connection  Required. Connection resource.
   /// @param update_mask  Required. You can modify only the fields listed below.
+  ///  @n
   ///  To lock/unlock a connection:
   ///  * `lock_config`
+  ///  @n
   ///  To suspend/resume a connection:
   ///  * `suspended`
+  ///  @n
   ///  To update the connection details:
   ///  * `description`
   ///  * `labels`

--- a/google/cloud/contactcenterinsights/v1/contact_center_insights_client.h
+++ b/google/cloud/contactcenterinsights/v1/contact_center_insights_client.h
@@ -98,6 +98,7 @@ class ContactCenterInsightsClient {
   /// @param conversation_id  A unique ID for the new conversation. This ID will become the final
   ///  component of the conversation's resource name. If no ID is specified, a
   ///  server-generated ID will be used.
+  ///  @n
   ///  This value should be 4-64 characters and must match the regular
   ///  expression `^[a-z0-9-]{4,64}$`. Valid characters are `[a-z][0-9]-`
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/container/v1/cluster_manager_client.h
+++ b/google/cloud/container/v1/cluster_manager_client.h
@@ -427,11 +427,13 @@ class ClusterManagerClient {
   ///  Specified in the format `projects/*/locations/*/clusters/*`.
   /// @param logging_service  Required. The logging service the cluster should use to write logs.
   ///  Currently available options:
+  ///  @n
   ///  * `logging.googleapis.com/kubernetes` - The Cloud Logging
   ///  service with a Kubernetes-native resource model
   ///  * `logging.googleapis.com` - The legacy Cloud Logging service (no longer
   ///    available as of GKE 1.15).
   ///  * `none` - no logs will be exported from the cluster.
+  ///  @n
   ///  If left as an empty string,`logging.googleapis.com/kubernetes` will be
   ///  used for GKE 1.14+ or `logging.googleapis.com` for earlier versions.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -496,11 +498,13 @@ class ClusterManagerClient {
   ///  Specified in the format `projects/*/locations/*/clusters/*`.
   /// @param monitoring_service  Required. The monitoring service the cluster should use to write metrics.
   ///  Currently available options:
+  ///  @n
   ///  * "monitoring.googleapis.com/kubernetes" - The Cloud Monitoring
   ///  service with a Kubernetes-native resource model
   ///  * `monitoring.googleapis.com` - The legacy Cloud Monitoring service (no
   ///    longer available as of GKE 1.15).
   ///  * `none` - No metrics will be exported from the cluster.
+  ///  @n
   ///  If left as an empty string,`monitoring.googleapis.com/kubernetes` will be
   ///  used for GKE 1.14+ or `monitoring.googleapis.com` for earlier versions.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -634,6 +638,7 @@ class ClusterManagerClient {
   ///  cluster's nodes should be located. Changing the locations a cluster is in
   ///  will result in nodes being either created or removed from the cluster,
   ///  depending on whether locations are being added or removed.
+  ///  @n
   ///  This list must always include the cluster's primary zone.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -699,8 +704,10 @@ class ClusterManagerClient {
   /// @param name  The name (project, location, cluster) of the cluster to update.
   ///  Specified in the format `projects/*/locations/*/clusters/*`.
   /// @param master_version  Required. The Kubernetes version to change the master to.
+  ///  @n
   ///  Users may specify either explicit versions offered by Kubernetes Engine or
   ///  version aliases, which have the following behavior:
+  ///  @n
   ///  - "latest": picks the highest valid Kubernetes version
   ///  - "1.X": picks the highest valid patch+gke.N patch in the 1.X version
   ///  - "1.X.Y": picks the highest valid gke.N patch in the 1.X.Y version

--- a/google/cloud/datacatalog/lineage/v1/lineage_client.h
+++ b/google/cloud/datacatalog/lineage/v1/lineage_client.h
@@ -160,6 +160,7 @@ class LineageClient {
   /// Updates a process.
   ///
   /// @param process  Required. The lineage process to update.
+  ///  @n
   ///  The process's `name` field is used to identify the process to update.
   /// @param update_mask  The list of fields to update. Currently not used. The whole message is
   ///  updated.
@@ -493,7 +494,9 @@ class LineageClient {
   /// Updates a run.
   ///
   /// @param run  Required. The lineage run to update.
+  ///  @n
   ///  The run's `name` field is used to identify the run to update.
+  ///  @n
   ///  Format:
   ///  `projects/{project}/locations/{location}/processes/{process}/runs/{run}`.
   /// @param update_mask  The list of fields to update. Currently not used. The whole message is

--- a/google/cloud/datacatalog/v1/data_catalog_client.h
+++ b/google/cloud/datacatalog/v1/data_catalog_client.h
@@ -107,15 +107,19 @@ class DataCatalogClient {
   /// (https://cloud.google.com/data-catalog/docs/how-to/search-reference).
   ///
   /// @param scope  Required. The scope of this search request.
+  ///  @n
   ///  The `scope` is invalid if `include_org_ids`, `include_project_ids` are
   ///  empty AND `include_gcp_public_datasets` is set to `false`. In this case,
   ///  the request returns an error.
   /// @param query  Optional. The query string with a minimum of 3 characters and specific
   ///  syntax. For more information, see [Data Catalog search
   ///  syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference).
+  ///  @n
   ///  An empty query string returns all data assets (in the specified scope)
   ///  that you have access to.
+  ///  @n
   ///  A query string can be a simple `xyz` or qualified by predicates:
+  ///  @n
   ///  * `name:x`
   ///  * `column:y`
   ///  * `description:z`
@@ -238,9 +242,11 @@ class DataCatalogClient {
   ///
   /// @param parent  Required. The names of the project and location that the new entry group
   ///  belongs to.
+  ///  @n
   ///  Note: The entry group itself and its child resources might not be
   ///  stored in the location specified in its name.
   /// @param entry_group_id  Required. The ID of the entry group to create.
+  ///  @n
   ///  The ID must contain only letters (a-z, A-Z), numbers (0-9),
   ///  underscores (_), and must start with a letter or underscore.
   ///  The maximum size is 64 bytes when encoded in UTF-8.
@@ -455,6 +461,7 @@ class DataCatalogClient {
   ///
   /// @param entry_group  Required. Updates for the entry group. The `name` field must be set.
   /// @param update_mask  Names of fields whose values to overwrite on an entry group.
+  ///  @n
   ///  If this parameter is absent or empty, all modifiable fields
   ///  are overwritten. If such fields are non-required and omitted in the
   ///  request body, their values are emptied.
@@ -583,6 +590,7 @@ class DataCatalogClient {
   /// Lists entry groups.
   ///
   /// @param parent  Required. The name of the location that contains the entry groups to list.
+  ///  @n
   ///  Can be provided as a URL.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -670,9 +678,11 @@ class DataCatalogClient {
   /// An entry group can have a maximum of 100,000 entries.
   ///
   /// @param parent  Required. The name of the entry group this entry belongs to.
+  ///  @n
   ///  Note: The entry itself and its child resources might not be stored in
   ///  the location specified in its name.
   /// @param entry_id  Required. The ID of the entry to create.
+  ///  @n
   ///  The ID must contain only letters (a-z, A-Z), numbers (0-9),
   ///  and underscores (_).
   ///  The maximum size is 64 bytes when encoded in UTF-8.
@@ -783,19 +793,27 @@ class DataCatalogClient {
   ///
   /// @param entry  Required. Updates for the entry. The `name` field must be set.
   /// @param update_mask  Names of fields whose values to overwrite on an entry.
+  ///  @n
   ///  If this parameter is absent or empty, all modifiable fields
   ///  are overwritten. If such fields are non-required and omitted in the
   ///  request body, their values are emptied.
+  ///  @n
   ///  You can modify only the fields listed below.
+  ///  @n
   ///  For entries with type `DATA_STREAM`:
+  ///  @n
   ///  * `schema`
+  ///  @n
   ///  For entries with type `FILESET`:
+  ///  @n
   ///  * `schema`
   ///  * `display_name`
   ///  * `description`
   ///  * `gcs_fileset_spec`
   ///  * `gcs_fileset_spec.file_patterns`
+  ///  @n
   ///  For entries with `user_specified_type`:
+  ///  @n
   ///  * `schema`
   ///  * `display_name`
   ///  * `description`
@@ -1034,6 +1052,7 @@ class DataCatalogClient {
   /// [SearchCatalog][google.cloud.datacatalog.v1.DataCatalog.SearchCatalog].
   ///
   /// @param parent  Required. The name of the entry group that contains the entries to list.
+  ///  @n
   ///  Can be provided in URL format.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1198,6 +1217,7 @@ class DataCatalogClient {
   /// @param parent  Required. The name of the project and the template location
   ///  [region](https://cloud.google.com/data-catalog/docs/concepts/regions).
   /// @param tag_template_id  Required. The ID of the tag template to create.
+  ///  @n
   ///  The ID must contain only lowercase letters (a-z), numbers (0-9),
   ///  or underscores (_), and must start with a letter or underscore.
   ///  The maximum size is 64 bytes when encoded in UTF-8.
@@ -1370,9 +1390,11 @@ class DataCatalogClient {
   /// @param tag_template  Required. The template to update. The `name` field must be set.
   /// @param update_mask  Names of fields whose values to overwrite on a tag template. Currently,
   ///  only `display_name` and `is_publicly_readable` can be overwritten.
+  ///  @n
   ///  If this parameter is absent or empty, all modifiable fields
   ///  are overwritten. If such fields are non-required and omitted in the
   ///  request body, their values are emptied.
+  ///  @n
   ///  Note: Updating the `is_publicly_readable` field may require up to 12
   ///  hours to take effect in search results.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1447,6 +1469,7 @@ class DataCatalogClient {
   ///
   /// @param name  Required. The name of the tag template to delete.
   /// @param force  Required. If true, deletes all tags that use this template.
+  ///  @n
   ///  Currently, `true` is the only supported value.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1510,7 +1533,9 @@ class DataCatalogClient {
   /// @param parent  Required. The name of the project and the template location
   ///  [region](https://cloud.google.com/data-catalog/docs/concepts/regions).
   /// @param tag_template_field_id  Required. The ID of the tag template field to create.
+  ///  @n
   ///  Note: Adding a required field to an existing template is *not* allowed.
+  ///  @n
   ///  Field IDs can contain letters (both uppercase and lowercase), numbers
   ///  (0-9), underscores (_) and dashes (-). Field IDs must be at least 1
   ///  character long and at most 128 characters long. Field IDs must also be
@@ -1631,15 +1656,18 @@ class DataCatalogClient {
   /// @param tag_template_field  Required. The template to update.
   /// @param update_mask  Optional. Names of fields whose values to overwrite on an individual field
   ///  of a tag template. The following fields are modifiable:
+  ///  @n
   ///  * `display_name`
   ///  * `type.enum_type`
   ///  * `is_required`
+  ///  @n
   ///  If this parameter is absent or empty, all modifiable fields
   ///  are overwritten. If such fields are non-required and omitted in the request
   ///  body, their values are emptied with one exception: when updating an enum
   ///  type, the provided values are merged with the existing values. Therefore,
   ///  enum values can only be added, existing enum values cannot be deleted or
   ///  renamed.
+  ///  @n
   ///  Additionally, updating a template field from optional to required is
   ///  *not* allowed.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1859,6 +1887,7 @@ class DataCatalogClient {
   ///
   /// @param name  Required. The name of the tag template field to delete.
   /// @param force  Required. If true, deletes this field from any tags that use it.
+  ///  @n
   ///  Currently, `true` is the only supported value.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1929,8 +1958,10 @@ class DataCatalogClient {
   /// used to create the tag must be in the same organization.
   ///
   /// @param parent  Required. The name of the resource to attach this tag to.
+  ///  @n
   ///  Tags can be attached to entries or entry groups. An entry can have up to
   ///  1000 attached tags.
+  ///  @n
   ///  Note: The tag and its child resources might not be stored in
   ///  the location specified in its name.
   /// @param tag  Required. The tag to create.
@@ -2036,6 +2067,7 @@ class DataCatalogClient {
   /// @param tag  Required. The updated tag. The "name" field must be set.
   /// @param update_mask  Names of fields whose values to overwrite on a tag. Currently, a tag has
   ///  the only modifiable field with the name `fields`.
+  ///  @n
   ///  In general, if this parameter is absent or empty, all modifiable fields
   ///  are overwritten. If such fields are non-required and omitted in the
   ///  request body, their values are emptied.
@@ -2151,6 +2183,7 @@ class DataCatalogClient {
   /// lowercased.
   ///
   /// @param parent  Required. The name of the Data Catalog resource to list the tags of.
+  ///  @n
   ///  The resource can be an [Entry][google.cloud.datacatalog.v1.Entry]
   ///  or an [EntryGroup][google.cloud.datacatalog.v1.EntryGroup]
   ///  (without `/entries/{entries}` at the end).

--- a/google/cloud/datacatalog/v1/policy_tag_manager_client.h
+++ b/google/cloud/datacatalog/v1/policy_tag_manager_client.h
@@ -162,6 +162,7 @@ class PolicyTagManagerClient {
   /// BigQuery columns.
   ///
   /// @param name  Required. Resource name of the taxonomy to delete.
+  ///  @n
   ///  Note: All policy tags in this taxonomy are also deleted.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -480,6 +481,7 @@ class PolicyTagManagerClient {
   ///   descendants
   ///
   /// @param name  Required. Resource name of the policy tag to delete.
+  ///  @n
   ///  Note: All of its descendant policy tags are also deleted.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/dataproc/v1/autoscaling_policy_client.h
+++ b/google/cloud/dataproc/v1/autoscaling_policy_client.h
@@ -96,9 +96,11 @@ class AutoscalingPolicyServiceClient {
   ///
   /// @param parent  Required. The "resource name" of the region or location, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.autoscalingPolicies.create`, the resource name
   ///    of the region has the following format:
   ///    `projects/{project_id}/regions/{region}`
+  ///  @n
   ///  * For `projects.locations.autoscalingPolicies.create`, the resource name
   ///    of the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
@@ -235,9 +237,11 @@ class AutoscalingPolicyServiceClient {
   ///
   /// @param name  Required. The "resource name" of the autoscaling policy, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.autoscalingPolicies.get`, the resource name
   ///    of the policy has the following format:
   ///    `projects/{project_id}/regions/{region}/autoscalingPolicies/{policy_id}`
+  ///  @n
   ///  * For `projects.locations.autoscalingPolicies.get`, the resource name
   ///    of the policy has the following format:
   ///    `projects/{project_id}/locations/{location}/autoscalingPolicies/{policy_id}`
@@ -300,9 +304,11 @@ class AutoscalingPolicyServiceClient {
   ///
   /// @param parent  Required. The "resource name" of the region or location, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.autoscalingPolicies.list`, the resource name
   ///    of the region has the following format:
   ///    `projects/{project_id}/regions/{region}`
+  ///  @n
   ///  * For `projects.locations.autoscalingPolicies.list`, the resource name
   ///    of the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
@@ -385,9 +391,11 @@ class AutoscalingPolicyServiceClient {
   ///
   /// @param name  Required. The "resource name" of the autoscaling policy, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.autoscalingPolicies.delete`, the resource name
   ///    of the policy has the following format:
   ///    `projects/{project_id}/regions/{region}/autoscalingPolicies/{policy_id}`
+  ///  @n
   ///  * For `projects.locations.autoscalingPolicies.delete`, the resource name
   ///    of the policy has the following format:
   ///    `projects/{project_id}/locations/{location}/autoscalingPolicies/{policy_id}`

--- a/google/cloud/dataproc/v1/batch_controller_client.h
+++ b/google/cloud/dataproc/v1/batch_controller_client.h
@@ -94,6 +94,7 @@ class BatchControllerClient {
   /// @param batch  Required. The batch to create.
   /// @param batch_id  Optional. The ID to use for the batch, which will become the final
   ///  component of the batch's resource name.
+  ///  @n
   ///  This value must be 4-63 characters. Valid characters are `/[a-z][0-9]-/`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/dataproc/v1/cluster_controller_client.h
+++ b/google/cloud/dataproc/v1/cluster_controller_client.h
@@ -187,6 +187,7 @@ class ClusterControllerClient {
   ///  in a cluster to 5, the `update_mask` parameter would be
   ///  specified as `config.worker_config.num_instances`,
   ///  and the `PATCH` request body would specify the new value, as follows:
+  ///  @n
   ///      {
   ///        "config":{
   ///          "workerConfig":{
@@ -198,6 +199,7 @@ class ClusterControllerClient {
   ///  the `update_mask` parameter would be
   ///  `config.secondary_worker_config.num_instances`, and the `PATCH` request
   ///  body would be set as follows:
+  ///  @n
   ///      {
   ///        "config":{
   ///          "secondaryWorkerConfig":{
@@ -206,6 +208,7 @@ class ClusterControllerClient {
   ///        }
   ///      }
   ///  <strong>Note:</strong> Currently, only the following fields can be updated:
+  ///  @n
   ///   <table>
   ///   <!--<tbody>-->
   ///   <tr>
@@ -573,7 +576,9 @@ class ClusterControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the request.
   /// @param filter  Optional. A filter constraining the clusters to list. Filters are
   ///  case-sensitive and have the following syntax:
+  ///  @n
   ///  field = value [AND [field = value]] ...
+  ///  @n
   ///  where **field** is one of `status.state`, `clusterName`, or `labels.[KEY]`,
   ///  and `[KEY]` is a label key. **value** can be `*` to match all values.
   ///  `status.state` can be one of the following: `ACTIVE`, `INACTIVE`,
@@ -583,7 +588,9 @@ class ClusterControllerClient {
   ///  `clusterName` is the name of the cluster provided at creation time.
   ///  Only the logical `AND` operator is supported; space-separated items are
   ///  treated as having an implicit `AND` operator.
+  ///  @n
   ///  Example filter:
+  ///  @n
   ///  status.state = ACTIVE AND clusterName = mycluster
   ///  AND labels.env = staging AND labels.starred = *
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/dataproc/v1/job_controller_client.h
+++ b/google/cloud/dataproc/v1/job_controller_client.h
@@ -331,13 +331,17 @@ class JobControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the request.
   /// @param filter  Optional. A filter constraining the jobs to list. Filters are
   ///  case-sensitive and have the following syntax:
+  ///  @n
   ///  [field = value] AND [field [= value]] ...
+  ///  @n
   ///  where **field** is `status.state` or `labels.[KEY]`, and `[KEY]` is a label
   ///  key. **value** can be `*` to match all values.
   ///  `status.state` can be either `ACTIVE` or `NON_ACTIVE`.
   ///  Only the logical `AND` operator is supported; space-separated items are
   ///  treated as having an implicit `AND` operator.
+  ///  @n
   ///  Example filter:
+  ///  @n
   ///  status.state = ACTIVE AND labels.env = staging AND labels.starred = *
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/dataproc/v1/workflow_template_client.h
+++ b/google/cloud/dataproc/v1/workflow_template_client.h
@@ -96,9 +96,11 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param parent  Required. The resource name of the region or location, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.workflowTemplates.create`, the resource name of the
   ///    region has the following format:
   ///    `projects/{project_id}/regions/{region}`
+  ///  @n
   ///  * For `projects.locations.workflowTemplates.create`, the resource name of
   ///    the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
@@ -169,9 +171,11 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param name  Required. The resource name of the workflow template, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.workflowTemplates.get`, the resource name of the
   ///    template has the following format:
   ///    `projects/{project_id}/regions/{region}/workflowTemplates/{template_id}`
+  ///  @n
   ///  * For `projects.locations.workflowTemplates.get`, the resource name of the
   ///    template has the following format:
   ///    `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`
@@ -256,9 +260,11 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param name  Required. The resource name of the workflow template, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.workflowTemplates.instantiate`, the resource name
   ///  of the template has the following format:
   ///    `projects/{project_id}/regions/{region}/workflowTemplates/{template_id}`
+  ///  @n
   ///  * For `projects.locations.workflowTemplates.instantiate`, the resource name
   ///    of the template has the following format:
   ///    `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`
@@ -319,9 +325,11 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param name  Required. The resource name of the workflow template, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.workflowTemplates.instantiate`, the resource name
   ///  of the template has the following format:
   ///    `projects/{project_id}/regions/{region}/workflowTemplates/{template_id}`
+  ///  @n
   ///  * For `projects.locations.workflowTemplates.instantiate`, the resource name
   ///    of the template has the following format:
   ///    `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`
@@ -455,9 +463,11 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param parent  Required. The resource name of the region or location, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.workflowTemplates,instantiateinline`, the resource
   ///    name of the region has the following format:
   ///    `projects/{project_id}/regions/{region}`
+  ///  @n
   ///  * For `projects.locations.workflowTemplates.instantiateinline`, the
   ///    resource name of the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
@@ -578,6 +588,7 @@ class WorkflowTemplateServiceClient {
   /// must contain version that matches the current server version.
   ///
   /// @param template_  Required. The updated workflow template.
+  ///  @n
   ///  The `template.version` field must match the current version.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -642,9 +653,11 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param parent  Required. The resource name of the region or location, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.workflowTemplates,list`, the resource
   ///    name of the region has the following format:
   ///    `projects/{project_id}/regions/{region}`
+  ///  @n
   ///  * For `projects.locations.workflowTemplates.list`, the
   ///    resource name of the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
@@ -726,9 +739,11 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param name  Required. The resource name of the workflow template, as described
   ///  in https://cloud.google.com/apis/design/resource_names.
+  ///  @n
   ///  * For `projects.regions.workflowTemplates.delete`, the resource name
   ///  of the template has the following format:
   ///    `projects/{project_id}/regions/{region}/workflowTemplates/{template_id}`
+  ///  @n
   ///  * For `projects.locations.workflowTemplates.instantiate`, the resource name
   ///    of the template has the following format:
   ///    `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`

--- a/google/cloud/dialogflow_cx/deployments_client.h
+++ b/google/cloud/dialogflow_cx/deployments_client.h
@@ -95,6 +95,7 @@ class DeploymentsClient {
   ///
   /// @param parent  Required. The [Environment][google.cloud.dialogflow.cx.v3.Environment] to
   ///  list all environments for. Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>
   ///  @endcode

--- a/google/cloud/dialogflow_cx/environments_client.h
+++ b/google/cloud/dialogflow_cx/environments_client.h
@@ -487,6 +487,7 @@ class EnvironmentsClient {
   ///
   /// @param name  Required. Resource name of the environment to look up the history for.
   ///  Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>
   ///  @endcode

--- a/google/cloud/dialogflow_cx/experiments_client.h
+++ b/google/cloud/dialogflow_cx/experiments_client.h
@@ -95,6 +95,7 @@ class ExperimentsClient {
   ///
   /// @param parent  Required. The [Environment][google.cloud.dialogflow.cx.v3.Environment] to
   ///  list all environments for. Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>
   ///  @endcode

--- a/google/cloud/dialogflow_cx/session_entity_types_client.h
+++ b/google/cloud/dialogflow_cx/session_entity_types_client.h
@@ -96,10 +96,13 @@ class SessionEntityTypesClient {
   ///
   /// @param parent  Required. The session to list all session entity types from.
   ///  Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>
   ///  @endcode
@@ -183,13 +186,17 @@ class SessionEntityTypesClient {
   ///
   /// @param name  Required. The name of the session entity type.
   ///  Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
   ///  @endcode
+  ///  @n
   ///  If `Environment ID` is not specified, we assume the default 'draft'
   ///  environment.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -253,10 +260,13 @@ class SessionEntityTypesClient {
   ///
   /// @param parent  Required. The session to create a session entity type for.
   ///  Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>
   ///  @endcode
@@ -328,13 +338,17 @@ class SessionEntityTypesClient {
   ///
   /// @param session_entity_type  Required. The session entity type to update.
   ///  Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
   ///  @endcode
+  ///  @n
   ///  If `Environment ID` is not specified, we assume the default 'draft'
   ///  environment.
   /// @param update_mask  The mask to control which fields get updated.
@@ -402,13 +416,17 @@ class SessionEntityTypesClient {
   ///
   /// @param name  Required. The name of the session entity type to delete.
   ///  Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
   ///  @endcode
+  ///  @n
   ///  If `Environment ID` is not specified, we assume the default 'draft'
   ///  environment.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/dialogflow_cx/transition_route_groups_client.h
+++ b/google/cloud/dialogflow_cx/transition_route_groups_client.h
@@ -402,6 +402,7 @@ class TransitionRouteGroupsClient {
   /// @param name  Required. The name of the
   ///  [TransitionRouteGroup][google.cloud.dialogflow.cx.v3.TransitionRouteGroup]
   ///  to delete. Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/flows/<Flow ID>/transitionRouteGroups/<Transition Route Group ID>
   ///  @endcode

--- a/google/cloud/dialogflow_cx/versions_client.h
+++ b/google/cloud/dialogflow_cx/versions_client.h
@@ -538,6 +538,7 @@ class VersionsClient {
   ///
   /// @param base_version  Required. Name of the base flow version to compare with the target version.
   ///  Use version ID `0` to indicate the draft version of the specified flow.
+  ///  @n
   ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/
   ///  <Agent ID>/flows/<Flow ID>/versions/<Version ID>`.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/dialogflow_es/contexts_client.h
+++ b/google/cloud/dialogflow_es/contexts_client.h
@@ -171,10 +171,13 @@ class ContextsClient {
   /// Retrieves the specified context.
   ///
   /// @param name  Required. The name of the context. Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/contexts/<Context ID>`
   ///  @endcode
@@ -367,10 +370,13 @@ class ContextsClient {
   /// Deletes the specified context.
   ///
   /// @param name  Required. The name of the context to delete. Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/contexts/<Context ID>`
   ///  @endcode
@@ -427,10 +433,13 @@ class ContextsClient {
   /// Deletes all active contexts in the specified session.
   ///
   /// @param parent  Required. The name of the session to delete all contexts from. Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/sessions/<Session ID>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>
   ///  @endcode

--- a/google/cloud/dialogflow_es/documents_client.h
+++ b/google/cloud/dialogflow_es/documents_client.h
@@ -576,6 +576,7 @@ class DocumentsClient {
   ///  ID>/knowledgeBases/<Knowledge Base ID>/documents/<Document ID>`
   /// @param content_uri  Optional. The path of gcs source file for reloading document content. For
   ///  now, only gcs uri is supported.
+  ///  @n
   ///  For documents stored in Google Cloud Storage, these URIs must have
   ///  the form `gs://<bucket-name>/<object-name>`.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/dialogflow_es/environments_client.h
+++ b/google/cloud/dialogflow_es/environments_client.h
@@ -93,6 +93,7 @@ class EnvironmentsClient {
   ///
   /// @param parent  Required. The agent to list all environments from.
   ///  Format:
+  ///  @n
   ///  - `projects/<Project ID>/agent`
   ///  - `projects/<Project ID>/locations/<Location ID>/agent`
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/dialogflow_es/intents_client.h
+++ b/google/cloud/dialogflow_es/intents_client.h
@@ -93,6 +93,7 @@ class IntentsClient {
   /// @param parent  Required. The agent to list all intents from.
   ///  Format: `projects/<Project ID>/agent` or `projects/<Project
   ///  ID>/locations/<Location ID>/agent`.
+  ///  @n
   ///  Alternatively, you can specify the environment to list intents for.
   ///  Format: `projects/<Project ID>/agent/environments/<Environment ID>`
   ///  or `projects/<Project ID>/locations/<Location
@@ -136,6 +137,7 @@ class IntentsClient {
   /// @param parent  Required. The agent to list all intents from.
   ///  Format: `projects/<Project ID>/agent` or `projects/<Project
   ///  ID>/locations/<Location ID>/agent`.
+  ///  @n
   ///  Alternatively, you can specify the environment to list intents for.
   ///  Format: `projects/<Project ID>/agent/environments/<Environment ID>`
   ///  or `projects/<Project ID>/locations/<Location

--- a/google/cloud/dialogflow_es/session_entity_types_client.h
+++ b/google/cloud/dialogflow_es/session_entity_types_client.h
@@ -189,10 +189,13 @@ class SessionEntityTypesClient {
   /// with Google Assistant integration.
   ///
   /// @param name  Required. The name of the session entity type. Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
   ///  @endcode
@@ -454,10 +457,13 @@ class SessionEntityTypesClient {
   /// with Google Assistant integration.
   ///
   /// @param name  Required. The name of the entity type to delete. Format:
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
   ///  @endcode
+  ///  @n
   ///  or
+  ///  @n
   ///  @code
   ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
   ///  @endcode

--- a/google/cloud/dialogflow_es/sessions_client.h
+++ b/google/cloud/dialogflow_es/sessions_client.h
@@ -113,15 +113,20 @@ class SessionsClient {
   ///  and `User Id`. They can be a random number or some type of user and session
   ///  identifiers (preferably hashed). The length of the `Session ID` and
   ///  `User ID` must not exceed 36 characters.
+  ///  @n
   ///  For more information, see the [API interactions
   ///  guide](https://cloud.google.com/dialogflow/docs/api-overview).
+  ///  @n
   ///  Note: Always use agent versions for production traffic.
   ///  See [Versions and
   ///  environments](https://cloud.google.com/dialogflow/es/docs/agents-versions).
   /// @param query_input  Required. The input specification. It can be set to:
+  ///  @n
   ///  1.  an audio config
   ///      which instructs the speech recognizer how to process the speech audio,
+  ///  @n
   ///  2.  a conversational query in the form of text, or
+  ///  @n
   ///  3.  an event that specifies which intent to trigger.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/dialogflow_es/versions_client.h
+++ b/google/cloud/dialogflow_es/versions_client.h
@@ -91,6 +91,7 @@ class VersionsClient {
   ///
   /// @param parent  Required. The agent to list all versions from.
   ///  Supported formats:
+  ///  @n
   ///  - `projects/<Project ID>/agent`
   ///  - `projects/<Project ID>/locations/<Location ID>/agent`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -170,6 +171,7 @@ class VersionsClient {
   ///
   /// @param name  Required. The name of the version.
   ///  Supported formats:
+  ///  @n
   ///  - `projects/<Project ID>/agent/versions/<Version ID>`
   ///  - `projects/<Project ID>/locations/<Location ID>/agent/versions/<Version
   ///    ID>`
@@ -234,6 +236,7 @@ class VersionsClient {
   ///
   /// @param parent  Required. The agent to create a version for.
   ///  Supported formats:
+  ///  @n
   ///  - `projects/<Project ID>/agent`
   ///  - `projects/<Project ID>/locations/<Location ID>/agent`
   /// @param version  Required. The version to create.
@@ -303,6 +306,7 @@ class VersionsClient {
   ///
   /// @param version  Required. The version to update.
   ///  Supported formats:
+  ///  @n
   ///  - `projects/<Project ID>/agent/versions/<Version ID>`
   ///  - `projects/<Project ID>/locations/<Location ID>/agent/versions/<Version
   ///    ID>`
@@ -371,6 +375,7 @@ class VersionsClient {
   ///
   /// @param name  Required. The name of the version to delete.
   ///  Supported formats:
+  ///  @n
   ///  - `projects/<Project ID>/agent/versions/<Version ID>`
   ///  - `projects/<Project ID>/locations/<Location ID>/agent/versions/<Version
   ///    ID>`

--- a/google/cloud/dlp/v2/dlp_client.h
+++ b/google/cloud/dlp/v2/dlp_client.h
@@ -252,7 +252,9 @@ class DlpServiceClient {
   /// learn more.
   ///
   /// @param parent  The parent resource name.
+  ///  @n
   ///  The format of this value is as follows:
+  ///  @n
   ///      locations/<var>LOCATION_ID</var>
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -316,9 +318,11 @@ class DlpServiceClient {
   /// See https://cloud.google.com/dlp/docs/creating-templates to learn more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on the scope of the request
   ///  (project or organization) and whether you have [specified a processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
@@ -327,9 +331,11 @@ class DlpServiceClient {
   ///    `organizations/`<var>ORG_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Organizations scope, no location specified (defaults to global):<br/>
   ///    `organizations/`<var>ORG_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param inspect_template  Required. The InspectTemplate to create.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -523,9 +529,11 @@ class DlpServiceClient {
   /// See https://cloud.google.com/dlp/docs/creating-templates to learn more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on the scope of the request
   ///  (project or organization) and whether you have [specified a processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
@@ -534,9 +542,11 @@ class DlpServiceClient {
   ///    `organizations/`<var>ORG_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Organizations scope, no location specified (defaults to global):<br/>
   ///    `organizations/`<var>ORG_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -673,9 +683,11 @@ class DlpServiceClient {
   /// more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on the scope of the request
   ///  (project or organization) and whether you have [specified a processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
@@ -684,9 +696,11 @@ class DlpServiceClient {
   ///    `organizations/`<var>ORG_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Organizations scope, no location specified (defaults to global):<br/>
   ///    `organizations/`<var>ORG_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param deidentify_template  Required. The DeidentifyTemplate to create.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -890,9 +904,11 @@ class DlpServiceClient {
   /// more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on the scope of the request
   ///  (project or organization) and whether you have [specified a processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
@@ -901,9 +917,11 @@ class DlpServiceClient {
   ///    `organizations/`<var>ORG_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Organizations scope, no location specified (defaults to global):<br/>
   ///    `organizations/`<var>ORG_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1043,16 +1061,20 @@ class DlpServiceClient {
   /// See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on whether you have [specified a
   ///  processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
   ///    `projects/`<var>PROJECT_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param job_trigger  Required. The JobTrigger to create.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1308,16 +1330,20 @@ class DlpServiceClient {
   /// See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on whether you have [specified a
   ///  processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
   ///    `projects/`<var>PROJECT_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1489,16 +1515,20 @@ class DlpServiceClient {
   /// be all types, but may change over time as detectors are updated.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on whether you have [specified a
   ///  processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
   ///    `projects/`<var>PROJECT_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param inspect_job  An inspection job scans a storage repository for InfoTypes.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1535,16 +1565,20 @@ class DlpServiceClient {
   /// be all types, but may change over time as detectors are updated.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on whether you have [specified a
   ///  processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
   ///    `projects/`<var>PROJECT_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param risk_job  A risk analysis job calculates re-identification risk metrics for a
   ///  BigQuery table.
@@ -1616,16 +1650,20 @@ class DlpServiceClient {
   /// https://cloud.google.com/dlp/docs/compute-risk-analysis to learn more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on whether you have [specified a
   ///  processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
   ///    `projects/`<var>PROJECT_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1860,9 +1898,11 @@ class DlpServiceClient {
   /// learn more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on the scope of the request
   ///  (project or organization) and whether you have [specified a processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
@@ -1871,9 +1911,11 @@ class DlpServiceClient {
   ///    `organizations/`<var>ORG_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Organizations scope, no location specified (defaults to global):<br/>
   ///    `organizations/`<var>ORG_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param config  Required. Configuration of the storedInfoType to create.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -2076,16 +2118,20 @@ class DlpServiceClient {
   /// learn more.
   ///
   /// @param parent  Required. Parent resource name.
+  ///  @n
   ///  The format of this value varies depending on the scope of the request
   ///  (project or organization) and whether you have [specified a processing
   ///  location](https://cloud.google.com/dlp/docs/specifying-location):
+  ///  @n
   ///  + Projects scope, location specified:<br/>
   ///    `projects/`<var>PROJECT_ID</var>`/locations/`<var>LOCATION_ID</var>
   ///  + Projects scope, no location specified (defaults to global):<br/>
   ///    `projects/`<var>PROJECT_ID</var>
+  ///  @n
   ///  The following example `parent` string specifies a parent project with the
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
+  ///  @n
   ///      parent=projects/example-project/locations/europe-west3
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/filestore/v1/cloud_filestore_manager_client.h
+++ b/google/cloud/filestore/v1/cloud_filestore_manager_client.h
@@ -342,6 +342,7 @@ class CloudFilestoreManagerClient {
   /// @param update_mask  Mask of fields to update.  At least one path must be supplied in this
   ///  field.  The elements of the repeated paths field may only include these
   ///  fields:
+  ///  @n
   ///  * "description"
   ///  * "file_shares"
   ///  * "labels"
@@ -672,6 +673,7 @@ class CloudFilestoreManagerClient {
   /// @param snapshot  Required. A snapshot resource.
   /// @param snapshot_id  Required. The ID to use for the snapshot.
   ///  The ID must be unique within the specified instance.
+  ///  @n
   ///  This value must start with a lowercase letter followed by up to 62
   ///  lowercase letters, numbers, or hyphens, and cannot end with a hyphen.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1037,6 +1039,7 @@ class CloudFilestoreManagerClient {
   /// @param backup  Required. A [backup resource][google.cloud.filestore.v1.Backup]
   /// @param backup_id  Required. The ID to use for the backup.
   ///  The ID must be unique within the specified project and location.
+  ///  @n
   ///  This value must start with a lowercase letter followed by up to 62
   ///  lowercase letters, numbers, or hyphens, and cannot end with a hyphen.
   ///  Values that do not match this pattern will trigger an INVALID_ARGUMENT

--- a/google/cloud/gkehub/v1/gke_hub_client.h
+++ b/google/cloud/gkehub/v1/gke_hub_client.h
@@ -391,9 +391,11 @@ class GkeHubClient {
   /// @param resource  Required. The membership to create.
   /// @param membership_id  Required. Client chosen ID for the membership. `membership_id` must be a
   ///  valid RFC 1123 compliant DNS label:
+  ///  @n
   ///    1. At most 63 characters in length
   ///    2. It must consist of lower case alphanumeric characters or `-`
   ///    3. It must start and end with an alphanumeric character
+  ///  @n
   ///  Which can be expressed as the regex: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`,
   ///  with a maximum length of 63 characters.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/gkemulticloud/v1/attached_clusters_client.h
+++ b/google/cloud/gkemulticloud/v1/attached_clusters_client.h
@@ -102,17 +102,21 @@ class AttachedClustersClient {
   /// @param parent  Required. The parent location where this
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resource
   ///  will be created.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param attached_cluster  Required. The specification of the
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] to create.
   /// @param attached_cluster_id  Required. A client provided ID the resource. Must be unique within the
   ///  parent resource.
+  ///  @n
   ///  The provided ID will be part of the
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resource
   ///  name formatted as
   ///  `projects/<project-id>/locations/<region>/attachedClusters/<cluster-id>`.
+  ///  @n
   ///  Valid characters are `/[a-z][0-9]-/`. Cannot be longer than 63 characters.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -204,6 +208,7 @@ class AttachedClustersClient {
   ///  this field. The elements of the repeated paths field can only include these
   ///  fields from
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster]:
+  ///  @n
   ///   *   `description`.
   ///   *   `annotations`.
   ///   *   `platform_version`.
@@ -296,7 +301,9 @@ class AttachedClustersClient {
   /// @param parent  Required. The parent location where this
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resource
   ///  will be created.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param fleet_membership  Required. The name of the fleet membership resource to import.
@@ -387,8 +394,10 @@ class AttachedClustersClient {
   /// @param name  Required. The name of the
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resource
   ///  to describe.
+  ///  @n
   ///  `AttachedCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/attachedClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -454,7 +463,9 @@ class AttachedClustersClient {
   ///
   /// @param parent  Required. The parent location which owns this collection of
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resources.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -541,8 +552,10 @@ class AttachedClustersClient {
   ///
   /// @param name  Required. The resource name the
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] to delete.
+  ///  @n
   ///  `AttachedCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/attachedClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -629,8 +642,10 @@ class AttachedClustersClient {
   /// @param name  Required. The name of the
   ///  [AttachedServerConfig][google.cloud.gkemulticloud.v1.AttachedServerConfig]
   ///  resource to describe.
+  ///  @n
   ///  `AttachedServerConfig` names are formatted as
   ///  `projects/<project-id>/locations/<region>/attachedServerConfig`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -696,18 +711,24 @@ class AttachedClustersClient {
   /// @param parent  Required. The parent location where this
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resource
   ///  will be created.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param attached_cluster_id  Required. A client provided ID of the resource. Must be unique within the
   ///  parent resource.
+  ///  @n
   ///  The provided ID will be part of the
   ///  [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resource
   ///  name formatted as
   ///  `projects/<project-id>/locations/<region>/attachedClusters/<cluster-id>`.
+  ///  @n
   ///  Valid characters are `/[a-z][0-9]-/`. Cannot be longer than 63 characters.
+  ///  @n
   ///  When generating an install manifest for importing an existing Membership
   ///  resource, the attached_cluster_id field must be the Membership id.
+  ///  @n
   ///  Membership names are formatted as
   ///  `projects/<project-id>/locations/<region>/memberships/<membership-id>`.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/gkemulticloud/v1/aws_clusters_client.h
+++ b/google/cloud/gkemulticloud/v1/aws_clusters_client.h
@@ -99,17 +99,21 @@ class AwsClustersClient {
   /// @param parent  Required. The parent location where this
   ///  [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster] resource will be
   ///  created.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param aws_cluster  Required. The specification of the
   ///  [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster] to create.
   /// @param aws_cluster_id  Required. A client provided ID the resource. Must be unique within the
   ///  parent resource.
+  ///  @n
   ///  The provided ID will be part of the
   ///  [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster] resource name
   ///  formatted as
   ///  `projects/<project-id>/locations/<region>/awsClusters/<cluster-id>`.
+  ///  @n
   ///  Valid characters are `/[a-z][0-9]-/`. Cannot be longer than 63 characters.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -196,6 +200,7 @@ class AwsClustersClient {
   /// @param update_mask  Required. Mask of fields to update. At least one path must be supplied in
   ///  this field. The elements of the repeated paths field can only include these
   ///  fields from [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster]:
+  ///  @n
   ///   *   `description`.
   ///   *   `annotations`.
   ///   *   `control_plane.version`.
@@ -295,8 +300,10 @@ class AwsClustersClient {
   /// @param name  Required. The name of the
   ///  [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster] resource to
   ///  describe.
+  ///  @n
   ///  `AwsCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/awsClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -360,7 +367,9 @@ class AwsClustersClient {
   ///
   /// @param parent  Required. The parent location which owns this collection of
   ///  [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster] resources.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -449,8 +458,10 @@ class AwsClustersClient {
   ///
   /// @param name  Required. The resource name the
   ///  [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster] to delete.
+  ///  @n
   ///  `AwsCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/awsClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -580,18 +591,22 @@ class AwsClustersClient {
   ///
   /// @param parent  Required. The [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster]
   ///  resource where this node pool will be created.
+  ///  @n
   ///  `AwsCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/awsClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param aws_node_pool  Required. The specification of the
   ///  [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool] to create.
   /// @param aws_node_pool_id  Required. A client provided ID the resource. Must be unique within the
   ///  parent resource.
+  ///  @n
   ///  The provided ID will be part of the
   ///  [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool] resource name
   ///  formatted as
   ///  `projects/<project-id>/locations/<region>/awsClusters/<cluster-id>/awsNodePools/<node-pool-id>`.
+  ///  @n
   ///  Valid characters are `/[a-z][0-9]-/`. Cannot be longer than 63 characters.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -680,6 +695,7 @@ class AwsClustersClient {
   /// @param update_mask  Required. Mask of fields to update. At least one path must be supplied in
   ///  this field. The elements of the repeated paths field can only include these
   ///  fields from [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool]:
+  ///  @n
   ///   *   `annotations`.
   ///   *   `version`.
   ///   *   `autoscaling.min_node_count`.
@@ -778,8 +794,10 @@ class AwsClustersClient {
   /// @param name  Required. The name of the
   ///  [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool] resource to
   ///  describe.
+  ///  @n
   ///  `AwsNodePool` names are formatted as
   ///  `projects/<project-id>/locations/<region>/awsClusters/<cluster-id>/awsNodePools/<node-pool-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -844,8 +862,10 @@ class AwsClustersClient {
   ///
   /// @param parent  Required. The parent `AwsCluster` which owns this collection of
   ///  [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool] resources.
+  ///  @n
   ///  `AwsCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/awsClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -934,8 +954,10 @@ class AwsClustersClient {
   ///
   /// @param name  Required. The resource name the
   ///  [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool] to delete.
+  ///  @n
   ///  `AwsNodePool` names are formatted as
   ///  `projects/<project-id>/locations/<region>/awsClusters/<cluster-id>/awsNodePools/<node-pool-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1021,8 +1043,10 @@ class AwsClustersClient {
   /// @param name  Required. The name of the
   ///  [AwsServerConfig][google.cloud.gkemulticloud.v1.AwsServerConfig] resource
   ///  to describe.
+  ///  @n
   ///  `AwsServerConfig` names are formatted as
   ///  `projects/<project-id>/locations/<region>/awsServerConfig`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/gkemulticloud/v1/azure_clusters_client.h
+++ b/google/cloud/gkemulticloud/v1/azure_clusters_client.h
@@ -103,17 +103,21 @@ class AzureClustersClient {
   /// @param parent  Required. The parent location where this
   ///  [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] resource will be
   ///  created.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param azure_client  Required. The specification of the
   ///  [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] to create.
   /// @param azure_client_id  Required. A client provided ID the resource. Must be unique within the
   ///  parent resource.
+  ///  @n
   ///  The provided ID will be part of the
   ///  [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] resource name
   ///  formatted as
   ///  `projects/<project-id>/locations/<region>/azureClients/<client-id>`.
+  ///  @n
   ///  Valid characters are `/[a-z][0-9]-/`. Cannot be longer than 63 characters.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -203,9 +207,11 @@ class AzureClustersClient {
   /// @param name  Required. The name of the
   ///  [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] resource to
   ///  describe.
+  ///  @n
   ///  [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] names are
   ///  formatted as
   ///  `projects/<project-id>/locations/<region>/azureClients/<client-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -269,7 +275,9 @@ class AzureClustersClient {
   ///
   /// @param parent  Required. The parent location which owns this collection of
   ///  [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] resources.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -358,9 +366,11 @@ class AzureClustersClient {
   ///
   /// @param name  Required. The resource name the
   ///  [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] to delete.
+  ///  @n
   ///  [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] names are
   ///  formatted as
   ///  `projects/<project-id>/locations/<region>/azureClients/<client-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -453,17 +463,21 @@ class AzureClustersClient {
   /// @param parent  Required. The parent location where this
   ///  [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] resource will be
   ///  created.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param azure_cluster  Required. The specification of the
   ///  [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] to create.
   /// @param azure_cluster_id  Required. A client provided ID the resource. Must be unique within the
   ///  parent resource.
+  ///  @n
   ///  The provided ID will be part of the
   ///  [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] resource name
   ///  formatted as
   ///  `projects/<project-id>/locations/<region>/azureClusters/<cluster-id>`.
+  ///  @n
   ///  Valid characters are `/[a-z][0-9]-/`. Cannot be longer than 63 characters.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -551,6 +565,7 @@ class AzureClustersClient {
   /// @param update_mask  Required. Mask of fields to update. At least one path must be supplied in
   ///  this field. The elements of the repeated paths field can only include these
   ///  fields from [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster]:
+  ///  @n
   ///   *   `description`.
   ///   *   `azureClient`.
   ///   *   `control_plane.version`.
@@ -644,8 +659,10 @@ class AzureClustersClient {
   /// @param name  Required. The name of the
   ///  [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] resource to
   ///  describe.
+  ///  @n
   ///  `AzureCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/azureClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -709,7 +726,9 @@ class AzureClustersClient {
   ///
   /// @param parent  Required. The parent location which owns this collection of
   ///  [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] resources.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -798,8 +817,10 @@ class AzureClustersClient {
   ///
   /// @param name  Required. The resource name the
   ///  [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] to delete.
+  ///  @n
   ///  `AzureCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/azureClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud Platform resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -931,17 +952,21 @@ class AzureClustersClient {
   ///
   /// @param parent  Required. The [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster]
   ///  resource where this node pool will be created.
+  ///  @n
   ///  Location names are formatted as `projects/<project-id>/locations/<region>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param azure_node_pool  Required. The specification of the
   ///  [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool] to create.
   /// @param azure_node_pool_id  Required. A client provided ID the resource. Must be unique within the
   ///  parent resource.
+  ///  @n
   ///  The provided ID will be part of the
   ///  [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool] resource name
   ///  formatted as
   ///  `projects/<project-id>/locations/<region>/azureClusters/<cluster-id>/azureNodePools/<node-pool-id>`.
+  ///  @n
   ///  Valid characters are `/[a-z][0-9]-/`. Cannot be longer than 63 characters.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1032,6 +1057,7 @@ class AzureClustersClient {
   /// @param update_mask  Required. Mask of fields to update. At least one path must be supplied in
   ///  this field. The elements of the repeated paths field can only include these
   ///  fields from [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool]:
+  ///  @n
   ///   *.  `annotations`.
   ///   *   `version`.
   ///   *   `autoscaling.min_node_count`.
@@ -1114,8 +1140,10 @@ class AzureClustersClient {
   /// @param name  Required. The name of the
   ///  [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool] resource to
   ///  describe.
+  ///  @n
   ///  `AzureNodePool` names are formatted as
   ///  `projects/<project-id>/locations/<region>/azureClusters/<cluster-id>/azureNodePools/<node-pool-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1180,8 +1208,10 @@ class AzureClustersClient {
   ///
   /// @param parent  Required. The parent `AzureCluster` which owns this collection of
   ///  [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool] resources.
+  ///  @n
   ///  `AzureCluster` names are formatted as
   ///  `projects/<project-id>/locations/<region>/azureClusters/<cluster-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1271,8 +1301,10 @@ class AzureClustersClient {
   ///
   /// @param name  Required. The resource name the
   ///  [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool] to delete.
+  ///  @n
   ///  `AzureNodePool` names are formatted as
   ///  `projects/<project-id>/locations/<region>/azureClusters/<cluster-id>/azureNodePools/<node-pool-id>`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1359,8 +1391,10 @@ class AzureClustersClient {
   /// @param name  Required. The name of the
   ///  [AzureServerConfig][google.cloud.gkemulticloud.v1.AzureServerConfig]
   ///  resource to describe.
+  ///  @n
   ///  `AzureServerConfig` names are formatted as
   ///  `projects/<project-id>/locations/<region>/azureServerConfig`.
+  ///  @n
   ///  See [Resource Names](https://cloud.google.com/apis/design/resource_names)
   ///  for more details on Google Cloud resource names.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/iam/admin/v1/iam_client.h
+++ b/google/cloud/iam/admin/v1/iam_client.h
@@ -569,6 +569,7 @@ class IAMClient {
   ///
   /// @param name  Required. The resource name of the service account in the following format:
   ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  @n
   ///  Using `-` as a wildcard for the `PROJECT_ID`, will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
@@ -642,6 +643,7 @@ class IAMClient {
   ///
   /// @param name  Required. The resource name of the service account key in the following format:
   ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
+  ///  @n
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
@@ -878,6 +880,7 @@ class IAMClient {
   ///
   /// @param name  Required. The resource name of the service account key in the following format:
   ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
+  ///  @n
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
@@ -938,6 +941,7 @@ class IAMClient {
   ///
   /// @param name  Required. The resource name of the service account key in the following format:
   ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
+  ///  @n
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
@@ -1267,6 +1271,7 @@ class IAMClient {
   /// role.
   ///
   /// @param full_resource_name  Required. The full resource name to query from the list of grantable roles.
+  ///  @n
   ///  The name follows the Google Cloud Platform resource format.
   ///  For example, a Cloud Platform project with id `my-project` will be named
   ///  `//cloudresourcemanager.googleapis.com/projects/my-project`.

--- a/google/cloud/iam/credentials/v1/iam_credentials_client.h
+++ b/google/cloud/iam/credentials/v1/iam_credentials_client.h
@@ -107,6 +107,7 @@ class IAMCredentialsClient {
   ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
   ///  on the service account that is specified in the `name` field of the
   ///  request.
+  ///  @n
   ///  The delegates must have the following format:
   ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
   ///  character is required; replacing it with a project ID is invalid.
@@ -190,6 +191,7 @@ class IAMCredentialsClient {
   ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
   ///  on the service account that is specified in the `name` field of the
   ///  request.
+  ///  @n
   ///  The delegates must have the following format:
   ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
   ///  character is required; replacing it with a project ID is invalid.
@@ -268,6 +270,7 @@ class IAMCredentialsClient {
   ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
   ///  on the service account that is specified in the `name` field of the
   ///  request.
+  ///  @n
   ///  The delegates must have the following format:
   ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
   ///  character is required; replacing it with a project ID is invalid.
@@ -340,6 +343,7 @@ class IAMCredentialsClient {
   ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
   ///  on the service account that is specified in the `name` field of the
   ///  request.
+  ///  @n
   ///  The delegates must have the following format:
   ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
   ///  character is required; replacing it with a project ID is invalid.

--- a/google/cloud/iam/v2/policies_client.h
+++ b/google/cloud/iam/v2/policies_client.h
@@ -95,11 +95,13 @@ class PoliciesClient {
   /// @param parent  Required. The resource that the policy is attached to, along with the kind of policy
   ///  to list. Format:
   ///  `policies/{attachment_point}/denypolicies`
+  ///  @n
   ///
   ///  The attachment point is identified by its URL-encoded full resource name,
   ///  which means that the forward-slash character, `/`, must be written as
   ///  `%2F`. For example,
   ///  `policies/cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project/denypolicies`.
+  ///  @n
   ///  For organizations and folders, use the numeric ID in the full resource
   ///  name. For projects, you can use the alphanumeric or the numeric ID.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -182,10 +184,12 @@ class PoliciesClient {
   ///
   /// @param name  Required. The resource name of the policy to retrieve. Format:
   ///  `policies/{attachment_point}/denypolicies/{policy_id}`
+  ///  @n
   ///
   ///  Use the URL-encoded full resource name, which means that the forward-slash
   ///  character, `/`, must be written as `%2F`. For example,
   ///  `policies/cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project/denypolicies/my-policy`.
+  ///  @n
   ///  For organizations and folders, use the numeric ID in the full resource
   ///  name. For projects, you can use the alphanumeric or the numeric ID.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -246,11 +250,13 @@ class PoliciesClient {
   ///
   /// @param parent  Required. The resource that the policy is attached to, along with the kind of policy
   ///  to create. Format: `policies/{attachment_point}/denypolicies`
+  ///  @n
   ///
   ///  The attachment point is identified by its URL-encoded full resource name,
   ///  which means that the forward-slash character, `/`, must be written as
   ///  `%2F`. For example,
   ///  `policies/cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project/denypolicies`.
+  ///  @n
   ///  For organizations and folders, use the numeric ID in the full resource
   ///  name. For projects, you can use the alphanumeric or the numeric ID.
   /// @param policy  Required. The policy to create.
@@ -377,10 +383,12 @@ class PoliciesClient {
   ///
   /// @param name  Required. The resource name of the policy to delete. Format:
   ///  `policies/{attachment_point}/denypolicies/{policy_id}`
+  ///  @n
   ///
   ///  Use the URL-encoded full resource name, which means that the forward-slash
   ///  character, `/`, must be written as `%2F`. For example,
   ///  `policies/cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project/denypolicies/my-policy`.
+  ///  @n
   ///  For organizations and folders, use the numeric ID in the full resource
   ///  name. For projects, you can use the alphanumeric or the numeric ID.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/iap/v1/identity_aware_proxy_admin_client.h
+++ b/google/cloud/iap/v1/identity_aware_proxy_admin_client.h
@@ -350,6 +350,7 @@ class IdentityAwareProxyAdminServiceClient {
   /// @param tunnel_dest_group  Required. The TunnelDestGroup to create.
   /// @param tunnel_dest_group_id  Required. The ID to use for the TunnelDestGroup, which becomes the final
   ///  component of the resource name.
+  ///  @n
   ///  This value must be 4-63 characters, and valid characters
   ///  are `[a-z]-`.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/kms/v1/key_management_client.h
+++ b/google/cloud/kms/v1/key_management_client.h
@@ -1516,9 +1516,11 @@ class KeyManagementServiceClient {
   ///  [CryptoKey][google.cloud.kms.v1.CryptoKey] or
   ///  [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to use for
   ///  encryption.
+  ///  @n
   ///  If a [CryptoKey][google.cloud.kms.v1.CryptoKey] is specified, the server
   ///  will use its [primary version][google.cloud.kms.v1.CryptoKey.primary].
   /// @param plaintext  Required. The data to encrypt. Must be no larger than 64KiB.
+  ///  @n
   ///  The maximum size depends on the key version's
   ///  [protection_level][google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level].
   ///  For [SOFTWARE][google.cloud.kms.v1.ProtectionLevel.SOFTWARE],
@@ -1677,6 +1679,7 @@ class KeyManagementServiceClient {
   /// @param digest  Optional. The digest of the data to sign. The digest must be produced with
   ///  the same digest algorithm as specified by the key version's
   ///  [algorithm][google.cloud.kms.v1.CryptoKeyVersion.algorithm].
+  ///  @n
   ///  This field may not be supplied if
   ///  [AsymmetricSignRequest.data][google.cloud.kms.v1.AsymmetricSignRequest.data]
   ///  is supplied.

--- a/google/cloud/logging/v2/logging_service_v2_client.h
+++ b/google/cloud/logging/v2/logging_service_v2_client.h
@@ -94,13 +94,16 @@ class LoggingServiceV2Client {
   /// delete operation with a timestamp before the operation will be deleted.
   ///
   /// @param log_name  Required. The resource name of the log to delete:
+  ///  @n
   ///  * `projects/[PROJECT_ID]/logs/[LOG_ID]`
   ///  * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
   ///  * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
   ///  * `folders/[FOLDER_ID]/logs/[LOG_ID]`
+  ///  @n
   ///  `[LOG_ID]` must be URL-encoded. For example,
   ///  `"projects/my-project-id/logs/syslog"`,
   ///  `"organizations/123/logs/cloudaudit.googleapis.com%2Factivity"`.
+  ///  @n
   ///  For more information about log names, see
   ///  [LogEntry][google.logging.v2.LogEntry].
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -163,22 +166,28 @@ class LoggingServiceV2Client {
   ///
   /// @param log_name  Optional. A default log resource name that is assigned to all log entries
   ///  in `entries` that do not specify a value for `log_name`:
+  ///  @n
   ///  * `projects/[PROJECT_ID]/logs/[LOG_ID]`
   ///  * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
   ///  * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
   ///  * `folders/[FOLDER_ID]/logs/[LOG_ID]`
+  ///  @n
   ///  `[LOG_ID]` must be URL-encoded. For example:
+  ///  @n
   ///      "projects/my-project-id/logs/syslog"
   ///      "organizations/123/logs/cloudaudit.googleapis.com%2Factivity"
+  ///  @n
   ///  The permission `logging.logEntries.create` is needed on each project,
   ///  organization, billing account, or folder that is receiving new log
   ///  entries, whether the resource is specified in `logName` or in an
   ///  individual log entry.
   /// @param resource  Optional. A default monitored resource object that is assigned to all log
   ///  entries in `entries` that do not specify a value for `resource`. Example:
+  ///  @n
   ///      { "type": "gce_instance",
   ///        "labels": {
   ///          "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+  ///  @n
   ///  See [LogEntry][google.logging.v2.LogEntry].
   /// @param labels  Optional. Default labels that are added to the `labels` field of all log
   ///  entries in `entries`. If a log entry already has a label with the same key
@@ -190,17 +199,20 @@ class LoggingServiceV2Client {
   ///  entries in this list that do not include values for their corresponding
   ///  fields. For more information, see the
   ///  [LogEntry][google.logging.v2.LogEntry] type.
+  ///  @n
   ///  If the `timestamp` or `insert_id` fields are missing in log entries, then
   ///  this method supplies the current time or a unique identifier, respectively.
   ///  The supplied values are chosen so that, among the log entries that did not
   ///  supply their own values, the entries earlier in the list will sort before
   ///  the entries later in the list. See the `entries.list` method.
+  ///  @n
   ///  Log entries with timestamps that are more than the
   ///  [logs retention period](https://cloud.google.com/logging/quotas) in
   ///  the past or more than 24 hours in the future will not be available when
   ///  calling `entries.list`. However, those log entries can still be [exported
   ///  with
   ///  LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
+  ///  @n
   ///  To improve throughput and to avoid exceeding the
   ///  [quota limit](https://cloud.google.com/logging/quotas) for calls to
   ///  `entries.write`, you should try to include several log entries in this
@@ -277,15 +289,19 @@ class LoggingServiceV2Client {
   ///
   /// @param resource_names  Required. Names of one or more parent resources from which to
   ///  retrieve log entries:
+  ///  @n
   ///  *  `projects/[PROJECT_ID]`
   ///  *  `organizations/[ORGANIZATION_ID]`
   ///  *  `billingAccounts/[BILLING_ACCOUNT_ID]`
   ///  *  `folders/[FOLDER_ID]`
+  ///  @n
   ///  May alternatively be one or more views:
+  ///  @n
   ///   * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
   ///   * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
   ///   * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
   ///   * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  ///  @n
   ///  Projects listed in the `project_ids` field are added to this list.
   ///  A maximum of 100 resources may be specified in a single request.
   /// @param filter  Optional. Only log entries that match the filter are returned.  An empty
@@ -421,6 +437,7 @@ class LoggingServiceV2Client {
   /// Only logs that have entries are listed.
   ///
   /// @param parent  Required. The resource name to list logs for:
+  ///  @n
   ///  *  `projects/[PROJECT_ID]`
   ///  *  `organizations/[ORGANIZATION_ID]`
   ///  *  `billingAccounts/[BILLING_ACCOUNT_ID]`
@@ -534,22 +551,28 @@ class LoggingServiceV2Client {
   ///
   /// @param log_name  Optional. A default log resource name that is assigned to all log entries
   ///  in `entries` that do not specify a value for `log_name`:
+  ///  @n
   ///  * `projects/[PROJECT_ID]/logs/[LOG_ID]`
   ///  * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
   ///  * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
   ///  * `folders/[FOLDER_ID]/logs/[LOG_ID]`
+  ///  @n
   ///  `[LOG_ID]` must be URL-encoded. For example:
+  ///  @n
   ///      "projects/my-project-id/logs/syslog"
   ///      "organizations/123/logs/cloudaudit.googleapis.com%2Factivity"
+  ///  @n
   ///  The permission `logging.logEntries.create` is needed on each project,
   ///  organization, billing account, or folder that is receiving new log
   ///  entries, whether the resource is specified in `logName` or in an
   ///  individual log entry.
   /// @param resource  Optional. A default monitored resource object that is assigned to all log
   ///  entries in `entries` that do not specify a value for `resource`. Example:
+  ///  @n
   ///      { "type": "gce_instance",
   ///        "labels": {
   ///          "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+  ///  @n
   ///  See [LogEntry][google.logging.v2.LogEntry].
   /// @param labels  Optional. Default labels that are added to the `labels` field of all log
   ///  entries in `entries`. If a log entry already has a label with the same key
@@ -561,17 +584,20 @@ class LoggingServiceV2Client {
   ///  entries in this list that do not include values for their corresponding
   ///  fields. For more information, see the
   ///  [LogEntry][google.logging.v2.LogEntry] type.
+  ///  @n
   ///  If the `timestamp` or `insert_id` fields are missing in log entries, then
   ///  this method supplies the current time or a unique identifier, respectively.
   ///  The supplied values are chosen so that, among the log entries that did not
   ///  supply their own values, the entries earlier in the list will sort before
   ///  the entries later in the list. See the `entries.list` method.
+  ///  @n
   ///  Log entries with timestamps that are more than the
   ///  [logs retention period](https://cloud.google.com/logging/quotas) in
   ///  the past or more than 24 hours in the future will not be available when
   ///  calling `entries.list`. However, those log entries can still be [exported
   ///  with
   ///  LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
+  ///  @n
   ///  To improve throughput and to avoid exceeding the
   ///  [quota limit](https://cloud.google.com/logging/quotas) for calls to
   ///  `entries.write`, you should try to include several log entries in this

--- a/google/cloud/managedidentities/v1/managed_identities_client.h
+++ b/google/cloud/managedidentities/v1/managed_identities_client.h
@@ -130,6 +130,7 @@ class ManagedIdentitiesServiceClient {
   ///  `projects/{project_id}/locations/global`
   /// @param domain_name  Required. The fully qualified domain name.
   ///  e.g. mydomain.myorganization.com, with the following restrictions:
+  ///  @n
   ///   * Must contain only lowercase letters, numbers, periods and hyphens.
   ///   * Must start with a letter.
   ///   * Must contain between 2-64 characters.

--- a/google/cloud/memcache/v1/cloud_memcache_client.h
+++ b/google/cloud/memcache/v1/cloud_memcache_client.h
@@ -250,11 +250,13 @@ class CloudMemcacheClient {
   /// @param instance  Required. A Memcached Instance
   /// @param instance_id  Required. The logical name of the Memcached instance in the user
   ///  project with the following restrictions:
+  ///  @n
   ///  * Must contain only lowercase letters, numbers, and hyphens.
   ///  * Must start with a letter.
   ///  * Must be between 1-40 characters.
   ///  * Must end with a number or a letter.
   ///  * Must be unique within the user project / location.
+  ///  @n
   ///  If any of the above are not met, the API raises an invalid argument error.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -330,6 +332,7 @@ class CloudMemcacheClient {
   /// @param instance  Required. A Memcached Instance.
   ///  Only fields specified in update_mask are updated.
   /// @param update_mask  Required. Mask of fields to update.
+  ///  @n
   ///   *   `displayName`
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/monitoring/metricsscope/v1/metrics_scopes_client.h
+++ b/google/cloud/monitoring/metricsscope/v1/metrics_scopes_client.h
@@ -276,6 +276,7 @@ class MetricsScopesClient {
   /// @param name  Required. The resource name of the `MonitoredProject`.
   ///  Example:
   ///  `locations/global/metricsScopes/{SCOPING_PROJECT_ID_OR_NUMBER}/projects/{MONITORED_PROJECT_ID_OR_NUMBER}`
+  ///  @n
   ///  Authorization requires the following [Google
   ///  IAM](https://cloud.google.com/iam) permissions on both the `Metrics Scope`
   ///  and on the `MonitoredProject`: `monitoring.metricsScopes.link`

--- a/google/cloud/monitoring/v3/alert_policy_client.h
+++ b/google/cloud/monitoring/v3/alert_policy_client.h
@@ -101,7 +101,9 @@ class AlertPolicyServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name)
   ///  whose alert policies are to be listed. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
+  ///  @n
   ///  Note that this field names the parent container in which the alerting
   ///  policies to be listed are stored. To retrieve a single alerting policy
   ///  by name, use the
@@ -183,6 +185,7 @@ class AlertPolicyServiceClient {
   /// Gets a single alerting policy.
   ///
   /// @param name  Required. The alerting policy to retrieve. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -243,7 +246,9 @@ class AlertPolicyServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) in
   ///  which to create the alerting policy. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
+  ///  @n
   ///  Note that this field names the parent container in which the alerting
   ///  policy will be written, not the name of the created policy. |name| must be
   ///  a host project of a Metrics Scope, otherwise INVALID_ARGUMENT error will
@@ -314,7 +319,9 @@ class AlertPolicyServiceClient {
   /// Deletes an alerting policy.
   ///
   /// @param name  Required. The alerting policy to delete. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]
+  ///  @n
   ///  For more information, see [AlertPolicy][google.monitoring.v3.AlertPolicy].
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -374,12 +381,15 @@ class AlertPolicyServiceClient {
   ///  value of the corresponding field in the supplied policy (`alert_policy`),
   ///  or to the field's default value if the field is not in the supplied
   ///  alerting policy.  Fields not listed retain their previous value.
+  ///  @n
   ///  Examples of valid field masks include `display_name`, `documentation`,
   ///  `documentation.content`, `documentation.mime_type`, `user_labels`,
   ///  `user_label.nameofkey`, `enabled`, `conditions`, `combiner`, etc.
+  ///  @n
   ///  If this field is empty, then the supplied alerting policy replaces the
   ///  existing policy. It is the same as deleting the existing policy and
   ///  adding the supplied policy, except for the following:
+  ///  @n
   ///  +   The new policy will have the same `[ALERT_POLICY_ID]` as the former
   ///      policy. This gives you continuity with the former policy in your
   ///      notifications and incidents.

--- a/google/cloud/monitoring/v3/group_client.h
+++ b/google/cloud/monitoring/v3/group_client.h
@@ -104,6 +104,7 @@ class GroupServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name)
   ///  whose groups are to be listed. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -180,6 +181,7 @@ class GroupServiceClient {
   /// Gets a single group.
   ///
   /// @param name  Required. The group to retrieve. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -240,6 +242,7 @@ class GroupServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) in
   ///  which to create the group. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param group  Required. A group definition. It is an error to define the `name` field because
   ///  the system assigns the name.
@@ -363,6 +366,7 @@ class GroupServiceClient {
   /// Deletes an existing group.
   ///
   /// @param name  Required. The group to delete. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -414,6 +418,7 @@ class GroupServiceClient {
   /// Lists the monitored resources that are members of a group.
   ///
   /// @param name  Required. The group whose members are listed. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/monitoring/v3/metric_client.h
+++ b/google/cloud/monitoring/v3/metric_client.h
@@ -91,6 +91,7 @@ class MetricServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -169,7 +170,9 @@ class MetricServiceClient {
   /// Gets a single monitored resource descriptor. This method does not require a Workspace.
   ///
   /// @param name  Required. The monitored resource descriptor to get.  The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/monitoredResourceDescriptors/[RESOURCE_TYPE]
+  ///  @n
   ///  The `[RESOURCE_TYPE]` is a predefined type, such as
   ///  `cloudsql_database`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -233,6 +236,7 @@ class MetricServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -310,7 +314,9 @@ class MetricServiceClient {
   /// Gets a single metric descriptor. This method does not require a Workspace.
   ///
   /// @param name  Required. The metric descriptor on which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/metricDescriptors/[METRIC_ID]
+  ///  @n
   ///  An example value of `[METRIC_ID]` is
   ///  `"compute.googleapis.com/instance/disk/read_bytes_count"`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -446,7 +452,9 @@ class MetricServiceClient {
   /// deleted.
   ///
   /// @param name  Required. The metric descriptor on which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/metricDescriptors/[METRIC_ID]
+  ///  @n
   ///  An example of `[METRIC_ID]` is:
   ///  `"custom.googleapis.com/my_test_metric"`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -503,6 +511,7 @@ class MetricServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name),
   ///  organization or folder on which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   ///      organizations/[ORGANIZATION_ID]
   ///      folders/[FOLDER_ID]
@@ -510,6 +519,7 @@ class MetricServiceClient {
   ///  that specifies which time series should be returned.  The filter must
   ///  specify a single metric type, and can additionally specify metric labels
   ///  and other information. For example:
+  ///  @n
   ///      metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
   ///          metric.labels.instance_name = "my-instance-name"
   /// @param interval  Required. The time interval for which results should be returned. Only time series
@@ -598,12 +608,14 @@ class MetricServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param time_series  Required. The new data to be added to a list of time series.
   ///  Adds at most one data point to each of several time series.  The new data
   ///  point must be more recent than any other point in its time series.  Each
   ///  `TimeSeries` value must fully specify a unique time series by supplying
   ///  all label values for the metric and the monitored resource.
+  ///  @n
   ///  The maximum number of `TimeSeries` objects per `Create` request is 200.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -671,12 +683,14 @@ class MetricServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param time_series  Required. The new data to be added to a list of time series.
   ///  Adds at most one data point to each of several time series.  The new data
   ///  point must be more recent than any other point in its time series.  Each
   ///  `TimeSeries` value must fully specify a unique time series by supplying
   ///  all label values for the metric and the monitored resource.
+  ///  @n
   ///  The maximum number of `TimeSeries` objects per `Create` request is 200.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -746,12 +760,14 @@ class MetricServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param time_series  Required. The new data to be added to a list of time series.
   ///  Adds at most one data point to each of several time series.  The new data
   ///  point must be more recent than any other point in its time series.  Each
   ///  `TimeSeries` value must fully specify a unique time series by supplying
   ///  all label values for the metric and the monitored resource.
+  ///  @n
   ///  The maximum number of `TimeSeries` objects per `Create` request is 200.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/monitoring/v3/notification_channel_client.h
+++ b/google/cloud/monitoring/v3/notification_channel_client.h
@@ -98,7 +98,9 @@ class NotificationChannelServiceClient {
   ///
   /// @param name  Required. The REST resource name of the parent from which to retrieve
   ///  the notification channel descriptors. The expected syntax is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
+  ///  @n
   ///  Note that this
   ///  [names](https://cloud.google.com/monitoring/api/v3#project_name) the parent
   ///  container in which to look for the descriptors; to retrieve a single
@@ -185,6 +187,7 @@ class NotificationChannelServiceClient {
   /// are expected / permitted for a notification channel of the given type.
   ///
   /// @param name  Required. The channel type for which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/notificationChannelDescriptors/[CHANNEL_TYPE]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -248,7 +251,9 @@ class NotificationChannelServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
+  ///  @n
   ///  This names the container
   ///  in which to look for the notification channels; it does not name a
   ///  specific channel. To query a specific channel by REST resource name, use
@@ -336,6 +341,7 @@ class NotificationChannelServiceClient {
   /// that was supplied in the call to the create method.
   ///
   /// @param name  Required. The channel for which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/notificationChannels/[CHANNEL_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -401,7 +407,9 @@ class NotificationChannelServiceClient {
   ///
   /// @param name  Required. The [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
+  ///  @n
   ///  This names the container into which the channel will be
   ///  written, this does not name the newly created channel. The resulting
   ///  channel's name will have a normalized version of this field as a prefix,
@@ -538,6 +546,7 @@ class NotificationChannelServiceClient {
   /// Deletes a notification channel.
   ///
   /// @param name  Required. The channel for which to execute the request. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/notificationChannels/[CHANNEL_ID]
   /// @param force  If true, the notification channel will be deleted regardless of its
   ///  use in alert policies (the policies will be updated to remove the

--- a/google/cloud/monitoring/v3/service_monitoring_client.h
+++ b/google/cloud/monitoring/v3/service_monitoring_client.h
@@ -98,6 +98,7 @@ class ServiceMonitoringServiceClient {
   ///
   /// @param parent  Required. Resource [name](https://cloud.google.com/monitoring/api/v3#project_name) of
   ///  the parent workspace. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param service  Required. The `Service` to create.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -159,6 +160,7 @@ class ServiceMonitoringServiceClient {
   /// Get the named `Service`.
   ///
   /// @param name  Required. Resource name of the `Service`. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -220,6 +222,7 @@ class ServiceMonitoringServiceClient {
   /// @param parent  Required. Resource name of the parent containing the listed services, either a
   ///  [project](https://cloud.google.com/monitoring/api/v3#project_name) or a
   ///  Monitoring Workspace. The formats are:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   ///      workspaces/[HOST_PROJECT_ID_OR_NUMBER]
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -356,6 +359,7 @@ class ServiceMonitoringServiceClient {
   /// Soft delete this `Service`.
   ///
   /// @param name  Required. Resource name of the `Service` to delete. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -408,6 +412,7 @@ class ServiceMonitoringServiceClient {
   /// Create a `ServiceLevelObjective` for the given `Service`.
   ///
   /// @param parent  Required. Resource name of the parent `Service`. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]
   /// @param service_level_objective  Required. The `ServiceLevelObjective` to create.
   ///  The provided `name` will be respected if no `ServiceLevelObjective` exists
@@ -475,6 +480,7 @@ class ServiceMonitoringServiceClient {
   /// Get a `ServiceLevelObjective` by name.
   ///
   /// @param name  Required. Resource name of the `ServiceLevelObjective` to get. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]/serviceLevelObjectives/[SLO_NAME]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -536,6 +542,7 @@ class ServiceMonitoringServiceClient {
   ///
   /// @param parent  Required. Resource name of the parent containing the listed SLOs, either a
   ///  project or a Monitoring Workspace. The formats are:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]
   ///      workspaces/[HOST_PROJECT_ID_OR_NUMBER]/services/-
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -678,6 +685,7 @@ class ServiceMonitoringServiceClient {
   /// Delete the given `ServiceLevelObjective`.
   ///
   /// @param name  Required. Resource name of the `ServiceLevelObjective` to delete. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]/serviceLevelObjectives/[SLO_NAME]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/monitoring/v3/uptime_check_client.h
+++ b/google/cloud/monitoring/v3/uptime_check_client.h
@@ -102,6 +102,7 @@ class UptimeCheckServiceClient {
   /// @param parent  Required. The
   ///  [project](https://cloud.google.com/monitoring/api/v3#project_name) whose
   ///  Uptime check configurations are listed. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -180,6 +181,7 @@ class UptimeCheckServiceClient {
   /// Gets a single Uptime check configuration.
   ///
   /// @param name  Required. The Uptime check configuration to retrieve. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/uptimeCheckConfigs/[UPTIME_CHECK_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -241,6 +243,7 @@ class UptimeCheckServiceClient {
   /// @param parent  Required. The
   ///  [project](https://cloud.google.com/monitoring/api/v3#project_name) in which
   ///  to create the Uptime check. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param uptime_check_config  Required. The new Uptime check configuration.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -312,6 +315,7 @@ class UptimeCheckServiceClient {
   ///  the corresponding field is omitted in this partial Uptime check
   ///  configuration, it has the effect of deleting/clearing the field from the
   ///  configuration on the server.
+  ///  @n
   ///  The following fields can be updated: `display_name`,
   ///  `http_check`, `tcp_check`, `timeout`, `content_matchers`, and
   ///  `selected_regions`.
@@ -379,6 +383,7 @@ class UptimeCheckServiceClient {
   /// other dependent configs that would be rendered invalid by the deletion.
   ///
   /// @param name  Required. The Uptime check configuration to delete. The format is:
+  ///  @n
   ///      projects/[PROJECT_ID_OR_NUMBER]/uptimeCheckConfigs/[UPTIME_CHECK_ID]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/networkmanagement/v1/reachability_client.h
+++ b/google/cloud/networkmanagement/v1/reachability_client.h
@@ -255,6 +255,7 @@ class ReachabilityServiceClient {
   ///      `projects/{project_id}/locations/global`
   /// @param test_id  Required. The logical name of the Connectivity Test in your project
   ///  with the following restrictions:
+  ///  @n
   ///  * Must contain only lowercase letters, numbers, and hyphens.
   ///  * Must start with a letter.
   ///  * Must be between 1-40 characters.

--- a/google/cloud/notebooks/v1/managed_notebook_client.h
+++ b/google/cloud/notebooks/v1/managed_notebook_client.h
@@ -310,6 +310,7 @@ class ManagedNotebookServiceClient {
   ///  kernels, the `update_mask` parameter would be
   ///  specified as `software_config.kernels`,
   ///  and the `PATCH` request body would specify the new value, as follows:
+  ///  @n
   ///      {
   ///        "software_config":{
   ///          "kernels": [{
@@ -318,6 +319,7 @@ class ManagedNotebookServiceClient {
   ///             'latest' }],
   ///          }
   ///      }
+  ///  @n
   ///
   ///  Currently, only the following fields can be updated:
   ///  - `software_config.kernels`

--- a/google/cloud/osconfig/agentendpoint/v1/agent_endpoint_client.h
+++ b/google/cloud/osconfig/agentendpoint/v1/agent_endpoint_client.h
@@ -222,6 +222,7 @@ class AgentEndpointServiceClient {
   ///  where the audience is 'osconfig.googleapis.com' and the format is 'full'.
   /// @param task_id  Required. Unique identifier of the task this applies to.
   /// @param task_type  Required. The type of task to report progress on.
+  ///  @n
   ///  Progress must include the appropriate message based on this enum as
   ///  specified below:
   ///  APPLY_PATCHES = ApplyPatchesTaskProgress
@@ -296,6 +297,7 @@ class AgentEndpointServiceClient {
   ///  where the audience is 'osconfig.googleapis.com' and the format is 'full'.
   /// @param task_id  Required. Unique identifier of the task this applies to.
   /// @param task_type  Required. The type of task to report completed.
+  ///  @n
   ///  Output must include the appropriate message based on this enum as
   ///  specified below:
   ///  APPLY_PATCHES = ApplyPatchesTaskOutput

--- a/google/cloud/pubsub/schema_client.h
+++ b/google/cloud/pubsub/schema_client.h
@@ -91,11 +91,13 @@ class SchemaServiceClient {
   /// @param parent  Required. The name of the project in which to create the schema.
   ///  Format is `projects/{project-id}`.
   /// @param schema  Required. The schema object to create.
+  ///  @n
   ///  This schema's `name` parameter is ignored. The schema object returned
   ///  by CreateSchema will have a `name` made using the given `parent` and
   ///  `schema_id`.
   /// @param schema_id  The ID to use for the schema, which will become the final component of
   ///  the schema's resource name.
+  ///  @n
   ///  See https://cloud.google.com/pubsub/docs/admin#resource_names for resource
   ///  name constraints.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -430,6 +432,7 @@ class SchemaServiceClient {
   /// @param name  Required. The schema being rolled back with revision id.
   /// @param revision_id  Required. The revision ID to roll back to.
   ///  It must be a revision of the same schema.
+  ///  @n
   ///    Example: c7cfa2a8
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -491,6 +494,7 @@ class SchemaServiceClient {
   ///
   /// @param name  Required. The name of the schema revision to be deleted, with a revision ID
   ///  explicitly included.
+  ///  @n
   ///  Example: `projects/123/schemas/my-schema@c7cfa2a8`
   /// @param revision_id  Optional. This field is deprecated and should not be used for specifying
   ///  the revision ID. The revision ID should be specified via the `name`

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -97,6 +97,7 @@ class AdminServiceClient {
   ///  ignored.
   /// @param topic_id  Required. The ID to use for the topic, which will become the final
   ///  component of the topic's name.
+  ///  @n
   ///  This value is structured like: `my-topic-name`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -537,6 +538,7 @@ class AdminServiceClient {
   ///  ignored.
   /// @param subscription_id  Required. The ID to use for the subscription, which will become the final
   ///  component of the subscription's name.
+  ///  @n
   ///  This value is structured like: `my-sub-name`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -909,6 +911,7 @@ class AdminServiceClient {
   ///  ignored.
   /// @param reservation_id  Required. The ID to use for the reservation, which will become the final
   ///  component of the reservation's name.
+  ///  @n
   ///  This value is structured like: `my-reservation-name`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/recommender/v1/recommender_client.h
+++ b/google/cloud/recommender/v1/recommender_client.h
@@ -95,11 +95,17 @@ class RecommenderClient {
   ///
   /// @param parent  Required. The container resource on which to execute the request.
   ///  Acceptable formats:
+  ///  @n
   ///  * `projects/[PROJECT_NUMBER]/locations/[LOCATION]/insightTypes/[INSIGHT_TYPE_ID]`
+  ///  @n
   ///  * `projects/[PROJECT_ID]/locations/[LOCATION]/insightTypes/[INSIGHT_TYPE_ID]`
+  ///  @n
   ///  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION]/insightTypes/[INSIGHT_TYPE_ID]`
+  ///  @n
   ///  * `folders/[FOLDER_ID]/locations/[LOCATION]/insightTypes/[INSIGHT_TYPE_ID]`
+  ///  @n
   ///  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION]/insightTypes/[INSIGHT_TYPE_ID]`
+  ///  @n
   ///  LOCATION here refers to GCP Locations:
   ///  https://cloud.google.com/about/locations/
   ///  INSIGHT_TYPE_ID refers to supported insight types:
@@ -316,11 +322,17 @@ class RecommenderClient {
   ///
   /// @param parent  Required. The container resource on which to execute the request.
   ///  Acceptable formats:
+  ///  @n
   ///  * `projects/[PROJECT_NUMBER]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  * `projects/[PROJECT_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  * `folders/[FOLDER_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  LOCATION here refers to GCP Locations:
   ///  https://cloud.google.com/about/locations/
   ///  RECOMMENDER_ID refers to supported recommenders:
@@ -362,25 +374,40 @@ class RecommenderClient {
   ///
   /// @param parent  Required. The container resource on which to execute the request.
   ///  Acceptable formats:
+  ///  @n
   ///  * `projects/[PROJECT_NUMBER]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  * `projects/[PROJECT_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  * `folders/[FOLDER_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]`
+  ///  @n
   ///  LOCATION here refers to GCP Locations:
   ///  https://cloud.google.com/about/locations/
   ///  RECOMMENDER_ID refers to supported recommenders:
   ///  https://cloud.google.com/recommender/docs/recommenders.
   /// @param filter  Filter expression to restrict the recommendations returned. Supported
   ///  filter fields:
+  ///  @n
   ///  * `state_info.state`
+  ///  @n
   ///  * `recommenderSubtype`
+  ///  @n
   ///  * `priority`
+  ///  @n
   ///  Examples:
+  ///  @n
   ///  * `stateInfo.state = ACTIVE OR stateInfo.state = DISMISSED`
+  ///  @n
   ///  * `recommenderSubtype = REMOVE_ROLE OR recommenderSubtype = REPLACE_ROLE`
+  ///  @n
   ///  * `priority = P1 OR priority = P2`
+  ///  @n
   ///  * `stateInfo.state = ACTIVE AND (priority = P1 OR priority = P2)`
+  ///  @n
   ///  (These expressions are based on the filter language described at
   ///  https://google.aip.dev/160)
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -785,9 +812,13 @@ class RecommenderClient {
   /// config for each Recommender.
   ///
   /// @param name  Required. Name of the Recommendation Config to get.
+  ///  @n
   ///  Acceptable formats:
+  ///  @n
   ///  * `projects/[PROJECT_NUMBER]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]/config`
+  ///  @n
   ///  * `projects/[PROJECT_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]/config`
+  ///  @n
   ///  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION]/recommenders/[RECOMMENDER_ID]/config`
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -917,9 +948,13 @@ class RecommenderClient {
   /// config for each InsightType.
   ///
   /// @param name  Required. Name of the InsightTypeConfig to get.
+  ///  @n
   ///  Acceptable formats:
+  ///  @n
   ///  * `projects/[PROJECT_NUMBER]/locations/global/recommenders/[INSIGHT_TYPE_ID]/config`
+  ///  @n
   ///  * `projects/[PROJECT_ID]/locations/global/recommenders/[INSIGHT_TYPE_ID]/config`
+  ///  @n
   ///  * `organizations/[ORGANIZATION_ID]/locations/global/recommenders/[INSIGHT_TYPE_ID]/config`
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/redis/v1/cloud_redis_client.h
+++ b/google/cloud/redis/v1/cloud_redis_client.h
@@ -338,6 +338,7 @@ class CloudRedisClient {
   ///  where `location_id` refers to a GCP region.
   /// @param instance_id  Required. The logical name of the Redis instance in the customer project
   ///  with the following restrictions:
+  ///  @n
   ///  * Must contain only lowercase letters, numbers, and hyphens.
   ///  * Must start with a letter.
   ///  * Must be between 1-40 characters.
@@ -432,6 +433,7 @@ class CloudRedisClient {
   /// @param update_mask  Required. Mask of fields to update. At least one path must be supplied in
   ///  this field. The elements of the repeated paths field may only include these
   ///  fields from [Instance][google.cloud.redis.v1.Instance]:
+  ///  @n
   ///   *   `displayName`
   ///   *   `labels`
   ///   *   `memorySizeGb`

--- a/google/cloud/resourcemanager/v3/folders_client.h
+++ b/google/cloud/resourcemanager/v3/folders_client.h
@@ -166,8 +166,10 @@ class FoldersClient {
   /// @param parent  Required. The name of the parent resource whose folders are being listed.
   ///  Only children of this parent resource are listed; descendants are not
   ///  listed.
+  ///  @n
   ///  If the parent is a folder, use the value `folders/{folder_id}`. If the
   ///  parent is an organization, use the value `organizations/{org_id}`.
+  ///  @n
   ///  Access to this method is controlled by checking the
   ///  `resourcemanager.folders.list` permission on the `parent`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -259,11 +261,14 @@ class FoldersClient {
   /// @param query  Optional. Search criteria used to select the folders to return.
   ///  If no search criteria is specified then all accessible folders will be
   ///  returned.
+  ///  @n
   ///  Query expressions can be used to restrict results based upon displayName,
   ///  state and parent, where the operators `=` (`:`) `NOT`, `AND` and `OR`
   ///  can be used along with the suffix wildcard symbol `*`.
+  ///  @n
   ///  The `displayName` field in a query expression should use escaped quotes
   ///  for values that include whitespace to prevent unexpected behavior.
+  ///  @n
   ///  ```
   ///  | Field                   | Description                            |
   ///  |-------------------------|----------------------------------------|
@@ -271,7 +276,9 @@ class FoldersClient {
   ///  | parent                  | Filters by parent (for example: folders/123). |
   ///  | state, lifecycleState   | Filters by state.                      |
   ///  ```
+  ///  @n
   ///  Some example queries are:
+  ///  @n
   ///  * Query `displayName=Test*` returns Folder resources whose display name
   ///  starts with "Test".
   ///  * Query `state=ACTIVE` returns Folder resources with

--- a/google/cloud/resourcemanager/v3/organizations_client.h
+++ b/google/cloud/resourcemanager/v3/organizations_client.h
@@ -156,6 +156,7 @@ class OrganizationsClient {
   ///
   /// @param query  Optional. An optional query string used to filter the Organizations to
   ///  return in the response. Query rules are case-insensitive.
+  ///  @n
   ///
   ///  ```
   ///  | Field            | Description                                |
@@ -164,8 +165,10 @@ class OrganizationsClient {
   ///  customer id. |
   ///  | domain           | Filters by domain.                         |
   ///  ```
+  ///  @n
   ///  Organizations may be queried by `directoryCustomerId` or by
   ///  `domain`, where the domain is a G Suite domain, for example:
+  ///  @n
   ///  * Query `directorycustomerid:123456789` returns Organization
   ///  resources with `owner.directory_customer_id` equal to `123456789`.
   ///  * Query `domain:google.com` returns Organization resources corresponding

--- a/google/cloud/resourcemanager/v3/projects_client.h
+++ b/google/cloud/resourcemanager/v3/projects_client.h
@@ -162,6 +162,7 @@ class ProjectsClient {
   /// @param parent  Required. The name of the parent resource whose projects are being listed.
   ///  Only children of this parent resource are listed; descendants are not
   ///  listed.
+  ///  @n
   ///  If the parent is a folder, use the value `folders/{folder_id}`. If the
   ///  parent is an organization, use the value `organizations/{org_id}`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -257,6 +258,7 @@ class ProjectsClient {
   ///  `resourcemanager.projects.get` permission to. If multiple fields are
   ///  included in the query, then it will return results that match any of the
   ///  fields. Some eligible fields are:
+  ///  @n
   ///  - **`displayName`, `name`**: Filters by displayName.
   ///  - **`parent`**: Project's parent (for example: `folders/123`,
   ///  `organizations/*`). Prefer `parent` field over `parent.type` and
@@ -268,8 +270,11 @@ class ProjectsClient {
   ///  - **`labels`**: Filters by label name or value.
   ///  - **`labels.<key>` (where `<key>` is the name of a label)**: Filters by label
   ///  name.
+  ///  @n
   ///  Search expressions are case insensitive.
+  ///  @n
   ///  Some examples queries:
+  ///  @n
   ///
   ///  - **`name:how*`**: The project's name starts with "how".
   ///  - **`name:Howl`**: The project's name is `Howl` or `howl`.
@@ -279,6 +284,7 @@ class ProjectsClient {
   ///  - **`labels.color:red`**:  The project's label `color` has the value `red`.
   ///  - **`labels.color:red labels.size:big`**: The project's label `color` has
   ///  the value `red` or its label `size` has the value `big`.
+  ///  @n
   ///  If no query is specified, the call will return projects for which the user
   ///  has the `resourcemanager.projects.get` permission.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -372,8 +378,10 @@ class ProjectsClient {
   /// `DeleteOperation`.
   ///
   /// @param project  Required. The Project to create.
+  ///  @n
   ///  Project ID is required. If the requested ID is unavailable, the request
   ///  fails.
+  ///  @n
   ///  If the `parent` field is set, the `resourcemanager.projects.create`
   ///  permission is checked on the parent resource. If no parent is set and
   ///  the authorization credentials belong to an Organization, the parent
@@ -785,6 +793,7 @@ class ProjectsClient {
   /// this project.
   ///
   /// @param name  Required. The name of the project (for example, `projects/415104041262`).
+  ///  @n
   ///  Required.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/resourcesettings/v1/resource_settings_client.h
+++ b/google/cloud/resourcesettings/v1/resource_settings_client.h
@@ -104,6 +104,7 @@ class ResourceSettingsServiceClient {
   ///
   /// @param parent  Required. The Cloud resource that parents the setting. Must be in one of the
   ///  following forms:
+  ///  @n
   ///  * `projects/{project_number}`
   ///  * `projects/{project_id}`
   ///  * `folders/{folder_id}`

--- a/google/cloud/retail/v2/catalog_client.h
+++ b/google/cloud/retail/v2/catalog_client.h
@@ -91,6 +91,7 @@ class CatalogServiceClient {
   /// the project.
   ///
   /// @param parent  Required. The account resource name with an associated location.
+  ///  @n
   ///  If the caller does not have permission to list
   ///  [Catalog][google.cloud.retail.v2.Catalog]s under this location, regardless
   ///  of whether or not this location exists, a PERMISSION_DENIED error is
@@ -172,13 +173,16 @@ class CatalogServiceClient {
   /// Updates the [Catalog][google.cloud.retail.v2.Catalog]s.
   ///
   /// @param catalog  Required. The [Catalog][google.cloud.retail.v2.Catalog] to update.
+  ///  @n
   ///  If the caller does not have permission to update the
   ///  [Catalog][google.cloud.retail.v2.Catalog], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.
+  ///  @n
   ///  If the [Catalog][google.cloud.retail.v2.Catalog] to update does not exist,
   ///  a NOT_FOUND error is returned.
   /// @param update_mask  Indicates which fields in the provided
   ///  [Catalog][google.cloud.retail.v2.Catalog] to update.
+  ///  @n
   ///  If an unsupported or unknown field is provided, an INVALID_ARGUMENT error
   ///  is returned.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -482,18 +486,22 @@ class CatalogServiceClient {
   ///
   /// @param completion_config  Required. The [CompletionConfig][google.cloud.retail.v2.CompletionConfig]
   ///  to update.
+  ///  @n
   ///  If the caller does not have permission to update the
   ///  [CompletionConfig][google.cloud.retail.v2.CompletionConfig], then a
   ///  PERMISSION_DENIED error is returned.
+  ///  @n
   ///  If the [CompletionConfig][google.cloud.retail.v2.CompletionConfig] to
   ///  update does not exist, a NOT_FOUND error is returned.
   /// @param update_mask  Indicates which fields in the provided
   ///  [CompletionConfig][google.cloud.retail.v2.CompletionConfig] to update. The
   ///  following are the only supported fields:
+  ///  @n
   ///  * [CompletionConfig.matching_order][google.cloud.retail.v2.CompletionConfig.matching_order]
   ///  * [CompletionConfig.max_suggestions][google.cloud.retail.v2.CompletionConfig.max_suggestions]
   ///  * [CompletionConfig.min_prefix_length][google.cloud.retail.v2.CompletionConfig.min_prefix_length]
   ///  * [CompletionConfig.auto_learning][google.cloud.retail.v2.CompletionConfig.auto_learning]
+  ///  @n
   ///  If not set, all supported fields are updated.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -624,7 +632,9 @@ class CatalogServiceClient {
   /// @param update_mask  Indicates which fields in the provided
   ///  [AttributesConfig][google.cloud.retail.v2.AttributesConfig] to update. The
   ///  following is the only supported field:
+  ///  @n
   ///  * [AttributesConfig.catalog_attributes][google.cloud.retail.v2.AttributesConfig.catalog_attributes]
+  ///  @n
   ///  If not set, all supported fields are updated.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/retail/v2/product_client.h
+++ b/google/cloud/retail/v2/product_client.h
@@ -100,13 +100,16 @@ class ProductServiceClient {
   /// @param product_id  Required. The ID to use for the [Product][google.cloud.retail.v2.Product],
   ///  which will become the final component of the
   ///  [Product.name][google.cloud.retail.v2.Product.name].
+  ///  @n
   ///  If the caller does not have permission to create the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.
+  ///  @n
   ///  This field must be unique among all
   ///  [Product][google.cloud.retail.v2.Product]s with the same
   ///  [parent][google.cloud.retail.v2.CreateProductRequest.parent]. Otherwise, an
   ///  ALREADY_EXISTS error is returned.
+  ///  @n
   ///  This field must be a UTF-8 encoded string with a length limit of 128
   ///  characters. Otherwise, an INVALID_ARGUMENT error is returned.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -171,9 +174,11 @@ class ProductServiceClient {
   /// @param name  Required. Full resource name of [Product][google.cloud.retail.v2.Product],
   ///  such as
   ///  `projects/*/locations/global/catalogs/default_catalog/branches/default_branch/products/some_product_id`.
+  ///  @n
   ///  If the caller does not have permission to access the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.
+  ///  @n
   ///  If the requested [Product][google.cloud.retail.v2.Product] does not exist,
   ///  a NOT_FOUND error is returned.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -237,6 +242,7 @@ class ProductServiceClient {
   ///  `projects/*/locations/global/catalogs/default_catalog/branches/0`. Use
   ///  `default_branch` as the branch ID, to list products under the default
   ///  branch.
+  ///  @n
   ///  If the caller does not have permission to list
   ///  [Product][google.cloud.retail.v2.Product]s under this branch, regardless of
   ///  whether or not this branch exists, a PERMISSION_DENIED error is returned.
@@ -316,9 +322,11 @@ class ProductServiceClient {
   /// Updates a [Product][google.cloud.retail.v2.Product].
   ///
   /// @param product  Required. The product to update/create.
+  ///  @n
   ///  If the caller does not have permission to update the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.
+  ///  @n
   ///  If the [Product][google.cloud.retail.v2.Product] to update does not exist
   ///  and
   ///  [allow_missing][google.cloud.retail.v2.UpdateProductRequest.allow_missing]
@@ -327,8 +335,10 @@ class ProductServiceClient {
   ///  [Product][google.cloud.retail.v2.Product] to update. The immutable and
   ///  output only fields are NOT supported. If not set, all supported fields (the
   ///  fields that are neither immutable nor output only) are updated.
+  ///  @n
   ///  If an unsupported or unknown field is provided, an INVALID_ARGUMENT error
   ///  is returned.
+  ///  @n
   ///  The attribute key can be updated by setting the mask path as
   ///  "attributes.${key_name}". If a key name is present in the mask but not in
   ///  the patching product from the request, this key will be deleted after the
@@ -394,11 +404,14 @@ class ProductServiceClient {
   /// @param name  Required. Full resource name of [Product][google.cloud.retail.v2.Product],
   ///  such as
   ///  `projects/*/locations/global/catalogs/default_catalog/branches/default_branch/products/some_product_id`.
+  ///  @n
   ///  If the caller does not have permission to delete the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.
+  ///  @n
   ///  If the [Product][google.cloud.retail.v2.Product] to delete does not exist,
   ///  a NOT_FOUND error is returned.
+  ///  @n
   ///  The [Product][google.cloud.retail.v2.Product] to delete can neither be a
   ///  [Product.Type.COLLECTION][google.cloud.retail.v2.Product.Type.COLLECTION]
   ///  [Product][google.cloud.retail.v2.Product] member nor a
@@ -406,6 +419,7 @@ class ProductServiceClient {
   ///  [Product][google.cloud.retail.v2.Product] with more than one
   ///  [variants][google.cloud.retail.v2.Product.Type.VARIANT]. Otherwise, an
   ///  INVALID_ARGUMENT error is returned.
+  ///  @n
   ///  All inventory information for the named
   ///  [Product][google.cloud.retail.v2.Product] will be deleted.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -556,54 +570,67 @@ class ProductServiceClient {
   ///
   /// @param inventory  Required. The inventory information to update. The allowable fields to
   ///  update are:
+  ///  @n
   ///  * [Product.price_info][google.cloud.retail.v2.Product.price_info]
   ///  * [Product.availability][google.cloud.retail.v2.Product.availability]
   ///  * [Product.available_quantity][google.cloud.retail.v2.Product.available_quantity]
   ///  * [Product.fulfillment_info][google.cloud.retail.v2.Product.fulfillment_info]
   ///  The updated inventory fields must be specified in
   ///  [SetInventoryRequest.set_mask][google.cloud.retail.v2.SetInventoryRequest.set_mask].
+  ///  @n
   ///  If
   ///  [SetInventoryRequest.inventory.name][google.cloud.retail.v2.Product.name]
   ///  is empty or invalid, an INVALID_ARGUMENT error is returned.
+  ///  @n
   ///  If the caller does not have permission to update the
   ///  [Product][google.cloud.retail.v2.Product] named in
   ///  [Product.name][google.cloud.retail.v2.Product.name], regardless of whether
   ///  or not it exists, a PERMISSION_DENIED error is returned.
+  ///  @n
   ///  If the [Product][google.cloud.retail.v2.Product] to update does not have
   ///  existing inventory information, the provided inventory information will be
   ///  inserted.
+  ///  @n
   ///  If the [Product][google.cloud.retail.v2.Product] to update has existing
   ///  inventory information, the provided inventory information will be merged
   ///  while respecting the last update time for each inventory field, using the
   ///  provided or default value for
   ///  [SetInventoryRequest.set_time][google.cloud.retail.v2.SetInventoryRequest.set_time].
+  ///  @n
   ///  The caller can replace place IDs for a subset of fulfillment types in the
   ///  following ways:
+  ///  @n
   ///  * Adds "fulfillment_info" in
   ///  [SetInventoryRequest.set_mask][google.cloud.retail.v2.SetInventoryRequest.set_mask]
   ///  * Specifies only the desired fulfillment types and corresponding place IDs
   ///  to update in
   ///  [SetInventoryRequest.inventory.fulfillment_info][google.cloud.retail.v2.Product.fulfillment_info]
+  ///  @n
   ///  The caller can clear all place IDs from a subset of fulfillment types in
   ///  the following ways:
+  ///  @n
   ///  * Adds "fulfillment_info" in
   ///  [SetInventoryRequest.set_mask][google.cloud.retail.v2.SetInventoryRequest.set_mask]
   ///  * Specifies only the desired fulfillment types to clear in
   ///  [SetInventoryRequest.inventory.fulfillment_info][google.cloud.retail.v2.Product.fulfillment_info]
   ///  * Checks that only the desired fulfillment info types have empty
   ///  [SetInventoryRequest.inventory.fulfillment_info.place_ids][google.cloud.retail.v2.FulfillmentInfo.place_ids]
+  ///  @n
   ///  The last update time is recorded for the following inventory fields:
   ///  * [Product.price_info][google.cloud.retail.v2.Product.price_info]
   ///  * [Product.availability][google.cloud.retail.v2.Product.availability]
   ///  * [Product.available_quantity][google.cloud.retail.v2.Product.available_quantity]
   ///  * [Product.fulfillment_info][google.cloud.retail.v2.Product.fulfillment_info]
+  ///  @n
   ///  If a full overwrite of inventory information while ignoring timestamps is
   ///  needed,
   ///  [ProductService.UpdateProduct][google.cloud.retail.v2.ProductService.UpdateProduct]
   ///  should be invoked instead.
   /// @param set_mask  Indicates which inventory fields in the provided
   ///  [Product][google.cloud.retail.v2.Product] to update.
+  ///  @n
   ///  At least one field must be provided.
+  ///  @n
   ///  If an unsupported or unknown field is provided, an INVALID_ARGUMENT error
   ///  is returned and the entire update will be ignored.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -781,6 +808,7 @@ class ProductServiceClient {
   /// @param product  Required. Full resource name of [Product][google.cloud.retail.v2.Product],
   ///  such as
   ///  `projects/*/locations/global/catalogs/default_catalog/branches/default_branch/products/some_product_id`.
+  ///  @n
   ///  If the caller does not have permission to access the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.
@@ -931,6 +959,7 @@ class ProductServiceClient {
   /// @param product  Required. Full resource name of [Product][google.cloud.retail.v2.Product],
   ///  such as
   ///  `projects/*/locations/global/catalogs/default_catalog/branches/default_branch/products/some_product_id`.
+  ///  @n
   ///  If the caller does not have permission to access the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.
@@ -1080,6 +1109,7 @@ class ProductServiceClient {
   /// @param product  Required. Full resource name of [Product][google.cloud.retail.v2.Product],
   ///  such as
   ///  `projects/*/locations/global/catalogs/default_catalog/branches/default_branch/products/some_product_id`.
+  ///  @n
   ///  If the caller does not have permission to access the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.
@@ -1224,6 +1254,7 @@ class ProductServiceClient {
   /// @param product  Required. Full resource name of [Product][google.cloud.retail.v2.Product],
   ///  such as
   ///  `projects/*/locations/global/catalogs/default_catalog/branches/default_branch/products/some_product_id`.
+  ///  @n
   ///  If the caller does not have permission to access the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not it
   ///  exists, a PERMISSION_DENIED error is returned.

--- a/google/cloud/scheduler/v1/cloud_scheduler_client.h
+++ b/google/cloud/scheduler/v1/cloud_scheduler_client.h
@@ -301,6 +301,7 @@ class CloudSchedulerClient {
   ///
   /// @param job  Required. The new job properties.
   ///  [name][google.cloud.scheduler.v1.Job.name] must be specified.
+  ///  @n
   ///  Output only fields cannot be modified using UpdateJob.
   ///  Any value specified for an output only field will be ignored.
   /// @param update_mask  A  mask used to specify which fields of the job are being updated.

--- a/google/cloud/secretmanager/v1/secret_manager_client.h
+++ b/google/cloud/secretmanager/v1/secret_manager_client.h
@@ -182,6 +182,7 @@ class SecretManagerServiceClient {
   /// @param parent  Required. The resource name of the project to associate with the
   ///  [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`.
   /// @param secret_id  Required. This must be unique within the project.
+  ///  @n
   ///  A secret ID is a string with a maximum length of 255 characters and can
   ///  contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
   ///  underscore (`_`) characters.
@@ -571,6 +572,7 @@ class SecretManagerServiceClient {
   ///
   /// @param name  Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
   ///  `projects/*/secrets/*/versions/*`.
+  ///  @n
   ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
   ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -638,6 +640,7 @@ class SecretManagerServiceClient {
   ///
   /// @param name  Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
   ///  `projects/*/secrets/*/versions/*`.
+  ///  @n
   ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
   ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/securitycenter/v1/security_center_client.h
+++ b/google/cloud/securitycenter/v1/security_center_client.h
@@ -1310,13 +1310,17 @@ class SecurityCenterClient {
   /// @param group_by  Required. Expression that defines what assets fields to use for grouping
   ///  (including `state_change`). The string value should follow SQL syntax:
   ///  comma separated list of fields. For example: "parent,resource_name".
+  ///  @n
   ///  The following fields are supported:
+  ///  @n
   ///  * resource_name
   ///  * category
   ///  * state
   ///  * parent
   ///  * severity
+  ///  @n
   ///  The following fields are supported when compare_duration is set:
+  ///  @n
   ///  * state_change
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -2352,6 +2356,7 @@ class SecurityCenterClient {
   ///
   /// @param external_system  Required. The external system resource to update.
   /// @param update_mask  The FieldMask to use when updating the external system resource.
+  ///  @n
   ///  If empty all mutable fields will be updated.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -2417,6 +2422,7 @@ class SecurityCenterClient {
   ///
   /// @param finding  Required. The finding resource to update or create if it does not already
   ///  exist. parent, security_marks, and update_time will be ignored.
+  ///  @n
   ///  In the case of creation, the finding id portion of the name must be
   ///  alphanumeric and less than or equal to 32 characters and greater than 0
   ///  characters in length.
@@ -2575,6 +2581,7 @@ class SecurityCenterClient {
   ///
   /// @param notification_config  Required. The notification config to update.
   /// @param update_mask  The FieldMask to use when updating the notification config.
+  ///  @n
   ///  If empty all mutable fields will be updated.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/servicemanagement/v1/service_manager_client.h
+++ b/google/cloud/servicemanagement/v1/service_manager_client.h
@@ -545,6 +545,7 @@ class ServiceManagerClient {
   ///  [overview](https://cloud.google.com/service-infrastructure/docs/overview) for naming requirements.  For
   ///  example: `example.googleapis.com`.
   /// @param config_id  Required. The id of the service configuration resource.
+  ///  @n
   ///  This field must be specified for the server to return all fields, including
   ///  `SourceInfo`.
   /// @param view  Specifies which parts of the Service Config should be returned in the

--- a/google/cloud/speech/v2/speech_client.h
+++ b/google/cloud/speech/v2/speech_client.h
@@ -95,6 +95,7 @@ class SpeechClient {
   /// @param recognizer  Required. The Recognizer to create.
   /// @param recognizer_id  The ID to use for the Recognizer, which will become the final component of
   ///  the Recognizer's resource name.
+  ///  @n
   ///  This value should be 4-63 characters, and valid characters
   ///  are /[a-z][0-9]-/.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -311,6 +312,7 @@ class SpeechClient {
   /// Updates the [Recognizer][google.cloud.speech.v2.Recognizer].
   ///
   /// @param recognizer  Required. The Recognizer to update.
+  ///  @n
   ///  The Recognizer's `name` field is used to identify the Recognizer to update.
   ///  Format: `projects/{project}/locations/{location}/recognizers/{recognizer}`.
   /// @param update_mask  The list of fields to update. If empty, all non-default valued fields are
@@ -810,6 +812,7 @@ class SpeechClient {
   /// Updates the [Config][google.cloud.speech.v2.Config].
   ///
   /// @param config  Required. The config to update.
+  ///  @n
   ///  The config's `name` field is used to identify the config to be updated.
   ///  The expected format is `projects/{project}/locations/{location}/config`.
   /// @param update_mask  The list of fields to be updated.
@@ -876,6 +879,7 @@ class SpeechClient {
   /// @param custom_class  Required. The CustomClass to create.
   /// @param custom_class_id  The ID to use for the CustomClass, which will become the final component of
   ///  the CustomClass's resource name.
+  ///  @n
   ///  This value should be 4-63 characters, and valid characters
   ///  are /[a-z][0-9]-/.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1088,6 +1092,7 @@ class SpeechClient {
   /// Updates the [CustomClass][google.cloud.speech.v2.CustomClass].
   ///
   /// @param custom_class  Required. The CustomClass to update.
+  ///  @n
   ///  The CustomClass's `name` field is used to identify the CustomClass to
   ///  update. Format:
   ///  `projects/{project}/locations/{location}/customClasses/{custom_class}`.
@@ -1312,6 +1317,7 @@ class SpeechClient {
   /// @param phrase_set  Required. The PhraseSet to create.
   /// @param phrase_set_id  The ID to use for the PhraseSet, which will become the final component of
   ///  the PhraseSet's resource name.
+  ///  @n
   ///  This value should be 4-63 characters, and valid characters
   ///  are /[a-z][0-9]-/.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1524,6 +1530,7 @@ class SpeechClient {
   /// Updates the [PhraseSet][google.cloud.speech.v2.PhraseSet].
   ///
   /// @param phrase_set  Required. The PhraseSet to update.
+  ///  @n
   ///  The PhraseSet's `name` field is used to identify the PhraseSet to update.
   ///  Format: `projects/{project}/locations/{location}/phraseSets/{phrase_set}`.
   /// @param update_mask  The list of fields to update. If empty, all non-default valued fields are

--- a/google/cloud/storagetransfer/v1/storage_transfer_client.h
+++ b/google/cloud/storagetransfer/v1/storage_transfer_client.h
@@ -418,13 +418,16 @@ class StorageTransferServiceClient {
   ///  agent pool.
   /// @param agent_pool  Required. The agent pool to create.
   /// @param agent_pool_id  Required. The ID of the agent pool to create.
+  ///  @n
   ///  The `agent_pool_id` must meet the following requirements:
+  ///  @n
   ///  *   Length of 128 characters or less.
   ///  *   Not start with the string `goog`.
   ///  *   Start with a lowercase ASCII character, followed by:
   ///      *   Zero or more: lowercase Latin alphabet characters, numerals,
   ///          hyphens (`-`), periods (`.`), underscores (`_`), or tildes (`~`).
   ///      *   One or more numerals or lowercase ASCII characters.
+  ///  @n
   ///  As expressed by the regular expression:
   ///  `^(?!goog)[a-z]([a-z0-9-._~]*[a-z0-9])?$`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -488,8 +491,11 @@ class StorageTransferServiceClient {
   ///
   /// @param agent_pool  Required. The agent pool to update. `agent_pool` is expected to specify following
   ///  fields:
+  ///  @n
   ///  *  [name][google.storagetransfer.v1.AgentPool.name]
+  ///  @n
   ///  *  [display_name][google.storagetransfer.v1.AgentPool.display_name]
+  ///  @n
   ///  *  [bandwidth_limit][google.storagetransfer.v1.AgentPool.bandwidth_limit]
   ///  An `UpdateAgentPoolRequest` with any other fields is rejected
   ///  with the error [INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT].
@@ -497,7 +503,9 @@ class StorageTransferServiceClient {
   ///  (https://developers.google.com/protocol-buffers/docs/reference/google.protobuf)
   ///  of the fields in `agentPool` to update in this request.
   ///  The following `agentPool` fields can be updated:
+  ///  @n
   ///  *  [display_name][google.storagetransfer.v1.AgentPool.display_name]
+  ///  @n
   ///  *  [bandwidth_limit][google.storagetransfer.v1.AgentPool.bandwidth_limit]
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/support/v2/case_client.h
+++ b/google/cloud/support/v2/case_client.h
@@ -342,6 +342,7 @@ class CaseServiceClient {
   ///  as part of this request. Supported values are `priority`, `display_name`,
   ///  and `subscriber_email_addresses`. If no fields are specified, all supported
   ///  fields are updated.
+  ///  @n
   ///  WARNING: If you do not provide a field mask, then you might accidentally
   ///  clear some fields. For example, if you leave the field mask empty and do
   ///  not provide a value for `subscriber_email_addresses`, then

--- a/google/cloud/talent/v4/company_client.h
+++ b/google/cloud/talent/v4/company_client.h
@@ -89,6 +89,7 @@ class CompanyServiceClient {
   /// Creates a new company entity.
   ///
   /// @param parent  Required. Resource name of the tenant under which the company is created.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
   /// @param company  Required. The company to be created.
@@ -151,6 +152,7 @@ class CompanyServiceClient {
   /// Retrieves specified company.
   ///
   /// @param name  Required. The resource name of the company to be retrieved.
+  ///  @n
   ///  The format is
   ///  "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}", for
   ///  example, "projects/api-test-project/tenants/foo/companies/bar".
@@ -214,10 +216,12 @@ class CompanyServiceClient {
   /// @param company  Required. The company resource to replace the current resource in the
   ///  system.
   /// @param update_mask  Strongly recommended for the best service experience.
+  ///  @n
   ///  If [update_mask][google.cloud.talent.v4.UpdateCompanyRequest.update_mask]
   ///  is provided, only the specified fields in
   ///  [company][google.cloud.talent.v4.UpdateCompanyRequest.company] are updated.
   ///  Otherwise all the fields are updated.
+  ///  @n
   ///  A field mask to specify the company fields to be updated. Only
   ///  top level fields of [Company][google.cloud.talent.v4.Company] are
   ///  supported.
@@ -281,6 +285,7 @@ class CompanyServiceClient {
   /// Prerequisite: The company has no jobs associated with it.
   ///
   /// @param name  Required. The resource name of the company to be deleted.
+  ///  @n
   ///  The format is
   ///  "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}", for
   ///  example, "projects/foo/tenants/bar/companies/baz".
@@ -336,6 +341,7 @@ class CompanyServiceClient {
   /// Lists all companies associated with the project.
   ///
   /// @param parent  Required. Resource name of the tenant under which the company is created.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/talent/v4/event_client.h
+++ b/google/cloud/talent/v4/event_client.h
@@ -95,6 +95,7 @@ class EventServiceClient {
   /// about self service tools.
   ///
   /// @param parent  Required. Resource name of the tenant under which the event is created.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
   /// @param client_event  Required. Events issued when end user interacts with customer's application

--- a/google/cloud/talent/v4/job_client.h
+++ b/google/cloud/talent/v4/job_client.h
@@ -93,6 +93,7 @@ class JobServiceClient {
   /// up to 5 minutes.
   ///
   /// @param parent  Required. The resource name of the tenant under which the job is created.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}". For example,
   ///  "projects/foo/tenants/bar".
   /// @param job  Required. The Job to be created.
@@ -158,6 +159,7 @@ class JobServiceClient {
   /// Begins executing a batch create jobs operation.
   ///
   /// @param parent  Required. The resource name of the tenant under which the job is created.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}". For example,
   ///  "projects/foo/tenants/bar".
   /// @param jobs  Required. The jobs to be created.
@@ -236,6 +238,7 @@ class JobServiceClient {
   /// within the last 90 days.
   ///
   /// @param name  Required. The resource name of the job to retrieve.
+  ///  @n
   ///  The format is
   ///  "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}". For
   ///  example, "projects/foo/tenants/bar/jobs/baz".
@@ -302,10 +305,12 @@ class JobServiceClient {
   ///
   /// @param job  Required. The Job to be updated.
   /// @param update_mask  Strongly recommended for the best service experience.
+  ///  @n
   ///  If [update_mask][google.cloud.talent.v4.UpdateJobRequest.update_mask] is
   ///  provided, only the specified fields in
   ///  [job][google.cloud.talent.v4.UpdateJobRequest.job] are updated. Otherwise
   ///  all the fields are updated.
+  ///  @n
   ///  A field mask to restrict the fields that are updated. Only
   ///  top level fields of [Job][google.cloud.talent.v4.Job] are supported.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -370,6 +375,7 @@ class JobServiceClient {
   /// Begins executing a batch update jobs operation.
   ///
   /// @param parent  Required. The resource name of the tenant under which the job is created.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}". For example,
   ///  "projects/foo/tenants/bar".
   /// @param jobs  Required. The jobs to be updated.
@@ -450,6 +456,7 @@ class JobServiceClient {
   /// up to 5 minutes.
   ///
   /// @param name  Required. The resource name of the job to be deleted.
+  ///  @n
   ///  The format is
   ///  "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}". For
   ///  example, "projects/foo/tenants/bar/jobs/baz".
@@ -506,12 +513,16 @@ class JobServiceClient {
   /// Begins executing a batch delete jobs operation.
   ///
   /// @param parent  Required. The resource name of the tenant under which the job is created.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}". For example,
   ///  "projects/foo/tenants/bar".
+  ///  @n
   ///  The parent of all of the jobs specified in `names` must match this field.
   /// @param names  The names of the jobs to delete.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}".
   ///  For example, "projects/foo/tenants/bar/jobs/baz".
+  ///  @n
   ///  A maximum of 200 jobs can be deleted in a batch.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -585,18 +596,25 @@ class JobServiceClient {
   /// Lists jobs by filter.
   ///
   /// @param parent  Required. The resource name of the tenant under which the job is created.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}". For example,
   ///  "projects/foo/tenants/bar".
   /// @param filter  Required. The filter string specifies the jobs to be enumerated.
+  ///  @n
   ///  Supported operator: =, AND
+  ///  @n
   ///  The fields eligible for filtering are:
+  ///  @n
   ///  * `companyName`
   ///  * `requisitionId`
   ///  * `status` Available values: OPEN, EXPIRED, ALL. Defaults to
   ///  OPEN if no value is specified.
+  ///  @n
   ///  At least one of `companyName` and `requisitionId` must present or an
   ///  INVALID_ARGUMENT error is thrown.
+  ///  @n
   ///  Sample Query:
+  ///  @n
   ///  * companyName = "projects/foo/tenants/bar/companies/baz"
   ///  * companyName = "projects/foo/tenants/bar/companies/baz" AND
   ///  requisitionId = "req-1"

--- a/google/cloud/talent/v4/tenant_client.h
+++ b/google/cloud/talent/v4/tenant_client.h
@@ -89,6 +89,7 @@ class TenantServiceClient {
   /// Creates a new tenant entity.
   ///
   /// @param parent  Required. Resource name of the project under which the tenant is created.
+  ///  @n
   ///  The format is "projects/{project_id}", for example,
   ///  "projects/foo".
   /// @param tenant  Required. The tenant to be created.
@@ -151,6 +152,7 @@ class TenantServiceClient {
   /// Retrieves specified tenant.
   ///
   /// @param name  Required. The resource name of the tenant to be retrieved.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -213,10 +215,12 @@ class TenantServiceClient {
   /// @param tenant  Required. The tenant resource to replace the current resource in the
   ///  system.
   /// @param update_mask  Strongly recommended for the best service experience.
+  ///  @n
   ///  If [update_mask][google.cloud.talent.v4.UpdateTenantRequest.update_mask] is
   ///  provided, only the specified fields in
   ///  [tenant][google.cloud.talent.v4.UpdateTenantRequest.tenant] are updated.
   ///  Otherwise all the fields are updated.
+  ///  @n
   ///  A field mask to specify the tenant fields to be updated. Only
   ///  top level fields of [Tenant][google.cloud.talent.v4.Tenant] are supported.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -278,6 +282,7 @@ class TenantServiceClient {
   /// Deletes specified tenant.
   ///
   /// @param name  Required. The resource name of the tenant to be deleted.
+  ///  @n
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -331,6 +336,7 @@ class TenantServiceClient {
   /// Lists all tenants associated with the project.
   ///
   /// @param parent  Required. Resource name of the project under which the tenant is created.
+  ///  @n
   ///  The format is "projects/{project_id}", for example,
   ///  "projects/foo".
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/tasks/v2/cloud_tasks_client.h
+++ b/google/cloud/tasks/v2/cloud_tasks_client.h
@@ -240,10 +240,12 @@ class CloudTasksClient {
   ///
   /// @param parent  Required. The location name in which the queue will be created.
   ///  For example: `projects/PROJECT_ID/locations/LOCATION_ID`
+  ///  @n
   ///  The list of allowed locations can be obtained by calling Cloud
   ///  Tasks' implementation of
   ///  [ListLocations][google.cloud.location.Locations.ListLocations].
   /// @param queue  Required. The queue to create.
+  ///  @n
   ///  [Queue's name][google.cloud.tasks.v2.Queue.name] cannot be the same as an existing queue.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -329,11 +331,14 @@ class CloudTasksClient {
   /// this method.
   ///
   /// @param queue  Required. The queue to create or update.
+  ///  @n
   ///  The queue's [name][google.cloud.tasks.v2.Queue.name] must be specified.
+  ///  @n
   ///  Output only fields cannot be modified using UpdateQueue.
   ///  Any value specified for an output only field will be ignored.
   ///  The queue's [name][google.cloud.tasks.v2.Queue.name] cannot be changed.
   /// @param update_mask  A mask used to specify which fields of the queue are being updated.
+  ///  @n
   ///  If empty, then all fields will be updated.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -1144,17 +1149,22 @@ class CloudTasksClient {
   ///
   /// @param parent  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+  ///  @n
   ///  The queue must already exist.
   /// @param task  Required. The task to add.
+  ///  @n
   ///  Task names have the following format:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.
   ///  The user can optionally specify a task [name][google.cloud.tasks.v2.Task.name]. If a
   ///  name is not specified then the system will generate a random
   ///  unique task id, which will be set in the task returned in the
   ///  [response][google.cloud.tasks.v2.Task.name].
+  ///  @n
   ///  If [schedule_time][google.cloud.tasks.v2.Task.schedule_time] is not set or is in the
   ///  past then Cloud Tasks will set it to the current time.
+  ///  @n
   ///  Task De-duplication:
+  ///  @n
   ///  Explicitly specifying a task ID enables task de-duplication.  If
   ///  a task's ID is identical to that of an existing task or a task
   ///  that was deleted or executed recently then the call will fail
@@ -1164,6 +1174,7 @@ class CloudTasksClient {
   ///  deleted or executed. If the task's queue was created using queue.yaml or
   ///  queue.xml, then another task with the same name can't be created
   ///  for ~9days after the original task was deleted or executed.
+  ///  @n
   ///  Because there is an extra lookup cost to identify duplicate task
   ///  names, these [CreateTask][google.cloud.tasks.v2.CloudTasks.CreateTask] calls have significantly
   ///  increased latency. Using hashed strings for the task id or for

--- a/google/cloud/translate/v3/translation_client.h
+++ b/google/cloud/translate/v3/translation_client.h
@@ -94,12 +94,16 @@ class TranslationServiceClient {
   ///
   /// @param parent  Required. Project or location to make a call. Must refer to a caller's
   ///  project.
+  ///  @n
   ///  Format: `projects/{project-number-or-id}` or
   ///  `projects/{project-number-or-id}/locations/{location-id}`.
+  ///  @n
   ///  For global calls, use `projects/{project-number-or-id}/locations/global` or
   ///  `projects/{project-number-or-id}`.
+  ///  @n
   ///  Non-global location is required for requests using AutoML models or
   ///  custom glossaries.
+  ///  @n
   ///  Models and glossaries must be within the same region (have same
   ///  location-id), otherwise an INVALID_ARGUMENT (400) error is returned.
   /// @param target_language_code  Required. The ISO-639 language code to use for translation of the input
@@ -135,24 +139,33 @@ class TranslationServiceClient {
   ///
   /// @param parent  Required. Project or location to make a call. Must refer to a caller's
   ///  project.
+  ///  @n
   ///  Format: `projects/{project-number-or-id}` or
   ///  `projects/{project-number-or-id}/locations/{location-id}`.
+  ///  @n
   ///  For global calls, use `projects/{project-number-or-id}/locations/global` or
   ///  `projects/{project-number-or-id}`.
+  ///  @n
   ///  Non-global location is required for requests using AutoML models or
   ///  custom glossaries.
+  ///  @n
   ///  Models and glossaries must be within the same region (have same
   ///  location-id), otherwise an INVALID_ARGUMENT (400) error is returned.
   /// @param model  Optional. The `model` type requested for this translation.
+  ///  @n
   ///  The format depends on model type:
+  ///  @n
   ///  - AutoML Translation models:
   ///    `projects/{project-number-or-id}/locations/{location-id}/models/{model-id}`
+  ///  @n
   ///  - General (built-in) models:
   ///    `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`,
+  ///  @n
   ///
   ///  For global (non-regionalized) requests, use `location-id` `global`.
   ///  For example,
   ///  `projects/{project-number-or-id}/locations/global/models/general/nmt`.
+  ///  @n
   ///  If not provided, the default Google model (NMT) will be used.
   /// @param mime_type  Optional. The format of the source text, for example, "text/html",
   ///   "text/plain". If left blank, the MIME type defaults to "text/html".
@@ -228,17 +241,23 @@ class TranslationServiceClient {
   ///
   /// @param parent  Required. Project or location to make a call. Must refer to a caller's
   ///  project.
+  ///  @n
   ///  Format: `projects/{project-number-or-id}/locations/{location-id}` or
   ///  `projects/{project-number-or-id}`.
+  ///  @n
   ///  For global calls, use `projects/{project-number-or-id}/locations/global` or
   ///  `projects/{project-number-or-id}`.
+  ///  @n
   ///  Only models within the same region (has same location-id) can be used.
   ///  Otherwise an INVALID_ARGUMENT (400) error is returned.
   /// @param model  Optional. The language detection model to be used.
+  ///  @n
   ///  Format:
   ///  `projects/{project-number-or-id}/locations/{location-id}/models/language-detection/{model-id}`
+  ///  @n
   ///  Only one language detection model is currently supported:
   ///  `projects/{project-number-or-id}/locations/{location-id}/models/language-detection/default`.
+  ///  @n
   ///  If not specified, the default model is used.
   /// @param mime_type  Optional. The format of the source text, for example, "text/html",
   ///  "text/plain". If left blank, the MIME type defaults to "text/html".
@@ -305,19 +324,27 @@ class TranslationServiceClient {
   ///
   /// @param parent  Required. Project or location to make a call. Must refer to a caller's
   ///  project.
+  ///  @n
   ///  Format: `projects/{project-number-or-id}` or
   ///  `projects/{project-number-or-id}/locations/{location-id}`.
+  ///  @n
   ///  For global calls, use `projects/{project-number-or-id}/locations/global` or
   ///  `projects/{project-number-or-id}`.
+  ///  @n
   ///  Non-global location is required for AutoML models.
+  ///  @n
   ///  Only models within the same region (have same location-id) can be used,
   ///  otherwise an INVALID_ARGUMENT (400) error is returned.
   /// @param model  Optional. Get supported languages of this model.
+  ///  @n
   ///  The format depends on model type:
+  ///  @n
   ///  - AutoML Translation models:
   ///    `projects/{project-number-or-id}/locations/{location-id}/models/{model-id}`
+  ///  @n
   ///  - General (built-in) models:
   ///    `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`,
+  ///  @n
   ///
   ///  Returns languages supported by the specified model.
   ///  If missing, we get supported languages of Google general NMT model.
@@ -470,8 +497,11 @@ class TranslationServiceClient {
   /// google.longrunning.Operation.name to poll the status of the call.
   ///
   /// @param parent  Required. Location to make a regional call.
+  ///  @n
   ///  Format: `projects/{project-number-or-id}/locations/{location-id}`.
+  ///  @n
   ///  The `global` location is not supported for batch translation.
+  ///  @n
   ///  Only AutoML Translation models or glossaries within the same region (have
   ///  the same location-id) can be used, otherwise an INVALID_ARGUMENT (400)
   ///  error is returned.

--- a/google/cloud/video/livestream/v1/livestream_client.h
+++ b/google/cloud/video/livestream/v1/livestream_client.h
@@ -385,6 +385,7 @@ class LivestreamServiceClient {
   /// @param channel  Required. The channel resource to be updated.
   /// @param update_mask  Field mask is used to specify the fields to be overwritten in the Channel
   ///  resource by the update. You can only update the following fields:
+  ///  @n
   ///  * [`inputAttachments`](https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.channels#inputattachment)
   ///  * [`inputConfig`](https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.channels#inputconfig)
   ///  * [`output`](https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.channels#output)
@@ -395,8 +396,10 @@ class LivestreamServiceClient {
   ///  * [`logConfig`](https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.channels#logconfig)
   ///  * [`timecodeConfig`](https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.channels#timecodeconfig)
   ///  * [`encryptions`](https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.channels#encryption)
+  ///  @n
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask.
+  ///  @n
   ///  If the mask is not present, then each field from the list above is updated
   ///  if the field appears in the request payload. To unset a field, add the
   ///  field to the update mask and remove it from the request payload.
@@ -910,10 +913,13 @@ class LivestreamServiceClient {
   /// @param input  Required. The input resource to be updated.
   /// @param update_mask  Field mask is used to specify the fields to be overwritten in the Input
   ///  resource by the update. You can only update the following fields:
+  ///  @n
   ///  * [`preprocessingConfig`](https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.inputs#PreprocessingConfig)
   ///  * [`securityRules`](https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.inputs#SecurityRule)
+  ///  @n
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask.
+  ///  @n
   ///  If the mask is not present, then each field from the list above is updated
   ///  if the field appears in the request payload. To unset a field, add the
   ///  field to the update mask and remove it from the request payload.

--- a/google/cloud/video/stitcher/v1/video_stitcher_client.h
+++ b/google/cloud/video/stitcher/v1/video_stitcher_client.h
@@ -101,6 +101,7 @@ class VideoStitcherServiceClient {
   /// @param cdn_key  Required. The CDN key resource to create.
   /// @param cdn_key_id  Required. The ID to use for the CDN key, which will become the final
   ///  component of the CDN key's resource name.
+  ///  @n
   ///  This value should conform to RFC-1034, which restricts to
   ///  lower-case letters, numbers, and hyphen, with the first character a
   ///  letter, the last a letter or a number, and a 63 character maximum.

--- a/google/cloud/video/transcoder/v1/transcoder_client.h
+++ b/google/cloud/video/transcoder/v1/transcoder_client.h
@@ -348,6 +348,7 @@ class TranscoderServiceClient {
   /// @param job_template  Required. Parameters for creating job template.
   /// @param job_template_id  Required. The ID to use for the job template, which will become the final
   ///  component of the job template's resource name.
+  ///  @n
   ///  This value should be 4-63 characters, and valid characters must match the
   ///  regular expression `[a-zA-Z][a-zA-Z0-9_-]*`.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/vision/v1/product_search_client.h
+++ b/google/cloud/vision/v1/product_search_client.h
@@ -118,6 +118,7 @@ class ProductSearchClient {
   ///   4096 characters.
   ///
   /// @param parent  Required. The project in which the ProductSet should be created.
+  ///  @n
   ///  Format is `projects/PROJECT_ID/locations/LOC_ID`.
   /// @param product_set  Required. The ProductSet to create.
   /// @param product_set_id  A user-supplied resource id for this ProductSet. If set, the server will
@@ -194,6 +195,7 @@ class ProductSearchClient {
   ///   than 1.
   ///
   /// @param parent  Required. The project from which ProductSets should be listed.
+  ///  @n
   ///  Format is `projects/PROJECT_ID/locations/LOC_ID`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -280,6 +282,7 @@ class ProductSearchClient {
   /// * Returns NOT_FOUND if the ProductSet does not exist.
   ///
   /// @param name  Required. Resource name of the ProductSet to get.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -424,6 +427,7 @@ class ProductSearchClient {
   /// The actual image files are not deleted from Google Cloud Storage.
   ///
   /// @param name  Required. Resource name of the ProductSet to delete.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -487,6 +491,7 @@ class ProductSearchClient {
   /// * Returns INVALID_ARGUMENT if product_category is missing or invalid.
   ///
   /// @param parent  Required. The project in which the Product should be created.
+  ///  @n
   ///  Format is
   ///  `projects/PROJECT_ID/locations/LOC_ID`.
   /// @param product  Required. The product to create.
@@ -565,6 +570,7 @@ class ProductSearchClient {
   /// * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
   ///
   /// @param parent  Required. The project OR ProductSet from which Products should be listed.
+  ///  @n
   ///  Format:
   ///  `projects/PROJECT_ID/locations/LOC_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -651,6 +657,7 @@ class ProductSearchClient {
   /// * Returns NOT_FOUND if the Product does not exist.
   ///
   /// @param name  Required. Resource name of the Product to get.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -812,6 +819,7 @@ class ProductSearchClient {
   /// until all related caches are refreshed.
   ///
   /// @param name  Required. Resource name of product to delete.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -887,6 +895,7 @@ class ProductSearchClient {
   /// * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
   ///
   /// @param parent  Required. Resource name of the product in which to create the reference image.
+  ///  @n
   ///  Format is
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
   /// @param reference_image  Required. The reference image to create.
@@ -979,6 +988,7 @@ class ProductSearchClient {
   /// The actual image files are not deleted from Google Cloud Storage.
   ///
   /// @param name  Required. The resource name of the reference image to delete.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1044,6 +1054,7 @@ class ProductSearchClient {
   ///   than 1.
   ///
   /// @param parent  Required. Resource name of the product containing the reference images.
+  ///  @n
   ///  Format is
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1132,6 +1143,7 @@ class ProductSearchClient {
   /// * Returns NOT_FOUND if the specified image does not exist.
   ///
   /// @param name  Required. The resource name of the ReferenceImage to get.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1203,9 +1215,11 @@ class ProductSearchClient {
   /// * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
   ///
   /// @param name  Required. The resource name for the ProductSet to modify.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
   /// @param product  Required. The resource name for the Product to be added to this ProductSet.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1267,9 +1281,11 @@ class ProductSearchClient {
   /// Removes a Product from the specified ProductSet.
   ///
   /// @param name  Required. The resource name for the ProductSet to modify.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
   /// @param product  Required. The resource name for the Product to be removed from this ProductSet.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1332,6 +1348,7 @@ class ProductSearchClient {
   /// * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
   ///
   /// @param name  Required. The ProductSet resource for which to retrieve Products.
+  ///  @n
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1426,6 +1443,7 @@ class ProductSearchClient {
   /// [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
   ///
   /// @param parent  Required. The project in which the ProductSets should be imported.
+  ///  @n
   ///  Format is `projects/PROJECT_ID/locations/LOC_ID`.
   /// @param input_config  Required. The input content for the list of requests.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -1540,6 +1558,7 @@ class ProductSearchClient {
   /// `Operation.metadata` contains `BatchOperationMetadata`. (progress)
   ///
   /// @param parent  Required. The project and location in which the Products should be deleted.
+  ///  @n
   ///  Format is `projects/PROJECT_ID/locations/LOC_ID`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/vmmigration/v1/vm_migration_client.h
+++ b/google/cloud/vmmigration/v1/vm_migration_client.h
@@ -653,6 +653,7 @@ class VmMigrationClient {
   /// @param utilization_report  Required. The report to create.
   /// @param utilization_report_id  Required. The ID to use for the report, which will become the final
   ///  component of the reports's resource name.
+  ///  @n
   ///  This value maximum length is 63 characters, and valid characters
   ///  are /[a-z][0-9]-/. It must start with an english letter and must not
   ///  end with a hyphen.

--- a/google/cloud/vmwareengine/v1/vmware_engine_client.h
+++ b/google/cloud/vmwareengine/v1/vmware_engine_client.h
@@ -248,6 +248,7 @@ class VmwareEngineClient {
   ///  This identifier must be unique among each `PrivateCloud` within the parent
   ///  and becomes the final token in the name URI.
   ///  The identifier must meet the following requirements:
+  ///  @n
   ///  * Only contains 1-63 alphanumeric characters and hyphens
   ///  * Begins with an alphabetical character
   ///  * Ends with a non-hyphen character
@@ -765,6 +766,7 @@ class VmwareEngineClient {
   ///  This identifier must be unique among clusters within the parent and becomes
   ///  the final token in the name URI.
   ///  The identifier must meet the following requirements:
+  ///  @n
   ///  * Only contains 1-63 alphanumeric characters and hyphens
   ///  * Begins with an alphabetical character
   ///  * Ends with a non-hyphen character
@@ -1531,6 +1533,7 @@ class VmwareEngineClient {
   ///  created. This identifier must be unique among `HcxActivationKey` resources
   ///  within the parent and becomes the final token in the name URI.
   ///  The identifier must meet the following requirements:
+  ///  @n
   ///  * Only contains 1-63 alphanumeric characters and hyphens
   ///  * Begins with an alphabetical character
   ///  * Ends with a non-hyphen character
@@ -1914,6 +1917,7 @@ class VmwareEngineClient {
   ///  `projects/{my-project}/locations/{us-central1}/networkPolicies` and becomes
   ///  the final token in the name URI.
   ///  The identifier must meet the following requirements:
+  ///  @n
   ///  * Only contains 1-63 alphanumeric characters and hyphens
   ///  * Begins with an alphabetical character
   ///  * Ends with a non-hyphen character
@@ -2189,6 +2193,7 @@ class VmwareEngineClient {
   ///  This identifier must be unique among VMware Engine network resources
   ///  within the parent and becomes the final token in the name URI. The
   ///  identifier must meet the following requirements:
+  ///  @n
   ///  * For networks of type LEGACY, adheres to the format:
   ///  `{region-id}-default`. Replace `{region-id}` with the region where you want
   ///  to create the VMware Engine network. For example, "us-central1-default".

--- a/google/cloud/workflows/v1/workflows_client.h
+++ b/google/cloud/workflows/v1/workflows_client.h
@@ -235,6 +235,7 @@ class WorkflowsClient {
   /// @param workflow  Required. Workflow to be created.
   /// @param workflow_id  Required. The ID of the workflow to be created. It has to fulfill the
   ///  following requirements:
+  ///  @n
   ///  * Must contain only letters, numbers, underscores and hyphens.
   ///  * Must start with a letter.
   ///  * Must be between 1-64 characters.


### PR DESCRIPTION
The command to describe function parameters (`@param`) stops the
description on the first blank line. Use `@n` (aka `\n`) to create a
linebreak without introducing a blank line.

Maybe helps with #11019

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11695)
<!-- Reviewable:end -->
