### PR TITLE
cleanup: streaming write test nits

### DIFF
--- a/google/cloud/internal/streaming_write_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_logging_test.cc
@@ -72,7 +72,7 @@ TEST_F(StreamingWriteRpcLoggingTest, Write) {
   TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
   google::protobuf::Timestamp request;
   request.set_seconds(123456);
-  stream.Write(request, grpc::WriteOptions{});
+  EXPECT_TRUE(stream.Write(request, grpc::WriteOptions{}));
   auto const lines = log_.ExtractLines();
   EXPECT_THAT(lines, Contains(AllOf(HasSubstr("Write"), HasSubstr("test-id"),
                                     HasSubstr("1970-01-02T10:17:36Z"))));

--- a/google/cloud/internal/streaming_write_rpc_tracing_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_tracing_test.cc
@@ -92,9 +92,9 @@ TEST(StreamingWriteRpcTracingTest, Write) {
   auto span = MakeSpan("span");
   TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
                       span);
-  stream.Write(100, grpc::WriteOptions{});
-  stream.Write(200, grpc::WriteOptions{});
-  stream.Write(300, grpc::WriteOptions{}.set_last_message());
+  EXPECT_TRUE(stream.Write(100, grpc::WriteOptions{}));
+  EXPECT_FALSE(stream.Write(200, grpc::WriteOptions{}));
+  EXPECT_TRUE(stream.Write(300, grpc::WriteOptions{}.set_last_message()));
   stream.Close();
 
   auto spans = span_catcher->GetSpans();


### PR DESCRIPTION
verify that the wrappers pass along the value returned by the child for writes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11826)
<!-- Reviewable:end -->
