### PR TITLE
cleanup(channel): build on all tested platforms

### DIFF
--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -42,12 +42,6 @@ cc_library(
     name = "google_cloud_cpp_channel",
     srcs = [":srcs"],
     hdrs = [":hdrs"],
-    # TODO(#8125): Re-enable the macos and Windows builds.
-    target_compatible_with = select({
-        "@platforms//os:macos": ["@platforms//:incompatible"],
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -17,8 +17,7 @@
 # TODO(#8125): enable on GCC < 8.0
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
                                                   VERSION_LESS 8.0)
-    message(WARNING "Cannot build google/cloud/channel "
-                    "with GCC < 8.0.")
+    message(WARNING "Cannot build google/cloud/channel with GCC < 8.0.")
     return()
 endif ()
 

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -14,19 +14,6 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#8125): Re-enable this on macOS and GCC < 8.0.
-if (APPLE)
-    message(WARNING "Cannot build google/cloud/channel "
-                    "on Apple platforms until #8125 is fixed.")
-    return()
-endif ()
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
-                                                  VERSION_LESS 8.0)
-    message(WARNING "Cannot build google/cloud/channel "
-                    "with GCC < 8.0 until #8125 is fixed.")
-    return()
-endif ()
-
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Cloud Channel API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Channel API")

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -14,6 +14,14 @@
 # limitations under the License.
 # ~~~
 
+# TODO(#8125): enable on GCC < 8.0
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
+                                                  VERSION_LESS 8.0)
+    message(WARNING "Cannot build google/cloud/channel "
+                    "with GCC < 8.0.")
+    return()
+endif ()
+
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Cloud Channel API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Channel API")


### PR DESCRIPTION
We used to exclude some platforms because Protobuf lacked protection against the `DOMAIN` macro being defined in the system.

Part of the work for #8125

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11721)
<!-- Reviewable:end -->
