### PR TITLE
impl(generator): switch to a more likely to be unique field name

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -497,7 +497,7 @@ std::string FormatResourceAccessor(
     google::protobuf::Descriptor const& request) {
   for (int i = 0; i != request.field_count(); ++i) {
     auto const* field = request.field(i);
-    if (field->has_json_name() && field->json_name() == "resource") {
+    if (field->has_json_name() && field->json_name() == "__json_request_body") {
       return absl::StrCat("request.", field->name(), "()");
     }
   }

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -441,7 +441,7 @@ char const* const kServiceProto =
     "message Baz {\n"
     "  string project = 1;\n"
     "  string instance = 2;\n"
-    "  Foo foo_resource = 3 [json_name=\"resource\"];\n"
+    "  Foo foo_resource = 3 [json_name=\"__json_request_body\"];\n"
     "}\n"
     "// Leading comments about service Service.\n"
     "service Service {\n"

--- a/generator/internal/discovery_file_test.cc
+++ b/generator/internal/discovery_file_test.cc
@@ -184,7 +184,7 @@ message DoFooRequest {
   // Description for fooId.
   optional string foo_id = 1;
 
-  optional Foo my_foo_resource = 2 [json_name="resource"];
+  optional Foo my_foo_resource = 2 [json_name="__json_request_body"];
 
   // Description for project.
   optional string project = 3;
@@ -285,7 +285,7 @@ message DoFooRequest {
   // Description for fooId.
   optional string foo_id = 1;
 
-  optional Foo my_foo_resource = 2 [json_name="resource"];
+  optional Foo my_foo_resource = 2 [json_name="__json_request_body"];
 
   // Description for project.
   optional string project = 3;
@@ -360,7 +360,7 @@ message DoFooRequest {
   // Description for fooId.
   optional string foo_id = 1;
 
-  optional Foo my_foo_resource = 2 [json_name="resource"];
+  optional Foo my_foo_resource = 2 [json_name="__json_request_body"];
 
   // Description for project.
   optional string project = 3;

--- a/generator/internal/discovery_type_vertex.cc
+++ b/generator/internal/discovery_type_vertex.cc
@@ -273,7 +273,7 @@ std::string DiscoveryTypeVertex::FormatFieldOptions(
                                absl::StrCat("\"", field_name, "\""));
   }
   if (field_json.value("is_resource", false)) {
-    field_options.emplace_back("json_name", "resource");
+    field_options.emplace_back("json_name", "__json_request_body");
   }
 
   if (!field_options.empty()) {

--- a/generator/internal/discovery_type_vertex_test.cc
+++ b/generator/internal/discovery_type_vertex_test.cc
@@ -141,9 +141,9 @@ TEST(DiscoveryTypeVertexTest, FormatFieldOptionsRequiredIsResource) {
   auto json =
       nlohmann::json::parse(kRequiredIsResourceFieldJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  EXPECT_THAT(
-      DiscoveryTypeVertex::FormatFieldOptions("test_field", json),
-      Eq(" [(google.api.field_behavior) = REQUIRED,json_name=\"resource\"]"));
+  EXPECT_THAT(DiscoveryTypeVertex::FormatFieldOptions("test_field", json),
+              Eq(" [(google.api.field_behavior) = "
+                 "REQUIRED,json_name=\"__json_request_body\"]"));
 }
 
 struct DetermineTypesSuccess {


### PR DESCRIPTION
part of the work for #10980

"resource" was occurring as an actual field name and causing proto parsing errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11698)
<!-- Reviewable:end -->
