### PR TITLE
ci: skip `debugger` in Bazel+quickstart builds too

### DIFF
--- a/ci/kokoro/windows/builds/quickstart-bazel.ps1
+++ b/ci/kokoro/windows/builds/quickstart-bazel.ps1
@@ -46,7 +46,11 @@ function Get-Released-Quickstarts {
         #   TODO(#8145) - asset (TRUE/FALSE macros)
         #   TODO(#8125) - channel (DOMAIN macro)
         #   TODO(#10737) - dialogflow_es triggers bug in Bazel 6.0.0
-        Where-Object { -not ("asset", "channel", "dialogflow_es" -contains $_) } |
+        # In addition, the `google/cloud/debugger/quickstart` directory is gone.
+        # However, we use the previous release of `google-cloud-cpp` in these
+        # builds, where the target still exists:
+        #    TODO(#11772) - deprecated library.
+        Where-Object { -not ("asset", "channel", "dialogflow_es", "debugger" -contains $_) } |
         # TODO(#9923) - compiling all quickstarts on Windows is too slow
         Get-Random -Count 10
     Pop-Location


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11788)
<!-- Reviewable:end -->
