### PR TITLE
feat(storage): better error messages in signed URLs

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -358,7 +358,6 @@ StatusOr<Client::SignBlobResponseRaw> Client::SignBlobImpl(
     SigningAccount const& signing_account, std::string const& string_to_sign) {
   auto credentials = raw_client_->client_options().credentials();
 
-  std::string signing_account_email = SigningEmail(signing_account);
   // First try to sign locally.
   auto signed_blob = credentials->SignBlob(signing_account, string_to_sign);
   if (signed_blob) {
@@ -370,7 +369,8 @@ StatusOr<Client::SignBlobResponseRaw> Client::SignBlobImpl(
   // credentials account. In either case, try to sign using the API.
   // In this case, however, we want to validate the signing account, because
   // otherwise the errors are almost impossible to troubleshoot.
-  if (signing_account_email.empty()) {
+  auto signing_email = SigningEmail(signing_account);
+  if (signing_email.empty()) {
     return google::cloud::internal::InvalidArgumentError(
         "signing account cannot be empty."
         " The client library was unable to fetch a valid signing email from"
@@ -379,7 +379,7 @@ StatusOr<Client::SignBlobResponseRaw> Client::SignBlobImpl(
         GCP_ERROR_INFO());
   }
   internal::SignBlobRequest sign_request(
-      signing_account_email, internal::Base64Encode(string_to_sign), {});
+      std::move(signing_email), internal::Base64Encode(string_to_sign), {});
   auto response = raw_client_->SignBlob(sign_request);
   if (!response) return response.status();
   auto decoded = internal::Base64Decode(response->signed_blob);

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/filesystem.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/log.h"
 #include <fstream>
@@ -367,6 +368,16 @@ StatusOr<Client::SignBlobResponseRaw> Client::SignBlobImpl(
   // If signing locally fails that may be because the credentials do not
   // support signing, or because the signing account is different than the
   // credentials account. In either case, try to sign using the API.
+  // In this case, however, we want to validate the signing account, because
+  // otherwise the errors are almost impossible to troubleshoot.
+  if (signing_account_email.empty()) {
+    return google::cloud::internal::InvalidArgumentError(
+        "signing account cannot be empty."
+        " The client library was unable to fetch a valid signing email from"
+        " the configured credentials, and the application did not provide"
+        " a value in the `google::cloud::storage::SigningAccount` option.",
+        GCP_ERROR_INFO());
+  }
   internal::SignBlobRequest sign_request(
       signing_account_email, internal::Base64Encode(string_to_sign), {});
   auto response = raw_client_->SignBlob(sign_request);

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -137,6 +137,7 @@ TEST_F(CreateSignedPolicyDocRPCTest, SignRemote) {
   auto client = ClientForMock();
   auto actual = client.CreateSignedPolicyDocument(
       CreatePolicyDocumentForTest(),
+      SigningAccount("test-only-invalid@example.com"),
       Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_THAT(actual->signature, expected_signed_blob);
@@ -148,7 +149,10 @@ TEST_F(CreateSignedPolicyDocRPCTest, SignPolicyTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::SignBlobResponse>(
       mock_, EXPECT_CALL(*mock_, SignBlob),
       [](Client& client) {
-        return client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest())
+        return client
+            .CreateSignedPolicyDocument(
+                CreatePolicyDocumentForTest(),
+                SigningAccount("test-only-invalid@example.com"))
             .status();
       },
       "SignBlob");
@@ -161,7 +165,10 @@ TEST_F(CreateSignedPolicyDocRPCTest, SignPolicyPermanentFailure) {
   testing::PermanentFailureStatusTest<internal::SignBlobResponse>(
       client, EXPECT_CALL(*mock_, SignBlob),
       [](Client& client) {
-        return client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest())
+        return client
+            .CreateSignedPolicyDocument(
+                CreatePolicyDocumentForTest(),
+                SigningAccount("test-only-invalid@example.com"))
             .status();
       },
       "SignBlob");


### PR DESCRIPTION
The error messages for signed URL functions (`CreateV2SignedUrl()`, `CreateV4SignedUrl()` and `CreatedSignedPolicyDocument()`) were not helpful when the signing account is missing.

Fixes #11740

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11741)
<!-- Reviewable:end -->
