### PR TITLE
ci: minimum tested Bazel is 5.4.1

### DIFF
--- a/ci/cloudbuild/builds/bazel-oldest.sh
+++ b/ci/cloudbuild/builds/bazel-oldest.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-export USE_BAZEL_VERSION=4.2.4
+export USE_BAZEL_VERSION=5.4.1
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh


### PR DESCRIPTION
The next version of gRPC won't compile with Bazel 4.2.1. They are doing the right thing, we had extended the life of 4.2.1 to accomodate one customer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11785)
<!-- Reviewable:end -->
