### PR TITLE
feat(storage): offer mock client without decorators

### DIFF
--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -29,7 +29,7 @@ TEST(StorageMockingSamples, MockReadObject) {
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  auto client = gcs::testing::ClientFromMock(mock);
+  auto client = gcs::testing::UndecoratedClientFromMock(mock);
 
   std::string const text = "this is a mock http response";
   std::size_t offset = 0;
@@ -72,7 +72,7 @@ TEST(StorageMockingSamples, MockWriteObject) {
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  auto client = gcs::testing::ClientFromMock(mock);
+  auto client = gcs::testing::UndecoratedClientFromMock(mock);
 
   gcs::ObjectMetadata expected_metadata;
 
@@ -97,7 +97,7 @@ TEST(StorageMockingSamples, MockReadObjectFailure) {
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  auto client = gcs::testing::ClientFromMock(mock);
+  auto client = gcs::testing::UndecoratedClientFromMock(mock);
 
   std::string text = "this is a mock http response";
   EXPECT_CALL(*mock, ReadObject)
@@ -130,7 +130,7 @@ TEST(StorageMockingSamples, MockWriteObjectFailure) {
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  auto client = gcs::testing::ClientFromMock(mock);
+  auto client = gcs::testing::UndecoratedClientFromMock(mock);
 
   using gcs::internal::CreateResumableUploadResponse;
   using gcs::internal::QueryResumableUploadResponse;

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -406,6 +406,7 @@ if (BUILD_TESTING)
         testing/client_unit_test.cc
         testing/client_unit_test.h
         testing/constants.h
+        testing/mock_client.cc
         testing/mock_client.h
         testing/mock_http_request.cc
         testing/mock_http_request.h

--- a/google/cloud/storage/storage_client_testing.bzl
+++ b/google/cloud/storage/storage_client_testing.bzl
@@ -35,6 +35,7 @@ storage_client_testing_hdrs = [
 
 storage_client_testing_srcs = [
     "testing/client_unit_test.cc",
+    "testing/mock_client.cc",
     "testing/mock_http_request.cc",
     "testing/object_integration_test.cc",
     "testing/random_names.cc",

--- a/google/cloud/storage/testing/mock_client.cc
+++ b/google/cloud/storage/testing/mock_client.cc
@@ -1,0 +1,29 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/testing/mock_client.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace testing {
+
+Client UndecoratedClientFromMock(std::shared_ptr<MockClient> mock) {
+  return internal::ClientImplDetails::CreateWithoutDecorations(std::move(mock));
+}
+
+}  // namespace testing
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -185,13 +185,25 @@ class MockStreambuf : public internal::ObjectWriteStreambuf {
   MOCK_METHOD(std::uint64_t, next_expected_byte, (), (const, override));
 };
 
-/// Create a client configured to use the given mock.
+/**
+ * Create a client configured to use the given mock.
+ *
+ * Unless you specifically need to mock the behavior of retries, prefer
+ * #google::cloud::storage::testing::UndecoratedClientFromMock
+ */
 template <typename... Policies>
 Client ClientFromMock(std::shared_ptr<MockClient> const& mock,
                       Policies&&... p) {
   return internal::ClientImplDetails::CreateClient(
       mock, std::forward<Policies>(p)...);
 }
+
+/**
+ * Create a client configured to use the given mock.
+ *
+ * This client does not retry on transient errors.
+ */
+Client UndecoratedClientFromMock(std::shared_ptr<MockClient> mock);
 
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -189,7 +189,7 @@ class MockStreambuf : public internal::ObjectWriteStreambuf {
  * Create a client configured to use the given mock.
  *
  * Unless you specifically need to mock the behavior of retries, prefer
- * #google::cloud::storage::testing::UndecoratedClientFromMock
+ * `UndecoratedClientFromMock()`.
  */
 template <typename... Policies>
 Client ClientFromMock(std::shared_ptr<MockClient> const& mock,

--- a/google/cloud/storage/testing/remove_stale_buckets_test.cc
+++ b/google/cloud/storage/testing/remove_stale_buckets_test.cc
@@ -72,7 +72,7 @@ TEST(CleanupStaleBucketsTest, RemoveBucketContents) {
   EXPECT_CALL(*mock, GetBucketMetadata)
       .WillOnce(
           Return(make_status_or(BucketMetadata{}.set_name("fake-bucket"))));
-  auto client = internal::ClientImplDetails::CreateWithoutDecorations(mock);
+  auto client = UndecoratedClientFromMock(mock);
   auto const actual = RemoveBucketAndContents(client, "fake-bucket");
   EXPECT_STATUS_OK(actual);
 }
@@ -114,7 +114,7 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
         return response;
       });
 
-  auto client = internal::ClientImplDetails::CreateWithoutDecorations(mock);
+  auto client = UndecoratedClientFromMock(mock);
   auto const actual = RemoveStaleBuckets(client, "matching", create_time_limit);
   EXPECT_STATUS_OK(actual);
 }


### PR DESCRIPTION
Motivated by #11613 

This allows customers to mock a single response from a `RawClient` (instead of N responses in the case of transient errors).

Prefer the `UndecoratedClientFromMock` > `ClientFromMock` in the public samples. I did not update our unit tests.

I did not think about whether extra effort is needed to make the install work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11697)
<!-- Reviewable:end -->
