### PR TITLE
fix: better support for cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,23 @@ add_custom_target(all-docfx)
 find_package(absl CONFIG REQUIRED)
 if (${GOOGLE_CLOUD_CPP_ENABLE_GRPC})
     find_package(gRPC REQUIRED QUIET)
+    # `Protobuf_PROTOC_EXECUTABLE` is pretty standard. It has been in use by
+    # CMake's FindProtobuf module for years, and it is defined by Protobuf's
+    # CMake configuration files. There is no obvious analog for the gRPC plugin.
+    # gRPC only exports the targets (e.g. `gRPC::grpc_cpp_plugin`) when
+    # applicable. We define our own variable.
+    set(GOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE
+        $<TARGET_FILE:gRPC::grpc_cpp_plugin>
+        CACHE
+            STRING
+            [==[Override gRPC's protoc plugin location.
+`google-cloud-cpp` uses the gRPC's protoc plugin to generate gRPC stub code.
+One may need to override the default location when cross-compiling, as the gRPC
+package will point to the target environment and the plugin won't run on the
+host environment.
+]==])
+    mark_as_advanced(GOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE)
+
     set(GOOGLE_CLOUD_CPP_FIND_DEPENDENCY_PROTOBUF
         "find_dependency(Protobuf CONFIG)")
     find_package(Protobuf CONFIG QUIET)

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -203,15 +203,11 @@ function (google_cloud_cpp_generate_grpcpp SRCS)
         if (NOT Protobuf_PROTOC_EXECUTABLE)
             set(Protobuf_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
         endif ()
-        if (NOT _gRPC_CPP_PLUGIN_EXECUTABLE)
-            set(_gRPC_CPP_PLUGIN_EXECUTABLE
-                $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
-        endif ()
         add_custom_command(
             OUTPUT "${grpc_pb_cc}" "${grpc_pb_h}"
             COMMAND
                 ${Protobuf_PROTOC_EXECUTABLE} ARGS
-                --plugin=protoc-gen-grpc=${_gRPC_CPP_PLUGIN_EXECUTABLE}
+                --plugin=protoc-gen-grpc=${GOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE}
                 "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
                 "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" ${protobuf_include_path}
                 "${file_path}"

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -205,7 +205,7 @@ function (google_cloud_cpp_generate_grpcpp SRCS)
         endif ()
         if (NOT _gRPC_CPP_PLUGIN_EXECUTABLE)
             set(_gRPC_CPP_PLUGIN_EXECUTABLE
-                $<TARGET_FILE:grpc::grpc_cpp_plugin>)
+                $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
         endif ()
         add_custom_command(
             OUTPUT "${grpc_pb_cc}" "${grpc_pb_h}"

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -98,14 +98,17 @@ function (google_cloud_cpp_generate_proto SRCS)
         set(pb_h "${CMAKE_CURRENT_BINARY_DIR}/${D}/${file_stem}.pb.h")
         list(APPEND ${SRCS} "${pb_cc}" "${pb_h}")
 
+        if (NOT Protobuf_PROTOC_EXECUTABLE)
+            set(Protobuf_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
+        endif ()
         if (${_opt_LOCAL_INCLUDE})
             add_custom_command(
                 OUTPUT "${pb_cc}" "${pb_h}"
                 COMMAND
-                    $<TARGET_FILE:protobuf::protoc> ARGS --cpp_out
+                    ${Protobuf_PROTOC_EXECUTABLE} ARGS --cpp_out
                     "${CMAKE_CURRENT_BINARY_DIR}/${D}" ${protobuf_include_path}
                     "${file_name}"
-                DEPENDS "${file_path}" protobuf::protoc
+                DEPENDS "${file_path}"
                 WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${D}"
                 COMMENT "Running C++ protocol buffer compiler on ${file_path}"
                 VERBATIM)
@@ -113,10 +116,10 @@ function (google_cloud_cpp_generate_proto SRCS)
             add_custom_command(
                 OUTPUT "${pb_cc}" "${pb_h}"
                 COMMAND
-                    $<TARGET_FILE:protobuf::protoc> ARGS --cpp_out
+                    ${Protobuf_PROTOC_EXECUTABLE} ARGS --cpp_out
                     "${CMAKE_CURRENT_BINARY_DIR}" ${protobuf_include_path}
                     "${file_path}"
-                DEPENDS "${file_path}" protobuf::protoc
+                DEPENDS "${file_path}"
                 COMMENT "Running C++ protocol buffer compiler on ${file_path}"
                 VERBATIM)
         endif ()
@@ -197,15 +200,22 @@ function (google_cloud_cpp_generate_grpcpp SRCS)
             "${CMAKE_CURRENT_BINARY_DIR}/${D}/${file_stem}.grpc.pb.cc")
         set(grpc_pb_h "${CMAKE_CURRENT_BINARY_DIR}/${D}/${file_stem}.grpc.pb.h")
         list(APPEND ${SRCS} "${grpc_pb_cc}" "${grpc_pb_h}")
+        if (NOT Protobuf_PROTOC_EXECUTABLE)
+            set(Protobuf_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
+        endif ()
+        if (NOT DEFINED _gRPC_CPP_PLUGIN_EXECUTABLE)
+            set(_gRPC_CPP_PLUGIN_EXECUTABLE
+                $<TARGET_FILE:grpc::grpc_cpp_plugin>)
+        endif ()
         add_custom_command(
             OUTPUT "${grpc_pb_cc}" "${grpc_pb_h}"
             COMMAND
-                $<TARGET_FILE:protobuf::protoc> ARGS
-                --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
+                ${Protobuf_PROTOC_EXECUTABLE} ARGS
+                --plugin=protoc-gen-grpc=${_gRPC_CPP_PLUGIN_EXECUTABLE}
                 "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
                 "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" ${protobuf_include_path}
                 "${file_path}"
-            DEPENDS "${file_path}" protobuf::protoc gRPC::grpc_cpp_plugin
+            DEPENDS "${file_path}"
             COMMENT "Running gRPC C++ protocol buffer compiler on ${file_path}"
             VERBATIM)
     endforeach ()

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -203,7 +203,7 @@ function (google_cloud_cpp_generate_grpcpp SRCS)
         if (NOT Protobuf_PROTOC_EXECUTABLE)
             set(Protobuf_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
         endif ()
-        if (NOT DEFINED _gRPC_CPP_PLUGIN_EXECUTABLE)
+        if (NOT _gRPC_CPP_PLUGIN_EXECUTABLE)
             set(_gRPC_CPP_PLUGIN_EXECUTABLE
                 $<TARGET_FILE:grpc::grpc_cpp_plugin>)
         endif ()

--- a/doc/compile-time-configuration.md
+++ b/doc/compile-time-configuration.md
@@ -41,6 +41,18 @@ a [GitHub Discussion]. With that said:
   opposed to gRPC over HTTP/2) in some libraries.
 - `experimental-opentelemetry` enables support for [OpenTelemetry].
 
+### Override Protobuf compiler and gRPC's plugin
+
+`google-cloud-cpp` uses the protobuf compiler and gRPC's plugin to generate
+code from the Protobuf API definitions. By default it finds these tools using
+the targets exported by `find_package(Protobuf CONFIG)` and
+`find_package(gRPC CONFIG)`.  These defaults do not work when cross-compiling,
+as the packages will point to the tools for the **target** environment, and
+they may not run in the host environment, where the build is running.
+
+You can override these tools using `-DProtobuf_PROTOC_EXECUTABLE=/path/...` and
+`-DGOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE=/other-path/...`.
+
 ### Disabling C++ Exceptions
 
 `google-cloud-cpp` does not throw exceptions to signal errors. Though in some

--- a/examples/hello_world_grpc/CMakeLists.txt
+++ b/examples/hello_world_grpc/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_command(
            "${CMAKE_CURRENT_BINARY_DIR}/hello_world.pb.cc"
            "${CMAKE_CURRENT_BINARY_DIR}/hello_world.pb.h"
     COMMAND
-        $<TARGET_FILE:protobuf::protoc> ARGS
+        ${Protobuf_PROTOC_EXECUTABLE} ARGS
         --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
         "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
         "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -162,7 +162,7 @@ target_link_libraries(
 
 # Generate protobuf code and library
 if (COMMAND protobuf_generate)
-    set(protobuf_PROTOC_EXE $<TARGET_FILE:protobuf::protoc>)
+    set(protobuf_PROTOC_EXE ${Protobuf_PROTOC_EXECUTABLE})
     add_library(google_cloud_cpp_generator_config)
     protobuf_generate(LANGUAGE cpp TARGET google_cloud_cpp_generator_config
                       PROTOS generator_config.proto)


### PR DESCRIPTION
Allow overrides for the `protobuf::protoc` and `gRPC::grpc_cpp_plugin` targets. On cross-compilation builds the targets point to the binaries for the *target*, but we need binaries that can run on the *host* build.

Fixes #11779

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11782)
<!-- Reviewable:end -->
