### PR TITLE
ci: run generate-libraries on GCB

### DIFF
--- a/ci/cloudbuild/builds/integration-production.sh
+++ b/ci/cloudbuild/builds/integration-production.sh
@@ -24,7 +24,6 @@ source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
-export HTTP_TRANSCODING_TEST=yes
 
 mapfile -t args < <(bazel::common_args)
 bazel test "${args[@]}" --test_tag_filters=-integration-test ...

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -25,8 +25,7 @@ options:
     'COMMIT_SHA=${COMMIT_SHA}',
     'PR_NUMBER=${_PR_NUMBER}',
     'TRIGGER_TYPE=${_TRIGGER_TYPE}',
-    'GENERATE_GOLDEN_ONLY=""',
-    'HTTP_TRANSCODING_TEST=""',
+    'GENERATE_GOLDEN_ONLY=',
     'CONSOLE_LOG_URL=https://console.cloud.google.com/cloud-build/builds;region=us-east1/${BUILD_ID};tab=detail?project=${PROJECT_ID}',
     'RAW_LOG_URL=https://storage.googleapis.com/${_LOGS_BUCKET}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}/log-${BUILD_ID}.txt'
   ]


### PR DESCRIPTION
Builds would succeed because `GENERATE_GOLDEN_ONLY` was the string `\"\"`, not the empty string. Which would cause us to hit the branches of this `if` statement intended for development only: https://github.com/googleapis/google-cloud-cpp/blob/02f0266d5cf31ad735467e4d001b7399808a1536/ci/cloudbuild/builds/generate-libraries.sh#L64-L66

e.g. this: https://pantheon.corp.google.com/cloud-build/builds;region=us-east1/d4c7d23d-b8aa-4edb-acd9-f840e76169f8;step=3?project=cloud-cpp-testing-resources

This hasn't been a problem, because we run `generate-libraries-pr` locally (not on GCB) all of the time.

Also remove `HTTP_TRANSCODING_TEST` because it does not do anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11795)
<!-- Reviewable:end -->
