### PR TITLE
ci: also exclude '.pb' files from whitespace checks

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -132,7 +132,10 @@ time {
   expressions+=("-e" "':x;/^\n*$/{\$d;N;bx;}'")
   # Adds a trailing newline if one doesn't already exist
   expressions+=("-e" "'\$a\'")
-  git_files -z | grep -zv '\.gz$' | grep -zv 'googleapis.patch$' | grep -zv '\.png$' |
+  git_files -z | grep -zv 'googleapis.patch$' |
+    grep -zv '\.gz$' |
+    grep -zv '\.pb$' |
+    grep -zv '\.png$' |
     (xargs -r -0 grep -ZPL "\b[D]O NOT EDIT\b" || true) |
     xargs -r -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11816)
<!-- Reviewable:end -->
