### PR TITLE
impl(generator): emit longrunning operation services methods as synchronous

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -154,6 +154,12 @@ message DiscoveryDocumentDefinedProduct {
   // Location of Discovery Document for services that only support REST.
   string discovery_document_url = 1;
 
+  // For products that do not use google::longrunning::Operation to handle
+  // long running operations, they typically define their own operation type
+  // and services to handle them. We need to take care to generate these as
+  // simple, synchronous services.
+  repeated string operation_services = 3;
+
   // Services that are generated from the protos created from the
   // discovery document.
   repeated ServiceConfiguration rest_services = 2;

--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -154,10 +154,10 @@ message DiscoveryDocumentDefinedProduct {
   // Location of Discovery Document for services that only support REST.
   string discovery_document_url = 1;
 
-  // For products that do not use google::longrunning::Operation to handle
-  // long running operations, they typically define their own operation type
-  // and services to handle them. We need to take care to generate these as
-  // simple, synchronous services.
+  // Products that do not use google::longrunning::Operation to handle long
+  // running operations typically define their own operation type and services
+  // to handle them. We need to take care to generate these as simple,
+  // synchronous services.
   repeated string operation_services = 3;
 
   // Services that are generated from the protos created from the

--- a/generator/internal/discovery_document.h
+++ b/generator/internal/discovery_document.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_DOCUMENT_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DISCOVERY_DOCUMENT_H
 
+#include <set>
 #include <string>
 
 namespace google {
@@ -26,6 +27,7 @@ struct DiscoveryDocumentProperties {
   std::string default_hostname;
   std::string product_name;
   std::string version;
+  std::set<std::string> operation_services;
 };
 
 }  // namespace generator_internal

--- a/generator/internal/discovery_file_test.cc
+++ b/generator/internal/discovery_file_test.cc
@@ -231,7 +231,7 @@ message GetMyResourcesRequest {
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
   DiscoveryDocumentProperties document_properties{
-      "my/service", "https://default.host", "my_product", "v1"};
+      "my/service", "https://default.host", "my_product", "v1", {}};
   auto result = f.FormatFile(document_properties, types, os);
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(os.str(), Eq(kExpectedProto));
@@ -331,7 +331,7 @@ message GetMyResourcesRequest {
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
   DiscoveryDocumentProperties document_properties{
-      "my/service", "https://default.host", "my_product", "v1"};
+      "my/service", "https://default.host", "my_product", "v1", {}};
   auto result = f.FormatFile(document_properties, types, os);
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(os.str(), Eq(kExpectedProto));
@@ -395,7 +395,8 @@ message GetMyResourcesRequest {
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  DiscoveryDocumentProperties document_properties{"", "", "my_product", "v1"};
+  DiscoveryDocumentProperties document_properties{
+      "", "", "my_product", "v1", {}};
   auto result = f.FormatFile(document_properties, types, os);
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(os.str(), Eq(kExpectedProto));
@@ -454,7 +455,7 @@ service MyResources {
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
   DiscoveryDocumentProperties document_properties{
-      "my/service", "https://default.host", "my_product", "v1"};
+      "my/service", "https://default.host", "my_product", "v1", {}};
   auto result = f.FormatFile(document_properties, types, os);
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(os.str(), Eq(kExpectedProto));
@@ -509,7 +510,8 @@ TEST(DiscoveryFile, FormatFileResourceScopeError) {
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  DiscoveryDocumentProperties document_properties{"", "", "my_product", "v1"};
+  DiscoveryDocumentProperties document_properties{
+      "", "", "my_product", "v1", {}};
   auto result = f.FormatFile(document_properties, types, os);
   EXPECT_THAT(result,
               StatusIs(StatusCode::kInvalidArgument, HasSubstr("scope")));
@@ -564,7 +566,8 @@ TEST(DiscoveryFile, FormatFileTypeMissingError) {
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Foo", DiscoveryTypeVertex{"Foo", "my.package.name", {}});
   std::stringstream os;
-  DiscoveryDocumentProperties document_properties{"", "", "my_product", "v1"};
+  DiscoveryDocumentProperties document_properties{
+      "", "", "my_product", "v1", {}};
   auto result = f.FormatFile(document_properties, types, os);
   EXPECT_THAT(result, StatusIs(StatusCode::kInvalidArgument,
                                HasSubstr("neither $ref nor type")));

--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -111,14 +111,14 @@ StatusOr<std::string> DiscoveryResource::FormatRpcOptions(
   // that we need to introduce additional in the future if we come across other
   // LRO defining conventions.
   // https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources
-  std::string operation_scope;
+  std::string longrunning_operation_service;
   std::vector<std::string> params =
       method_json.value("parameterOrder", std::vector<std::string>{});
   if (!params.empty()) {
     if (internal::Contains(params, "zone")) {
-      operation_scope = "ZoneOperations";
+      longrunning_operation_service = "ZoneOperations";
     } else if (internal::Contains(params, "region")) {
-      operation_scope = "RegionOperations";
+      longrunning_operation_service = "RegionOperations";
     }
     if (!request_resource_field_name.empty()) {
       params.push_back(request_resource_field_name);
@@ -135,16 +135,16 @@ StatusOr<std::string> DiscoveryResource::FormatRpcOptions(
   if (method_json.contains("response") &&
       method_json["response"].value("$ref", "") == "Operation" &&
       !internal::Contains(operation_services, CapitalizeFirstLetter(name_))) {
-    if (operation_scope.empty()) {
+    if (longrunning_operation_service.empty()) {
       if (internal::Contains(params, "project")) {
-        operation_scope = "GlobalOperations";
+        longrunning_operation_service = "GlobalOperations";
       } else {
-        operation_scope = "GlobalOrganizationOperations";
+        longrunning_operation_service = "GlobalOrganizationOperations";
       }
     }
     rpc_options.push_back(
         absl::StrFormat("    option (google.cloud.operation_service) = \"%s\";",
-                        operation_scope));
+                        longrunning_operation_service));
   }
   return absl::StrJoin(rpc_options, "\n");
 }

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -59,9 +59,10 @@ class DiscoveryResource {
 
   // Examines the method JSON to determine the google.api.http,
   // google.api.method_signature, and google.cloud.operation_service options.
-  static StatusOr<std::string> FormatRpcOptions(
+  StatusOr<std::string> FormatRpcOptions(
       nlohmann::json const& method_json, std::string const& base_path,
-      DiscoveryTypeVertex const* request_type);
+      std::set<std::string> const& operation_services,
+      DiscoveryTypeVertex const* request_type) const;
 
   // Summarize all the scopes found in the resource methods for inclusion as
   // a service level google.api.oauth_scopes option.

--- a/generator/internal/discovery_resource_test.cc
+++ b/generator/internal/discovery_resource_test.cc
@@ -94,8 +94,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -129,8 +128,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPatchZone) {
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -164,8 +162,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegion) {
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -192,8 +189,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobal) {
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -224,8 +220,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationResponse) {
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -246,8 +241,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetNoParams) {
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -266,15 +260,14 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetNoParamsOperation) {
       post: "base/path/doFoo"
       body: "*"
     };
-    option (google.cloud.operation_service) = "GlobalOperations";)""";
+    option (google.cloud.operation_service) = "GlobalOrganizationOperations";)""";
   auto method_json = nlohmann::json::parse(kMethodJson, nullptr, false);
   ASSERT_TRUE(method_json.is_object());
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
@@ -290,8 +283,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsMissingPath) {
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   EXPECT_THAT(
       options,
       StatusIs(StatusCode::kInvalidArgument,
@@ -309,12 +301,76 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsMissingHttpMethod) {
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
   DiscoveryTypeVertex t("myType", "", type_json);
-  auto options =
-      DiscoveryResource::FormatRpcOptions(method_json, "base/path", &t);
+  auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   EXPECT_THAT(
       options,
       StatusIs(StatusCode::kInvalidArgument,
                HasSubstr("Method does not define httpMethod and/or path.")));
+}
+
+TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegionOperationService) {
+  auto constexpr kTypeJson = R"""({
+  "request_resource_field_name": "my_request_resource"
+})""";
+  auto constexpr kMethodJson = R"""({
+  "path": "projects/{project}/regions/{region}/myTests/{fooId}/method1",
+  "httpMethod": "PUT",
+  "response": {
+    "$ref": "Operation"
+  },
+  "parameterOrder": [
+    "project",
+    "region",
+    "fooId"
+  ]
+})""";
+  auto constexpr kExpectedProto =
+      R"""(    option (google.api.http) = {
+      put: "base/path/projects/{project=project}/regions/{region=region}/myTests/{foo_id=foo_id}/method1"
+      body: "my_request_resource"
+    };
+    option (google.api.method_signature) = "project,region,foo_id,my_request_resource";)""";
+  auto method_json = nlohmann::json::parse(kMethodJson, nullptr, false);
+  ASSERT_TRUE(method_json.is_object());
+  auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(type_json.is_object());
+  DiscoveryResource r("regionOperations", "", method_json);
+  DiscoveryTypeVertex t("myType", "", type_json);
+  auto options =
+      r.FormatRpcOptions(method_json, "base/path", {"RegionOperations"}, &t);
+  ASSERT_STATUS_OK(options);
+  EXPECT_THAT(*options, Eq(kExpectedProto));
+}
+
+TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationService) {
+  auto constexpr kTypeJson = R"""({})""";
+  auto constexpr kMethodJson = R"""({
+  "path": "projects/{project}/global/myTests/{foo}:cancel",
+  "httpMethod": "POST",
+  "response": {
+    "$ref": "Operation"
+  },
+  "parameterOrder": [
+    "project",
+    "foo"
+  ]
+})""";
+  auto constexpr kExpectedProto =
+      R"""(    option (google.api.http) = {
+      post: "base/path/projects/{project=project}/global/myTests/{foo=foo}:cancel"
+      body: "*"
+    };
+    option (google.api.method_signature) = "project,foo";)""";
+  auto method_json = nlohmann::json::parse(kMethodJson, nullptr, false);
+  ASSERT_TRUE(method_json.is_object());
+  auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(type_json.is_object());
+  DiscoveryResource r("GlobalOperations", "", method_json);
+  DiscoveryTypeVertex t("myType", "", type_json);
+  auto options =
+      r.FormatRpcOptions(method_json, "base/path", {"GlobalOperations"}, &t);
+  ASSERT_STATUS_OK(options);
+  EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
 TEST(DiscoveryResourceTest, FormatOAuthScopesPresent) {
@@ -501,7 +557,7 @@ service MyResources {
   DiscoveryTypeVertex t3("Operation", "other.package", operation_type_json);
   r.AddResponseType("Operation", &t3);
   DiscoveryDocumentProperties document_properties{
-      "base/path", "https://my.endpoint.com", "", ""};
+      "base/path", "https://my.endpoint.com", "", "", {}};
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   ASSERT_STATUS_OK(emitted_proto);
   EXPECT_THAT(*emitted_proto, Eq(kExpectedProto));
@@ -532,7 +588,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingOAuthScopes) {
                         get_request_type_json);
   r.AddRequestType("GetMyResourcesRequest", &t);
   DiscoveryDocumentProperties document_properties{
-      "base/path", "https://my.endpoint.com", "", ""};
+      "base/path", "https://my.endpoint.com", "", "", {}};
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,
@@ -569,7 +625,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingRequestType) {
   ASSERT_TRUE(resource_json.is_object());
   DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryDocumentProperties document_properties{
-      "base/path", "https://my.endpoint.com", "", ""};
+      "base/path", "https://my.endpoint.com", "", "", {}};
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,
@@ -609,7 +665,7 @@ service MyResources {
   ASSERT_TRUE(resource_json.is_object());
   DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryDocumentProperties document_properties{
-      "base/path", "https://my.endpoint.com", "", ""};
+      "base/path", "https://my.endpoint.com", "", "", {}};
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   ASSERT_STATUS_OK(emitted_proto);
   EXPECT_THAT(*emitted_proto, Eq(kExpectedProto));
@@ -642,7 +698,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceErrorFormattingRpcOptions) {
                         get_request_type_json);
   r.AddRequestType("GetMyResourcesRequest", &t);
   DiscoveryDocumentProperties document_properties{
-      "base/path", "https://my.endpoint.com", "", ""};
+      "base/path", "https://my.endpoint.com", "", "", {}};
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -79,10 +79,10 @@ StatusOr<std::string> DefaultHostFromRootUrl(nlohmann::json const& json);
 StatusOr<nlohmann::json> GetDiscoveryDoc(std::string const& url);
 
 // Emit protos generated from the discovery_doc.
-Status GenerateProtosFromDiscoveryDoc(nlohmann::json const& discovery_doc,
-                                      std::string const& protobuf_proto_path,
-                                      std::string const& googleapis_proto_path,
-                                      std::string const& output_path);
+Status GenerateProtosFromDiscoveryDoc(
+    nlohmann::json const& discovery_doc, std::string const& protobuf_proto_path,
+    std::string const& googleapis_proto_path, std::string const& output_path,
+    std::set<std::string> operation_services = {});
 
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -870,7 +870,7 @@ TEST(CreateFilesFromResourcesTest, NonEmptyResources) {
       "foos",
       DiscoveryResource("foos", "google.cloud.cpp.product_name.foos.version",
                         resource_json));
-  DiscoveryDocumentProperties props{"", "", "product_name", "version"};
+  DiscoveryDocumentProperties props{"", "", "product_name", "version", {}};
   auto result = CreateFilesFromResources(resources, props, "tmp");
   ASSERT_THAT(result, SizeIs(1));
   EXPECT_THAT(result.front().resource_name(), Eq("foos"));
@@ -882,7 +882,7 @@ TEST(CreateFilesFromResourcesTest, NonEmptyResources) {
 
 TEST(CreateFilesFromResourcesTest, EmptyResources) {
   std::map<std::string, DiscoveryResource> resources;
-  DiscoveryDocumentProperties props{"", "", "product_name", "version"};
+  DiscoveryDocumentProperties props{"", "", "product_name", "version", {}};
   auto result = CreateFilesFromResources(resources, props, "tmp");
   EXPECT_THAT(result, IsEmpty());
 }
@@ -944,7 +944,7 @@ TEST(AssignResourcesAndTypesToFilesTest,
   ASSERT_TRUE(operation_type_json.is_object());
   types.emplace("Operation",
                 DiscoveryTypeVertex("Operation", "", operation_type_json));
-  DiscoveryDocumentProperties props{"", "", "product_name", "version"};
+  DiscoveryDocumentProperties props{"", "", "product_name", "version", {}};
   auto result =
       AssignResourcesAndTypesToFiles(resources, types, props, "output_path");
   ASSERT_THAT(result.size(), Eq(2));

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -210,13 +210,8 @@ google::cloud::Status GenerateProtosForRestProducts(
         google::cloud::generator_internal::GenerateProtosFromDiscoveryDoc(
             *doc, generator_args.protobuf_proto_path,
             generator_args.googleapis_proto_path, generator_args.output_path,
-            [&]() {
-              std::set<std::string> s;
-              for (auto const& e : p.operation_services()) {
-                s.insert(e);
-              }
-              return s;
-            }());
+            std::set<std::string>(p.operation_services().begin(),
+                                  p.operation_services().end()));
     if (!status.ok()) return status;
   }
 

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -209,7 +209,14 @@ google::cloud::Status GenerateProtosForRestProducts(
     auto status =
         google::cloud::generator_internal::GenerateProtosFromDiscoveryDoc(
             *doc, generator_args.protobuf_proto_path,
-            generator_args.googleapis_proto_path, generator_args.output_path);
+            generator_args.googleapis_proto_path, generator_args.output_path,
+            [&]() {
+              std::set<std::string> s;
+              for (auto const& e : p.operation_services()) {
+                s.insert(e);
+              }
+              return s;
+            }());
     if (!status.ok()) return status;
   }
 


### PR DESCRIPTION
part of the work for #11531 

The services that are used to poll longrunning operations for compute need to be emitted as synchronous services, even though their methods have a response type of `Operation`. We define the necessary services as part of the config.

We continue to hard code some of the logic for compute as its not obvious at this time if we need to abstract this behavior to handle other REST-only services.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11710)
<!-- Reviewable:end -->
