### PR TITLE
docs(otel): introduce a sample

### DIFF
--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -21,7 +21,8 @@ set(DOXYGEN_PROJECT_BRIEF
     "Provides exporters for sending telemetry to Google Cloud services in C++.")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "otel_internal")
-set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
+set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/quickstart"
+                         "${CMAKE_CURRENT_SOURCE_DIR}/samples")
 
 include(GoogleCloudCppDoxygen)
 google_cloud_cpp_doxygen_targets("opentelemetry" DEPENDS cloud-docs
@@ -103,6 +104,7 @@ if (NOT BUILD_TESTING)
 endif ()
 
 add_subdirectory(integration_tests)
+add_subdirectory(samples)
 
 set(opentelemetry_unit_tests # cmake-format: sort
                              internal/recordable_test.cc trace_exporter_test.cc)

--- a/google/cloud/opentelemetry/configure_basic_tracing.h
+++ b/google/cloud/opentelemetry/configure_basic_tracing.h
@@ -116,16 +116,7 @@ class BasicTracingConfiguration {
  * you can use an environment variable (or any other configuration source)
  * to initialize its value.
  *
- * @code
- *   auto const rate = [](char const* v) -> double {
- *     if (v == nullptr) return 0.01; // By default use 1% sampling.
- *     return std::stoi(v) / 100.0;
- *   }(std::getenv("MY_CONFIG_VARIABLE"))
- *   auto tracing = google::cloud::opentelemetry::ConfigureBasicTracing(
- *       google::cloud::Project(tracing_project),
- *       google::cloud::Options{}
- *           .set<google::cloud::opentelemetry::BasicTracingRateOption>(rate));
- * @endcode
+ * @snippet samples.cc otel-basic-tracing-rate
  * @endparblock
  *
  * @param project the project to send the traces to.

--- a/google/cloud/opentelemetry/samples/BUILD.bazel
+++ b/google/cloud/opentelemetry/samples/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
+
+[cc_test(
+    name = test.replace("/", "_").replace(".cc", ""),
+    srcs = [test],
+    tags = ["integration-test"],
+    deps = [
+        "//:experimental-opentelemetry",
+        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
+    ],
+) for test in glob(["*.cc"])]

--- a/google/cloud/opentelemetry/samples/CMakeLists.txt
+++ b/google/cloud/opentelemetry/samples/CMakeLists.txt
@@ -1,0 +1,17 @@
+# ~~~
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+google_cloud_cpp_add_samples("opentelemetry")

--- a/google/cloud/opentelemetry/samples/CMakeLists.txt
+++ b/google/cloud/opentelemetry/samples/CMakeLists.txt
@@ -14,4 +14,6 @@
 # limitations under the License.
 # ~~~
 
-google_cloud_cpp_add_samples("opentelemetry")
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+    google_cloud_cpp_add_samples("opentelemetry")
+endif ()

--- a/google/cloud/opentelemetry/samples/samples.cc
+++ b/google/cloud/opentelemetry/samples/samples.cc
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/example_driver.h"
+#include <opentelemetry/trace/provider.h>
+#include <string>
+#include <vector>
+
+namespace {
+using ::google::cloud::internal::GetEnv;
+
+void MyApplicationCode() {
+  auto provider = opentelemetry::trace::Provider::GetTracerProvider();
+  auto tracer = provider->GetTracer("gcloud-cpp/otel-samples");
+  auto span = tracer->StartSpan("otel-samples");
+  span->End();
+}
+
+void BasicTracingRate(std::vector<std::string> const& argv) {
+  //! [otel-basic-tracing-rate]
+  namespace gc = ::google::cloud;
+  namespace otel = ::google::cloud::otel;
+  [](std::string project_id) {
+    auto project = gc::Project(std::move(project_id));
+    auto options = gc::Options{}.set<otel::BasicTracingRateOption>(.001);
+    auto configuration = gc::otel::ConfigureBasicTracing(project, options);
+
+    MyApplicationCode();
+  }
+  //! [otel-basic-tracing-rate]
+  (argv.at(0));
+}
+
+void AutoRun(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+  });
+  auto project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value();
+
+  std::cout << "\nRunning BasicTracingRate() sample" << std::endl;
+  BasicTracingRate({project_id});
+
+  std::cout << "\nAutoRun done" << std::endl;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+  google::cloud::testing_util::Example example({
+      {"basic-tracing-rate", BasicTracingRate},
+      {"auto", AutoRun},
+  });
+  return example.Run(argc, argv);
+}


### PR DESCRIPTION
Part of the work for #11360 

---

Start with one sample. One is better than none.

Arguably I should just do `void MyApplicationCode() {};`. But I like the idea of something potentially happening if the sample is run from the command line. (of course with the hardcoded .001 sample rate, `otel-basic-tracing-rate` will barely ever do anything). I am open to other opinions.

---

Note that the `google/cloud/opentelemetry/...` integration tests do not run for any CMake builds. (I think this is also true of the most generated `google/cloud/${library}/samples/...`). I did run them manually to make sure they worked.

```
2023-05-25T16:25:57Z (+36s)
--------------------------------------------------------------------
|   Running OpenTelemetry integration tests (against production)   |
--------------------------------------------------------------------
Test project /workspace/cmake-out
3/3 Test #131: opentelemetry_samples
100% tests passed, 0 tests failed out of 3
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11728)
<!-- Reviewable:end -->
