### PR TITLE
impl: faster check-api runs

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -41,12 +41,12 @@ io::run cmake "${cmake_args[@]}" \
 io::run cmake --build cmake-out
 io::run cmake --install cmake-out >/dev/null
 
-if [ -z "${GOOGLE_CLOUD_CPP_CHECK_API}" ]; then
+if [ "${GOOGLE_CLOUD_CPP_CHECK_API:-}" ]; then
+  IFS=',' read -ra library_list <<<"${GOOGLE_CLOUD_CPP_CHECK_API}"
+else
   mapfile -t library_list < <(cmake -DCMAKE_MODULE_PATH="${PWD}/cmake" -P cmake/print-ga-libraries.cmake 2>&1)
   # These libraries are not "features", but they are part of the public API
   library_list+=("common" "grpc_utils")
-else
-  IFS=',' read -ra library_list <<< "${GOOGLE_CLOUD_CPP_CHECK_API}"
 fi
 
 # Uses `abi-dumper` to dump the ABI for the given library, which should

--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -226,10 +226,8 @@ ci/cloudbuild/build.sh -t checkers-pr
 For new GA libraries you need to create the API baseline.
 
 ```
-ci/cloudbuild/build.sh -t check-api-pr
-git add ci/abi-dumps/google_cloud_cpp_${library}.expected.abi.dump.gz
-git commit -m"Add API baseline" ci/abi-dumps/google_cloud_cpp_${library}.expected.abi.dump.gz
-git restore ci/abi-dumps/
+env GOOGLE_CLOUD_CPP_CHECK_API=${library} ci/cloudbuild/build.sh -t check-api-pr
+git commit -m"Add API baseline" ci/abi-dumps/
 ```
 
 ## Verify everything compiles


### PR DESCRIPTION
There are times when we want to run `check-api-pr` and we only care about one library. (e.g. when we generate a new library).

Add a `GOOGLE_CLOUD_CPP_CHECK_API=common,bigtable,kms` env variable to only check a subset of the libraries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11719)
<!-- Reviewable:end -->
