### PR TITLE
impl(generator): emit LRO code for REST rpc with bespoke Operation type

### DIFF
--- a/generator/internal/connection_impl_rest_generator.cc
+++ b/generator/internal/connection_impl_rest_generator.cc
@@ -297,7 +297,7 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ request) {
   auto extractor = [&] {
     if (IsGRPCLongrunningOperation(method)) {
       // One of the variations is how to extract the value from the operation
-      // result, some operations use the metadata, some the data. We need to
+      // result. Some operations use the metadata, some the data. We need to
       // provide the right function to
       // internal::AsyncRestLongRunningOperation.
       if (IsLongrunningMetadataTypeUsedAsResponse(method)) {
@@ -310,12 +310,7 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ request) {
     // TODO(#11639): improve error handling by interrogating error details in
     // the Operation type (if available).
     return R"""(
-    [](StatusOr<$longrunning_deduced_response_type$> op, std::string const&) -> StatusOr<$longrunning_deduced_response_type$>{
-        if (!op) {
-          // TODO(#11639): improve error handling by interrogating error
-          // details in the Operation type (if available).
-          return op.status();
-        }
+    [](StatusOr<$longrunning_deduced_response_type$> op, std::string const&) {
         return op;
     },)""";
   };
@@ -328,7 +323,7 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ request) {
     },)""";
   };
 
-  auto get_request_set_operation_name = [&] {
+  auto get_request_set_operation = [&] {
     if (IsGRPCLongrunningOperation(method)) return "";
     return R"""(
     [request](std::string const& op, $longrunning_get_operation_request_type$& r) {
@@ -336,7 +331,7 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ request) {
     },)""";
   };
 
-  auto cancel_request_set_operation_name = [&] {
+  auto cancel_request_set_operation = [&] {
     if (IsGRPCLongrunningOperation(method)) return "";
     return R"""(
     [request](std::string const& op, $longrunning_cancel_operation_request_type$& r) {
@@ -383,8 +378,8 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ const& request) 
     retry_policy(), backoff_policy(),
     idempotency_policy()->$method_name$(request),
     polling_policy(), __func__)""",
-        is_operation_done(), get_request_set_operation_name(),
-        cancel_request_set_operation_name(), R"""())""",
+        is_operation_done(), get_request_set_operation(),
+        cancel_request_set_operation(), R"""())""",
         // Finally, the internal::AsyncRestLongRunningOperation helper may
         // return `future<StatusOr<google::protobuf::Empty>>`, in this case we
         // add a bit of code to drop the `protobuf::Empty`:

--- a/generator/internal/connection_impl_rest_generator.cc
+++ b/generator/internal/connection_impl_rest_generator.cc
@@ -283,6 +283,67 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ request) {
 )""";
   }
 
