### PR TITLE
refactor(bigtable): future-proof ReadRows mocking

### DIFF
--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -74,9 +74,17 @@ future<std::vector<FailedMutation>> DataConnection::AsyncBulkApply(
       Status(StatusCode::kUnimplemented, "not-implemented"), mut.size()));
 }
 
-RowReader DataConnection::ReadRows(
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string const&, RowSet, std::int64_t, Filter) {
+RowReader DataConnection::ReadRows(std::string const& table_name,
+                                   RowSet row_set, std::int64_t rows_limit,
+                                   Filter filter) {
+  return ReadRowsFull(ReadRowsParams{
+      std::move(table_name),
+      google::cloud::internal::CurrentOptions().get<AppProfileIdOption>(),
+      std::move(row_set), rows_limit, std::move(filter)});
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+RowReader DataConnection::ReadRowsFull(ReadRowsParams) {
   return MakeRowReader(std::make_shared<bigtable_internal::StatusOnlyRowReader>(
       Status(StatusCode::kUnimplemented, "not implemented")));
 }

--- a/google/cloud/bigtable/data_connection.h
+++ b/google/cloud/bigtable/data_connection.h
@@ -42,6 +42,15 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/// Wrap the arguments to `ReadRows()`.
+struct ReadRowsParams {
+  std::string table_name;
+  std::string app_profile_id;
+  RowSet row_set;
+  std::int64_t rows_limit;
+  Filter filter = Filter::PassAllFilter();
+};
+
 /**
  * A connection to the Cloud Bigtable Data API.
  *
@@ -93,8 +102,11 @@ class DataConnection {
   virtual future<std::vector<FailedMutation>> AsyncBulkApply(
       std::string const& table_name, BulkMutation mut);
 
+  /// Prefer to use `ReadRowsFull()` in mocks.
   virtual RowReader ReadRows(std::string const& table_name, RowSet row_set,
                              std::int64_t rows_limit, Filter filter);
+
+  virtual RowReader ReadRowsFull(ReadRowsParams params);
 
   virtual StatusOr<std::pair<bool, Row>> ReadRow(std::string const& table_name,
                                                  std::string row_key,

--- a/google/cloud/bigtable/examples/howto_mock_data_api.cc
+++ b/google/cloud/bigtable/examples/howto_mock_data_api.cc
@@ -42,7 +42,7 @@ TEST(MockTableTest, ReadRowsSuccess) {
   // yield "r1" then "r2":
   //! [simulate-call]
   std::vector<cbt::Row> rows = {cbt::Row("r1", {}), cbt::Row("r2", {})};
-  EXPECT_CALL(*mock, ReadRows)
+  EXPECT_CALL(*mock, ReadRowsFull)
       .WillOnce(Return(ByMove(cbtm::MakeRowReader(rows))));
   //! [simulate-call]
 
@@ -72,7 +72,7 @@ TEST(MockTableTest, ReadRowsFailure) {
 
   // Return a `RowReader` that yields only a failing status (no rows).
   gc::Status final_status(gc::StatusCode::kPermissionDenied, "fail");
-  EXPECT_CALL(*mock, ReadRows)
+  EXPECT_CALL(*mock, ReadRowsFull)
       .WillOnce(Return(ByMove(cbtm::MakeRowReader({}, final_status))));
 
   cbt::Table table(mock, cbt::TableResource("project", "instance", "table"));

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -173,13 +173,12 @@ DataConnectionImpl::AsyncBulkApply(std::string const& table_name,
                                   app_profile_id(), table_name, std::move(mut));
 }
 
-bigtable::RowReader DataConnectionImpl::ReadRows(std::string const& table_name,
-                                                 bigtable::RowSet row_set,
-                                                 std::int64_t rows_limit,
-                                                 bigtable::Filter filter) {
+bigtable::RowReader DataConnectionImpl::ReadRowsFull(
+    bigtable::ReadRowsParams params) {
   auto impl = std::make_shared<DefaultRowReader>(
-      stub_, app_profile_id(), table_name, std::move(row_set), rows_limit,
-      std::move(filter), retry_policy(), backoff_policy());
+      stub_, std::move(params.app_profile_id), std::move(params.table_name),
+      std::move(params.row_set), params.rows_limit, std::move(params.filter),
+      retry_policy(), backoff_policy());
   return MakeRowReader(std::move(impl));
 }
 
@@ -188,8 +187,9 @@ StatusOr<std::pair<bool, bigtable::Row>> DataConnectionImpl::ReadRow(
     bigtable::Filter filter) {
   bigtable::RowSet row_set(std::move(row_key));
   std::int64_t const rows_limit = 1;
-  auto reader =
-      ReadRows(table_name, std::move(row_set), rows_limit, std::move(filter));
+  auto reader = ReadRowsFull(
+      bigtable::ReadRowsParams{table_name, app_profile_id(), std::move(row_set),
+                               rows_limit, std::move(filter)});
 
   auto it = reader.begin();
   if (it == reader.end()) return std::make_pair(false, bigtable::Row("", {}));

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -52,10 +52,7 @@ class DataConnectionImpl : public bigtable::DataConnection {
   future<std::vector<bigtable::FailedMutation>> AsyncBulkApply(
       std::string const& table_name, bigtable::BulkMutation mut) override;
 
-  bigtable::RowReader ReadRows(std::string const& table_name,
-                               bigtable::RowSet row_set,
-                               std::int64_t rows_limit,
-                               bigtable::Filter filter) override;
+  bigtable::RowReader ReadRowsFull(bigtable::ReadRowsParams params) override;
 
   StatusOr<std::pair<bool, bigtable::Row>> ReadRow(
       std::string const& table_name, std::string row_key,

--- a/google/cloud/bigtable/internal/data_tracing_connection.cc
+++ b/google/cloud/bigtable/internal/data_tracing_connection.cc
@@ -90,14 +90,10 @@ class DataTracingConnection : public bigtable::DataConnection {
     });
   }
 
-  bigtable::RowReader ReadRows(std::string const& table_name,
-                               bigtable::RowSet row_set,
-                               std::int64_t rows_limit,
-                               bigtable::Filter filter) override {
+  bigtable::RowReader ReadRowsFull(bigtable::ReadRowsParams params) override {
     auto span = internal::MakeSpan("bigtable::Table::ReadRows");
     auto scope = opentelemetry::trace::Scope(span);
-    auto reader = child_->ReadRows(table_name, std::move(row_set), rows_limit,
-                                   std::move(filter));
+    auto reader = child_->ReadRowsFull(std::move(params));
     return MakeTracedRowReader(std::move(span), std::move(reader));
   }
 

--- a/google/cloud/bigtable/mocks/mock_row_reader.h
+++ b/google/cloud/bigtable/mocks/mock_row_reader.h
@@ -46,7 +46,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *   std::vector<cbt::Row> rows = {cbt::Row("r1", {}), cbt::Row("r2", {})};
  *
  *   auto mock = std::shared_ptr<cbtm::MockDataConnection>();
- *   EXPECT_CALL(*mock, ReadRows)
+ *   EXPECT_CALL(*mock, ReadRowsFull)
  *       .WillOnce(Return(cbtm::MakeRowReader(rows)));
  *
  *   auto table = cbt::Table(mock);


### PR DESCRIPTION
Part of the work for \<mystery bigtable feature\>

Googlers can see: go/cloud-cxx:how-to-grow-bigtable-read-rows

The new Connection API allows us to add additional `ReadRowsRequest` configuration parameters.

I think we should include `app_profile_id` in the params struct. It is easier to check in the params struct than in `google::cloud::mocks::CurrentOptions()`.

Note that we cannot `internal::ExtractOption<AppProfileIdOption>` in the connection layer, because the current options are ` const&`. I think it is safer to just use `.get<>` instead of changing the method to `Options& internal::CurrentOptions()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11725)
<!-- Reviewable:end -->