+  auto lro_template_types = [&] {
+    if (IsGRPCLongrunningOperation(method)) {
+      return R"""($longrunning_deduced_response_type$)""";
+    }
+    return R"""(
+    $longrunning_deduced_response_type$,
+    $longrunning_response_type$,
+    $longrunning_get_operation_request_type$,
+    $longrunning_cancel_operation_request_type$)""";
+  };
+
+  auto extractor = [&] {
+    if (IsGRPCLongrunningOperation(method)) {
+      // One of the variations is how to extract the value from the operation
+      // result, some operations use the metadata, some the data. We need to
+      // provide the right function to
+      // internal::AsyncRestLongRunningOperation.
+      if (IsLongrunningMetadataTypeUsedAsResponse(method)) {
+        return R"""(
+    &google::cloud::internal::ExtractLongRunningResultMetadata<$longrunning_deduced_response_type$>,)""";
+      }
+      return R"""(
+    &google::cloud::internal::ExtractLongRunningResultResponse<$longrunning_deduced_response_type$>,)""";
+    }
+    // TODO(#11639): improve error handling by interrogating error details in
+    // the Operation type (if available).
+    return R"""(
+    [](StatusOr<$longrunning_deduced_response_type$> op, std::string const&) -> StatusOr<$longrunning_deduced_response_type$>{
+        if (!op) {
+          // TODO(#11639): improve error handling by interrogating error
+          // details in the Operation type (if available).
+          return op.status();
+        }
+        return op;
+    },)""";
+  };
+
+  auto is_operation_done = [&] {
+    if (IsGRPCLongrunningOperation(method)) return "";
+    return R"""(,
+    []($longrunning_deduced_response_type$ const& op) {
+        return op.status() == "DONE";
+    },)""";
+  };
+
+  auto get_request_set_operation_name = [&] {
+    if (IsGRPCLongrunningOperation(method)) return "";
+    return R"""(
+    [request](std::string const& op, $longrunning_get_operation_request_type$& r) {
+        $longrunning_set_operation_fields$
+    },)""";
+  };
+
+  auto cancel_request_set_operation_name = [&] {
+    if (IsGRPCLongrunningOperation(method)) return "";
+    return R"""(
+    [request](std::string const& op, $longrunning_cancel_operation_request_type$& r) {
+        $longrunning_set_operation_fields$
+    })""";
+  };
+
   if (IsLongrunningOperation(method)) {
     return absl::StrCat(
         // The return type may be a simple `Status` or the
@@ -299,7 +360,8 @@ future<StatusOr<$longrunning_deduced_response_type$>>)""",
         R"""(
 $connection_impl_rest_class_name$::$method_name$($request_type$ const& request) {
   auto& stub = stub_;
-  return rest_internal::AsyncRestLongRunningOperation<$longrunning_deduced_response_type$>(
+  return rest_internal::AsyncRestLongRunningOperation<)""",
+        lro_template_types(), R"""(>(
     background_->cq(), request,
     [stub](CompletionQueue& cq,
           std::unique_ptr<rest_internal::RestContext> context,
@@ -308,28 +370,21 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ const& request) 
     },
     [stub](CompletionQueue& cq,
           std::unique_ptr<rest_internal::RestContext> context,
-          google::longrunning::GetOperationRequest const& request) {
+          $longrunning_get_operation_request_type$ const& request) {
      return stub->AsyncGetOperation(cq, std::move(context), request);
     },
     [stub](CompletionQueue& cq,
           std::unique_ptr<rest_internal::RestContext> context,
-          google::longrunning::CancelOperationRequest const& request) {
+          $longrunning_cancel_operation_request_type$ const& request) {
      return stub->AsyncCancelOperation(cq, std::move(context), request);
     },)""",
-        // One of the variations is how to extract the value from the operation
-        // result, some operations use the metadata, some the data. We need to
-        // provide the right function to
-        // internal::AsyncRestLongRunningOperation.
-        IsLongrunningMetadataTypeUsedAsResponse(method) ?
-                                                        R"""(
-    &google::cloud::internal::ExtractLongRunningResultMetadata<$longrunning_deduced_response_type$>,)"""
-                                                        :
-                                                        R"""(
-    &google::cloud::internal::ExtractLongRunningResultResponse<$longrunning_deduced_response_type$>,)""",
+        extractor(),
         R"""(
     retry_policy(), backoff_policy(),
     idempotency_policy()->$method_name$(request),
-    polling_policy(), __func__))""",
+    polling_policy(), __func__)""",
+        is_operation_done(), get_request_set_operation_name(),
+        cancel_request_set_operation_name(), R"""())""",
         // Finally, the internal::AsyncRestLongRunningOperation helper may
         // return `future<StatusOr<google::protobuf::Empty>>`, in this case we
         // add a bit of code to drop the `protobuf::Empty`:

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -766,6 +766,7 @@ VarsDictionary CreateServiceVars(
       absl::StrCat(vars["product_path"], "internal/",
                    ServiceNameToFilePath(descriptor.name()), "_tracing_stub.h");
   SetRetryStatusCodeExpression(vars);
+  SetLongrunningOperationServiceVars(descriptor, vars);
   return vars;
 }
 

--- a/generator/internal/logging_decorator_rest_generator.cc
+++ b/generator/internal/logging_decorator_rest_generator.cc
@@ -118,23 +118,8 @@ class $logging_rest_class_name$ : public $stub_rest_class_name$ {
   }
 
   if (HasLongrunningMethod()) {
-    // long running operation support methods
-    if (HasGRPCLongrunningOperation()) {
-      HeaderPrint(
-          R"""(
-  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::longrunning::GetOperationRequest const& request) override;
-
-  future<Status> AsyncCancelOperation(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::longrunning::CancelOperationRequest const& request) override;
-)""");
-    } else {
-      HeaderPrint(
-          R"""(
+    HeaderPrint(
+        R"""(
   future<StatusOr<$longrunning_response_type$>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
@@ -145,7 +130,6 @@ class $logging_rest_class_name$ : public $stub_rest_class_name$ {
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $longrunning_cancel_operation_request_type$ const& request) override;
 )""");
-    }
   }
 
   HeaderPrint(R"""(
@@ -281,41 +265,8 @@ $logging_rest_class_name$::Async$method_name$(
   }
 
   if (HasLongrunningMethod()) {
-    // long running operation support methods
-    if (HasGRPCLongrunningOperation()) {
-      CcPrint(
-          R"""(
-future<StatusOr<google::longrunning::Operation>>
-$logging_rest_class_name$::AsyncGetOperation(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<rest_internal::RestContext> rest_context,
-    google::longrunning::GetOperationRequest const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](CompletionQueue& cq,
-             std::unique_ptr<rest_internal::RestContext> rest_context,
-             google::longrunning::GetOperationRequest const& request) {
-        return child_->AsyncGetOperation(cq, std::move(rest_context), request);
-      },
-      cq, std::move(rest_context), request, __func__, tracing_options_);
-}
-
-future<Status>
-$logging_rest_class_name$::AsyncCancelOperation(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<rest_internal::RestContext> rest_context,
-    google::longrunning::CancelOperationRequest const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](CompletionQueue& cq,
-             std::unique_ptr<rest_internal::RestContext> rest_context,
-             google::longrunning::CancelOperationRequest const& request) {
-        return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
-      },
-      cq, std::move(rest_context), request, __func__, tracing_options_);
-}
-)""");
-    } else {
-      CcPrint(
-          R"""(
+    CcPrint(
+        R"""(
 future<StatusOr<$longrunning_response_type$>>
 $logging_rest_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
@@ -344,7 +295,6 @@ $logging_rest_class_name$::AsyncCancelOperation(
       cq, std::move(rest_context), request, __func__, tracing_options_);
 }
 )""");
-    }
   }
 
   CcCloseNamespaces();

--- a/generator/internal/longrunning.cc
+++ b/generator/internal/longrunning.cc
@@ -160,6 +160,10 @@ void SetLongrunningOperationServiceVars(
           "google::longrunning::GetOperationRequest";
       service_vars["longrunning_cancel_operation_request_type"] =
           "google::longrunning::CancelOperationRequest";
+      service_vars["longrunning_get_operation_path"] =
+          R"""(absl::StrCat("/v1/", request.name()))""";
+      service_vars["longrunning_cancel_operation_path"] =
+          R"""(absl::StrCat("/v1/", request.name(), ":cancel"))""";
       return;
     }
     if (!method->options()

--- a/generator/internal/longrunning_test.cc
+++ b/generator/internal/longrunning_test.cc
@@ -597,6 +597,13 @@ TEST_F(LongrunningVarsTest, SetLongrunningOperationServiceVarsGRPC) {
   EXPECT_THAT(vars,
               Contains(Pair("longrunning_cancel_operation_request_type",
                             "google::longrunning::CancelOperationRequest")));
+  EXPECT_THAT(vars,
+              Contains(Pair("longrunning_get_operation_path",
+                            R"""(absl::StrCat("/v1/", request.name()))""")));
+  EXPECT_THAT(
+      vars,
+      Contains(Pair("longrunning_cancel_operation_path",
+                    R"""(absl::StrCat("/v1/", request.name(), ":cancel"))""")));
 }
 
 TEST_F(LongrunningVarsTest, SetLongrunningOperationServiceVarsNonGRPCGlobal) {

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -114,10 +114,11 @@ Status MetadataDecoratorRestGenerator::GenerateHeader() {
   HeaderLocalIncludes({vars("stub_rest_header_path"), "google/cloud/future.h",
                        "google/cloud/rest_options.h",
                        "google/cloud/version.h"});
-  HeaderSystemIncludes(
-      {vars("proto_header_path"),
-       HasLongrunningMethod() ? "google/longrunning/operations.pb.h" : "",
-       "memory", "string"});
+  HeaderSystemIncludes({vars("proto_header_path"),
+                        HasLongrunningMethod()
+                            ? vars("longrunning_operation_include_header")
+                            : "",
+                        "memory", "string"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
@@ -136,7 +137,7 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
 
     if (IsLongrunningOperation(method)) {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  google::cloud::future<StatusOr<google::longrunning::Operation>> Async$method_name$(
+  google::cloud::future<StatusOr<$response_type$>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $request_type$ const& request) override;
@@ -180,8 +181,9 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
 
   if (HasLongrunningMethod()) {
     // long running operation support methods
-    HeaderPrint(
-        R"""(
+    if (HasGRPCLongrunningOperation()) {
+      HeaderPrint(
+          R"""(
   google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
@@ -192,6 +194,20 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::longrunning::CancelOperationRequest const& request) override;
 )""");
+    } else {
+      HeaderPrint(
+          R"""(
+  google::cloud::future<StatusOr<$longrunning_response_type$>> AsyncGetOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
+      $longrunning_get_operation_request_type$ const& request) override;
+
+  google::cloud::future<Status> AsyncCancelOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
+      $longrunning_cancel_operation_request_type$ const& request) override;
+)""");
+    }
   }
 
   HeaderPrint(R"""(
@@ -248,7 +264,7 @@ $metadata_rest_class_name$::$metadata_rest_class_name$(
     if (!HasHttpAnnotation(method)) continue;
     if (IsLongrunningOperation(method)) {
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
-future<StatusOr<google::longrunning::Operation>>
+future<StatusOr<$response_type$>>
 $metadata_rest_class_name$::Async$method_name$(
       CompletionQueue& cq,
       std::unique_ptr<rest_internal::RestContext> rest_context,
@@ -327,7 +343,9 @@ $metadata_rest_class_name$::Async$method_name$(
 
   if (HasLongrunningMethod()) {
     // long running operation support methods
-    CcPrint(R"""(
+    if (HasGRPCLongrunningOperation()) {
+      CcPrint(
+          R"""(
 future<StatusOr<google::longrunning::Operation>>
 $metadata_rest_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
@@ -346,6 +364,28 @@ $metadata_rest_class_name$::AsyncCancelOperation(
   return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
 }
 )""");
+    } else {
+      CcPrint(
+          R"""(
+future<StatusOr<$longrunning_response_type$>>
+$metadata_rest_class_name$::AsyncGetOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
+    $longrunning_get_operation_request_type$ const& request) {
+  SetMetadata(*rest_context);
+  return child_->AsyncGetOperation(cq, std::move(rest_context), request);
+}
+
+future<Status>
+$metadata_rest_class_name$::AsyncCancelOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
+    $longrunning_cancel_operation_request_type$ const& request) {
+  SetMetadata(*rest_context);
+  return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
+}
+)""");
+    }
   }
 
   // The metadata options supported come from

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -180,23 +180,8 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
   }
 
   if (HasLongrunningMethod()) {
-    // long running operation support methods
-    if (HasGRPCLongrunningOperation()) {
-      HeaderPrint(
-          R"""(
-  google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::longrunning::GetOperationRequest const& request) override;
-
-  google::cloud::future<Status> AsyncCancelOperation(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::longrunning::CancelOperationRequest const& request) override;
-)""");
-    } else {
-      HeaderPrint(
-          R"""(
+    HeaderPrint(
+        R"""(
   google::cloud::future<StatusOr<$longrunning_response_type$>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
@@ -207,7 +192,6 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $longrunning_cancel_operation_request_type$ const& request) override;
 )""");
-    }
   }
 
   HeaderPrint(R"""(
@@ -342,31 +326,8 @@ $metadata_rest_class_name$::Async$method_name$(
   }
 
   if (HasLongrunningMethod()) {
-    // long running operation support methods
-    if (HasGRPCLongrunningOperation()) {
-      CcPrint(
-          R"""(
-future<StatusOr<google::longrunning::Operation>>
-$metadata_rest_class_name$::AsyncGetOperation(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<rest_internal::RestContext> rest_context,
-    google::longrunning::GetOperationRequest const& request) {
-  SetMetadata(*rest_context);
-  return child_->AsyncGetOperation(cq, std::move(rest_context), request);
-}
-
-future<Status>
-$metadata_rest_class_name$::AsyncCancelOperation(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<rest_internal::RestContext> rest_context,
-    google::longrunning::CancelOperationRequest const& request) {
-  SetMetadata(*rest_context);
-  return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
-}
-)""");
-    } else {
-      CcPrint(
-          R"""(
+    CcPrint(
+        R"""(
 future<StatusOr<$longrunning_response_type$>>
 $metadata_rest_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
@@ -385,7 +346,6 @@ $metadata_rest_class_name$::AsyncCancelOperation(
   return child_->AsyncCancelOperation(cq, std::move(rest_context), request);
 }
 )""");
-    }
   }
 
   // The metadata options supported come from

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -214,23 +214,8 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
   }
 
   if (HasLongrunningMethod()) {
-    // long running operation support methods
-    if (HasGRPCLongrunningOperation()) {
-      HeaderPrint(
-          R"""(
-  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::longrunning::GetOperationRequest const& request) override;
-
-  future<Status> AsyncCancelOperation(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::longrunning::CancelOperationRequest const& request) override;
-)""");
-    } else {
-      HeaderPrint(
-          R"""(
+    HeaderPrint(
+        R"""(
   future<StatusOr<$longrunning_response_type$>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
@@ -241,7 +226,6 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       $longrunning_cancel_operation_request_type$ const& request) override;
 )""");
-    }
   }
 
   // private members and close default stub class definition


### PR DESCRIPTION
part of the work for #11531 

Adds an additional case in the generator for LRO methods that do not use the `google::longrunning::Operation` type and its associated methods. Existing tests verify that nothing has changed for the `google::longrunning::Operation` paths. Tests for the custom operation type path will be introduced later and will take the form of the generated compute services and integration tests for those services. This is a consequence of needing to hard code some of the substitution variables to compute specific types and services.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11723)
<!-- Reviewable:end -->
