### PR TITLE
impl(generator): metadata decorator fixed headers

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -31,8 +31,10 @@ namespace golden_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GoldenKitchenSinkMetadata::GoldenKitchenSinkMetadata(
-    std::shared_ptr<GoldenKitchenSinkStub> child)
+    std::shared_ptr<GoldenKitchenSinkStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
@@ -221,6 +223,9 @@ void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata(

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
  public:
   ~GoldenKitchenSinkMetadata() override = default;
-  explicit GoldenKitchenSinkMetadata(std::shared_ptr<GoldenKitchenSinkStub> child);
+  explicit GoldenKitchenSinkMetadata(
+      std::shared_ptr<GoldenKitchenSinkStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
       grpc::ClientContext& context,
@@ -106,6 +109,7 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<GoldenKitchenSinkStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.cc
@@ -31,8 +31,10 @@ namespace golden_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GoldenThingAdminMetadata::GoldenThingAdminMetadata(
-    std::shared_ptr<GoldenThingAdminStub> child)
+    std::shared_ptr<GoldenThingAdminStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::test::admin::database::v1::ListDatabasesResponse>
@@ -307,6 +309,9 @@ void GoldenThingAdminMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GoldenThingAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata(

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GoldenThingAdminMetadata : public GoldenThingAdminStub {
  public:
   ~GoldenThingAdminMetadata() override = default;
-  explicit GoldenThingAdminMetadata(std::shared_ptr<GoldenThingAdminStub> child);
+  explicit GoldenThingAdminMetadata(
+      std::shared_ptr<GoldenThingAdminStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
       grpc::ClientContext& context,
@@ -138,6 +141,7 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<GoldenThingAdminStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -39,6 +39,7 @@ using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::google::test::admin::database::v1::Request;
 using ::google::test::admin::database::v1::Response;
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::AnyOf;
 using ::testing::Contains;
 using ::testing::Not;
@@ -464,6 +465,28 @@ TEST_F(MetadataDecoratorTest, ExplicitRoutingNestedField) {
   // extract its metadata).
   (void)stub.ExplicitRouting2(context1, request);
   (void)stub.ExplicitRouting2(context2, request);
+}
+
+TEST_F(MetadataDecoratorTest, FixedMetadata) {
+  // We do this for a single RPC, we are using some knowledge of the
+  // implementation to assert that this is enough.
+  EXPECT_CALL(*mock_, GenerateAccessToken)
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::test::admin::database::v1::
+                           GenerateAccessTokenRequest const&) {
+        auto metadata = GetMetadata(context);
+        EXPECT_THAT(metadata,
+                    AllOf(Contains(Pair("test-key-1", "test-value-1")),
+                          Contains(Pair("test-key-2", "test-value-2"))));
+        return TransientError();
+      });
+
+  GoldenKitchenSinkMetadata stub(
+      mock_, {{"test-key-1", "test-value-1"}, {"test-key-2", "test-value-2"}});
+  grpc::ClientContext context;
+  google::test::admin::database::v1::GenerateAccessTokenRequest request;
+  auto status = stub.GenerateAccessToken(context, request);
+  EXPECT_EQ(TransientError(), status.status());
 }
 
 }  // namespace

--- a/google/cloud/accessapproval/v1/internal/access_approval_metadata_decorator.cc
+++ b/google/cloud/accessapproval/v1/internal/access_approval_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace accessapproval_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AccessApprovalMetadata::AccessApprovalMetadata(
-    std::shared_ptr<AccessApprovalStub> child)
+    std::shared_ptr<AccessApprovalStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -122,6 +124,9 @@ void AccessApprovalMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AccessApprovalMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/accessapproval/v1/internal/access_approval_metadata_decorator.h
+++ b/google/cloud/accessapproval/v1/internal/access_approval_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AccessApprovalMetadata : public AccessApprovalStub {
  public:
   ~AccessApprovalMetadata() override = default;
-  explicit AccessApprovalMetadata(std::shared_ptr<AccessApprovalStub> child);
+  explicit AccessApprovalMetadata(
+      std::shared_ptr<AccessApprovalStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::accessapproval::v1::ListApprovalRequestsResponse>
   ListApprovalRequests(
@@ -93,6 +96,7 @@ class AccessApprovalMetadata : public AccessApprovalStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AccessApprovalStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/accesscontextmanager/v1/internal/access_context_manager_metadata_decorator.cc
+++ b/google/cloud/accesscontextmanager/v1/internal/access_context_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace accesscontextmanager_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AccessContextManagerMetadata::AccessContextManagerMetadata(
-    std::shared_ptr<AccessContextManagerStub> child)
+    std::shared_ptr<AccessContextManagerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -309,6 +311,9 @@ void AccessContextManagerMetadata::SetMetadata(
 
 void AccessContextManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/accesscontextmanager/v1/internal/access_context_manager_metadata_decorator.h
+++ b/google/cloud/accesscontextmanager/v1/internal/access_context_manager_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class AccessContextManagerMetadata : public AccessContextManagerStub {
  public:
   ~AccessContextManagerMetadata() override = default;
   explicit AccessContextManagerMetadata(
-      std::shared_ptr<AccessContextManagerStub> child);
+      std::shared_ptr<AccessContextManagerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<
       google::identity::accesscontextmanager::v1::ListAccessPoliciesResponse>
@@ -207,6 +209,7 @@ class AccessContextManagerMetadata : public AccessContextManagerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AccessContextManagerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/advisorynotifications/v1/internal/advisory_notifications_metadata_decorator.cc
+++ b/google/cloud/advisorynotifications/v1/internal/advisory_notifications_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace advisorynotifications_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AdvisoryNotificationsServiceMetadata::AdvisoryNotificationsServiceMetadata(
-    std::shared_ptr<AdvisoryNotificationsServiceStub> child)
+    std::shared_ptr<AdvisoryNotificationsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -61,6 +63,9 @@ void AdvisoryNotificationsServiceMetadata::SetMetadata(
 void AdvisoryNotificationsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/advisorynotifications/v1/internal/advisory_notifications_metadata_decorator.h
+++ b/google/cloud/advisorynotifications/v1/internal/advisory_notifications_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class AdvisoryNotificationsServiceMetadata
  public:
   ~AdvisoryNotificationsServiceMetadata() override = default;
   explicit AdvisoryNotificationsServiceMetadata(
-      std::shared_ptr<AdvisoryNotificationsServiceStub> child);
+      std::shared_ptr<AdvisoryNotificationsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::advisorynotifications::v1::ListNotificationsResponse>
   ListNotifications(
@@ -54,6 +56,7 @@ class AdvisoryNotificationsServiceMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AdvisoryNotificationsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/alloydb/v1/internal/alloy_db_admin_metadata_decorator.cc
+++ b/google/cloud/alloydb/v1/internal/alloy_db_admin_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace alloydb_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AlloyDBAdminMetadata::AlloyDBAdminMetadata(
-    std::shared_ptr<AlloyDBAdminStub> child)
+    std::shared_ptr<AlloyDBAdminStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -231,6 +233,9 @@ void AlloyDBAdminMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AlloyDBAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/alloydb/v1/internal/alloy_db_admin_metadata_decorator.h
+++ b/google/cloud/alloydb/v1/internal/alloy_db_admin_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AlloyDBAdminMetadata : public AlloyDBAdminStub {
  public:
   ~AlloyDBAdminMetadata() override = default;
-  explicit AlloyDBAdminMetadata(std::shared_ptr<AlloyDBAdminStub> child);
+  explicit AlloyDBAdminMetadata(
+      std::shared_ptr<AlloyDBAdminStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::alloydb::v1::ListClustersResponse> ListClusters(
       grpc::ClientContext& context,
@@ -153,6 +156,7 @@ class AlloyDBAdminMetadata : public AlloyDBAdminStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AlloyDBAdminStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/apigateway/v1/internal/api_gateway_metadata_decorator.cc
+++ b/google/cloud/apigateway/v1/internal/api_gateway_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace apigateway_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ApiGatewayServiceMetadata::ApiGatewayServiceMetadata(
-    std::shared_ptr<ApiGatewayServiceStub> child)
+    std::shared_ptr<ApiGatewayServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -187,6 +189,9 @@ void ApiGatewayServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ApiGatewayServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/apigateway/v1/internal/api_gateway_metadata_decorator.h
+++ b/google/cloud/apigateway/v1/internal/api_gateway_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ApiGatewayServiceMetadata : public ApiGatewayServiceStub {
  public:
   ~ApiGatewayServiceMetadata() override = default;
   explicit ApiGatewayServiceMetadata(
-      std::shared_ptr<ApiGatewayServiceStub> child);
+      std::shared_ptr<ApiGatewayServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::apigateway::v1::ListGatewaysResponse> ListGateways(
       grpc::ClientContext& context,
@@ -130,6 +132,7 @@ class ApiGatewayServiceMetadata : public ApiGatewayServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ApiGatewayServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/apigeeconnect/v1/internal/connection_metadata_decorator.cc
+++ b/google/cloud/apigeeconnect/v1/internal/connection_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace apigeeconnect_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ConnectionServiceMetadata::ConnectionServiceMetadata(
-    std::shared_ptr<ConnectionServiceStub> child)
+    std::shared_ptr<ConnectionServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/apigeeconnect/v1/internal/connection_metadata_decorator.h
+++ b/google/cloud/apigeeconnect/v1/internal/connection_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ConnectionServiceMetadata : public ConnectionServiceStub {
  public:
   ~ConnectionServiceMetadata() override = default;
   explicit ConnectionServiceMetadata(
-      std::shared_ptr<ConnectionServiceStub> child);
+      std::shared_ptr<ConnectionServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::apigeeconnect::v1::ListConnectionsResponse>
   ListConnections(
@@ -47,6 +49,7 @@ class ConnectionServiceMetadata : public ConnectionServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ConnectionServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/apikeys/v2/internal/api_keys_metadata_decorator.cc
+++ b/google/cloud/apikeys/v2/internal/api_keys_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace apikeys_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ApiKeysMetadata::ApiKeysMetadata(std::shared_ptr<ApiKeysStub> child)
+ApiKeysMetadata::ApiKeysMetadata(
+    std::shared_ptr<ApiKeysStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -124,6 +127,9 @@ void ApiKeysMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ApiKeysMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/apikeys/v2/internal/api_keys_metadata_decorator.h
+++ b/google/cloud/apikeys/v2/internal/api_keys_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ApiKeysMetadata : public ApiKeysStub {
  public:
   ~ApiKeysMetadata() override = default;
-  explicit ApiKeysMetadata(std::shared_ptr<ApiKeysStub> child);
+  explicit ApiKeysMetadata(
+      std::shared_ptr<ApiKeysStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateKey(
       google::cloud::CompletionQueue& cq,
@@ -87,6 +90,7 @@ class ApiKeysMetadata : public ApiKeysStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ApiKeysStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/appengine/v1/internal/applications_metadata_decorator.cc
+++ b/google/cloud/appengine/v1/internal/applications_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace appengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ApplicationsMetadata::ApplicationsMetadata(
-    std::shared_ptr<ApplicationsStub> child)
+    std::shared_ptr<ApplicationsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -94,6 +96,9 @@ void ApplicationsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ApplicationsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/appengine/v1/internal/applications_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/applications_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ApplicationsMetadata : public ApplicationsStub {
  public:
   ~ApplicationsMetadata() override = default;
-  explicit ApplicationsMetadata(std::shared_ptr<ApplicationsStub> child);
+  explicit ApplicationsMetadata(
+      std::shared_ptr<ApplicationsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::appengine::v1::Application> GetApplication(
       grpc::ClientContext& context,
@@ -70,6 +73,7 @@ class ApplicationsMetadata : public ApplicationsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ApplicationsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/appengine/v1/internal/authorized_certificates_metadata_decorator.cc
+++ b/google/cloud/appengine/v1/internal/authorized_certificates_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace appengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AuthorizedCertificatesMetadata::AuthorizedCertificatesMetadata(
-    std::shared_ptr<AuthorizedCertificatesStub> child)
+    std::shared_ptr<AuthorizedCertificatesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -81,6 +83,9 @@ void AuthorizedCertificatesMetadata::SetMetadata(
 
 void AuthorizedCertificatesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/appengine/v1/internal/authorized_certificates_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/authorized_certificates_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class AuthorizedCertificatesMetadata : public AuthorizedCertificatesStub {
  public:
   ~AuthorizedCertificatesMetadata() override = default;
   explicit AuthorizedCertificatesMetadata(
-      std::shared_ptr<AuthorizedCertificatesStub> child);
+      std::shared_ptr<AuthorizedCertificatesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::appengine::v1::ListAuthorizedCertificatesResponse>
   ListAuthorizedCertificates(
@@ -70,6 +72,7 @@ class AuthorizedCertificatesMetadata : public AuthorizedCertificatesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AuthorizedCertificatesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/appengine/v1/internal/authorized_domains_metadata_decorator.cc
+++ b/google/cloud/appengine/v1/internal/authorized_domains_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace appengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AuthorizedDomainsMetadata::AuthorizedDomainsMetadata(
-    std::shared_ptr<AuthorizedDomainsStub> child)
+    std::shared_ptr<AuthorizedDomainsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void AuthorizedDomainsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AuthorizedDomainsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/appengine/v1/internal/authorized_domains_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/authorized_domains_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class AuthorizedDomainsMetadata : public AuthorizedDomainsStub {
  public:
   ~AuthorizedDomainsMetadata() override = default;
   explicit AuthorizedDomainsMetadata(
-      std::shared_ptr<AuthorizedDomainsStub> child);
+      std::shared_ptr<AuthorizedDomainsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::appengine::v1::ListAuthorizedDomainsResponse>
   ListAuthorizedDomains(
@@ -47,6 +49,7 @@ class AuthorizedDomainsMetadata : public AuthorizedDomainsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AuthorizedDomainsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/appengine/v1/internal/domain_mappings_metadata_decorator.cc
+++ b/google/cloud/appengine/v1/internal/domain_mappings_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace appengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DomainMappingsMetadata::DomainMappingsMetadata(
-    std::shared_ptr<DomainMappingsStub> child)
+    std::shared_ptr<DomainMappingsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -102,6 +104,9 @@ void DomainMappingsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DomainMappingsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/appengine/v1/internal/domain_mappings_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/domain_mappings_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DomainMappingsMetadata : public DomainMappingsStub {
  public:
   ~DomainMappingsMetadata() override = default;
-  explicit DomainMappingsMetadata(std::shared_ptr<DomainMappingsStub> child);
+  explicit DomainMappingsMetadata(
+      std::shared_ptr<DomainMappingsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::appengine::v1::ListDomainMappingsResponse>
   ListDomainMappings(
@@ -78,6 +81,7 @@ class DomainMappingsMetadata : public DomainMappingsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DomainMappingsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/appengine/v1/internal/firewall_metadata_decorator.cc
+++ b/google/cloud/appengine/v1/internal/firewall_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace appengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-FirewallMetadata::FirewallMetadata(std::shared_ptr<FirewallStub> child)
+FirewallMetadata::FirewallMetadata(
+    std::shared_ptr<FirewallStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -87,6 +90,9 @@ void FirewallMetadata::SetMetadata(grpc::ClientContext& context,
 
 void FirewallMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/appengine/v1/internal/firewall_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/firewall_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FirewallMetadata : public FirewallStub {
  public:
   ~FirewallMetadata() override = default;
-  explicit FirewallMetadata(std::shared_ptr<FirewallStub> child);
+  explicit FirewallMetadata(
+      std::shared_ptr<FirewallStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::appengine::v1::ListIngressRulesResponse> ListIngressRules(
       grpc::ClientContext& context,
@@ -66,6 +69,7 @@ class FirewallMetadata : public FirewallStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<FirewallStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/appengine/v1/internal/instances_metadata_decorator.cc
+++ b/google/cloud/appengine/v1/internal/instances_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace appengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-InstancesMetadata::InstancesMetadata(std::shared_ptr<InstancesStub> child)
+InstancesMetadata::InstancesMetadata(
+    std::shared_ptr<InstancesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -91,6 +94,9 @@ void InstancesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void InstancesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/appengine/v1/internal/instances_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/instances_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class InstancesMetadata : public InstancesStub {
  public:
   ~InstancesMetadata() override = default;
-  explicit InstancesMetadata(std::shared_ptr<InstancesStub> child);
+  explicit InstancesMetadata(
+      std::shared_ptr<InstancesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::appengine::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,
@@ -69,6 +72,7 @@ class InstancesMetadata : public InstancesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<InstancesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/appengine/v1/internal/services_metadata_decorator.cc
+++ b/google/cloud/appengine/v1/internal/services_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace appengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ServicesMetadata::ServicesMetadata(std::shared_ptr<ServicesStub> child)
+ServicesMetadata::ServicesMetadata(
+    std::shared_ptr<ServicesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -91,6 +94,9 @@ void ServicesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServicesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/appengine/v1/internal/services_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/services_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServicesMetadata : public ServicesStub {
  public:
   ~ServicesMetadata() override = default;
-  explicit ServicesMetadata(std::shared_ptr<ServicesStub> child);
+  explicit ServicesMetadata(
+      std::shared_ptr<ServicesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::appengine::v1::ListServicesResponse> ListServices(
       grpc::ClientContext& context,
@@ -69,6 +72,7 @@ class ServicesMetadata : public ServicesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ServicesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/appengine/v1/internal/versions_metadata_decorator.cc
+++ b/google/cloud/appengine/v1/internal/versions_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace appengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-VersionsMetadata::VersionsMetadata(std::shared_ptr<VersionsStub> child)
+VersionsMetadata::VersionsMetadata(
+    std::shared_ptr<VersionsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -100,6 +103,9 @@ void VersionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VersionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/appengine/v1/internal/versions_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/versions_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VersionsMetadata : public VersionsStub {
  public:
   ~VersionsMetadata() override = default;
-  explicit VersionsMetadata(std::shared_ptr<VersionsStub> child);
+  explicit VersionsMetadata(
+      std::shared_ptr<VersionsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::appengine::v1::ListVersionsResponse> ListVersions(
       grpc::ClientContext& context,
@@ -74,6 +77,7 @@ class VersionsMetadata : public VersionsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<VersionsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/artifactregistry/v1/internal/artifact_registry_metadata_decorator.cc
+++ b/google/cloud/artifactregistry/v1/internal/artifact_registry_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace artifactregistry_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ArtifactRegistryMetadata::ArtifactRegistryMetadata(
-    std::shared_ptr<ArtifactRegistryStub> child)
+    std::shared_ptr<ArtifactRegistryStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -366,6 +368,9 @@ void ArtifactRegistryMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ArtifactRegistryMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/artifactregistry/v1/internal/artifact_registry_metadata_decorator.h
+++ b/google/cloud/artifactregistry/v1/internal/artifact_registry_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ArtifactRegistryMetadata : public ArtifactRegistryStub {
  public:
   ~ArtifactRegistryMetadata() override = default;
   explicit ArtifactRegistryMetadata(
-      std::shared_ptr<ArtifactRegistryStub> child);
+      std::shared_ptr<ArtifactRegistryStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::devtools::artifactregistry::v1::ListDockerImagesResponse>
   ListDockerImages(
@@ -242,6 +244,7 @@ class ArtifactRegistryMetadata : public ArtifactRegistryStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ArtifactRegistryStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/asset/v1/internal/asset_metadata_decorator.cc
+++ b/google/cloud/asset/v1/internal/asset_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace asset_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AssetServiceMetadata::AssetServiceMetadata(
-    std::shared_ptr<AssetServiceStub> child)
+    std::shared_ptr<AssetServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -247,6 +249,9 @@ void AssetServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AssetServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/asset/v1/internal/asset_metadata_decorator.h
+++ b/google/cloud/asset/v1/internal/asset_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AssetServiceMetadata : public AssetServiceStub {
  public:
   ~AssetServiceMetadata() override = default;
-  explicit AssetServiceMetadata(std::shared_ptr<AssetServiceStub> child);
+  explicit AssetServiceMetadata(
+      std::shared_ptr<AssetServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncExportAssets(
       google::cloud::CompletionQueue& cq,
@@ -164,6 +167,7 @@ class AssetServiceMetadata : public AssetServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AssetServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/assuredworkloads/v1/internal/assured_workloads_metadata_decorator.cc
+++ b/google/cloud/assuredworkloads/v1/internal/assured_workloads_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace assuredworkloads_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AssuredWorkloadsServiceMetadata::AssuredWorkloadsServiceMetadata(
-    std::shared_ptr<AssuredWorkloadsServiceStub> child)
+    std::shared_ptr<AssuredWorkloadsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -134,6 +136,9 @@ void AssuredWorkloadsServiceMetadata::SetMetadata(
 void AssuredWorkloadsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/assuredworkloads/v1/internal/assured_workloads_metadata_decorator.h
+++ b/google/cloud/assuredworkloads/v1/internal/assured_workloads_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class AssuredWorkloadsServiceMetadata : public AssuredWorkloadsServiceStub {
  public:
   ~AssuredWorkloadsServiceMetadata() override = default;
   explicit AssuredWorkloadsServiceMetadata(
-      std::shared_ptr<AssuredWorkloadsServiceStub> child);
+      std::shared_ptr<AssuredWorkloadsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateWorkload(
       google::cloud::CompletionQueue& cq,
@@ -102,6 +104,7 @@ class AssuredWorkloadsServiceMetadata : public AssuredWorkloadsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AssuredWorkloadsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/automl/v1/internal/auto_ml_metadata_decorator.cc
+++ b/google/cloud/automl/v1/internal/auto_ml_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace automl_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-AutoMlMetadata::AutoMlMetadata(std::shared_ptr<AutoMlStub> child)
+AutoMlMetadata::AutoMlMetadata(
+    std::shared_ptr<AutoMlStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -207,6 +210,9 @@ void AutoMlMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AutoMlMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/automl/v1/internal/auto_ml_metadata_decorator.h
+++ b/google/cloud/automl/v1/internal/auto_ml_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AutoMlMetadata : public AutoMlStub {
  public:
   ~AutoMlMetadata() override = default;
-  explicit AutoMlMetadata(std::shared_ptr<AutoMlStub> child);
+  explicit AutoMlMetadata(
+      std::shared_ptr<AutoMlStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDataset(
       google::cloud::CompletionQueue& cq,
@@ -136,6 +139,7 @@ class AutoMlMetadata : public AutoMlStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AutoMlStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/automl/v1/internal/prediction_metadata_decorator.cc
+++ b/google/cloud/automl/v1/internal/prediction_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace automl_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PredictionServiceMetadata::PredictionServiceMetadata(
-    std::shared_ptr<PredictionServiceStub> child)
+    std::shared_ptr<PredictionServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -76,6 +78,9 @@ void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/automl/v1/internal/prediction_metadata_decorator.h
+++ b/google/cloud/automl/v1/internal/prediction_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class PredictionServiceMetadata : public PredictionServiceStub {
  public:
   ~PredictionServiceMetadata() override = default;
   explicit PredictionServiceMetadata(
-      std::shared_ptr<PredictionServiceStub> child);
+      std::shared_ptr<PredictionServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::automl::v1::PredictResponse> Predict(
       grpc::ClientContext& context,
@@ -61,6 +63,7 @@ class PredictionServiceMetadata : public PredictionServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PredictionServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_metadata_decorator.cc
+++ b/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace baremetalsolution_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BareMetalSolutionMetadata::BareMetalSolutionMetadata(
-    std::shared_ptr<BareMetalSolutionStub> child)
+    std::shared_ptr<BareMetalSolutionStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -231,6 +233,9 @@ void BareMetalSolutionMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BareMetalSolutionMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_metadata_decorator.h
+++ b/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class BareMetalSolutionMetadata : public BareMetalSolutionStub {
  public:
   ~BareMetalSolutionMetadata() override = default;
   explicit BareMetalSolutionMetadata(
-      std::shared_ptr<BareMetalSolutionStub> child);
+      std::shared_ptr<BareMetalSolutionStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::baremetalsolution::v2::ListInstancesResponse>
   ListInstances(
@@ -164,6 +166,7 @@ class BareMetalSolutionMetadata : public BareMetalSolutionStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BareMetalSolutionStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/batch/v1/internal/batch_metadata_decorator.cc
+++ b/google/cloud/batch/v1/internal/batch_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace batch_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BatchServiceMetadata::BatchServiceMetadata(
-    std::shared_ptr<BatchServiceStub> child)
+    std::shared_ptr<BatchServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -105,6 +107,9 @@ void BatchServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BatchServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/batch/v1/internal/batch_metadata_decorator.h
+++ b/google/cloud/batch/v1/internal/batch_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BatchServiceMetadata : public BatchServiceStub {
  public:
   ~BatchServiceMetadata() override = default;
-  explicit BatchServiceMetadata(std::shared_ptr<BatchServiceStub> child);
+  explicit BatchServiceMetadata(
+      std::shared_ptr<BatchServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::batch::v1::Job> CreateJob(
       grpc::ClientContext& context,
@@ -76,6 +79,7 @@ class BatchServiceMetadata : public BatchServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BatchServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_metadata_decorator.cc
+++ b/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_metadata_decorator.cc
@@ -30,8 +30,10 @@ namespace beyondcorp_appconnections_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AppConnectionsServiceMetadata::AppConnectionsServiceMetadata(
-    std::shared_ptr<AppConnectionsServiceStub> child)
+    std::shared_ptr<AppConnectionsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -120,6 +122,9 @@ void AppConnectionsServiceMetadata::SetMetadata(
 
 void AppConnectionsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_metadata_decorator.h
+++ b/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_metadata_decorator.h
@@ -25,6 +25,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -35,7 +36,8 @@ class AppConnectionsServiceMetadata : public AppConnectionsServiceStub {
  public:
   ~AppConnectionsServiceMetadata() override = default;
   explicit AppConnectionsServiceMetadata(
-      std::shared_ptr<AppConnectionsServiceStub> child);
+      std::shared_ptr<AppConnectionsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<
       google::cloud::beyondcorp::appconnections::v1::ListAppConnectionsResponse>
@@ -89,6 +91,7 @@ class AppConnectionsServiceMetadata : public AppConnectionsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AppConnectionsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_metadata_decorator.cc
+++ b/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace beyondcorp_appconnectors_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AppConnectorsServiceMetadata::AppConnectorsServiceMetadata(
-    std::shared_ptr<AppConnectorsServiceStub> child)
+    std::shared_ptr<AppConnectorsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -117,6 +119,9 @@ void AppConnectorsServiceMetadata::SetMetadata(
 
 void AppConnectorsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_metadata_decorator.h
+++ b/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class AppConnectorsServiceMetadata : public AppConnectorsServiceStub {
  public:
   ~AppConnectorsServiceMetadata() override = default;
   explicit AppConnectorsServiceMetadata(
-      std::shared_ptr<AppConnectorsServiceStub> child);
+      std::shared_ptr<AppConnectorsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<
       google::cloud::beyondcorp::appconnectors::v1::ListAppConnectorsResponse>
@@ -87,6 +89,7 @@ class AppConnectorsServiceMetadata : public AppConnectorsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AppConnectorsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_metadata_decorator.cc
+++ b/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace beyondcorp_appgateways_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AppGatewaysServiceMetadata::AppGatewaysServiceMetadata(
-    std::shared_ptr<AppGatewaysServiceStub> child)
+    std::shared_ptr<AppGatewaysServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -97,6 +99,9 @@ void AppGatewaysServiceMetadata::SetMetadata(
 
 void AppGatewaysServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_metadata_decorator.h
+++ b/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class AppGatewaysServiceMetadata : public AppGatewaysServiceStub {
  public:
   ~AppGatewaysServiceMetadata() override = default;
   explicit AppGatewaysServiceMetadata(
-      std::shared_ptr<AppGatewaysServiceStub> child);
+      std::shared_ptr<AppGatewaysServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::beyondcorp::appgateways::v1::ListAppGatewaysResponse>
   ListAppGateways(
@@ -76,6 +78,7 @@ class AppGatewaysServiceMetadata : public AppGatewaysServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AppGatewaysServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/beyondcorp/clientconnectorservices/v1/internal/client_connector_services_metadata_decorator.cc
+++ b/google/cloud/beyondcorp/clientconnectorservices/v1/internal/client_connector_services_metadata_decorator.cc
@@ -30,8 +30,10 @@ namespace beyondcorp_clientconnectorservices_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ClientConnectorServicesServiceMetadata::ClientConnectorServicesServiceMetadata(
-    std::shared_ptr<ClientConnectorServicesServiceStub> child)
+    std::shared_ptr<ClientConnectorServicesServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -115,6 +117,9 @@ void ClientConnectorServicesServiceMetadata::SetMetadata(
 void ClientConnectorServicesServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/beyondcorp/clientconnectorservices/v1/internal/client_connector_services_metadata_decorator.h
+++ b/google/cloud/beyondcorp/clientconnectorservices/v1/internal/client_connector_services_metadata_decorator.h
@@ -25,6 +25,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -36,7 +37,8 @@ class ClientConnectorServicesServiceMetadata
  public:
   ~ClientConnectorServicesServiceMetadata() override = default;
   explicit ClientConnectorServicesServiceMetadata(
-      std::shared_ptr<ClientConnectorServicesServiceStub> child);
+      std::shared_ptr<ClientConnectorServicesServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::beyondcorp::clientconnectorservices::v1::
                ListClientConnectorServicesResponse>
@@ -89,6 +91,7 @@ class ClientConnectorServicesServiceMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ClientConnectorServicesServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/beyondcorp/clientgateways/v1/internal/client_gateways_metadata_decorator.cc
+++ b/google/cloud/beyondcorp/clientgateways/v1/internal/client_gateways_metadata_decorator.cc
@@ -30,8 +30,10 @@ namespace beyondcorp_clientgateways_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ClientGatewaysServiceMetadata::ClientGatewaysServiceMetadata(
-    std::shared_ptr<ClientGatewaysServiceStub> child)
+    std::shared_ptr<ClientGatewaysServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -99,6 +101,9 @@ void ClientGatewaysServiceMetadata::SetMetadata(
 
 void ClientGatewaysServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/beyondcorp/clientgateways/v1/internal/client_gateways_metadata_decorator.h
+++ b/google/cloud/beyondcorp/clientgateways/v1/internal/client_gateways_metadata_decorator.h
@@ -25,6 +25,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -35,7 +36,8 @@ class ClientGatewaysServiceMetadata : public ClientGatewaysServiceStub {
  public:
   ~ClientGatewaysServiceMetadata() override = default;
   explicit ClientGatewaysServiceMetadata(
-      std::shared_ptr<ClientGatewaysServiceStub> child);
+      std::shared_ptr<ClientGatewaysServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<
       google::cloud::beyondcorp::clientgateways::v1::ListClientGatewaysResponse>
@@ -76,6 +78,7 @@ class ClientGatewaysServiceMetadata : public ClientGatewaysServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ClientGatewaysServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_metadata_decorator.cc
+++ b/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigquery_analyticshub_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AnalyticsHubServiceMetadata::AnalyticsHubServiceMetadata(
-    std::shared_ptr<AnalyticsHubServiceStub> child)
+    std::shared_ptr<AnalyticsHubServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -171,6 +173,9 @@ void AnalyticsHubServiceMetadata::SetMetadata(
 
 void AnalyticsHubServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_metadata_decorator.h
+++ b/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class AnalyticsHubServiceMetadata : public AnalyticsHubServiceStub {
  public:
   ~AnalyticsHubServiceMetadata() override = default;
   explicit AnalyticsHubServiceMetadata(
-      std::shared_ptr<AnalyticsHubServiceStub> child);
+      std::shared_ptr<AnalyticsHubServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::bigquery::analyticshub::v1::ListDataExchangesResponse>
   ListDataExchanges(
@@ -118,6 +120,7 @@ class AnalyticsHubServiceMetadata : public AnalyticsHubServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AnalyticsHubServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigquery/connection/v1/internal/connection_metadata_decorator.cc
+++ b/google/cloud/bigquery/connection/v1/internal/connection_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigquery_connection_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ConnectionServiceMetadata::ConnectionServiceMetadata(
-    std::shared_ptr<ConnectionServiceStub> child)
+    std::shared_ptr<ConnectionServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -108,6 +110,9 @@ void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigquery/connection/v1/internal/connection_metadata_decorator.h
+++ b/google/cloud/bigquery/connection/v1/internal/connection_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ConnectionServiceMetadata : public ConnectionServiceStub {
  public:
   ~ConnectionServiceMetadata() override = default;
   explicit ConnectionServiceMetadata(
-      std::shared_ptr<ConnectionServiceStub> child);
+      std::shared_ptr<ConnectionServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::bigquery::connection::v1::Connection>
   CreateConnection(
@@ -81,6 +83,7 @@ class ConnectionServiceMetadata : public ConnectionServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ConnectionServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigquery/datapolicies/v1/internal/data_policy_metadata_decorator.cc
+++ b/google/cloud/bigquery/datapolicies/v1/internal/data_policy_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigquery_datapolicies_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DataPolicyServiceMetadata::DataPolicyServiceMetadata(
-    std::shared_ptr<DataPolicyServiceStub> child)
+    std::shared_ptr<DataPolicyServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -117,6 +119,9 @@ void DataPolicyServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DataPolicyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigquery/datapolicies/v1/internal/data_policy_metadata_decorator.h
+++ b/google/cloud/bigquery/datapolicies/v1/internal/data_policy_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class DataPolicyServiceMetadata : public DataPolicyServiceStub {
  public:
   ~DataPolicyServiceMetadata() override = default;
   explicit DataPolicyServiceMetadata(
-      std::shared_ptr<DataPolicyServiceStub> child);
+      std::shared_ptr<DataPolicyServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>
   CreateDataPolicy(
@@ -87,6 +89,7 @@ class DataPolicyServiceMetadata : public DataPolicyServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DataPolicyServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigquery_datatransfer_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DataTransferServiceMetadata::DataTransferServiceMetadata(
-    std::shared_ptr<DataTransferServiceStub> child)
+    std::shared_ptr<DataTransferServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -177,6 +179,9 @@ void DataTransferServiceMetadata::SetMetadata(
 
 void DataTransferServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class DataTransferServiceMetadata : public DataTransferServiceStub {
  public:
   ~DataTransferServiceMetadata() override = default;
   explicit DataTransferServiceMetadata(
-      std::shared_ptr<DataTransferServiceStub> child);
+      std::shared_ptr<DataTransferServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::bigquery::datatransfer::v1::DataSource> GetDataSource(
       grpc::ClientContext& context,
@@ -126,6 +128,7 @@ class DataTransferServiceMetadata : public DataTransferServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DataTransferServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigquery/migration/v2/internal/migration_metadata_decorator.cc
+++ b/google/cloud/bigquery/migration/v2/internal/migration_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigquery_migration_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 MigrationServiceMetadata::MigrationServiceMetadata(
-    std::shared_ptr<MigrationServiceStub> child)
+    std::shared_ptr<MigrationServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -103,6 +105,9 @@ void MigrationServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void MigrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigquery/migration/v2/internal/migration_metadata_decorator.h
+++ b/google/cloud/bigquery/migration/v2/internal/migration_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class MigrationServiceMetadata : public MigrationServiceStub {
  public:
   ~MigrationServiceMetadata() override = default;
   explicit MigrationServiceMetadata(
-      std::shared_ptr<MigrationServiceStub> child);
+      std::shared_ptr<MigrationServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::bigquery::migration::v2::MigrationWorkflow>
   CreateMigrationWorkflow(
@@ -83,6 +85,7 @@ class MigrationServiceMetadata : public MigrationServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<MigrationServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigquery_reservation_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ReservationServiceMetadata::ReservationServiceMetadata(
-    std::shared_ptr<ReservationServiceStub> child)
+    std::shared_ptr<ReservationServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -232,6 +234,9 @@ void ReservationServiceMetadata::SetMetadata(
 
 void ReservationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ReservationServiceMetadata : public ReservationServiceStub {
  public:
   ~ReservationServiceMetadata() override = default;
   explicit ReservationServiceMetadata(
-      std::shared_ptr<ReservationServiceStub> child);
+      std::shared_ptr<ReservationServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::bigquery::reservation::v1::Reservation>
   CreateReservation(
@@ -164,6 +166,7 @@ class ReservationServiceMetadata : public ReservationServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ReservationServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_metadata_decorator.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigquery_storage_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BigQueryReadMetadata::BigQueryReadMetadata(
-    std::shared_ptr<BigQueryReadStub> child)
+    std::shared_ptr<BigQueryReadStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -69,6 +71,9 @@ void BigQueryReadMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BigQueryReadMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_metadata_decorator.h
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigQueryReadMetadata : public BigQueryReadStub {
  public:
   ~BigQueryReadMetadata() override = default;
-  explicit BigQueryReadMetadata(std::shared_ptr<BigQueryReadStub> child);
+  explicit BigQueryReadMetadata(
+      std::shared_ptr<BigQueryReadStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       grpc::ClientContext& context,
@@ -57,6 +60,7 @@ class BigQueryReadMetadata : public BigQueryReadStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BigQueryReadStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_write_metadata_decorator.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_write_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigquery_storage_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BigQueryWriteMetadata::BigQueryWriteMetadata(
-    std::shared_ptr<BigQueryWriteStub> child)
+    std::shared_ptr<BigQueryWriteStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -96,6 +98,9 @@ void BigQueryWriteMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BigQueryWriteMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_write_metadata_decorator.h
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_write_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigQueryWriteMetadata : public BigQueryWriteStub {
  public:
   ~BigQueryWriteMetadata() override = default;
-  explicit BigQueryWriteMetadata(std::shared_ptr<BigQueryWriteStub> child);
+  explicit BigQueryWriteMetadata(
+      std::shared_ptr<BigQueryWriteStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::bigquery::storage::v1::WriteStream> CreateWriteStream(
       grpc::ClientContext& context,
@@ -74,6 +77,7 @@ class BigQueryWriteMetadata : public BigQueryWriteStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BigQueryWriteStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigtable_admin_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BigtableInstanceAdminMetadata::BigtableInstanceAdminMetadata(
-    std::shared_ptr<BigtableInstanceAdminStub> child)
+    std::shared_ptr<BigtableInstanceAdminStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -228,6 +230,9 @@ void BigtableInstanceAdminMetadata::SetMetadata(
 
 void BigtableInstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class BigtableInstanceAdminMetadata : public BigtableInstanceAdminStub {
  public:
   ~BigtableInstanceAdminMetadata() override = default;
   explicit BigtableInstanceAdminMetadata(
-      std::shared_ptr<BigtableInstanceAdminStub> child);
+      std::shared_ptr<BigtableInstanceAdminStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateInstance(
       google::cloud::CompletionQueue& cq,
@@ -154,6 +156,7 @@ class BigtableInstanceAdminMetadata : public BigtableInstanceAdminStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BigtableInstanceAdminStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace bigtable_admin_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BigtableTableAdminMetadata::BigtableTableAdminMetadata(
-    std::shared_ptr<BigtableTableAdminStub> child)
+    std::shared_ptr<BigtableTableAdminStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -220,6 +222,9 @@ void BigtableTableAdminMetadata::SetMetadata(
 
 void BigtableTableAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class BigtableTableAdminMetadata : public BigtableTableAdminStub {
  public:
   ~BigtableTableAdminMetadata() override = default;
   explicit BigtableTableAdminMetadata(
-      std::shared_ptr<BigtableTableAdminStub> child);
+      std::shared_ptr<BigtableTableAdminStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       grpc::ClientContext& context,
@@ -144,6 +146,7 @@ class BigtableTableAdminMetadata : public BigtableTableAdminStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BigtableTableAdminStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
@@ -30,8 +30,11 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-BigtableMetadata::BigtableMetadata(std::shared_ptr<BigtableStub> child)
+BigtableMetadata::BigtableMetadata(
+    std::shared_ptr<BigtableStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -470,6 +473,9 @@ void BigtableMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BigtableMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigtableMetadata : public BigtableStub {
  public:
   ~BigtableMetadata() override = default;
-  explicit BigtableMetadata(std::shared_ptr<BigtableStub> child);
+  explicit BigtableMetadata(
+      std::shared_ptr<BigtableStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
@@ -109,6 +112,7 @@ class BigtableMetadata : public BigtableStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BigtableStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/billing/budgets/v1/internal/budget_metadata_decorator.cc
+++ b/google/cloud/billing/budgets/v1/internal/budget_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace billing_budgets_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BudgetServiceMetadata::BudgetServiceMetadata(
-    std::shared_ptr<BudgetServiceStub> child)
+    std::shared_ptr<BudgetServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -81,6 +83,9 @@ void BudgetServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BudgetServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/billing/budgets/v1/internal/budget_metadata_decorator.h
+++ b/google/cloud/billing/budgets/v1/internal/budget_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BudgetServiceMetadata : public BudgetServiceStub {
  public:
   ~BudgetServiceMetadata() override = default;
-  explicit BudgetServiceMetadata(std::shared_ptr<BudgetServiceStub> child);
+  explicit BudgetServiceMetadata(
+      std::shared_ptr<BudgetServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::billing::budgets::v1::Budget> CreateBudget(
       grpc::ClientContext& context,
@@ -65,6 +68,7 @@ class BudgetServiceMetadata : public BudgetServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BudgetServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/billing/v1/internal/cloud_billing_metadata_decorator.cc
+++ b/google/cloud/billing/v1/internal/cloud_billing_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace billing_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudBillingMetadata::CloudBillingMetadata(
-    std::shared_ptr<CloudBillingStub> child)
+    std::shared_ptr<CloudBillingStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -121,6 +123,9 @@ void CloudBillingMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudBillingMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/billing/v1/internal/cloud_billing_metadata_decorator.h
+++ b/google/cloud/billing/v1/internal/cloud_billing_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudBillingMetadata : public CloudBillingStub {
  public:
   ~CloudBillingMetadata() override = default;
-  explicit CloudBillingMetadata(std::shared_ptr<CloudBillingStub> child);
+  explicit CloudBillingMetadata(
+      std::shared_ptr<CloudBillingStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::billing::v1::BillingAccount> GetBillingAccount(
       grpc::ClientContext& context,
@@ -91,6 +94,7 @@ class CloudBillingMetadata : public CloudBillingStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudBillingStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/billing/v1/internal/cloud_catalog_metadata_decorator.cc
+++ b/google/cloud/billing/v1/internal/cloud_catalog_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace billing_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudCatalogMetadata::CloudCatalogMetadata(
-    std::shared_ptr<CloudCatalogStub> child)
+    std::shared_ptr<CloudCatalogStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -58,6 +60,9 @@ void CloudCatalogMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudCatalogMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/billing/v1/internal/cloud_catalog_metadata_decorator.h
+++ b/google/cloud/billing/v1/internal/cloud_catalog_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudCatalogMetadata : public CloudCatalogStub {
  public:
   ~CloudCatalogMetadata() override = default;
-  explicit CloudCatalogMetadata(std::shared_ptr<CloudCatalogStub> child);
+  explicit CloudCatalogMetadata(
+      std::shared_ptr<CloudCatalogStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::billing::v1::ListServicesResponse> ListServices(
       grpc::ClientContext& context,
@@ -48,6 +51,7 @@ class CloudCatalogMetadata : public CloudCatalogStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudCatalogStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace binaryauthorization_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BinauthzManagementServiceV1Metadata::BinauthzManagementServiceV1Metadata(
-    std::shared_ptr<BinauthzManagementServiceV1Stub> child)
+    std::shared_ptr<BinauthzManagementServiceV1Stub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -103,6 +105,9 @@ void BinauthzManagementServiceV1Metadata::SetMetadata(
 void BinauthzManagementServiceV1Metadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_metadata_decorator.h
+++ b/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class BinauthzManagementServiceV1Metadata
  public:
   ~BinauthzManagementServiceV1Metadata() override = default;
   explicit BinauthzManagementServiceV1Metadata(
-      std::shared_ptr<BinauthzManagementServiceV1Stub> child);
+      std::shared_ptr<BinauthzManagementServiceV1Stub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::binaryauthorization::v1::Policy> GetPolicy(
       grpc::ClientContext& context,
@@ -78,6 +80,7 @@ class BinauthzManagementServiceV1Metadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BinauthzManagementServiceV1Stub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/binaryauthorization/v1/internal/system_policy_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/v1/internal/system_policy_v1_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace binaryauthorization_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SystemPolicyV1Metadata::SystemPolicyV1Metadata(
-    std::shared_ptr<SystemPolicyV1Stub> child)
+    std::shared_ptr<SystemPolicyV1Stub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -51,6 +53,9 @@ void SystemPolicyV1Metadata::SetMetadata(grpc::ClientContext& context,
 
 void SystemPolicyV1Metadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/binaryauthorization/v1/internal/system_policy_v1_metadata_decorator.h
+++ b/google/cloud/binaryauthorization/v1/internal/system_policy_v1_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SystemPolicyV1Metadata : public SystemPolicyV1Stub {
  public:
   ~SystemPolicyV1Metadata() override = default;
-  explicit SystemPolicyV1Metadata(std::shared_ptr<SystemPolicyV1Stub> child);
+  explicit SystemPolicyV1Metadata(
+      std::shared_ptr<SystemPolicyV1Stub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::binaryauthorization::v1::Policy> GetSystemPolicy(
       grpc::ClientContext& context,
@@ -45,6 +48,7 @@ class SystemPolicyV1Metadata : public SystemPolicyV1Stub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SystemPolicyV1Stub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace binaryauthorization_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ValidationHelperV1Metadata::ValidationHelperV1Metadata(
-    std::shared_ptr<ValidationHelperV1Stub> child)
+    std::shared_ptr<ValidationHelperV1Stub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -52,6 +54,9 @@ void ValidationHelperV1Metadata::SetMetadata(
 
 void ValidationHelperV1Metadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_metadata_decorator.h
+++ b/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ValidationHelperV1Metadata : public ValidationHelperV1Stub {
  public:
   ~ValidationHelperV1Metadata() override = default;
   explicit ValidationHelperV1Metadata(
-      std::shared_ptr<ValidationHelperV1Stub> child);
+      std::shared_ptr<ValidationHelperV1Stub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::binaryauthorization::v1::
                ValidateAttestationOccurrenceResponse>
@@ -48,6 +50,7 @@ class ValidationHelperV1Metadata : public ValidationHelperV1Stub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ValidationHelperV1Stub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/certificatemanager/v1/internal/certificate_manager_metadata_decorator.cc
+++ b/google/cloud/certificatemanager/v1/internal/certificate_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace certificatemanager_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CertificateManagerMetadata::CertificateManagerMetadata(
-    std::shared_ptr<CertificateManagerStub> child)
+    std::shared_ptr<CertificateManagerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -299,6 +301,9 @@ void CertificateManagerMetadata::SetMetadata(
 
 void CertificateManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/certificatemanager/v1/internal/certificate_manager_metadata_decorator.h
+++ b/google/cloud/certificatemanager/v1/internal/certificate_manager_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class CertificateManagerMetadata : public CertificateManagerStub {
  public:
   ~CertificateManagerMetadata() override = default;
   explicit CertificateManagerMetadata(
-      std::shared_ptr<CertificateManagerStub> child);
+      std::shared_ptr<CertificateManagerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::certificatemanager::v1::ListCertificatesResponse>
   ListCertificates(
@@ -202,6 +204,7 @@ class CertificateManagerMetadata : public CertificateManagerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CertificateManagerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/channel/v1/internal/cloud_channel_metadata_decorator.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace channel_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudChannelServiceMetadata::CloudChannelServiceMetadata(
-    std::shared_ptr<CloudChannelServiceStub> child)
+    std::shared_ptr<CloudChannelServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -452,6 +454,9 @@ void CloudChannelServiceMetadata::SetMetadata(
 
 void CloudChannelServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/channel/v1/internal/cloud_channel_metadata_decorator.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class CloudChannelServiceMetadata : public CloudChannelServiceStub {
  public:
   ~CloudChannelServiceMetadata() override = default;
   explicit CloudChannelServiceMetadata(
-      std::shared_ptr<CloudChannelServiceStub> child);
+      std::shared_ptr<CloudChannelServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::channel::v1::ListCustomersResponse> ListCustomers(
       grpc::ClientContext& context,
@@ -307,6 +309,7 @@ class CloudChannelServiceMetadata : public CloudChannelServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudChannelServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/cloudbuild/v1/internal/cloud_build_metadata_decorator.cc
+++ b/google/cloud/cloudbuild/v1/internal/cloud_build_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace cloudbuild_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-CloudBuildMetadata::CloudBuildMetadata(std::shared_ptr<CloudBuildStub> child)
+CloudBuildMetadata::CloudBuildMetadata(
+    std::shared_ptr<CloudBuildStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -211,6 +214,9 @@ void CloudBuildMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudBuildMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/cloudbuild/v1/internal/cloud_build_metadata_decorator.h
+++ b/google/cloud/cloudbuild/v1/internal/cloud_build_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudBuildMetadata : public CloudBuildStub {
  public:
   ~CloudBuildMetadata() override = default;
-  explicit CloudBuildMetadata(std::shared_ptr<CloudBuildStub> child);
+  explicit CloudBuildMetadata(
+      std::shared_ptr<CloudBuildStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBuild(
       google::cloud::CompletionQueue& cq,
@@ -151,6 +154,7 @@ class CloudBuildMetadata : public CloudBuildStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudBuildStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/cloudbuild/v2/internal/repository_manager_metadata_decorator.cc
+++ b/google/cloud/cloudbuild/v2/internal/repository_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace cloudbuild_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 RepositoryManagerMetadata::RepositoryManagerMetadata(
-    std::shared_ptr<RepositoryManagerStub> child)
+    std::shared_ptr<RepositoryManagerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -172,6 +174,9 @@ void RepositoryManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void RepositoryManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/cloudbuild/v2/internal/repository_manager_metadata_decorator.h
+++ b/google/cloud/cloudbuild/v2/internal/repository_manager_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class RepositoryManagerMetadata : public RepositoryManagerStub {
  public:
   ~RepositoryManagerMetadata() override = default;
   explicit RepositoryManagerMetadata(
-      std::shared_ptr<RepositoryManagerStub> child);
+      std::shared_ptr<RepositoryManagerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateConnection(
       google::cloud::CompletionQueue& cq,
@@ -127,6 +129,7 @@ class RepositoryManagerMetadata : public RepositoryManagerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<RepositoryManagerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/composer/v1/internal/environments_metadata_decorator.cc
+++ b/google/cloud/composer/v1/internal/environments_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace composer_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 EnvironmentsMetadata::EnvironmentsMetadata(
-    std::shared_ptr<EnvironmentsStub> child)
+    std::shared_ptr<EnvironmentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -128,6 +130,9 @@ void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/composer/v1/internal/environments_metadata_decorator.h
+++ b/google/cloud/composer/v1/internal/environments_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EnvironmentsMetadata : public EnvironmentsStub {
  public:
   ~EnvironmentsMetadata() override = default;
-  explicit EnvironmentsMetadata(std::shared_ptr<EnvironmentsStub> child);
+  explicit EnvironmentsMetadata(
+      std::shared_ptr<EnvironmentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateEnvironment(
       google::cloud::CompletionQueue& cq,
@@ -92,6 +95,7 @@ class EnvironmentsMetadata : public EnvironmentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EnvironmentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/composer/v1/internal/image_versions_metadata_decorator.cc
+++ b/google/cloud/composer/v1/internal/image_versions_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace composer_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ImageVersionsMetadata::ImageVersionsMetadata(
-    std::shared_ptr<ImageVersionsStub> child)
+    std::shared_ptr<ImageVersionsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -52,6 +54,9 @@ void ImageVersionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ImageVersionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/composer/v1/internal/image_versions_metadata_decorator.h
+++ b/google/cloud/composer/v1/internal/image_versions_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ImageVersionsMetadata : public ImageVersionsStub {
  public:
   ~ImageVersionsMetadata() override = default;
-  explicit ImageVersionsMetadata(std::shared_ptr<ImageVersionsStub> child);
+  explicit ImageVersionsMetadata(
+      std::shared_ptr<ImageVersionsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::orchestration::airflow::service::v1::
                ListImageVersionsResponse>
@@ -46,6 +49,7 @@ class ImageVersionsMetadata : public ImageVersionsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ImageVersionsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/confidentialcomputing/v1/internal/confidential_computing_metadata_decorator.cc
+++ b/google/cloud/confidentialcomputing/v1/internal/confidential_computing_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace confidentialcomputing_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ConfidentialComputingMetadata::ConfidentialComputingMetadata(
-    std::shared_ptr<ConfidentialComputingStub> child)
+    std::shared_ptr<ConfidentialComputingStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -60,6 +62,9 @@ void ConfidentialComputingMetadata::SetMetadata(
 
 void ConfidentialComputingMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/confidentialcomputing/v1/internal/confidential_computing_metadata_decorator.h
+++ b/google/cloud/confidentialcomputing/v1/internal/confidential_computing_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ConfidentialComputingMetadata : public ConfidentialComputingStub {
  public:
   ~ConfidentialComputingMetadata() override = default;
   explicit ConfidentialComputingMetadata(
-      std::shared_ptr<ConfidentialComputingStub> child);
+      std::shared_ptr<ConfidentialComputingStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::confidentialcomputing::v1::Challenge> CreateChallenge(
       grpc::ClientContext& context,
@@ -52,6 +54,7 @@ class ConfidentialComputingMetadata : public ConfidentialComputingStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ConfidentialComputingStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/connectors/v1/internal/connectors_metadata_decorator.cc
+++ b/google/cloud/connectors/v1/internal/connectors_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace connectors_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ConnectorsMetadata::ConnectorsMetadata(std::shared_ptr<ConnectorsStub> child)
+ConnectorsMetadata::ConnectorsMetadata(
+    std::shared_ptr<ConnectorsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -204,6 +207,9 @@ void ConnectorsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ConnectorsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/connectors/v1/internal/connectors_metadata_decorator.h
+++ b/google/cloud/connectors/v1/internal/connectors_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConnectorsMetadata : public ConnectorsStub {
  public:
   ~ConnectorsMetadata() override = default;
-  explicit ConnectorsMetadata(std::shared_ptr<ConnectorsStub> child);
+  explicit ConnectorsMetadata(
+      std::shared_ptr<ConnectorsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::connectors::v1::ListConnectionsResponse>
   ListConnections(grpc::ClientContext& context,
@@ -145,6 +148,7 @@ class ConnectorsMetadata : public ConnectorsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ConnectorsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_metadata_decorator.cc
+++ b/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace contactcenterinsights_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ContactCenterInsightsMetadata::ContactCenterInsightsMetadata(
-    std::shared_ptr<ContactCenterInsightsStub> child)
+    std::shared_ptr<ContactCenterInsightsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -404,6 +406,9 @@ void ContactCenterInsightsMetadata::SetMetadata(
 
 void ContactCenterInsightsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_metadata_decorator.h
+++ b/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ContactCenterInsightsMetadata : public ContactCenterInsightsStub {
  public:
   ~ContactCenterInsightsMetadata() override = default;
   explicit ContactCenterInsightsMetadata(
-      std::shared_ptr<ContactCenterInsightsStub> child);
+      std::shared_ptr<ContactCenterInsightsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
   CreateConversation(
@@ -264,6 +266,7 @@ class ContactCenterInsightsMetadata : public ContactCenterInsightsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ContactCenterInsightsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace container_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ClusterManagerMetadata::ClusterManagerMetadata(
-    std::shared_ptr<ClusterManagerStub> child)
+    std::shared_ptr<ClusterManagerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -306,6 +308,9 @@ void ClusterManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ClusterManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.h
+++ b/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ClusterManagerMetadata : public ClusterManagerStub {
  public:
   ~ClusterManagerMetadata() override = default;
-  explicit ClusterManagerMetadata(std::shared_ptr<ClusterManagerStub> child);
+  explicit ClusterManagerMetadata(
+      std::shared_ptr<ClusterManagerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::container::v1::ListClustersResponse> ListClusters(
       grpc::ClientContext& context,
@@ -186,6 +189,7 @@ class ClusterManagerMetadata : public ClusterManagerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ClusterManagerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/containeranalysis/v1/internal/container_analysis_metadata_decorator.cc
+++ b/google/cloud/containeranalysis/v1/internal/container_analysis_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace containeranalysis_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ContainerAnalysisMetadata::ContainerAnalysisMetadata(
-    std::shared_ptr<ContainerAnalysisStub> child)
+    std::shared_ptr<ContainerAnalysisStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -74,6 +76,9 @@ void ContainerAnalysisMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ContainerAnalysisMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/containeranalysis/v1/internal/container_analysis_metadata_decorator.h
+++ b/google/cloud/containeranalysis/v1/internal/container_analysis_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ContainerAnalysisMetadata : public ContainerAnalysisStub {
  public:
   ~ContainerAnalysisMetadata() override = default;
   explicit ContainerAnalysisMetadata(
-      std::shared_ptr<ContainerAnalysisStub> child);
+      std::shared_ptr<ContainerAnalysisStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,
@@ -60,6 +62,7 @@ class ContainerAnalysisMetadata : public ContainerAnalysisStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ContainerAnalysisStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/containeranalysis/v1/internal/grafeas_metadata_decorator.cc
+++ b/google/cloud/containeranalysis/v1/internal/grafeas_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace containeranalysis_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-GrafeasMetadata::GrafeasMetadata(std::shared_ptr<GrafeasStub> child)
+GrafeasMetadata::GrafeasMetadata(
+    std::shared_ptr<GrafeasStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -141,6 +144,9 @@ void GrafeasMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GrafeasMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/containeranalysis/v1/internal/grafeas_metadata_decorator.h
+++ b/google/cloud/containeranalysis/v1/internal/grafeas_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GrafeasMetadata : public GrafeasStub {
  public:
   ~GrafeasMetadata() override = default;
-  explicit GrafeasMetadata(std::shared_ptr<GrafeasStub> child);
+  explicit GrafeasMetadata(
+      std::shared_ptr<GrafeasStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<grafeas::v1::Occurrence> GetOccurrence(
       grpc::ClientContext& context,
@@ -95,6 +98,7 @@ class GrafeasMetadata : public GrafeasStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<GrafeasStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/datacatalog/lineage/v1/internal/lineage_metadata_decorator.cc
+++ b/google/cloud/datacatalog/lineage/v1/internal/lineage_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace datacatalog_lineage_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-LineageMetadata::LineageMetadata(std::shared_ptr<LineageStub> child)
+LineageMetadata::LineageMetadata(
+    std::shared_ptr<LineageStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -197,6 +200,9 @@ void LineageMetadata::SetMetadata(grpc::ClientContext& context,
 
 void LineageMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/datacatalog/lineage/v1/internal/lineage_metadata_decorator.h
+++ b/google/cloud/datacatalog/lineage/v1/internal/lineage_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LineageMetadata : public LineageStub {
  public:
   ~LineageMetadata() override = default;
-  explicit LineageMetadata(std::shared_ptr<LineageStub> child);
+  explicit LineageMetadata(
+      std::shared_ptr<LineageStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::datacatalog::lineage::v1::Process> CreateProcess(
       grpc::ClientContext& context,
@@ -139,6 +142,7 @@ class LineageMetadata : public LineageStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<LineageStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/datacatalog/v1/internal/data_catalog_metadata_decorator.cc
+++ b/google/cloud/datacatalog/v1/internal/data_catalog_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace datacatalog_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-DataCatalogMetadata::DataCatalogMetadata(std::shared_ptr<DataCatalogStub> child)
+DataCatalogMetadata::DataCatalogMetadata(
+    std::shared_ptr<DataCatalogStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -327,6 +330,9 @@ void DataCatalogMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DataCatalogMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/datacatalog/v1/internal/data_catalog_metadata_decorator.h
+++ b/google/cloud/datacatalog/v1/internal/data_catalog_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DataCatalogMetadata : public DataCatalogStub {
  public:
   ~DataCatalogMetadata() override = default;
-  explicit DataCatalogMetadata(std::shared_ptr<DataCatalogStub> child);
+  explicit DataCatalogMetadata(
+      std::shared_ptr<DataCatalogStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::datacatalog::v1::SearchCatalogResponse> SearchCatalog(
       grpc::ClientContext& context,
@@ -217,6 +220,7 @@ class DataCatalogMetadata : public DataCatalogStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DataCatalogStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_metadata_decorator.cc
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace datacatalog_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PolicyTagManagerMetadata::PolicyTagManagerMetadata(
-    std::shared_ptr<PolicyTagManagerStub> child)
+    std::shared_ptr<PolicyTagManagerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -142,6 +144,9 @@ void PolicyTagManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PolicyTagManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_metadata_decorator.h
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class PolicyTagManagerMetadata : public PolicyTagManagerStub {
  public:
   ~PolicyTagManagerMetadata() override = default;
   explicit PolicyTagManagerMetadata(
-      std::shared_ptr<PolicyTagManagerStub> child);
+      std::shared_ptr<PolicyTagManagerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> CreateTaxonomy(
       grpc::ClientContext& context,
@@ -103,6 +105,7 @@ class PolicyTagManagerMetadata : public PolicyTagManagerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PolicyTagManagerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_metadata_decorator.cc
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace datacatalog_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PolicyTagManagerSerializationMetadata::PolicyTagManagerSerializationMetadata(
-    std::shared_ptr<PolicyTagManagerSerializationStub> child)
+    std::shared_ptr<PolicyTagManagerSerializationStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -67,6 +69,9 @@ void PolicyTagManagerSerializationMetadata::SetMetadata(
 void PolicyTagManagerSerializationMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_metadata_decorator.h
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class PolicyTagManagerSerializationMetadata
  public:
   ~PolicyTagManagerSerializationMetadata() override = default;
   explicit PolicyTagManagerSerializationMetadata(
-      std::shared_ptr<PolicyTagManagerSerializationStub> child);
+      std::shared_ptr<PolicyTagManagerSerializationStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> ReplaceTaxonomy(
       grpc::ClientContext& context,
@@ -59,6 +61,7 @@ class PolicyTagManagerSerializationMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PolicyTagManagerSerializationStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/datamigration/v1/internal/data_migration_metadata_decorator.cc
+++ b/google/cloud/datamigration/v1/internal/data_migration_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace datamigration_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DataMigrationServiceMetadata::DataMigrationServiceMetadata(
-    std::shared_ptr<DataMigrationServiceStub> child)
+    std::shared_ptr<DataMigrationServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -398,6 +400,9 @@ void DataMigrationServiceMetadata::SetMetadata(
 
 void DataMigrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/datamigration/v1/internal/data_migration_metadata_decorator.h
+++ b/google/cloud/datamigration/v1/internal/data_migration_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class DataMigrationServiceMetadata : public DataMigrationServiceStub {
  public:
   ~DataMigrationServiceMetadata() override = default;
   explicit DataMigrationServiceMetadata(
-      std::shared_ptr<DataMigrationServiceStub> child);
+      std::shared_ptr<DataMigrationServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::clouddms::v1::ListMigrationJobsResponse>
   ListMigrationJobs(grpc::ClientContext& context,
@@ -270,6 +272,7 @@ class DataMigrationServiceMetadata : public DataMigrationServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DataMigrationServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dataplex/v1/internal/content_metadata_decorator.cc
+++ b/google/cloud/dataplex/v1/internal/content_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dataplex_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ContentServiceMetadata::ContentServiceMetadata(
-    std::shared_ptr<ContentServiceStub> child)
+    std::shared_ptr<ContentServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -103,6 +105,9 @@ void ContentServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ContentServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dataplex/v1/internal/content_metadata_decorator.h
+++ b/google/cloud/dataplex/v1/internal/content_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ContentServiceMetadata : public ContentServiceStub {
  public:
   ~ContentServiceMetadata() override = default;
-  explicit ContentServiceMetadata(std::shared_ptr<ContentServiceStub> child);
+  explicit ContentServiceMetadata(
+      std::shared_ptr<ContentServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dataplex::v1::Content> CreateContent(
       grpc::ClientContext& context,
@@ -74,6 +77,7 @@ class ContentServiceMetadata : public ContentServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ContentServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dataplex/v1/internal/dataplex_metadata_decorator.cc
+++ b/google/cloud/dataplex/v1/internal/dataplex_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dataplex_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DataplexServiceMetadata::DataplexServiceMetadata(
-    std::shared_ptr<DataplexServiceStub> child)
+    std::shared_ptr<DataplexServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -332,6 +334,9 @@ void DataplexServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DataplexServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dataplex/v1/internal/dataplex_metadata_decorator.h
+++ b/google/cloud/dataplex/v1/internal/dataplex_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DataplexServiceMetadata : public DataplexServiceStub {
  public:
   ~DataplexServiceMetadata() override = default;
-  explicit DataplexServiceMetadata(std::shared_ptr<DataplexServiceStub> child);
+  explicit DataplexServiceMetadata(
+      std::shared_ptr<DataplexServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateLake(
       google::cloud::CompletionQueue& cq,
@@ -206,6 +209,7 @@ class DataplexServiceMetadata : public DataplexServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DataplexServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dataplex/v1/internal/metadata_metadata_decorator.cc
+++ b/google/cloud/dataplex/v1/internal/metadata_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dataplex_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 MetadataServiceMetadata::MetadataServiceMetadata(
-    std::shared_ptr<MetadataServiceStub> child)
+    std::shared_ptr<MetadataServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -112,6 +114,9 @@ void MetadataServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void MetadataServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dataplex/v1/internal/metadata_metadata_decorator.h
+++ b/google/cloud/dataplex/v1/internal/metadata_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MetadataServiceMetadata : public MetadataServiceStub {
  public:
   ~MetadataServiceMetadata() override = default;
-  explicit MetadataServiceMetadata(std::shared_ptr<MetadataServiceStub> child);
+  explicit MetadataServiceMetadata(
+      std::shared_ptr<MetadataServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dataplex::v1::Entity> CreateEntity(
       grpc::ClientContext& context,
@@ -79,6 +82,7 @@ class MetadataServiceMetadata : public MetadataServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<MetadataServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dataproc/v1/internal/autoscaling_policy_metadata_decorator.cc
+++ b/google/cloud/dataproc/v1/internal/autoscaling_policy_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dataproc_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AutoscalingPolicyServiceMetadata::AutoscalingPolicyServiceMetadata(
-    std::shared_ptr<AutoscalingPolicyServiceStub> child)
+    std::shared_ptr<AutoscalingPolicyServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -86,6 +88,9 @@ void AutoscalingPolicyServiceMetadata::SetMetadata(
 void AutoscalingPolicyServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dataproc/v1/internal/autoscaling_policy_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/autoscaling_policy_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class AutoscalingPolicyServiceMetadata : public AutoscalingPolicyServiceStub {
  public:
   ~AutoscalingPolicyServiceMetadata() override = default;
   explicit AutoscalingPolicyServiceMetadata(
-      std::shared_ptr<AutoscalingPolicyServiceStub> child);
+      std::shared_ptr<AutoscalingPolicyServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
   CreateAutoscalingPolicy(
@@ -69,6 +71,7 @@ class AutoscalingPolicyServiceMetadata : public AutoscalingPolicyServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AutoscalingPolicyServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dataproc/v1/internal/batch_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/v1/internal/batch_controller_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dataproc_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BatchControllerMetadata::BatchControllerMetadata(
-    std::shared_ptr<BatchControllerStub> child)
+    std::shared_ptr<BatchControllerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -90,6 +92,9 @@ void BatchControllerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BatchControllerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dataproc/v1/internal/batch_controller_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/batch_controller_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BatchControllerMetadata : public BatchControllerStub {
  public:
   ~BatchControllerMetadata() override = default;
-  explicit BatchControllerMetadata(std::shared_ptr<BatchControllerStub> child);
+  explicit BatchControllerMetadata(
+      std::shared_ptr<BatchControllerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBatch(
       google::cloud::CompletionQueue& cq,
@@ -68,6 +71,7 @@ class BatchControllerMetadata : public BatchControllerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<BatchControllerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dataproc/v1/internal/cluster_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/v1/internal/cluster_controller_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dataproc_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ClusterControllerMetadata::ClusterControllerMetadata(
-    std::shared_ptr<ClusterControllerStub> child)
+    std::shared_ptr<ClusterControllerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -129,6 +131,9 @@ void ClusterControllerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ClusterControllerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dataproc/v1/internal/cluster_controller_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/cluster_controller_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ClusterControllerMetadata : public ClusterControllerStub {
  public:
   ~ClusterControllerMetadata() override = default;
   explicit ClusterControllerMetadata(
-      std::shared_ptr<ClusterControllerStub> child);
+      std::shared_ptr<ClusterControllerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateCluster(
       google::cloud::CompletionQueue& cq,
@@ -94,6 +96,7 @@ class ClusterControllerMetadata : public ClusterControllerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ClusterControllerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dataproc/v1/internal/job_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/v1/internal/job_controller_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dataproc_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 JobControllerMetadata::JobControllerMetadata(
-    std::shared_ptr<JobControllerStub> child)
+    std::shared_ptr<JobControllerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -111,6 +113,9 @@ void JobControllerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void JobControllerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dataproc/v1/internal/job_controller_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/job_controller_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class JobControllerMetadata : public JobControllerStub {
  public:
   ~JobControllerMetadata() override = default;
-  explicit JobControllerMetadata(std::shared_ptr<JobControllerStub> child);
+  explicit JobControllerMetadata(
+      std::shared_ptr<JobControllerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dataproc::v1::Job> SubmitJob(
       grpc::ClientContext& context,
@@ -80,6 +83,7 @@ class JobControllerMetadata : public JobControllerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<JobControllerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dataproc/v1/internal/workflow_template_metadata_decorator.cc
+++ b/google/cloud/dataproc/v1/internal/workflow_template_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dataproc_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 WorkflowTemplateServiceMetadata::WorkflowTemplateServiceMetadata(
-    std::shared_ptr<WorkflowTemplateServiceStub> child)
+    std::shared_ptr<WorkflowTemplateServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -121,6 +123,9 @@ void WorkflowTemplateServiceMetadata::SetMetadata(
 void WorkflowTemplateServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dataproc/v1/internal/workflow_template_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/workflow_template_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class WorkflowTemplateServiceMetadata : public WorkflowTemplateServiceStub {
  public:
   ~WorkflowTemplateServiceMetadata() override = default;
   explicit WorkflowTemplateServiceMetadata(
-      std::shared_ptr<WorkflowTemplateServiceStub> child);
+      std::shared_ptr<WorkflowTemplateServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
   CreateWorkflowTemplate(
@@ -94,6 +96,7 @@ class WorkflowTemplateServiceMetadata : public WorkflowTemplateServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<WorkflowTemplateServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/datastream/v1/internal/datastream_metadata_decorator.cc
+++ b/google/cloud/datastream/v1/internal/datastream_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace datastream_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-DatastreamMetadata::DatastreamMetadata(std::shared_ptr<DatastreamStub> child)
+DatastreamMetadata::DatastreamMetadata(
+    std::shared_ptr<DatastreamStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -275,6 +278,9 @@ void DatastreamMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DatastreamMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/datastream/v1/internal/datastream_metadata_decorator.h
+++ b/google/cloud/datastream/v1/internal/datastream_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DatastreamMetadata : public DatastreamStub {
  public:
   ~DatastreamMetadata() override = default;
-  explicit DatastreamMetadata(std::shared_ptr<DatastreamStub> child);
+  explicit DatastreamMetadata(
+      std::shared_ptr<DatastreamStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::datastream::v1::ListConnectionProfilesResponse>
   ListConnectionProfiles(
@@ -189,6 +192,7 @@ class DatastreamMetadata : public DatastreamStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DatastreamStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/deploy/v1/internal/cloud_deploy_metadata_decorator.cc
+++ b/google/cloud/deploy/v1/internal/cloud_deploy_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace deploy_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-CloudDeployMetadata::CloudDeployMetadata(std::shared_ptr<CloudDeployStub> child)
+CloudDeployMetadata::CloudDeployMetadata(
+    std::shared_ptr<CloudDeployStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -270,6 +273,9 @@ void CloudDeployMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudDeployMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/deploy/v1/internal/cloud_deploy_metadata_decorator.h
+++ b/google/cloud/deploy/v1/internal/cloud_deploy_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudDeployMetadata : public CloudDeployStub {
  public:
   ~CloudDeployMetadata() override = default;
-  explicit CloudDeployMetadata(std::shared_ptr<CloudDeployStub> child);
+  explicit CloudDeployMetadata(
+      std::shared_ptr<CloudDeployStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::deploy::v1::ListDeliveryPipelinesResponse>
   ListDeliveryPipelines(
@@ -170,6 +173,7 @@ class CloudDeployMetadata : public CloudDeployStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudDeployStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/agents_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/agents_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-AgentsMetadata::AgentsMetadata(std::shared_ptr<AgentsStub> child)
+AgentsMetadata::AgentsMetadata(
+    std::shared_ptr<AgentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -129,6 +132,9 @@ void AgentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AgentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/agents_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/agents_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AgentsMetadata : public AgentsStub {
  public:
   ~AgentsMetadata() override = default;
-  explicit AgentsMetadata(std::shared_ptr<AgentsStub> child);
+  explicit AgentsMetadata(
+      std::shared_ptr<AgentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListAgentsResponse> ListAgents(
       grpc::ClientContext& context,
@@ -99,6 +102,7 @@ class AgentsMetadata : public AgentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AgentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/changelogs_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/changelogs_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ChangelogsMetadata::ChangelogsMetadata(std::shared_ptr<ChangelogsStub> child)
+ChangelogsMetadata::ChangelogsMetadata(
+    std::shared_ptr<ChangelogsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -57,6 +60,9 @@ void ChangelogsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ChangelogsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/changelogs_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/changelogs_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ChangelogsMetadata : public ChangelogsStub {
  public:
   ~ChangelogsMetadata() override = default;
-  explicit ChangelogsMetadata(std::shared_ptr<ChangelogsStub> child);
+  explicit ChangelogsMetadata(
+      std::shared_ptr<ChangelogsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListChangelogsResponse>
   ListChangelogs(grpc::ClientContext& context,
@@ -50,6 +53,7 @@ class ChangelogsMetadata : public ChangelogsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ChangelogsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/deployments_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/deployments_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-DeploymentsMetadata::DeploymentsMetadata(std::shared_ptr<DeploymentsStub> child)
+DeploymentsMetadata::DeploymentsMetadata(
+    std::shared_ptr<DeploymentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -57,6 +60,9 @@ void DeploymentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DeploymentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/deployments_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/deployments_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DeploymentsMetadata : public DeploymentsStub {
  public:
   ~DeploymentsMetadata() override = default;
-  explicit DeploymentsMetadata(std::shared_ptr<DeploymentsStub> child);
+  explicit DeploymentsMetadata(
+      std::shared_ptr<DeploymentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListDeploymentsResponse>
   ListDeployments(
@@ -51,6 +54,7 @@ class DeploymentsMetadata : public DeploymentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DeploymentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/entity_types_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/entity_types_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-EntityTypesMetadata::EntityTypesMetadata(std::shared_ptr<EntityTypesStub> child)
+EntityTypesMetadata::EntityTypesMetadata(
+    std::shared_ptr<EntityTypesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -80,6 +83,9 @@ void EntityTypesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EntityTypesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/entity_types_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/entity_types_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EntityTypesMetadata : public EntityTypesStub {
  public:
   ~EntityTypesMetadata() override = default;
-  explicit EntityTypesMetadata(std::shared_ptr<EntityTypesStub> child);
+  explicit EntityTypesMetadata(
+      std::shared_ptr<EntityTypesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListEntityTypesResponse>
   ListEntityTypes(
@@ -66,6 +69,7 @@ class EntityTypesMetadata : public EntityTypesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EntityTypesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/environments_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/environments_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 EnvironmentsMetadata::EnvironmentsMetadata(
-    std::shared_ptr<EnvironmentsStub> child)
+    std::shared_ptr<EnvironmentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -140,6 +142,9 @@ void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/environments_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/environments_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EnvironmentsMetadata : public EnvironmentsStub {
  public:
   ~EnvironmentsMetadata() override = default;
-  explicit EnvironmentsMetadata(std::shared_ptr<EnvironmentsStub> child);
+  explicit EnvironmentsMetadata(
+      std::shared_ptr<EnvironmentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListEnvironmentsResponse>
   ListEnvironments(
@@ -103,6 +106,7 @@ class EnvironmentsMetadata : public EnvironmentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EnvironmentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/experiments_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/experiments_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ExperimentsMetadata::ExperimentsMetadata(std::shared_ptr<ExperimentsStub> child)
+ExperimentsMetadata::ExperimentsMetadata(
+    std::shared_ptr<ExperimentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -96,6 +99,9 @@ void ExperimentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ExperimentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/experiments_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/experiments_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ExperimentsMetadata : public ExperimentsStub {
  public:
   ~ExperimentsMetadata() override = default;
-  explicit ExperimentsMetadata(std::shared_ptr<ExperimentsStub> child);
+  explicit ExperimentsMetadata(
+      std::shared_ptr<ExperimentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListExperimentsResponse>
   ListExperiments(
@@ -76,6 +79,7 @@ class ExperimentsMetadata : public ExperimentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ExperimentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/flows_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/flows_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-FlowsMetadata::FlowsMetadata(std::shared_ptr<FlowsStub> child)
+FlowsMetadata::FlowsMetadata(
+    std::shared_ptr<FlowsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -135,6 +138,9 @@ void FlowsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void FlowsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/flows_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/flows_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FlowsMetadata : public FlowsStub {
  public:
   ~FlowsMetadata() override = default;
-  explicit FlowsMetadata(std::shared_ptr<FlowsStub> child);
+  explicit FlowsMetadata(
+      std::shared_ptr<FlowsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::Flow> CreateFlow(
       grpc::ClientContext& context,
@@ -104,6 +107,7 @@ class FlowsMetadata : public FlowsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<FlowsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/intents_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/intents_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IntentsMetadata::IntentsMetadata(std::shared_ptr<IntentsStub> child)
+IntentsMetadata::IntentsMetadata(
+    std::shared_ptr<IntentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -79,6 +82,9 @@ void IntentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IntentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/intents_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/intents_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IntentsMetadata : public IntentsStub {
  public:
   ~IntentsMetadata() override = default;
-  explicit IntentsMetadata(std::shared_ptr<IntentsStub> child);
+  explicit IntentsMetadata(
+      std::shared_ptr<IntentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListIntentsResponse> ListIntents(
       grpc::ClientContext& context,
@@ -65,6 +68,7 @@ class IntentsMetadata : public IntentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IntentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/pages_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/pages_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-PagesMetadata::PagesMetadata(std::shared_ptr<PagesStub> child)
+PagesMetadata::PagesMetadata(
+    std::shared_ptr<PagesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -77,6 +80,9 @@ void PagesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PagesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/pages_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/pages_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PagesMetadata : public PagesStub {
  public:
   ~PagesMetadata() override = default;
-  explicit PagesMetadata(std::shared_ptr<PagesStub> child);
+  explicit PagesMetadata(
+      std::shared_ptr<PagesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListPagesResponse> ListPages(
       grpc::ClientContext& context,
@@ -64,6 +67,7 @@ class PagesMetadata : public PagesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PagesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/security_settings_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/security_settings_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SecuritySettingsServiceMetadata::SecuritySettingsServiceMetadata(
-    std::shared_ptr<SecuritySettingsServiceStub> child)
+    std::shared_ptr<SecuritySettingsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -88,6 +90,9 @@ void SecuritySettingsServiceMetadata::SetMetadata(
 void SecuritySettingsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/security_settings_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/security_settings_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class SecuritySettingsServiceMetadata : public SecuritySettingsServiceStub {
  public:
   ~SecuritySettingsServiceMetadata() override = default;
   explicit SecuritySettingsServiceMetadata(
-      std::shared_ptr<SecuritySettingsServiceStub> child);
+      std::shared_ptr<SecuritySettingsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>
   CreateSecuritySettings(
@@ -70,6 +72,7 @@ class SecuritySettingsServiceMetadata : public SecuritySettingsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SecuritySettingsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SessionEntityTypesMetadata::SessionEntityTypesMetadata(
-    std::shared_ptr<SessionEntityTypesStub> child)
+    std::shared_ptr<SessionEntityTypesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -87,6 +89,9 @@ void SessionEntityTypesMetadata::SetMetadata(
 
 void SessionEntityTypesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class SessionEntityTypesMetadata : public SessionEntityTypesStub {
  public:
   ~SessionEntityTypesMetadata() override = default;
   explicit SessionEntityTypesMetadata(
-      std::shared_ptr<SessionEntityTypesStub> child);
+      std::shared_ptr<SessionEntityTypesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListSessionEntityTypesResponse>
   ListSessionEntityTypes(
@@ -70,6 +72,7 @@ class SessionEntityTypesMetadata : public SessionEntityTypesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SessionEntityTypesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/sessions_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/sessions_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-SessionsMetadata::SessionsMetadata(std::shared_ptr<SessionsStub> child)
+SessionsMetadata::SessionsMetadata(
+    std::shared_ptr<SessionsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -76,6 +79,9 @@ void SessionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SessionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/sessions_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/sessions_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SessionsMetadata : public SessionsStub {
  public:
   ~SessionsMetadata() override = default;
-  explicit SessionsMetadata(std::shared_ptr<SessionsStub> child);
+  explicit SessionsMetadata(
+      std::shared_ptr<SessionsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::DetectIntentResponse>
   DetectIntent(grpc::ClientContext& context,
@@ -62,6 +65,7 @@ class SessionsMetadata : public SessionsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SessionsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/test_cases_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/test_cases_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-TestCasesMetadata::TestCasesMetadata(std::shared_ptr<TestCasesStub> child)
+TestCasesMetadata::TestCasesMetadata(
+    std::shared_ptr<TestCasesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -162,6 +165,9 @@ void TestCasesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TestCasesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/test_cases_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/test_cases_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TestCasesMetadata : public TestCasesStub {
  public:
   ~TestCasesMetadata() override = default;
-  explicit TestCasesMetadata(std::shared_ptr<TestCasesStub> child);
+  explicit TestCasesMetadata(
+      std::shared_ptr<TestCasesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListTestCasesResponse>
   ListTestCases(grpc::ClientContext& context,
@@ -117,6 +120,7 @@ class TestCasesMetadata : public TestCasesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TestCasesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TransitionRouteGroupsMetadata::TransitionRouteGroupsMetadata(
-    std::shared_ptr<TransitionRouteGroupsStub> child)
+    std::shared_ptr<TransitionRouteGroupsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -87,6 +89,9 @@ void TransitionRouteGroupsMetadata::SetMetadata(
 
 void TransitionRouteGroupsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class TransitionRouteGroupsMetadata : public TransitionRouteGroupsStub {
  public:
   ~TransitionRouteGroupsMetadata() override = default;
   explicit TransitionRouteGroupsMetadata(
-      std::shared_ptr<TransitionRouteGroupsStub> child);
+      std::shared_ptr<TransitionRouteGroupsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListTransitionRouteGroupsResponse>
   ListTransitionRouteGroups(
@@ -70,6 +72,7 @@ class TransitionRouteGroupsMetadata : public TransitionRouteGroupsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TransitionRouteGroupsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/versions_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/versions_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-VersionsMetadata::VersionsMetadata(std::shared_ptr<VersionsStub> child)
+VersionsMetadata::VersionsMetadata(
+    std::shared_ptr<VersionsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -115,6 +118,9 @@ void VersionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VersionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/versions_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/versions_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VersionsMetadata : public VersionsStub {
  public:
   ~VersionsMetadata() override = default;
-  explicit VersionsMetadata(std::shared_ptr<VersionsStub> child);
+  explicit VersionsMetadata(
+      std::shared_ptr<VersionsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListVersionsResponse>
   ListVersions(grpc::ClientContext& context,
@@ -89,6 +92,7 @@ class VersionsMetadata : public VersionsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<VersionsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_cx/internal/webhooks_metadata_decorator.cc
+++ b/google/cloud/dialogflow_cx/internal/webhooks_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-WebhooksMetadata::WebhooksMetadata(std::shared_ptr<WebhooksStub> child)
+WebhooksMetadata::WebhooksMetadata(
+    std::shared_ptr<WebhooksStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -80,6 +83,9 @@ void WebhooksMetadata::SetMetadata(grpc::ClientContext& context,
 
 void WebhooksMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_cx/internal/webhooks_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/webhooks_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WebhooksMetadata : public WebhooksStub {
  public:
   ~WebhooksMetadata() override = default;
-  explicit WebhooksMetadata(std::shared_ptr<WebhooksStub> child);
+  explicit WebhooksMetadata(
+      std::shared_ptr<WebhooksStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListWebhooksResponse>
   ListWebhooks(grpc::ClientContext& context,
@@ -65,6 +68,7 @@ class WebhooksMetadata : public WebhooksStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<WebhooksStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/agents_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/agents_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-AgentsMetadata::AgentsMetadata(std::shared_ptr<AgentsStub> child)
+AgentsMetadata::AgentsMetadata(
+    std::shared_ptr<AgentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -131,6 +134,9 @@ void AgentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AgentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/agents_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/agents_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AgentsMetadata : public AgentsStub {
  public:
   ~AgentsMetadata() override = default;
-  explicit AgentsMetadata(std::shared_ptr<AgentsStub> child);
+  explicit AgentsMetadata(
+      std::shared_ptr<AgentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::Agent> GetAgent(
       grpc::ClientContext& context,
@@ -96,6 +99,7 @@ class AgentsMetadata : public AgentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AgentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/answer_records_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/answer_records_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AnswerRecordsMetadata::AnswerRecordsMetadata(
-    std::shared_ptr<AnswerRecordsStub> child)
+    std::shared_ptr<AnswerRecordsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -58,6 +60,9 @@ void AnswerRecordsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AnswerRecordsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/answer_records_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/answer_records_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AnswerRecordsMetadata : public AnswerRecordsStub {
  public:
   ~AnswerRecordsMetadata() override = default;
-  explicit AnswerRecordsMetadata(std::shared_ptr<AnswerRecordsStub> child);
+  explicit AnswerRecordsMetadata(
+      std::shared_ptr<AnswerRecordsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListAnswerRecordsResponse>
   ListAnswerRecords(
@@ -51,6 +54,7 @@ class AnswerRecordsMetadata : public AnswerRecordsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AnswerRecordsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/contexts_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/contexts_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ContextsMetadata::ContextsMetadata(std::shared_ptr<ContextsStub> child)
+ContextsMetadata::ContextsMetadata(
+    std::shared_ptr<ContextsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -86,6 +89,9 @@ void ContextsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ContextsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/contexts_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/contexts_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ContextsMetadata : public ContextsStub {
  public:
   ~ContextsMetadata() override = default;
-  explicit ContextsMetadata(std::shared_ptr<ContextsStub> child);
+  explicit ContextsMetadata(
+      std::shared_ptr<ContextsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListContextsResponse> ListContexts(
       grpc::ClientContext& context,
@@ -69,6 +72,7 @@ class ContextsMetadata : public ContextsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ContextsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ConversationDatasetsMetadata::ConversationDatasetsMetadata(
-    std::shared_ptr<ConversationDatasetsStub> child)
+    std::shared_ptr<ConversationDatasetsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -109,6 +111,9 @@ void ConversationDatasetsMetadata::SetMetadata(
 
 void ConversationDatasetsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ConversationDatasetsMetadata : public ConversationDatasetsStub {
  public:
   ~ConversationDatasetsMetadata() override = default;
   explicit ConversationDatasetsMetadata(
-      std::shared_ptr<ConversationDatasetsStub> child);
+      std::shared_ptr<ConversationDatasetsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>>
   AsyncCreateConversationDataset(
@@ -84,6 +86,7 @@ class ConversationDatasetsMetadata : public ConversationDatasetsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ConversationDatasetsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/conversation_models_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_models_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ConversationModelsMetadata::ConversationModelsMetadata(
-    std::shared_ptr<ConversationModelsStub> child)
+    std::shared_ptr<ConversationModelsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -147,6 +149,9 @@ void ConversationModelsMetadata::SetMetadata(
 
 void ConversationModelsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/conversation_models_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/conversation_models_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ConversationModelsMetadata : public ConversationModelsStub {
  public:
   ~ConversationModelsMetadata() override = default;
   explicit ConversationModelsMetadata(
-      std::shared_ptr<ConversationModelsStub> child);
+      std::shared_ptr<ConversationModelsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateConversationModel(
       google::cloud::CompletionQueue& cq,
@@ -109,6 +111,7 @@ class ConversationModelsMetadata : public ConversationModelsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ConversationModelsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ConversationProfilesMetadata::ConversationProfilesMetadata(
-    std::shared_ptr<ConversationProfilesStub> child)
+    std::shared_ptr<ConversationProfilesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -128,6 +130,9 @@ void ConversationProfilesMetadata::SetMetadata(
 
 void ConversationProfilesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ConversationProfilesMetadata : public ConversationProfilesStub {
  public:
   ~ConversationProfilesMetadata() override = default;
   explicit ConversationProfilesMetadata(
-      std::shared_ptr<ConversationProfilesStub> child);
+      std::shared_ptr<ConversationProfilesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListConversationProfilesResponse>
   ListConversationProfiles(
@@ -95,6 +97,7 @@ class ConversationProfilesMetadata : public ConversationProfilesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ConversationProfilesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/conversations_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/conversations_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ConversationsMetadata::ConversationsMetadata(
-    std::shared_ptr<ConversationsStub> child)
+    std::shared_ptr<ConversationsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -101,6 +103,9 @@ void ConversationsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ConversationsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/conversations_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/conversations_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConversationsMetadata : public ConversationsStub {
  public:
   ~ConversationsMetadata() override = default;
-  explicit ConversationsMetadata(std::shared_ptr<ConversationsStub> child);
+  explicit ConversationsMetadata(
+      std::shared_ptr<ConversationsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::Conversation> CreateConversation(
       grpc::ClientContext& context,
@@ -78,6 +81,7 @@ class ConversationsMetadata : public ConversationsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ConversationsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/documents_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/documents_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-DocumentsMetadata::DocumentsMetadata(std::shared_ptr<DocumentsStub> child)
+DocumentsMetadata::DocumentsMetadata(
+    std::shared_ptr<DocumentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -128,6 +131,9 @@ void DocumentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DocumentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/documents_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/documents_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DocumentsMetadata : public DocumentsStub {
  public:
   ~DocumentsMetadata() override = default;
-  explicit DocumentsMetadata(std::shared_ptr<DocumentsStub> child);
+  explicit DocumentsMetadata(
+      std::shared_ptr<DocumentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListDocumentsResponse> ListDocuments(
       grpc::ClientContext& context,
@@ -97,6 +100,7 @@ class DocumentsMetadata : public DocumentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DocumentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/entity_types_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/entity_types_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-EntityTypesMetadata::EntityTypesMetadata(std::shared_ptr<EntityTypesStub> child)
+EntityTypesMetadata::EntityTypesMetadata(
+    std::shared_ptr<EntityTypesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -144,6 +147,9 @@ void EntityTypesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EntityTypesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/entity_types_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/entity_types_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EntityTypesMetadata : public EntityTypesStub {
  public:
   ~EntityTypesMetadata() override = default;
-  explicit EntityTypesMetadata(std::shared_ptr<EntityTypesStub> child);
+  explicit EntityTypesMetadata(
+      std::shared_ptr<EntityTypesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListEntityTypesResponse>
   ListEntityTypes(grpc::ClientContext& context,
@@ -106,6 +109,7 @@ class EntityTypesMetadata : public EntityTypesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EntityTypesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/environments_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/environments_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 EnvironmentsMetadata::EnvironmentsMetadata(
-    std::shared_ptr<EnvironmentsStub> child)
+    std::shared_ptr<EnvironmentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -90,6 +92,9 @@ void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/environments_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/environments_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EnvironmentsMetadata : public EnvironmentsStub {
  public:
   ~EnvironmentsMetadata() override = default;
-  explicit EnvironmentsMetadata(std::shared_ptr<EnvironmentsStub> child);
+  explicit EnvironmentsMetadata(
+      std::shared_ptr<EnvironmentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListEnvironmentsResponse>
   ListEnvironments(grpc::ClientContext& context,
@@ -71,6 +74,7 @@ class EnvironmentsMetadata : public EnvironmentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EnvironmentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/fulfillments_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/fulfillments_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 FulfillmentsMetadata::FulfillmentsMetadata(
-    std::shared_ptr<FulfillmentsStub> child)
+    std::shared_ptr<FulfillmentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -58,6 +60,9 @@ void FulfillmentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void FulfillmentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/fulfillments_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/fulfillments_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FulfillmentsMetadata : public FulfillmentsStub {
  public:
   ~FulfillmentsMetadata() override = default;
-  explicit FulfillmentsMetadata(std::shared_ptr<FulfillmentsStub> child);
+  explicit FulfillmentsMetadata(
+      std::shared_ptr<FulfillmentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::Fulfillment> GetFulfillment(
       grpc::ClientContext& context,
@@ -50,6 +53,7 @@ class FulfillmentsMetadata : public FulfillmentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<FulfillmentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/intents_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/intents_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IntentsMetadata::IntentsMetadata(std::shared_ptr<IntentsStub> child)
+IntentsMetadata::IntentsMetadata(
+    std::shared_ptr<IntentsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -112,6 +115,9 @@ void IntentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IntentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/intents_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/intents_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IntentsMetadata : public IntentsStub {
  public:
   ~IntentsMetadata() override = default;
-  explicit IntentsMetadata(std::shared_ptr<IntentsStub> child);
+  explicit IntentsMetadata(
+      std::shared_ptr<IntentsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListIntentsResponse> ListIntents(
       grpc::ClientContext& context,
@@ -86,6 +89,7 @@ class IntentsMetadata : public IntentsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IntentsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 KnowledgeBasesMetadata::KnowledgeBasesMetadata(
-    std::shared_ptr<KnowledgeBasesStub> child)
+    std::shared_ptr<KnowledgeBasesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -82,6 +84,9 @@ void KnowledgeBasesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void KnowledgeBasesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class KnowledgeBasesMetadata : public KnowledgeBasesStub {
  public:
   ~KnowledgeBasesMetadata() override = default;
-  explicit KnowledgeBasesMetadata(std::shared_ptr<KnowledgeBasesStub> child);
+  explicit KnowledgeBasesMetadata(
+      std::shared_ptr<KnowledgeBasesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListKnowledgeBasesResponse>
   ListKnowledgeBases(
@@ -66,6 +69,7 @@ class KnowledgeBasesMetadata : public KnowledgeBasesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<KnowledgeBasesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/participants_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/participants_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ParticipantsMetadata::ParticipantsMetadata(
-    std::shared_ptr<ParticipantsStub> child)
+    std::shared_ptr<ParticipantsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -116,6 +118,9 @@ void ParticipantsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ParticipantsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/participants_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/participants_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ParticipantsMetadata : public ParticipantsStub {
  public:
   ~ParticipantsMetadata() override = default;
-  explicit ParticipantsMetadata(std::shared_ptr<ParticipantsStub> child);
+  explicit ParticipantsMetadata(
+      std::shared_ptr<ParticipantsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::Participant> CreateParticipant(
       grpc::ClientContext& context,
@@ -89,6 +92,7 @@ class ParticipantsMetadata : public ParticipantsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ParticipantsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/session_entity_types_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SessionEntityTypesMetadata::SessionEntityTypesMetadata(
-    std::shared_ptr<SessionEntityTypesStub> child)
+    std::shared_ptr<SessionEntityTypesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -86,6 +88,9 @@ void SessionEntityTypesMetadata::SetMetadata(
 
 void SessionEntityTypesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/session_entity_types_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class SessionEntityTypesMetadata : public SessionEntityTypesStub {
  public:
   ~SessionEntityTypesMetadata() override = default;
   explicit SessionEntityTypesMetadata(
-      std::shared_ptr<SessionEntityTypesStub> child);
+      std::shared_ptr<SessionEntityTypesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListSessionEntityTypesResponse>
   ListSessionEntityTypes(
@@ -70,6 +72,7 @@ class SessionEntityTypesMetadata : public SessionEntityTypesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SessionEntityTypesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/sessions_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/sessions_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-SessionsMetadata::SessionsMetadata(std::shared_ptr<SessionsStub> child)
+SessionsMetadata::SessionsMetadata(
+    std::shared_ptr<SessionsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -59,6 +62,9 @@ void SessionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SessionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/sessions_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/sessions_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SessionsMetadata : public SessionsStub {
  public:
   ~SessionsMetadata() override = default;
-  explicit SessionsMetadata(std::shared_ptr<SessionsStub> child);
+  explicit SessionsMetadata(
+      std::shared_ptr<SessionsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::DetectIntentResponse> DetectIntent(
       grpc::ClientContext& context,
@@ -52,6 +55,7 @@ class SessionsMetadata : public SessionsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SessionsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dialogflow_es/internal/versions_metadata_decorator.cc
+++ b/google/cloud/dialogflow_es/internal/versions_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-VersionsMetadata::VersionsMetadata(std::shared_ptr<VersionsStub> child)
+VersionsMetadata::VersionsMetadata(
+    std::shared_ptr<VersionsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -79,6 +82,9 @@ void VersionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VersionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dialogflow_es/internal/versions_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/versions_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VersionsMetadata : public VersionsStub {
  public:
   ~VersionsMetadata() override = default;
-  explicit VersionsMetadata(std::shared_ptr<VersionsStub> child);
+  explicit VersionsMetadata(
+      std::shared_ptr<VersionsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::dialogflow::v2::ListVersionsResponse> ListVersions(
       grpc::ClientContext& context,
@@ -64,6 +67,7 @@ class VersionsMetadata : public VersionsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<VersionsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/dlp/v2/internal/dlp_metadata_decorator.cc
+++ b/google/cloud/dlp/v2/internal/dlp_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace dlp_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-DlpServiceMetadata::DlpServiceMetadata(std::shared_ptr<DlpServiceStub> child)
+DlpServiceMetadata::DlpServiceMetadata(
+    std::shared_ptr<DlpServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -304,6 +307,9 @@ void DlpServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DlpServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/dlp/v2/internal/dlp_metadata_decorator.h
+++ b/google/cloud/dlp/v2/internal/dlp_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DlpServiceMetadata : public DlpServiceStub {
  public:
   ~DlpServiceMetadata() override = default;
-  explicit DlpServiceMetadata(std::shared_ptr<DlpServiceStub> child);
+  explicit DlpServiceMetadata(
+      std::shared_ptr<DlpServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::privacy::dlp::v2::InspectContentResponse> InspectContent(
       grpc::ClientContext& context,
@@ -205,6 +208,7 @@ class DlpServiceMetadata : public DlpServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DlpServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/documentai/v1/internal/document_processor_metadata_decorator.cc
+++ b/google/cloud/documentai/v1/internal/document_processor_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace documentai_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DocumentProcessorServiceMetadata::DocumentProcessorServiceMetadata(
-    std::shared_ptr<DocumentProcessorServiceStub> child)
+    std::shared_ptr<DocumentProcessorServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -255,6 +257,9 @@ void DocumentProcessorServiceMetadata::SetMetadata(
 void DocumentProcessorServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/documentai/v1/internal/document_processor_metadata_decorator.h
+++ b/google/cloud/documentai/v1/internal/document_processor_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class DocumentProcessorServiceMetadata : public DocumentProcessorServiceStub {
  public:
   ~DocumentProcessorServiceMetadata() override = default;
   explicit DocumentProcessorServiceMetadata(
-      std::shared_ptr<DocumentProcessorServiceStub> child);
+      std::shared_ptr<DocumentProcessorServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::documentai::v1::ProcessResponse> ProcessDocument(
       grpc::ClientContext& context,
@@ -178,6 +180,7 @@ class DocumentProcessorServiceMetadata : public DocumentProcessorServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DocumentProcessorServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/edgecontainer/v1/internal/edge_container_metadata_decorator.cc
+++ b/google/cloud/edgecontainer/v1/internal/edge_container_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace edgecontainer_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 EdgeContainerMetadata::EdgeContainerMetadata(
-    std::shared_ptr<EdgeContainerStub> child)
+    std::shared_ptr<EdgeContainerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -207,6 +209,9 @@ void EdgeContainerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EdgeContainerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/edgecontainer/v1/internal/edge_container_metadata_decorator.h
+++ b/google/cloud/edgecontainer/v1/internal/edge_container_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EdgeContainerMetadata : public EdgeContainerStub {
  public:
   ~EdgeContainerMetadata() override = default;
-  explicit EdgeContainerMetadata(std::shared_ptr<EdgeContainerStub> child);
+  explicit EdgeContainerMetadata(
+      std::shared_ptr<EdgeContainerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::edgecontainer::v1::ListClustersResponse> ListClusters(
       grpc::ClientContext& context,
@@ -146,6 +149,7 @@ class EdgeContainerMetadata : public EdgeContainerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EdgeContainerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/eventarc/publishing/v1/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/eventarc/publishing/v1/internal/publisher_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace eventarc_publishing_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-PublisherMetadata::PublisherMetadata(std::shared_ptr<PublisherStub> child)
+PublisherMetadata::PublisherMetadata(
+    std::shared_ptr<PublisherStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -60,6 +63,9 @@ void PublisherMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PublisherMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/eventarc/publishing/v1/internal/publisher_metadata_decorator.h
+++ b/google/cloud/eventarc/publishing/v1/internal/publisher_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PublisherMetadata : public PublisherStub {
  public:
   ~PublisherMetadata() override = default;
-  explicit PublisherMetadata(std::shared_ptr<PublisherStub> child);
+  explicit PublisherMetadata(
+      std::shared_ptr<PublisherStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::eventarc::publishing::v1::
                PublishChannelConnectionEventsResponse>
@@ -53,6 +56,7 @@ class PublisherMetadata : public PublisherStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PublisherStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/eventarc/v1/internal/eventarc_metadata_decorator.cc
+++ b/google/cloud/eventarc/v1/internal/eventarc_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace eventarc_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-EventarcMetadata::EventarcMetadata(std::shared_ptr<EventarcStub> child)
+EventarcMetadata::EventarcMetadata(
+    std::shared_ptr<EventarcStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -211,6 +214,9 @@ void EventarcMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EventarcMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/eventarc/v1/internal/eventarc_metadata_decorator.h
+++ b/google/cloud/eventarc/v1/internal/eventarc_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EventarcMetadata : public EventarcStub {
  public:
   ~EventarcMetadata() override = default;
-  explicit EventarcMetadata(std::shared_ptr<EventarcStub> child);
+  explicit EventarcMetadata(
+      std::shared_ptr<EventarcStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::eventarc::v1::Trigger> GetTrigger(
       grpc::ClientContext& context,
@@ -147,6 +150,7 @@ class EventarcMetadata : public EventarcStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EventarcStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/filestore/v1/internal/cloud_filestore_manager_metadata_decorator.cc
+++ b/google/cloud/filestore/v1/internal/cloud_filestore_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace filestore_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudFilestoreManagerMetadata::CloudFilestoreManagerMetadata(
-    std::shared_ptr<CloudFilestoreManagerStub> child)
+    std::shared_ptr<CloudFilestoreManagerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -197,6 +199,9 @@ void CloudFilestoreManagerMetadata::SetMetadata(
 
 void CloudFilestoreManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/filestore/v1/internal/cloud_filestore_manager_metadata_decorator.h
+++ b/google/cloud/filestore/v1/internal/cloud_filestore_manager_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class CloudFilestoreManagerMetadata : public CloudFilestoreManagerStub {
  public:
   ~CloudFilestoreManagerMetadata() override = default;
   explicit CloudFilestoreManagerMetadata(
-      std::shared_ptr<CloudFilestoreManagerStub> child);
+      std::shared_ptr<CloudFilestoreManagerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::filestore::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,
@@ -138,6 +140,7 @@ class CloudFilestoreManagerMetadata : public CloudFilestoreManagerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudFilestoreManagerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/functions/v1/internal/cloud_functions_metadata_decorator.cc
+++ b/google/cloud/functions/v1/internal/cloud_functions_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace functions_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudFunctionsServiceMetadata::CloudFunctionsServiceMetadata(
-    std::shared_ptr<CloudFunctionsServiceStub> child)
+    std::shared_ptr<CloudFunctionsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -148,6 +150,9 @@ void CloudFunctionsServiceMetadata::SetMetadata(
 
 void CloudFunctionsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/functions/v1/internal/cloud_functions_metadata_decorator.h
+++ b/google/cloud/functions/v1/internal/cloud_functions_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class CloudFunctionsServiceMetadata : public CloudFunctionsServiceStub {
  public:
   ~CloudFunctionsServiceMetadata() override = default;
   explicit CloudFunctionsServiceMetadata(
-      std::shared_ptr<CloudFunctionsServiceStub> child);
+      std::shared_ptr<CloudFunctionsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::functions::v1::ListFunctionsResponse> ListFunctions(
       grpc::ClientContext& context,
@@ -108,6 +110,7 @@ class CloudFunctionsServiceMetadata : public CloudFunctionsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudFunctionsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/gameservices/v1/internal/game_server_clusters_metadata_decorator.cc
+++ b/google/cloud/gameservices/v1/internal/game_server_clusters_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace gameservices_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GameServerClustersServiceMetadata::GameServerClustersServiceMetadata(
-    std::shared_ptr<GameServerClustersServiceStub> child)
+    std::shared_ptr<GameServerClustersServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -132,6 +134,9 @@ void GameServerClustersServiceMetadata::SetMetadata(
 void GameServerClustersServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/gameservices/v1/internal/game_server_clusters_metadata_decorator.h
+++ b/google/cloud/gameservices/v1/internal/game_server_clusters_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class GameServerClustersServiceMetadata : public GameServerClustersServiceStub {
  public:
   ~GameServerClustersServiceMetadata() override = default;
   explicit GameServerClustersServiceMetadata(
-      std::shared_ptr<GameServerClustersServiceStub> child);
+      std::shared_ptr<GameServerClustersServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::gaming::v1::ListGameServerClustersResponse>
   ListGameServerClusters(
@@ -99,6 +101,7 @@ class GameServerClustersServiceMetadata : public GameServerClustersServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<GameServerClustersServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/gameservices/v1/internal/game_server_configs_metadata_decorator.cc
+++ b/google/cloud/gameservices/v1/internal/game_server_configs_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace gameservices_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GameServerConfigsServiceMetadata::GameServerConfigsServiceMetadata(
-    std::shared_ptr<GameServerConfigsServiceStub> child)
+    std::shared_ptr<GameServerConfigsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -94,6 +96,9 @@ void GameServerConfigsServiceMetadata::SetMetadata(
 void GameServerConfigsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/gameservices/v1/internal/game_server_configs_metadata_decorator.h
+++ b/google/cloud/gameservices/v1/internal/game_server_configs_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class GameServerConfigsServiceMetadata : public GameServerConfigsServiceStub {
  public:
   ~GameServerConfigsServiceMetadata() override = default;
   explicit GameServerConfigsServiceMetadata(
-      std::shared_ptr<GameServerConfigsServiceStub> child);
+      std::shared_ptr<GameServerConfigsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::gaming::v1::ListGameServerConfigsResponse>
   ListGameServerConfigs(
@@ -75,6 +77,7 @@ class GameServerConfigsServiceMetadata : public GameServerConfigsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<GameServerConfigsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/gameservices/v1/internal/game_server_deployments_metadata_decorator.cc
+++ b/google/cloud/gameservices/v1/internal/game_server_deployments_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace gameservices_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GameServerDeploymentsServiceMetadata::GameServerDeploymentsServiceMetadata(
-    std::shared_ptr<GameServerDeploymentsServiceStub> child)
+    std::shared_ptr<GameServerDeploymentsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -148,6 +150,9 @@ void GameServerDeploymentsServiceMetadata::SetMetadata(
 void GameServerDeploymentsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/gameservices/v1/internal/game_server_deployments_metadata_decorator.h
+++ b/google/cloud/gameservices/v1/internal/game_server_deployments_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -35,7 +36,8 @@ class GameServerDeploymentsServiceMetadata
  public:
   ~GameServerDeploymentsServiceMetadata() override = default;
   explicit GameServerDeploymentsServiceMetadata(
-      std::shared_ptr<GameServerDeploymentsServiceStub> child);
+      std::shared_ptr<GameServerDeploymentsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::gaming::v1::ListGameServerDeploymentsResponse>
   ListGameServerDeployments(
@@ -112,6 +114,7 @@ class GameServerDeploymentsServiceMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<GameServerDeploymentsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/gameservices/v1/internal/realms_metadata_decorator.cc
+++ b/google/cloud/gameservices/v1/internal/realms_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace gameservices_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 RealmsServiceMetadata::RealmsServiceMetadata(
-    std::shared_ptr<RealmsServiceStub> child)
+    std::shared_ptr<RealmsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -109,6 +111,9 @@ void RealmsServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void RealmsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/gameservices/v1/internal/realms_metadata_decorator.h
+++ b/google/cloud/gameservices/v1/internal/realms_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RealmsServiceMetadata : public RealmsServiceStub {
  public:
   ~RealmsServiceMetadata() override = default;
-  explicit RealmsServiceMetadata(std::shared_ptr<RealmsServiceStub> child);
+  explicit RealmsServiceMetadata(
+      std::shared_ptr<RealmsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::gaming::v1::ListRealmsResponse> ListRealms(
       grpc::ClientContext& context,
@@ -79,6 +82,7 @@ class RealmsServiceMetadata : public RealmsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<RealmsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/gkehub/v1/internal/gke_hub_metadata_decorator.cc
+++ b/google/cloud/gkehub/v1/internal/gke_hub_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace gkehub_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-GkeHubMetadata::GkeHubMetadata(std::shared_ptr<GkeHubStub> child)
+GkeHubMetadata::GkeHubMetadata(
+    std::shared_ptr<GkeHubStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -150,6 +153,9 @@ void GkeHubMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GkeHubMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/gkehub/v1/internal/gke_hub_metadata_decorator.h
+++ b/google/cloud/gkehub/v1/internal/gke_hub_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GkeHubMetadata : public GkeHubStub {
  public:
   ~GkeHubMetadata() override = default;
-  explicit GkeHubMetadata(std::shared_ptr<GkeHubStub> child);
+  explicit GkeHubMetadata(
+      std::shared_ptr<GkeHubStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::gkehub::v1::ListMembershipsResponse> ListMemberships(
       grpc::ClientContext& context,
@@ -107,6 +110,7 @@ class GkeHubMetadata : public GkeHubStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<GkeHubStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/gkemulticloud/v1/internal/attached_clusters_metadata_decorator.cc
+++ b/google/cloud/gkemulticloud/v1/internal/attached_clusters_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace gkemulticloud_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AttachedClustersMetadata::AttachedClustersMetadata(
-    std::shared_ptr<AttachedClustersStub> child)
+    std::shared_ptr<AttachedClustersStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -137,6 +139,9 @@ void AttachedClustersMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AttachedClustersMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/gkemulticloud/v1/internal/attached_clusters_metadata_decorator.h
+++ b/google/cloud/gkemulticloud/v1/internal/attached_clusters_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class AttachedClustersMetadata : public AttachedClustersStub {
  public:
   ~AttachedClustersMetadata() override = default;
   explicit AttachedClustersMetadata(
-      std::shared_ptr<AttachedClustersStub> child);
+      std::shared_ptr<AttachedClustersStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateAttachedCluster(
       google::cloud::CompletionQueue& cq,
@@ -102,6 +104,7 @@ class AttachedClustersMetadata : public AttachedClustersStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AttachedClustersStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/gkemulticloud/v1/internal/aws_clusters_metadata_decorator.cc
+++ b/google/cloud/gkemulticloud/v1/internal/aws_clusters_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace gkemulticloud_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-AwsClustersMetadata::AwsClustersMetadata(std::shared_ptr<AwsClustersStub> child)
+AwsClustersMetadata::AwsClustersMetadata(
+    std::shared_ptr<AwsClustersStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -162,6 +165,9 @@ void AwsClustersMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AwsClustersMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/gkemulticloud/v1/internal/aws_clusters_metadata_decorator.h
+++ b/google/cloud/gkemulticloud/v1/internal/aws_clusters_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AwsClustersMetadata : public AwsClustersStub {
  public:
   ~AwsClustersMetadata() override = default;
-  explicit AwsClustersMetadata(std::shared_ptr<AwsClustersStub> child);
+  explicit AwsClustersMetadata(
+      std::shared_ptr<AwsClustersStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateAwsCluster(
       google::cloud::CompletionQueue& cq,
@@ -121,6 +124,7 @@ class AwsClustersMetadata : public AwsClustersStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AwsClustersStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/gkemulticloud/v1/internal/azure_clusters_metadata_decorator.cc
+++ b/google/cloud/gkemulticloud/v1/internal/azure_clusters_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace gkemulticloud_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AzureClustersMetadata::AzureClustersMetadata(
-    std::shared_ptr<AzureClustersStub> child)
+    std::shared_ptr<AzureClustersStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -205,6 +207,9 @@ void AzureClustersMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AzureClustersMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/gkemulticloud/v1/internal/azure_clusters_metadata_decorator.h
+++ b/google/cloud/gkemulticloud/v1/internal/azure_clusters_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AzureClustersMetadata : public AzureClustersStub {
  public:
   ~AzureClustersMetadata() override = default;
-  explicit AzureClustersMetadata(std::shared_ptr<AzureClustersStub> child);
+  explicit AzureClustersMetadata(
+      std::shared_ptr<AzureClustersStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateAzureClient(
       google::cloud::CompletionQueue& cq,
@@ -144,6 +147,7 @@ class AzureClustersMetadata : public AzureClustersStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AzureClustersStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace iam_admin_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IAMMetadata::IAMMetadata(std::shared_ptr<IAMStub> child)
+IAMMetadata::IAMMetadata(
+    std::shared_ptr<IAMStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -250,6 +253,9 @@ void IAMMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IAMMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.h
+++ b/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMMetadata : public IAMStub {
  public:
   ~IAMMetadata() override = default;
-  explicit IAMMetadata(std::shared_ptr<IAMStub> child);
+  explicit IAMMetadata(
+      std::shared_ptr<IAMStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
   ListServiceAccounts(grpc::ClientContext& context,
@@ -173,6 +176,7 @@ class IAMMetadata : public IAMStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IAMStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/iam/credentials/v1/internal/iam_credentials_metadata_decorator.cc
+++ b/google/cloud/iam/credentials/v1/internal/iam_credentials_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace iam_credentials_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IAMCredentialsMetadata::IAMCredentialsMetadata(
-    std::shared_ptr<IAMCredentialsStub> child)
+    std::shared_ptr<IAMCredentialsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -74,6 +76,9 @@ void IAMCredentialsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IAMCredentialsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/iam/credentials/v1/internal/iam_credentials_metadata_decorator.h
+++ b/google/cloud/iam/credentials/v1/internal/iam_credentials_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMCredentialsMetadata : public IAMCredentialsStub {
  public:
   ~IAMCredentialsMetadata() override = default;
-  explicit IAMCredentialsMetadata(std::shared_ptr<IAMCredentialsStub> child);
+  explicit IAMCredentialsMetadata(
+      std::shared_ptr<IAMCredentialsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
@@ -59,6 +62,7 @@ class IAMCredentialsMetadata : public IAMCredentialsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IAMCredentialsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/iam/v1/internal/iam_policy_metadata_decorator.cc
+++ b/google/cloud/iam/v1/internal/iam_policy_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace iam_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IAMPolicyMetadata::IAMPolicyMetadata(std::shared_ptr<IAMPolicyStub> child)
+IAMPolicyMetadata::IAMPolicyMetadata(
+    std::shared_ptr<IAMPolicyStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -63,6 +66,9 @@ void IAMPolicyMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IAMPolicyMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/iam/v1/internal/iam_policy_metadata_decorator.h
+++ b/google/cloud/iam/v1/internal/iam_policy_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMPolicyMetadata : public IAMPolicyStub {
  public:
   ~IAMPolicyMetadata() override = default;
-  explicit IAMPolicyMetadata(std::shared_ptr<IAMPolicyStub> child);
+  explicit IAMPolicyMetadata(
+      std::shared_ptr<IAMPolicyStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,
@@ -52,6 +55,7 @@ class IAMPolicyMetadata : public IAMPolicyStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IAMPolicyStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/iam/v2/internal/policies_metadata_decorator.cc
+++ b/google/cloud/iam/v2/internal/policies_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace iam_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-PoliciesMetadata::PoliciesMetadata(std::shared_ptr<PoliciesStub> child)
+PoliciesMetadata::PoliciesMetadata(
+    std::shared_ptr<PoliciesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -99,6 +102,9 @@ void PoliciesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PoliciesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/iam/v2/internal/policies_metadata_decorator.h
+++ b/google/cloud/iam/v2/internal/policies_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PoliciesMetadata : public PoliciesStub {
  public:
   ~PoliciesMetadata() override = default;
-  explicit PoliciesMetadata(std::shared_ptr<PoliciesStub> child);
+  explicit PoliciesMetadata(
+      std::shared_ptr<PoliciesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::iam::v2::ListPoliciesResponse> ListPolicies(
       grpc::ClientContext& context,
@@ -74,6 +77,7 @@ class PoliciesMetadata : public PoliciesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PoliciesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_admin_metadata_decorator.cc
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_admin_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace iap_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IdentityAwareProxyAdminServiceMetadata::IdentityAwareProxyAdminServiceMetadata(
-    std::shared_ptr<IdentityAwareProxyAdminServiceStub> child)
+    std::shared_ptr<IdentityAwareProxyAdminServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -123,6 +125,9 @@ void IdentityAwareProxyAdminServiceMetadata::SetMetadata(
 void IdentityAwareProxyAdminServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_admin_metadata_decorator.h
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_admin_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class IdentityAwareProxyAdminServiceMetadata
  public:
   ~IdentityAwareProxyAdminServiceMetadata() override = default;
   explicit IdentityAwareProxyAdminServiceMetadata(
-      std::shared_ptr<IdentityAwareProxyAdminServiceStub> child);
+      std::shared_ptr<IdentityAwareProxyAdminServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,
@@ -88,6 +90,7 @@ class IdentityAwareProxyAdminServiceMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IdentityAwareProxyAdminServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_metadata_decorator.cc
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace iap_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IdentityAwareProxyOAuthServiceMetadata::IdentityAwareProxyOAuthServiceMetadata(
-    std::shared_ptr<IdentityAwareProxyOAuthServiceStub> child)
+    std::shared_ptr<IdentityAwareProxyOAuthServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -110,6 +112,9 @@ void IdentityAwareProxyOAuthServiceMetadata::SetMetadata(
 void IdentityAwareProxyOAuthServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_metadata_decorator.h
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class IdentityAwareProxyOAuthServiceMetadata
  public:
   ~IdentityAwareProxyOAuthServiceMetadata() override = default;
   explicit IdentityAwareProxyOAuthServiceMetadata(
-      std::shared_ptr<IdentityAwareProxyOAuthServiceStub> child);
+      std::shared_ptr<IdentityAwareProxyOAuthServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::iap::v1::ListBrandsResponse> ListBrands(
       grpc::ClientContext& context,
@@ -83,6 +85,7 @@ class IdentityAwareProxyOAuthServiceMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IdentityAwareProxyOAuthServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/ids/v1/internal/ids_metadata_decorator.cc
+++ b/google/cloud/ids/v1/internal/ids_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace ids_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IDSMetadata::IDSMetadata(std::shared_ptr<IDSStub> child)
+IDSMetadata::IDSMetadata(
+    std::shared_ptr<IDSStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -90,6 +93,9 @@ void IDSMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IDSMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/ids/v1/internal/ids_metadata_decorator.h
+++ b/google/cloud/ids/v1/internal/ids_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IDSMetadata : public IDSStub {
  public:
   ~IDSMetadata() override = default;
-  explicit IDSMetadata(std::shared_ptr<IDSStub> child);
+  explicit IDSMetadata(
+      std::shared_ptr<IDSStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::ids::v1::ListEndpointsResponse> ListEndpoints(
       grpc::ClientContext& context,
@@ -69,6 +72,7 @@ class IDSMetadata : public IDSStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IDSStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/iot/v1/internal/device_manager_metadata_decorator.cc
+++ b/google/cloud/iot/v1/internal/device_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace iot_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DeviceManagerMetadata::DeviceManagerMetadata(
-    std::shared_ptr<DeviceManagerStub> child)
+    std::shared_ptr<DeviceManagerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -188,6 +190,9 @@ void DeviceManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DeviceManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/iot/v1/internal/device_manager_metadata_decorator.h
+++ b/google/cloud/iot/v1/internal/device_manager_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DeviceManagerMetadata : public DeviceManagerStub {
  public:
   ~DeviceManagerMetadata() override = default;
-  explicit DeviceManagerMetadata(std::shared_ptr<DeviceManagerStub> child);
+  explicit DeviceManagerMetadata(
+      std::shared_ptr<DeviceManagerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::iot::v1::DeviceRegistry> CreateDeviceRegistry(
       grpc::ClientContext& context,
@@ -128,6 +131,7 @@ class DeviceManagerMetadata : public DeviceManagerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DeviceManagerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/kms/inventory/v1/internal/key_dashboard_metadata_decorator.cc
+++ b/google/cloud/kms/inventory/v1/internal/key_dashboard_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace kms_inventory_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 KeyDashboardServiceMetadata::KeyDashboardServiceMetadata(
-    std::shared_ptr<KeyDashboardServiceStub> child)
+    std::shared_ptr<KeyDashboardServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void KeyDashboardServiceMetadata::SetMetadata(
 
 void KeyDashboardServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/kms/inventory/v1/internal/key_dashboard_metadata_decorator.h
+++ b/google/cloud/kms/inventory/v1/internal/key_dashboard_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class KeyDashboardServiceMetadata : public KeyDashboardServiceStub {
  public:
   ~KeyDashboardServiceMetadata() override = default;
   explicit KeyDashboardServiceMetadata(
-      std::shared_ptr<KeyDashboardServiceStub> child);
+      std::shared_ptr<KeyDashboardServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::kms::inventory::v1::ListCryptoKeysResponse>
   ListCryptoKeys(grpc::ClientContext& context,
@@ -46,6 +48,7 @@ class KeyDashboardServiceMetadata : public KeyDashboardServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<KeyDashboardServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/kms/inventory/v1/internal/key_tracking_metadata_decorator.cc
+++ b/google/cloud/kms/inventory/v1/internal/key_tracking_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace kms_inventory_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 KeyTrackingServiceMetadata::KeyTrackingServiceMetadata(
-    std::shared_ptr<KeyTrackingServiceStub> child)
+    std::shared_ptr<KeyTrackingServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -60,6 +62,9 @@ void KeyTrackingServiceMetadata::SetMetadata(
 
 void KeyTrackingServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/kms/inventory/v1/internal/key_tracking_metadata_decorator.h
+++ b/google/cloud/kms/inventory/v1/internal/key_tracking_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class KeyTrackingServiceMetadata : public KeyTrackingServiceStub {
  public:
   ~KeyTrackingServiceMetadata() override = default;
   explicit KeyTrackingServiceMetadata(
-      std::shared_ptr<KeyTrackingServiceStub> child);
+      std::shared_ptr<KeyTrackingServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::kms::inventory::v1::ProtectedResourcesSummary>
   GetProtectedResourcesSummary(
@@ -53,6 +55,7 @@ class KeyTrackingServiceMetadata : public KeyTrackingServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<KeyTrackingServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/kms/v1/internal/ekm_metadata_decorator.cc
+++ b/google/cloud/kms/v1/internal/ekm_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace kms_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-EkmServiceMetadata::EkmServiceMetadata(std::shared_ptr<EkmServiceStub> child)
+EkmServiceMetadata::EkmServiceMetadata(
+    std::shared_ptr<EkmServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -96,6 +99,9 @@ void EkmServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EkmServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/kms/v1/internal/ekm_metadata_decorator.h
+++ b/google/cloud/kms/v1/internal/ekm_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EkmServiceMetadata : public EkmServiceStub {
  public:
   ~EkmServiceMetadata() override = default;
-  explicit EkmServiceMetadata(std::shared_ptr<EkmServiceStub> child);
+  explicit EkmServiceMetadata(
+      std::shared_ptr<EkmServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::kms::v1::ListEkmConnectionsResponse>
   ListEkmConnections(grpc::ClientContext& context,
@@ -72,6 +75,7 @@ class EkmServiceMetadata : public EkmServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EkmServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/kms/v1/internal/key_management_metadata_decorator.cc
+++ b/google/cloud/kms/v1/internal/key_management_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace kms_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 KeyManagementServiceMetadata::KeyManagementServiceMetadata(
-    std::shared_ptr<KeyManagementServiceStub> child)
+    std::shared_ptr<KeyManagementServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -252,6 +254,9 @@ void KeyManagementServiceMetadata::SetMetadata(
 
 void KeyManagementServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/kms/v1/internal/key_management_metadata_decorator.h
+++ b/google/cloud/kms/v1/internal/key_management_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class KeyManagementServiceMetadata : public KeyManagementServiceStub {
  public:
   ~KeyManagementServiceMetadata() override = default;
   explicit KeyManagementServiceMetadata(
-      std::shared_ptr<KeyManagementServiceStub> child);
+      std::shared_ptr<KeyManagementServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::kms::v1::ListKeyRingsResponse> ListKeyRings(
       grpc::ClientContext& context,
@@ -155,6 +157,7 @@ class KeyManagementServiceMetadata : public KeyManagementServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<KeyManagementServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/language/v1/internal/language_metadata_decorator.cc
+++ b/google/cloud/language/v1/internal/language_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace language_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 LanguageServiceMetadata::LanguageServiceMetadata(
-    std::shared_ptr<LanguageServiceStub> child)
+    std::shared_ptr<LanguageServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -98,6 +100,9 @@ void LanguageServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void LanguageServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/language/v1/internal/language_metadata_decorator.h
+++ b/google/cloud/language/v1/internal/language_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LanguageServiceMetadata : public LanguageServiceStub {
  public:
   ~LanguageServiceMetadata() override = default;
-  explicit LanguageServiceMetadata(std::shared_ptr<LanguageServiceStub> child);
+  explicit LanguageServiceMetadata(
+      std::shared_ptr<LanguageServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
   AnalyzeSentiment(grpc::ClientContext& context,
@@ -73,6 +76,7 @@ class LanguageServiceMetadata : public LanguageServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<LanguageServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace logging_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 LoggingServiceV2Metadata::LoggingServiceV2Metadata(
-    std::shared_ptr<LoggingServiceV2Stub> child)
+    std::shared_ptr<LoggingServiceV2Stub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -101,6 +103,9 @@ void LoggingServiceV2Metadata::SetMetadata(grpc::ClientContext& context,
 
 void LoggingServiceV2Metadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.h
+++ b/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class LoggingServiceV2Metadata : public LoggingServiceV2Stub {
  public:
   ~LoggingServiceV2Metadata() override = default;
   explicit LoggingServiceV2Metadata(
-      std::shared_ptr<LoggingServiceV2Stub> child);
+      std::shared_ptr<LoggingServiceV2Stub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   Status DeleteLog(
       grpc::ClientContext& context,
@@ -75,6 +77,7 @@ class LoggingServiceV2Metadata : public LoggingServiceV2Stub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<LoggingServiceV2Stub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/managedidentities/v1/internal/managed_identities_metadata_decorator.cc
+++ b/google/cloud/managedidentities/v1/internal/managed_identities_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace managedidentities_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ManagedIdentitiesServiceMetadata::ManagedIdentitiesServiceMetadata(
-    std::shared_ptr<ManagedIdentitiesServiceStub> child)
+    std::shared_ptr<ManagedIdentitiesServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -150,6 +152,9 @@ void ManagedIdentitiesServiceMetadata::SetMetadata(
 void ManagedIdentitiesServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/managedidentities/v1/internal/managed_identities_metadata_decorator.h
+++ b/google/cloud/managedidentities/v1/internal/managed_identities_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ManagedIdentitiesServiceMetadata : public ManagedIdentitiesServiceStub {
  public:
   ~ManagedIdentitiesServiceMetadata() override = default;
   explicit ManagedIdentitiesServiceMetadata(
-      std::shared_ptr<ManagedIdentitiesServiceStub> child);
+      std::shared_ptr<ManagedIdentitiesServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateMicrosoftAdDomain(
       google::cloud::CompletionQueue& cq,
@@ -110,6 +112,7 @@ class ManagedIdentitiesServiceMetadata : public ManagedIdentitiesServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ManagedIdentitiesServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/memcache/v1/internal/cloud_memcache_metadata_decorator.cc
+++ b/google/cloud/memcache/v1/internal/cloud_memcache_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace memcache_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudMemcacheMetadata::CloudMemcacheMetadata(
-    std::shared_ptr<CloudMemcacheStub> child)
+    std::shared_ptr<CloudMemcacheStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -129,6 +131,9 @@ void CloudMemcacheMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudMemcacheMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/memcache/v1/internal/cloud_memcache_metadata_decorator.h
+++ b/google/cloud/memcache/v1/internal/cloud_memcache_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudMemcacheMetadata : public CloudMemcacheStub {
  public:
   ~CloudMemcacheMetadata() override = default;
-  explicit CloudMemcacheMetadata(std::shared_ptr<CloudMemcacheStub> child);
+  explicit CloudMemcacheMetadata(
+      std::shared_ptr<CloudMemcacheStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::memcache::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,
@@ -96,6 +99,7 @@ class CloudMemcacheMetadata : public CloudMemcacheStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudMemcacheStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/dashboard/v1/internal/dashboards_metadata_decorator.cc
+++ b/google/cloud/monitoring/dashboard/v1/internal/dashboards_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_dashboard_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DashboardsServiceMetadata::DashboardsServiceMetadata(
-    std::shared_ptr<DashboardsServiceStub> child)
+    std::shared_ptr<DashboardsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -81,6 +83,9 @@ void DashboardsServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DashboardsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/dashboard/v1/internal/dashboards_metadata_decorator.h
+++ b/google/cloud/monitoring/dashboard/v1/internal/dashboards_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class DashboardsServiceMetadata : public DashboardsServiceStub {
  public:
   ~DashboardsServiceMetadata() override = default;
   explicit DashboardsServiceMetadata(
-      std::shared_ptr<DashboardsServiceStub> child);
+      std::shared_ptr<DashboardsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::dashboard::v1::Dashboard> CreateDashboard(
       grpc::ClientContext& context,
@@ -66,6 +68,7 @@ class DashboardsServiceMetadata : public DashboardsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DashboardsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_metadata_decorator.cc
+++ b/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_metricsscope_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 MetricsScopesMetadata::MetricsScopesMetadata(
-    std::shared_ptr<MetricsScopesStub> child)
+    std::shared_ptr<MetricsScopesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -98,6 +100,9 @@ void MetricsScopesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void MetricsScopesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_metadata_decorator.h
+++ b/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MetricsScopesMetadata : public MetricsScopesStub {
  public:
   ~MetricsScopesMetadata() override = default;
-  explicit MetricsScopesMetadata(std::shared_ptr<MetricsScopesStub> child);
+  explicit MetricsScopesMetadata(
+      std::shared_ptr<MetricsScopesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::metricsscope::v1::MetricsScope> GetMetricsScope(
       grpc::ClientContext& context,
@@ -75,6 +78,7 @@ class MetricsScopesMetadata : public MetricsScopesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<MetricsScopesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/v3/internal/alert_policy_metadata_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/alert_policy_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AlertPolicyServiceMetadata::AlertPolicyServiceMetadata(
-    std::shared_ptr<AlertPolicyServiceStub> child)
+    std::shared_ptr<AlertPolicyServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -81,6 +83,9 @@ void AlertPolicyServiceMetadata::SetMetadata(
 
 void AlertPolicyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/v3/internal/alert_policy_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/alert_policy_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class AlertPolicyServiceMetadata : public AlertPolicyServiceStub {
  public:
   ~AlertPolicyServiceMetadata() override = default;
   explicit AlertPolicyServiceMetadata(
-      std::shared_ptr<AlertPolicyServiceStub> child);
+      std::shared_ptr<AlertPolicyServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::v3::ListAlertPoliciesResponse> ListAlertPolicies(
       grpc::ClientContext& context,
@@ -61,6 +63,7 @@ class AlertPolicyServiceMetadata : public AlertPolicyServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AlertPolicyServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/v3/internal/group_metadata_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/group_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GroupServiceMetadata::GroupServiceMetadata(
-    std::shared_ptr<GroupServiceStub> child)
+    std::shared_ptr<GroupServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -86,6 +88,9 @@ void GroupServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GroupServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/v3/internal/group_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/group_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GroupServiceMetadata : public GroupServiceStub {
  public:
   ~GroupServiceMetadata() override = default;
-  explicit GroupServiceMetadata(std::shared_ptr<GroupServiceStub> child);
+  explicit GroupServiceMetadata(
+      std::shared_ptr<GroupServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::v3::ListGroupsResponse> ListGroups(
       grpc::ClientContext& context,
@@ -64,6 +67,7 @@ class GroupServiceMetadata : public GroupServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<GroupServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/v3/internal/metric_metadata_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/metric_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 MetricServiceMetadata::MetricServiceMetadata(
-    std::shared_ptr<MetricServiceStub> child)
+    std::shared_ptr<MetricServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -121,6 +123,9 @@ void MetricServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void MetricServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/v3/internal/metric_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/metric_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MetricServiceMetadata : public MetricServiceStub {
  public:
   ~MetricServiceMetadata() override = default;
-  explicit MetricServiceMetadata(std::shared_ptr<MetricServiceStub> child);
+  explicit MetricServiceMetadata(
+      std::shared_ptr<MetricServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::v3::ListMonitoredResourceDescriptorsResponse>
   ListMonitoredResourceDescriptors(
@@ -90,6 +93,7 @@ class MetricServiceMetadata : public MetricServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<MetricServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/v3/internal/notification_channel_metadata_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/notification_channel_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 NotificationChannelServiceMetadata::NotificationChannelServiceMetadata(
-    std::shared_ptr<NotificationChannelServiceStub> child)
+    std::shared_ptr<NotificationChannelServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -127,6 +129,9 @@ void NotificationChannelServiceMetadata::SetMetadata(
 void NotificationChannelServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/v3/internal/notification_channel_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/notification_channel_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class NotificationChannelServiceMetadata
  public:
   ~NotificationChannelServiceMetadata() override = default;
   explicit NotificationChannelServiceMetadata(
-      std::shared_ptr<NotificationChannelServiceStub> child);
+      std::shared_ptr<NotificationChannelServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::v3::ListNotificationChannelDescriptorsResponse>
   ListNotificationChannelDescriptors(
@@ -102,6 +104,7 @@ class NotificationChannelServiceMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<NotificationChannelServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/v3/internal/query_metadata_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/query_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 QueryServiceMetadata::QueryServiceMetadata(
-    std::shared_ptr<QueryServiceStub> child)
+    std::shared_ptr<QueryServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void QueryServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void QueryServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/v3/internal/query_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/query_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class QueryServiceMetadata : public QueryServiceStub {
  public:
   ~QueryServiceMetadata() override = default;
-  explicit QueryServiceMetadata(std::shared_ptr<QueryServiceStub> child);
+  explicit QueryServiceMetadata(
+      std::shared_ptr<QueryServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::v3::QueryTimeSeriesResponse> QueryTimeSeries(
       grpc::ClientContext& context,
@@ -44,6 +47,7 @@ class QueryServiceMetadata : public QueryServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<QueryServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/v3/internal/service_monitoring_metadata_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/service_monitoring_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceMonitoringServiceMetadata::ServiceMonitoringServiceMetadata(
-    std::shared_ptr<ServiceMonitoringServiceStub> child)
+    std::shared_ptr<ServiceMonitoringServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -122,6 +124,9 @@ void ServiceMonitoringServiceMetadata::SetMetadata(
 void ServiceMonitoringServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/v3/internal/service_monitoring_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/service_monitoring_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ServiceMonitoringServiceMetadata : public ServiceMonitoringServiceStub {
  public:
   ~ServiceMonitoringServiceMetadata() override = default;
   explicit ServiceMonitoringServiceMetadata(
-      std::shared_ptr<ServiceMonitoringServiceStub> child);
+      std::shared_ptr<ServiceMonitoringServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::v3::Service> CreateService(
       grpc::ClientContext& context,
@@ -90,6 +92,7 @@ class ServiceMonitoringServiceMetadata : public ServiceMonitoringServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ServiceMonitoringServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/monitoring/v3/internal/uptime_check_metadata_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/uptime_check_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace monitoring_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 UptimeCheckServiceMetadata::UptimeCheckServiceMetadata(
-    std::shared_ptr<UptimeCheckServiceStub> child)
+    std::shared_ptr<UptimeCheckServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -90,6 +92,9 @@ void UptimeCheckServiceMetadata::SetMetadata(
 
 void UptimeCheckServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/monitoring/v3/internal/uptime_check_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/uptime_check_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class UptimeCheckServiceMetadata : public UptimeCheckServiceStub {
  public:
   ~UptimeCheckServiceMetadata() override = default;
   explicit UptimeCheckServiceMetadata(
-      std::shared_ptr<UptimeCheckServiceStub> child);
+      std::shared_ptr<UptimeCheckServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::monitoring::v3::ListUptimeCheckConfigsResponse>
   ListUptimeCheckConfigs(
@@ -72,6 +74,7 @@ class UptimeCheckServiceMetadata : public UptimeCheckServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<UptimeCheckServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/networkconnectivity/v1/internal/hub_metadata_decorator.cc
+++ b/google/cloud/networkconnectivity/v1/internal/hub_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace networkconnectivity_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-HubServiceMetadata::HubServiceMetadata(std::shared_ptr<HubServiceStub> child)
+HubServiceMetadata::HubServiceMetadata(
+    std::shared_ptr<HubServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -144,6 +147,9 @@ void HubServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void HubServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/networkconnectivity/v1/internal/hub_metadata_decorator.h
+++ b/google/cloud/networkconnectivity/v1/internal/hub_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class HubServiceMetadata : public HubServiceStub {
  public:
   ~HubServiceMetadata() override = default;
-  explicit HubServiceMetadata(std::shared_ptr<HubServiceStub> child);
+  explicit HubServiceMetadata(
+      std::shared_ptr<HubServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::networkconnectivity::v1::ListHubsResponse> ListHubs(
       grpc::ClientContext& context,
@@ -107,6 +110,7 @@ class HubServiceMetadata : public HubServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<HubServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/networkmanagement/v1/internal/reachability_metadata_decorator.cc
+++ b/google/cloud/networkmanagement/v1/internal/reachability_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace networkmanagement_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ReachabilityServiceMetadata::ReachabilityServiceMetadata(
-    std::shared_ptr<ReachabilityServiceStub> child)
+    std::shared_ptr<ReachabilityServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -117,6 +119,9 @@ void ReachabilityServiceMetadata::SetMetadata(
 
 void ReachabilityServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/networkmanagement/v1/internal/reachability_metadata_decorator.h
+++ b/google/cloud/networkmanagement/v1/internal/reachability_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ReachabilityServiceMetadata : public ReachabilityServiceStub {
  public:
   ~ReachabilityServiceMetadata() override = default;
   explicit ReachabilityServiceMetadata(
-      std::shared_ptr<ReachabilityServiceStub> child);
+      std::shared_ptr<ReachabilityServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::networkmanagement::v1::ListConnectivityTestsResponse>
   ListConnectivityTests(
@@ -88,6 +90,7 @@ class ReachabilityServiceMetadata : public ReachabilityServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ReachabilityServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/notebooks/v1/internal/managed_notebook_metadata_decorator.cc
+++ b/google/cloud/notebooks/v1/internal/managed_notebook_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace notebooks_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ManagedNotebookServiceMetadata::ManagedNotebookServiceMetadata(
-    std::shared_ptr<ManagedNotebookServiceStub> child)
+    std::shared_ptr<ManagedNotebookServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -174,6 +176,9 @@ void ManagedNotebookServiceMetadata::SetMetadata(
 
 void ManagedNotebookServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/notebooks/v1/internal/managed_notebook_metadata_decorator.h
+++ b/google/cloud/notebooks/v1/internal/managed_notebook_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class ManagedNotebookServiceMetadata : public ManagedNotebookServiceStub {
  public:
   ~ManagedNotebookServiceMetadata() override = default;
   explicit ManagedNotebookServiceMetadata(
-      std::shared_ptr<ManagedNotebookServiceStub> child);
+      std::shared_ptr<ManagedNotebookServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::notebooks::v1::ListRuntimesResponse> ListRuntimes(
       grpc::ClientContext& context,
@@ -126,6 +128,7 @@ class ManagedNotebookServiceMetadata : public ManagedNotebookServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ManagedNotebookServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/notebooks/v1/internal/notebook_metadata_decorator.cc
+++ b/google/cloud/notebooks/v1/internal/notebook_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace notebooks_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 NotebookServiceMetadata::NotebookServiceMetadata(
-    std::shared_ptr<NotebookServiceStub> child)
+    std::shared_ptr<NotebookServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -360,6 +362,9 @@ void NotebookServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void NotebookServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/notebooks/v1/internal/notebook_metadata_decorator.h
+++ b/google/cloud/notebooks/v1/internal/notebook_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class NotebookServiceMetadata : public NotebookServiceStub {
  public:
   ~NotebookServiceMetadata() override = default;
-  explicit NotebookServiceMetadata(std::shared_ptr<NotebookServiceStub> child);
+  explicit NotebookServiceMetadata(
+      std::shared_ptr<NotebookServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::notebooks::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,
@@ -246,6 +249,7 @@ class NotebookServiceMetadata : public NotebookServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<NotebookServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/optimization/v1/internal/fleet_routing_metadata_decorator.cc
+++ b/google/cloud/optimization/v1/internal/fleet_routing_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace optimization_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 FleetRoutingMetadata::FleetRoutingMetadata(
-    std::shared_ptr<FleetRoutingStub> child)
+    std::shared_ptr<FleetRoutingStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -76,6 +78,9 @@ void FleetRoutingMetadata::SetMetadata(grpc::ClientContext& context,
 
 void FleetRoutingMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/optimization/v1/internal/fleet_routing_metadata_decorator.h
+++ b/google/cloud/optimization/v1/internal/fleet_routing_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FleetRoutingMetadata : public FleetRoutingStub {
  public:
   ~FleetRoutingMetadata() override = default;
-  explicit FleetRoutingMetadata(std::shared_ptr<FleetRoutingStub> child);
+  explicit FleetRoutingMetadata(
+      std::shared_ptr<FleetRoutingStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::optimization::v1::OptimizeToursResponse>
   OptimizeTours(grpc::ClientContext& context,
@@ -62,6 +65,7 @@ class FleetRoutingMetadata : public FleetRoutingStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<FleetRoutingStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/orgpolicy/v2/internal/org_policy_metadata_decorator.cc
+++ b/google/cloud/orgpolicy/v2/internal/org_policy_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace orgpolicy_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-OrgPolicyMetadata::OrgPolicyMetadata(std::shared_ptr<OrgPolicyStub> child)
+OrgPolicyMetadata::OrgPolicyMetadata(
+    std::shared_ptr<OrgPolicyStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -93,6 +96,9 @@ void OrgPolicyMetadata::SetMetadata(grpc::ClientContext& context,
 
 void OrgPolicyMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/orgpolicy/v2/internal/org_policy_metadata_decorator.h
+++ b/google/cloud/orgpolicy/v2/internal/org_policy_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OrgPolicyMetadata : public OrgPolicyStub {
  public:
   ~OrgPolicyMetadata() override = default;
-  explicit OrgPolicyMetadata(std::shared_ptr<OrgPolicyStub> child);
+  explicit OrgPolicyMetadata(
+      std::shared_ptr<OrgPolicyStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::orgpolicy::v2::ListConstraintsResponse>
   ListConstraints(grpc::ClientContext& context,
@@ -73,6 +76,7 @@ class OrgPolicyMetadata : public OrgPolicyStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<OrgPolicyStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_metadata_decorator.cc
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace osconfig_agentendpoint_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AgentEndpointServiceMetadata::AgentEndpointServiceMetadata(
-    std::shared_ptr<AgentEndpointServiceStub> child)
+    std::shared_ptr<AgentEndpointServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -98,6 +100,9 @@ void AgentEndpointServiceMetadata::SetMetadata(
 
 void AgentEndpointServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_metadata_decorator.h
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class AgentEndpointServiceMetadata : public AgentEndpointServiceStub {
  public:
   ~AgentEndpointServiceMetadata() override = default;
   explicit AgentEndpointServiceMetadata(
-      std::shared_ptr<AgentEndpointServiceStub> child);
+      std::shared_ptr<AgentEndpointServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::cloud::osconfig::agentendpoint::v1::
@@ -79,6 +81,7 @@ class AgentEndpointServiceMetadata : public AgentEndpointServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AgentEndpointServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/osconfig/v1/internal/os_config_metadata_decorator.cc
+++ b/google/cloud/osconfig/v1/internal/os_config_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace osconfig_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 OsConfigServiceMetadata::OsConfigServiceMetadata(
-    std::shared_ptr<OsConfigServiceStub> child)
+    std::shared_ptr<OsConfigServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -139,6 +141,9 @@ void OsConfigServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void OsConfigServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/osconfig/v1/internal/os_config_metadata_decorator.h
+++ b/google/cloud/osconfig/v1/internal/os_config_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OsConfigServiceMetadata : public OsConfigServiceStub {
  public:
   ~OsConfigServiceMetadata() override = default;
-  explicit OsConfigServiceMetadata(std::shared_ptr<OsConfigServiceStub> child);
+  explicit OsConfigServiceMetadata(
+      std::shared_ptr<OsConfigServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::osconfig::v1::PatchJob> ExecutePatchJob(
       grpc::ClientContext& context,
@@ -101,6 +104,7 @@ class OsConfigServiceMetadata : public OsConfigServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<OsConfigServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/oslogin/v1/internal/os_login_metadata_decorator.cc
+++ b/google/cloud/oslogin/v1/internal/os_login_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace oslogin_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 OsLoginServiceMetadata::OsLoginServiceMetadata(
-    std::shared_ptr<OsLoginServiceStub> child)
+    std::shared_ptr<OsLoginServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -96,6 +98,9 @@ void OsLoginServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void OsLoginServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/oslogin/v1/internal/os_login_metadata_decorator.h
+++ b/google/cloud/oslogin/v1/internal/os_login_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OsLoginServiceMetadata : public OsLoginServiceStub {
  public:
   ~OsLoginServiceMetadata() override = default;
-  explicit OsLoginServiceMetadata(std::shared_ptr<OsLoginServiceStub> child);
+  explicit OsLoginServiceMetadata(
+      std::shared_ptr<OsLoginServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::oslogin::common::SshPublicKey> CreateSshPublicKey(
       grpc::ClientContext& context,
@@ -76,6 +79,7 @@ class OsLoginServiceMetadata : public OsLoginServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<OsLoginServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/policytroubleshooter/v1/internal/iam_checker_metadata_decorator.cc
+++ b/google/cloud/policytroubleshooter/v1/internal/iam_checker_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace policytroubleshooter_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IamCheckerMetadata::IamCheckerMetadata(std::shared_ptr<IamCheckerStub> child)
+IamCheckerMetadata::IamCheckerMetadata(
+    std::shared_ptr<IamCheckerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +53,9 @@ void IamCheckerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IamCheckerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/policytroubleshooter/v1/internal/iam_checker_metadata_decorator.h
+++ b/google/cloud/policytroubleshooter/v1/internal/iam_checker_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IamCheckerMetadata : public IamCheckerStub {
  public:
   ~IamCheckerMetadata() override = default;
-  explicit IamCheckerMetadata(std::shared_ptr<IamCheckerStub> child);
+  explicit IamCheckerMetadata(
+      std::shared_ptr<IamCheckerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<
       google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyResponse>
@@ -47,6 +50,7 @@ class IamCheckerMetadata : public IamCheckerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<IamCheckerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/privateca/v1/internal/certificate_authority_metadata_decorator.cc
+++ b/google/cloud/privateca/v1/internal/certificate_authority_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace privateca_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CertificateAuthorityServiceMetadata::CertificateAuthorityServiceMetadata(
-    std::shared_ptr<CertificateAuthorityServiceStub> child)
+    std::shared_ptr<CertificateAuthorityServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -351,6 +353,9 @@ void CertificateAuthorityServiceMetadata::SetMetadata(
 void CertificateAuthorityServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/privateca/v1/internal/certificate_authority_metadata_decorator.h
+++ b/google/cloud/privateca/v1/internal/certificate_authority_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -35,7 +36,8 @@ class CertificateAuthorityServiceMetadata
  public:
   ~CertificateAuthorityServiceMetadata() override = default;
   explicit CertificateAuthorityServiceMetadata(
-      std::shared_ptr<CertificateAuthorityServiceStub> child);
+      std::shared_ptr<CertificateAuthorityServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::security::privateca::v1::Certificate>
   CreateCertificate(
@@ -239,6 +241,7 @@ class CertificateAuthorityServiceMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CertificateAuthorityServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/profiler/v2/internal/profiler_metadata_decorator.cc
+++ b/google/cloud/profiler/v2/internal/profiler_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace profiler_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ProfilerServiceMetadata::ProfilerServiceMetadata(
-    std::shared_ptr<ProfilerServiceStub> child)
+    std::shared_ptr<ProfilerServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -67,6 +69,9 @@ void ProfilerServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ProfilerServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/profiler/v2/internal/profiler_metadata_decorator.h
+++ b/google/cloud/profiler/v2/internal/profiler_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProfilerServiceMetadata : public ProfilerServiceStub {
  public:
   ~ProfilerServiceMetadata() override = default;
-  explicit ProfilerServiceMetadata(std::shared_ptr<ProfilerServiceStub> child);
+  explicit ProfilerServiceMetadata(
+      std::shared_ptr<ProfilerServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::devtools::cloudprofiler::v2::Profile> CreateProfile(
       grpc::ClientContext& context,
@@ -55,6 +58,7 @@ class ProfilerServiceMetadata : public ProfilerServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ProfilerServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsub/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-PublisherMetadata::PublisherMetadata(std::shared_ptr<PublisherStub> child)
+PublisherMetadata::PublisherMetadata(
+    std::shared_ptr<PublisherStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -115,6 +118,9 @@ void PublisherMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PublisherMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsub/internal/publisher_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PublisherMetadata : public PublisherStub {
  public:
   ~PublisherMetadata() override = default;
-  explicit PublisherMetadata(std::shared_ptr<PublisherStub> child);
+  explicit PublisherMetadata(
+      std::shared_ptr<PublisherStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::pubsub::v1::Topic> CreateTopic(
       grpc::ClientContext& context,
@@ -83,6 +86,7 @@ class PublisherMetadata : public PublisherStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PublisherStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsub/internal/schema_metadata_decorator.cc
+++ b/google/cloud/pubsub/internal/schema_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SchemaServiceMetadata::SchemaServiceMetadata(
-    std::shared_ptr<SchemaServiceStub> child)
+    std::shared_ptr<SchemaServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -117,6 +119,9 @@ void SchemaServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SchemaServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsub/internal/schema_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/schema_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SchemaServiceMetadata : public SchemaServiceStub {
  public:
   ~SchemaServiceMetadata() override = default;
-  explicit SchemaServiceMetadata(std::shared_ptr<SchemaServiceStub> child);
+  explicit SchemaServiceMetadata(
+      std::shared_ptr<SchemaServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::pubsub::v1::Schema> CreateSchema(
       grpc::ClientContext& context,
@@ -80,6 +83,7 @@ class SchemaServiceMetadata : public SchemaServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SchemaServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsub/internal/subscriber_metadata_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-SubscriberMetadata::SubscriberMetadata(std::shared_ptr<SubscriberStub> child)
+SubscriberMetadata::SubscriberMetadata(
+    std::shared_ptr<SubscriberStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -162,6 +165,9 @@ void SubscriberMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SubscriberMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SubscriberMetadata : public SubscriberStub {
  public:
   ~SubscriberMetadata() override = default;
-  explicit SubscriberMetadata(std::shared_ptr<SubscriberStub> child);
+  explicit SubscriberMetadata(
+      std::shared_ptr<SubscriberStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
       grpc::ClientContext& context,
@@ -108,6 +111,7 @@ class SubscriberMetadata : public SubscriberStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SubscriberStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace pubsublite_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AdminServiceMetadata::AdminServiceMetadata(
-    std::shared_ptr<AdminServiceStub> child)
+    std::shared_ptr<AdminServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -219,6 +221,9 @@ void AdminServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AdminServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsublite/internal/admin_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/admin_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AdminServiceMetadata : public AdminServiceStub {
  public:
   ~AdminServiceMetadata() override = default;
-  explicit AdminServiceMetadata(std::shared_ptr<AdminServiceStub> child);
+  explicit AdminServiceMetadata(
+      std::shared_ptr<AdminServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       grpc::ClientContext& context,
@@ -154,6 +157,7 @@ class AdminServiceMetadata : public AdminServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<AdminServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsublite/internal/cursor_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/cursor_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace pubsublite_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CursorServiceMetadata::CursorServiceMetadata(
-    std::shared_ptr<CursorServiceStub> child)
+    std::shared_ptr<CursorServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -68,6 +70,9 @@ void CursorServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CursorServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsublite/internal/cursor_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/cursor_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CursorServiceMetadata : public CursorServiceStub {
  public:
   ~CursorServiceMetadata() override = default;
-  explicit CursorServiceMetadata(std::shared_ptr<CursorServiceStub> child);
+  explicit CursorServiceMetadata(
+      std::shared_ptr<CursorServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::pubsublite::v1::StreamingCommitCursorRequest,
@@ -58,6 +61,7 @@ class CursorServiceMetadata : public CursorServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CursorServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace pubsublite_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PartitionAssignmentServiceMetadata::PartitionAssignmentServiceMetadata(
-    std::shared_ptr<PartitionAssignmentServiceStub> child)
+    std::shared_ptr<PartitionAssignmentServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -53,6 +55,9 @@ void PartitionAssignmentServiceMetadata::SetMetadata(
 void PartitionAssignmentServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class PartitionAssignmentServiceMetadata
  public:
   ~PartitionAssignmentServiceMetadata() override = default;
   explicit PartitionAssignmentServiceMetadata(
-      std::shared_ptr<PartitionAssignmentServiceStub> child);
+      std::shared_ptr<PartitionAssignmentServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::pubsublite::v1::PartitionAssignmentRequest,
@@ -48,6 +50,7 @@ class PartitionAssignmentServiceMetadata
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PartitionAssignmentServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsublite/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/publisher_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace pubsublite_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PublisherServiceMetadata::PublisherServiceMetadata(
-    std::shared_ptr<PublisherServiceStub> child)
+    std::shared_ptr<PublisherServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -52,6 +54,9 @@ void PublisherServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PublisherServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsublite/internal/publisher_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/publisher_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class PublisherServiceMetadata : public PublisherServiceStub {
  public:
   ~PublisherServiceMetadata() override = default;
   explicit PublisherServiceMetadata(
-      std::shared_ptr<PublisherServiceStub> child);
+      std::shared_ptr<PublisherServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::pubsublite::v1::PublishRequest,
@@ -47,6 +49,7 @@ class PublisherServiceMetadata : public PublisherServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PublisherServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsublite/internal/subscriber_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/subscriber_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace pubsublite_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SubscriberServiceMetadata::SubscriberServiceMetadata(
-    std::shared_ptr<SubscriberServiceStub> child)
+    std::shared_ptr<SubscriberServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -52,6 +54,9 @@ void SubscriberServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SubscriberServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsublite/internal/subscriber_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/subscriber_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class SubscriberServiceMetadata : public SubscriberServiceStub {
  public:
   ~SubscriberServiceMetadata() override = default;
   explicit SubscriberServiceMetadata(
-      std::shared_ptr<SubscriberServiceStub> child);
+      std::shared_ptr<SubscriberServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::pubsublite::v1::SubscribeRequest,
@@ -47,6 +49,7 @@ class SubscriberServiceMetadata : public SubscriberServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SubscriberServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace pubsublite_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TopicStatsServiceMetadata::TopicStatsServiceMetadata(
-    std::shared_ptr<TopicStatsServiceStub> child)
+    std::shared_ptr<TopicStatsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -66,6 +68,9 @@ void TopicStatsServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TopicStatsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class TopicStatsServiceMetadata : public TopicStatsServiceStub {
  public:
   ~TopicStatsServiceMetadata() override = default;
   explicit TopicStatsServiceMetadata(
-      std::shared_ptr<TopicStatsServiceStub> child);
+      std::shared_ptr<TopicStatsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>
   ComputeMessageStats(
@@ -59,6 +61,7 @@ class TopicStatsServiceMetadata : public TopicStatsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TopicStatsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/recommender/v1/internal/recommender_metadata_decorator.cc
+++ b/google/cloud/recommender/v1/internal/recommender_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace recommender_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-RecommenderMetadata::RecommenderMetadata(std::shared_ptr<RecommenderStub> child)
+RecommenderMetadata::RecommenderMetadata(
+    std::shared_ptr<RecommenderStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -146,6 +149,9 @@ void RecommenderMetadata::SetMetadata(grpc::ClientContext& context,
 
 void RecommenderMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/recommender/v1/internal/recommender_metadata_decorator.h
+++ b/google/cloud/recommender/v1/internal/recommender_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RecommenderMetadata : public RecommenderStub {
  public:
   ~RecommenderMetadata() override = default;
-  explicit RecommenderMetadata(std::shared_ptr<RecommenderStub> child);
+  explicit RecommenderMetadata(
+      std::shared_ptr<RecommenderStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::recommender::v1::ListInsightsResponse> ListInsights(
       grpc::ClientContext& context,
@@ -108,6 +111,7 @@ class RecommenderMetadata : public RecommenderStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<RecommenderStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/redis/v1/internal/cloud_redis_metadata_decorator.cc
+++ b/google/cloud/redis/v1/internal/cloud_redis_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace redis_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-CloudRedisMetadata::CloudRedisMetadata(std::shared_ptr<CloudRedisStub> child)
+CloudRedisMetadata::CloudRedisMetadata(
+    std::shared_ptr<CloudRedisStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -153,6 +156,9 @@ void CloudRedisMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudRedisMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/redis/v1/internal/cloud_redis_metadata_decorator.h
+++ b/google/cloud/redis/v1/internal/cloud_redis_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudRedisMetadata : public CloudRedisStub {
  public:
   ~CloudRedisMetadata() override = default;
-  explicit CloudRedisMetadata(std::shared_ptr<CloudRedisStub> child);
+  explicit CloudRedisMetadata(
+      std::shared_ptr<CloudRedisStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::redis::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,
@@ -106,6 +109,7 @@ class CloudRedisMetadata : public CloudRedisStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudRedisStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/resourcemanager/v3/internal/folders_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/v3/internal/folders_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-FoldersMetadata::FoldersMetadata(std::shared_ptr<FoldersStub> child)
+FoldersMetadata::FoldersMetadata(
+    std::shared_ptr<FoldersStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -148,6 +151,9 @@ void FoldersMetadata::SetMetadata(grpc::ClientContext& context,
 
 void FoldersMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/resourcemanager/v3/internal/folders_metadata_decorator.h
+++ b/google/cloud/resourcemanager/v3/internal/folders_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FoldersMetadata : public FoldersStub {
  public:
   ~FoldersMetadata() override = default;
-  explicit FoldersMetadata(std::shared_ptr<FoldersStub> child);
+  explicit FoldersMetadata(
+      std::shared_ptr<FoldersStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::resourcemanager::v3::Folder> GetFolder(
       grpc::ClientContext& context,
@@ -108,6 +111,7 @@ class FoldersMetadata : public FoldersStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<FoldersStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/resourcemanager/v3/internal/organizations_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/v3/internal/organizations_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 OrganizationsMetadata::OrganizationsMetadata(
-    std::shared_ptr<OrganizationsStub> child)
+    std::shared_ptr<OrganizationsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -81,6 +83,9 @@ void OrganizationsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void OrganizationsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/resourcemanager/v3/internal/organizations_metadata_decorator.h
+++ b/google/cloud/resourcemanager/v3/internal/organizations_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OrganizationsMetadata : public OrganizationsStub {
  public:
   ~OrganizationsMetadata() override = default;
-  explicit OrganizationsMetadata(std::shared_ptr<OrganizationsStub> child);
+  explicit OrganizationsMetadata(
+      std::shared_ptr<OrganizationsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::resourcemanager::v3::Organization> GetOrganization(
       grpc::ClientContext& context,
@@ -63,6 +66,7 @@ class OrganizationsMetadata : public OrganizationsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<OrganizationsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/resourcemanager/v3/internal/projects_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/v3/internal/projects_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ProjectsMetadata::ProjectsMetadata(std::shared_ptr<ProjectsStub> child)
+ProjectsMetadata::ProjectsMetadata(
+    std::shared_ptr<ProjectsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -149,6 +152,9 @@ void ProjectsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ProjectsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/resourcemanager/v3/internal/projects_metadata_decorator.h
+++ b/google/cloud/resourcemanager/v3/internal/projects_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProjectsMetadata : public ProjectsStub {
  public:
   ~ProjectsMetadata() override = default;
-  explicit ProjectsMetadata(std::shared_ptr<ProjectsStub> child);
+  explicit ProjectsMetadata(
+      std::shared_ptr<ProjectsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::resourcemanager::v3::Project> GetProject(
       grpc::ClientContext& context,
@@ -109,6 +112,7 @@ class ProjectsMetadata : public ProjectsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ProjectsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace resourcesettings_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ResourceSettingsServiceMetadata::ResourceSettingsServiceMetadata(
-    std::shared_ptr<ResourceSettingsServiceStub> child)
+    std::shared_ptr<ResourceSettingsServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -67,6 +69,9 @@ void ResourceSettingsServiceMetadata::SetMetadata(
 void ResourceSettingsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ResourceSettingsServiceMetadata : public ResourceSettingsServiceStub {
  public:
   ~ResourceSettingsServiceMetadata() override = default;
   explicit ResourceSettingsServiceMetadata(
-      std::shared_ptr<ResourceSettingsServiceStub> child);
+      std::shared_ptr<ResourceSettingsServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::resourcesettings::v1::ListSettingsResponse>
   ListSettings(grpc::ClientContext& context,
@@ -56,6 +58,7 @@ class ResourceSettingsServiceMetadata : public ResourceSettingsServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ResourceSettingsServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/retail/v2/internal/catalog_metadata_decorator.cc
+++ b/google/cloud/retail/v2/internal/catalog_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace retail_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CatalogServiceMetadata::CatalogServiceMetadata(
-    std::shared_ptr<CatalogServiceStub> child)
+    std::shared_ptr<CatalogServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -131,6 +133,9 @@ void CatalogServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CatalogServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/retail/v2/internal/catalog_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/catalog_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CatalogServiceMetadata : public CatalogServiceStub {
  public:
   ~CatalogServiceMetadata() override = default;
-  explicit CatalogServiceMetadata(std::shared_ptr<CatalogServiceStub> child);
+  explicit CatalogServiceMetadata(
+      std::shared_ptr<CatalogServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::retail::v2::ListCatalogsResponse> ListCatalogs(
       grpc::ClientContext& context,
@@ -93,6 +96,7 @@ class CatalogServiceMetadata : public CatalogServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CatalogServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/retail/v2/internal/completion_metadata_decorator.cc
+++ b/google/cloud/retail/v2/internal/completion_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace retail_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CompletionServiceMetadata::CompletionServiceMetadata(
-    std::shared_ptr<CompletionServiceStub> child)
+    std::shared_ptr<CompletionServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -76,6 +78,9 @@ void CompletionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CompletionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/retail/v2/internal/completion_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/completion_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class CompletionServiceMetadata : public CompletionServiceStub {
  public:
   ~CompletionServiceMetadata() override = default;
   explicit CompletionServiceMetadata(
-      std::shared_ptr<CompletionServiceStub> child);
+      std::shared_ptr<CompletionServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::retail::v2::CompleteQueryResponse> CompleteQuery(
       grpc::ClientContext& context,
@@ -62,6 +64,7 @@ class CompletionServiceMetadata : public CompletionServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CompletionServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/retail/v2/internal/prediction_metadata_decorator.cc
+++ b/google/cloud/retail/v2/internal/prediction_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace retail_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PredictionServiceMetadata::PredictionServiceMetadata(
-    std::shared_ptr<PredictionServiceStub> child)
+    std::shared_ptr<PredictionServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/retail/v2/internal/prediction_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/prediction_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class PredictionServiceMetadata : public PredictionServiceStub {
  public:
   ~PredictionServiceMetadata() override = default;
   explicit PredictionServiceMetadata(
-      std::shared_ptr<PredictionServiceStub> child);
+      std::shared_ptr<PredictionServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::retail::v2::PredictResponse> Predict(
       grpc::ClientContext& context,
@@ -45,6 +47,7 @@ class PredictionServiceMetadata : public PredictionServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<PredictionServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/retail/v2/internal/product_metadata_decorator.cc
+++ b/google/cloud/retail/v2/internal/product_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace retail_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ProductServiceMetadata::ProductServiceMetadata(
-    std::shared_ptr<ProductServiceStub> child)
+    std::shared_ptr<ProductServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -151,6 +153,9 @@ void ProductServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ProductServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/retail/v2/internal/product_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/product_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProductServiceMetadata : public ProductServiceStub {
  public:
   ~ProductServiceMetadata() override = default;
-  explicit ProductServiceMetadata(std::shared_ptr<ProductServiceStub> child);
+  explicit ProductServiceMetadata(
+      std::shared_ptr<ProductServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::retail::v2::Product> CreateProduct(
       grpc::ClientContext& context,
@@ -105,6 +108,7 @@ class ProductServiceMetadata : public ProductServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ProductServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/retail/v2/internal/search_metadata_decorator.cc
+++ b/google/cloud/retail/v2/internal/search_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace retail_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SearchServiceMetadata::SearchServiceMetadata(
-    std::shared_ptr<SearchServiceStub> child)
+    std::shared_ptr<SearchServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void SearchServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SearchServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/retail/v2/internal/search_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/search_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SearchServiceMetadata : public SearchServiceStub {
  public:
   ~SearchServiceMetadata() override = default;
-  explicit SearchServiceMetadata(std::shared_ptr<SearchServiceStub> child);
+  explicit SearchServiceMetadata(
+      std::shared_ptr<SearchServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::retail::v2::SearchResponse> Search(
       grpc::ClientContext& context,
@@ -44,6 +47,7 @@ class SearchServiceMetadata : public SearchServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SearchServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/retail/v2/internal/user_event_metadata_decorator.cc
+++ b/google/cloud/retail/v2/internal/user_event_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace retail_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 UserEventServiceMetadata::UserEventServiceMetadata(
-    std::shared_ptr<UserEventServiceStub> child)
+    std::shared_ptr<UserEventServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -101,6 +103,9 @@ void UserEventServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void UserEventServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/retail/v2/internal/user_event_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/user_event_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class UserEventServiceMetadata : public UserEventServiceStub {
  public:
   ~UserEventServiceMetadata() override = default;
   explicit UserEventServiceMetadata(
-      std::shared_ptr<UserEventServiceStub> child);
+      std::shared_ptr<UserEventServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::retail::v2::UserEvent> WriteUserEvent(
       grpc::ClientContext& context,
@@ -79,6 +81,7 @@ class UserEventServiceMetadata : public UserEventServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<UserEventServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/run/v2/internal/revisions_metadata_decorator.cc
+++ b/google/cloud/run/v2/internal/revisions_metadata_decorator.cc
@@ -30,8 +30,11 @@ namespace cloud {
 namespace run_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-RevisionsMetadata::RevisionsMetadata(std::shared_ptr<RevisionsStub> child)
+RevisionsMetadata::RevisionsMetadata(
+    std::shared_ptr<RevisionsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -144,6 +147,9 @@ void RevisionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void RevisionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/run/v2/internal/revisions_metadata_decorator.h
+++ b/google/cloud/run/v2/internal/revisions_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RevisionsMetadata : public RevisionsStub {
  public:
   ~RevisionsMetadata() override = default;
-  explicit RevisionsMetadata(std::shared_ptr<RevisionsStub> child);
+  explicit RevisionsMetadata(
+      std::shared_ptr<RevisionsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::run::v2::Revision> GetRevision(
       grpc::ClientContext& context,
@@ -64,6 +67,7 @@ class RevisionsMetadata : public RevisionsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<RevisionsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/run/v2/internal/services_metadata_decorator.cc
+++ b/google/cloud/run/v2/internal/services_metadata_decorator.cc
@@ -30,8 +30,11 @@ namespace cloud {
 namespace run_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ServicesMetadata::ServicesMetadata(std::shared_ptr<ServicesStub> child)
+ServicesMetadata::ServicesMetadata(
+    std::shared_ptr<ServicesStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -224,6 +227,9 @@ void ServicesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServicesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/run/v2/internal/services_metadata_decorator.h
+++ b/google/cloud/run/v2/internal/services_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServicesMetadata : public ServicesStub {
  public:
   ~ServicesMetadata() override = default;
-  explicit ServicesMetadata(std::shared_ptr<ServicesStub> child);
+  explicit ServicesMetadata(
+      std::shared_ptr<ServicesStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateService(
       google::cloud::CompletionQueue& cq,
@@ -86,6 +89,7 @@ class ServicesMetadata : public ServicesStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ServicesStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/scheduler/v1/internal/cloud_scheduler_metadata_decorator.cc
+++ b/google/cloud/scheduler/v1/internal/cloud_scheduler_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace scheduler_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudSchedulerMetadata::CloudSchedulerMetadata(
-    std::shared_ptr<CloudSchedulerStub> child)
+    std::shared_ptr<CloudSchedulerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -99,6 +101,9 @@ void CloudSchedulerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudSchedulerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/scheduler/v1/internal/cloud_scheduler_metadata_decorator.h
+++ b/google/cloud/scheduler/v1/internal/cloud_scheduler_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudSchedulerMetadata : public CloudSchedulerStub {
  public:
   ~CloudSchedulerMetadata() override = default;
-  explicit CloudSchedulerMetadata(std::shared_ptr<CloudSchedulerStub> child);
+  explicit CloudSchedulerMetadata(
+      std::shared_ptr<CloudSchedulerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::scheduler::v1::ListJobsResponse> ListJobs(
       grpc::ClientContext& context,
@@ -72,6 +75,7 @@ class CloudSchedulerMetadata : public CloudSchedulerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudSchedulerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/secretmanager/v1/internal/secret_manager_metadata_decorator.cc
+++ b/google/cloud/secretmanager/v1/internal/secret_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace secretmanager_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SecretManagerServiceMetadata::SecretManagerServiceMetadata(
-    std::shared_ptr<SecretManagerServiceStub> child)
+    std::shared_ptr<SecretManagerServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -164,6 +166,9 @@ void SecretManagerServiceMetadata::SetMetadata(
 
 void SecretManagerServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/secretmanager/v1/internal/secret_manager_metadata_decorator.h
+++ b/google/cloud/secretmanager/v1/internal/secret_manager_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class SecretManagerServiceMetadata : public SecretManagerServiceStub {
  public:
   ~SecretManagerServiceMetadata() override = default;
   explicit SecretManagerServiceMetadata(
-      std::shared_ptr<SecretManagerServiceStub> child);
+      std::shared_ptr<SecretManagerServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::secretmanager::v1::ListSecretsResponse> ListSecrets(
       grpc::ClientContext& context,
@@ -117,6 +119,7 @@ class SecretManagerServiceMetadata : public SecretManagerServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SecretManagerServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace securitycenter_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SecurityCenterMetadata::SecurityCenterMetadata(
-    std::shared_ptr<SecurityCenterStub> child)
+    std::shared_ptr<SecurityCenterStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -446,6 +448,9 @@ void SecurityCenterMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SecurityCenterMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SecurityCenterMetadata : public SecurityCenterStub {
  public:
   ~SecurityCenterMetadata() override = default;
-  explicit SecurityCenterMetadata(std::shared_ptr<SecurityCenterStub> child);
+  explicit SecurityCenterMetadata(
+      std::shared_ptr<SecurityCenterStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncBulkMuteFindings(
       google::cloud::CompletionQueue& cq,
@@ -304,6 +307,7 @@ class SecurityCenterMetadata : public SecurityCenterStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SecurityCenterStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/servicecontrol/v1/internal/quota_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/v1/internal/quota_controller_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace servicecontrol_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 QuotaControllerMetadata::QuotaControllerMetadata(
-    std::shared_ptr<QuotaControllerStub> child)
+    std::shared_ptr<QuotaControllerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void QuotaControllerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void QuotaControllerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/servicecontrol/v1/internal/quota_controller_metadata_decorator.h
+++ b/google/cloud/servicecontrol/v1/internal/quota_controller_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class QuotaControllerMetadata : public QuotaControllerStub {
  public:
   ~QuotaControllerMetadata() override = default;
-  explicit QuotaControllerMetadata(std::shared_ptr<QuotaControllerStub> child);
+  explicit QuotaControllerMetadata(
+      std::shared_ptr<QuotaControllerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>
   AllocateQuota(grpc::ClientContext& context,
@@ -45,6 +48,7 @@ class QuotaControllerMetadata : public QuotaControllerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<QuotaControllerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/servicecontrol/v1/internal/service_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/v1/internal/service_controller_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace servicecontrol_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceControllerMetadata::ServiceControllerMetadata(
-    std::shared_ptr<ServiceControllerStub> child)
+    std::shared_ptr<ServiceControllerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -58,6 +60,9 @@ void ServiceControllerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServiceControllerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/servicecontrol/v1/internal/service_controller_metadata_decorator.h
+++ b/google/cloud/servicecontrol/v1/internal/service_controller_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ServiceControllerMetadata : public ServiceControllerStub {
  public:
   ~ServiceControllerMetadata() override = default;
   explicit ServiceControllerMetadata(
-      std::shared_ptr<ServiceControllerStub> child);
+      std::shared_ptr<ServiceControllerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::api::servicecontrol::v1::CheckResponse> Check(
       grpc::ClientContext& context,
@@ -49,6 +51,7 @@ class ServiceControllerMetadata : public ServiceControllerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ServiceControllerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/servicecontrol/v2/internal/service_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/v2/internal/service_controller_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace servicecontrol_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceControllerMetadata::ServiceControllerMetadata(
-    std::shared_ptr<ServiceControllerStub> child)
+    std::shared_ptr<ServiceControllerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -58,6 +60,9 @@ void ServiceControllerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServiceControllerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/servicecontrol/v2/internal/service_controller_metadata_decorator.h
+++ b/google/cloud/servicecontrol/v2/internal/service_controller_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class ServiceControllerMetadata : public ServiceControllerStub {
  public:
   ~ServiceControllerMetadata() override = default;
   explicit ServiceControllerMetadata(
-      std::shared_ptr<ServiceControllerStub> child);
+      std::shared_ptr<ServiceControllerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::api::servicecontrol::v2::CheckResponse> Check(
       grpc::ClientContext& context,
@@ -49,6 +51,7 @@ class ServiceControllerMetadata : public ServiceControllerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ServiceControllerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/servicedirectory/v1/internal/lookup_metadata_decorator.cc
+++ b/google/cloud/servicedirectory/v1/internal/lookup_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace servicedirectory_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 LookupServiceMetadata::LookupServiceMetadata(
-    std::shared_ptr<LookupServiceStub> child)
+    std::shared_ptr<LookupServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void LookupServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void LookupServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/servicedirectory/v1/internal/lookup_metadata_decorator.h
+++ b/google/cloud/servicedirectory/v1/internal/lookup_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LookupServiceMetadata : public LookupServiceStub {
  public:
   ~LookupServiceMetadata() override = default;
-  explicit LookupServiceMetadata(std::shared_ptr<LookupServiceStub> child);
+  explicit LookupServiceMetadata(
+      std::shared_ptr<LookupServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>
   ResolveService(
@@ -46,6 +49,7 @@ class LookupServiceMetadata : public LookupServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<LookupServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/servicedirectory/v1/internal/registration_metadata_decorator.cc
+++ b/google/cloud/servicedirectory/v1/internal/registration_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace servicedirectory_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 RegistrationServiceMetadata::RegistrationServiceMetadata(
-    std::shared_ptr<RegistrationServiceStub> child)
+    std::shared_ptr<RegistrationServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -184,6 +186,9 @@ void RegistrationServiceMetadata::SetMetadata(
 
 void RegistrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/servicedirectory/v1/internal/registration_metadata_decorator.h
+++ b/google/cloud/servicedirectory/v1/internal/registration_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class RegistrationServiceMetadata : public RegistrationServiceStub {
  public:
   ~RegistrationServiceMetadata() override = default;
   explicit RegistrationServiceMetadata(
-      std::shared_ptr<RegistrationServiceStub> child);
+      std::shared_ptr<RegistrationServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::servicedirectory::v1::Namespace> CreateNamespace(
       grpc::ClientContext& context,
@@ -129,6 +131,7 @@ class RegistrationServiceMetadata : public RegistrationServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<RegistrationServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/servicemanagement/v1/internal/service_manager_metadata_decorator.cc
+++ b/google/cloud/servicemanagement/v1/internal/service_manager_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace servicemanagement_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceManagerMetadata::ServiceManagerMetadata(
-    std::shared_ptr<ServiceManagerStub> child)
+    std::shared_ptr<ServiceManagerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -174,6 +176,9 @@ void ServiceManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServiceManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/servicemanagement/v1/internal/service_manager_metadata_decorator.h
+++ b/google/cloud/servicemanagement/v1/internal/service_manager_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceManagerMetadata : public ServiceManagerStub {
  public:
   ~ServiceManagerMetadata() override = default;
-  explicit ServiceManagerMetadata(std::shared_ptr<ServiceManagerStub> child);
+  explicit ServiceManagerMetadata(
+      std::shared_ptr<ServiceManagerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::api::servicemanagement::v1::ListServicesResponse>
   ListServices(grpc::ClientContext& context,
@@ -124,6 +127,7 @@ class ServiceManagerMetadata : public ServiceManagerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ServiceManagerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/serviceusage/v1/internal/service_usage_metadata_decorator.cc
+++ b/google/cloud/serviceusage/v1/internal/service_usage_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace serviceusage_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceUsageMetadata::ServiceUsageMetadata(
-    std::shared_ptr<ServiceUsageStub> child)
+    std::shared_ptr<ServiceUsageStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -110,6 +112,9 @@ void ServiceUsageMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServiceUsageMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/serviceusage/v1/internal/service_usage_metadata_decorator.h
+++ b/google/cloud/serviceusage/v1/internal/service_usage_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceUsageMetadata : public ServiceUsageStub {
  public:
   ~ServiceUsageMetadata() override = default;
-  explicit ServiceUsageMetadata(std::shared_ptr<ServiceUsageStub> child);
+  explicit ServiceUsageMetadata(
+      std::shared_ptr<ServiceUsageStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncEnableService(
       google::cloud::CompletionQueue& cq,
@@ -83,6 +86,7 @@ class ServiceUsageMetadata : public ServiceUsageStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ServiceUsageStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/shell/v1/internal/cloud_shell_metadata_decorator.cc
+++ b/google/cloud/shell/v1/internal/cloud_shell_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace shell_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudShellServiceMetadata::CloudShellServiceMetadata(
-    std::shared_ptr<CloudShellServiceStub> child)
+    std::shared_ptr<CloudShellServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -103,6 +105,9 @@ void CloudShellServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudShellServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/shell/v1/internal/cloud_shell_metadata_decorator.h
+++ b/google/cloud/shell/v1/internal/cloud_shell_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class CloudShellServiceMetadata : public CloudShellServiceStub {
  public:
   ~CloudShellServiceMetadata() override = default;
   explicit CloudShellServiceMetadata(
-      std::shared_ptr<CloudShellServiceStub> child);
+      std::shared_ptr<CloudShellServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::shell::v1::Environment> GetEnvironment(
       grpc::ClientContext& context,
@@ -78,6 +80,7 @@ class CloudShellServiceMetadata : public CloudShellServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudShellServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace spanner_admin_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DatabaseAdminMetadata::DatabaseAdminMetadata(
-    std::shared_ptr<DatabaseAdminStub> child)
+    std::shared_ptr<DatabaseAdminStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -229,6 +231,9 @@ void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.h
+++ b/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DatabaseAdminMetadata : public DatabaseAdminStub {
  public:
   ~DatabaseAdminMetadata() override = default;
-  explicit DatabaseAdminMetadata(std::shared_ptr<DatabaseAdminStub> child);
+  explicit DatabaseAdminMetadata(
+      std::shared_ptr<DatabaseAdminStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::spanner::admin::database::v1::ListDatabasesResponse>
   ListDatabases(
@@ -159,6 +162,7 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<DatabaseAdminStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace spanner_admin_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 InstanceAdminMetadata::InstanceAdminMetadata(
-    std::shared_ptr<InstanceAdminStub> child)
+    std::shared_ptr<InstanceAdminStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -182,6 +184,9 @@ void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context,
 
 void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.h
+++ b/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class InstanceAdminMetadata : public InstanceAdminStub {
  public:
   ~InstanceAdminMetadata() override = default;
-  explicit InstanceAdminMetadata(std::shared_ptr<InstanceAdminStub> child);
+  explicit InstanceAdminMetadata(
+      std::shared_ptr<InstanceAdminStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::spanner::admin::instance::v1::ListInstanceConfigsResponse>
   ListInstanceConfigs(
@@ -127,6 +130,7 @@ class InstanceAdminMetadata : public InstanceAdminStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<InstanceAdminStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/speech/v1/internal/speech_metadata_decorator.cc
+++ b/google/cloud/speech/v1/internal/speech_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace speech_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-SpeechMetadata::SpeechMetadata(std::shared_ptr<SpeechStub> child)
+SpeechMetadata::SpeechMetadata(
+    std::shared_ptr<SpeechStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -85,6 +88,9 @@ void SpeechMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SpeechMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/speech/v1/internal/speech_metadata_decorator.h
+++ b/google/cloud/speech/v1/internal/speech_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SpeechMetadata : public SpeechStub {
  public:
   ~SpeechMetadata() override = default;
-  explicit SpeechMetadata(std::shared_ptr<SpeechStub> child);
+  explicit SpeechMetadata(
+      std::shared_ptr<SpeechStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::speech::v1::RecognizeResponse> Recognize(
       grpc::ClientContext& context,
@@ -68,6 +71,7 @@ class SpeechMetadata : public SpeechStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SpeechStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/speech/v2/internal/speech_metadata_decorator.cc
+++ b/google/cloud/speech/v2/internal/speech_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace speech_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-SpeechMetadata::SpeechMetadata(std::shared_ptr<SpeechStub> child)
+SpeechMetadata::SpeechMetadata(
+    std::shared_ptr<SpeechStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -252,6 +255,9 @@ void SpeechMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SpeechMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/speech/v2/internal/speech_metadata_decorator.h
+++ b/google/cloud/speech/v2/internal/speech_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SpeechMetadata : public SpeechStub {
  public:
   ~SpeechMetadata() override = default;
-  explicit SpeechMetadata(std::shared_ptr<SpeechStub> child);
+  explicit SpeechMetadata(
+      std::shared_ptr<SpeechStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateRecognizer(
       google::cloud::CompletionQueue& cq,
@@ -173,6 +176,7 @@ class SpeechMetadata : public SpeechStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<SpeechStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -30,8 +30,11 @@ namespace cloud {
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StorageMetadata::StorageMetadata(std::shared_ptr<StorageStub> child)
+StorageMetadata::StorageMetadata(
+    std::shared_ptr<StorageStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -785,6 +788,9 @@ void StorageMetadata::SetMetadata(grpc::ClientContext& context,
 
 void StorageMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class StorageMetadata : public StorageStub {
  public:
   ~StorageMetadata() override = default;
-  explicit StorageMetadata(std::shared_ptr<StorageStub> child);
+  explicit StorageMetadata(
+      std::shared_ptr<StorageStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   Status DeleteBucket(
       grpc::ClientContext& context,
@@ -205,6 +208,7 @@ class StorageMetadata : public StorageStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<StorageStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/storageinsights/v1/internal/storage_insights_metadata_decorator.cc
+++ b/google/cloud/storageinsights/v1/internal/storage_insights_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace storageinsights_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StorageInsightsMetadata::StorageInsightsMetadata(
-    std::shared_ptr<StorageInsightsStub> child)
+    std::shared_ptr<StorageInsightsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -102,6 +104,9 @@ void StorageInsightsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void StorageInsightsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/storageinsights/v1/internal/storage_insights_metadata_decorator.h
+++ b/google/cloud/storageinsights/v1/internal/storage_insights_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class StorageInsightsMetadata : public StorageInsightsStub {
  public:
   ~StorageInsightsMetadata() override = default;
-  explicit StorageInsightsMetadata(std::shared_ptr<StorageInsightsStub> child);
+  explicit StorageInsightsMetadata(
+      std::shared_ptr<StorageInsightsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::storageinsights::v1::ListReportConfigsResponse>
   ListReportConfigs(
@@ -77,6 +80,7 @@ class StorageInsightsMetadata : public StorageInsightsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<StorageInsightsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/storagetransfer/v1/internal/storage_transfer_metadata_decorator.cc
+++ b/google/cloud/storagetransfer/v1/internal/storage_transfer_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace storagetransfer_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StorageTransferServiceMetadata::StorageTransferServiceMetadata(
-    std::shared_ptr<StorageTransferServiceStub> child)
+    std::shared_ptr<StorageTransferServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -170,6 +172,9 @@ void StorageTransferServiceMetadata::SetMetadata(
 
 void StorageTransferServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/storagetransfer/v1/internal/storage_transfer_metadata_decorator.h
+++ b/google/cloud/storagetransfer/v1/internal/storage_transfer_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class StorageTransferServiceMetadata : public StorageTransferServiceStub {
  public:
   ~StorageTransferServiceMetadata() override = default;
   explicit StorageTransferServiceMetadata(
-      std::shared_ptr<StorageTransferServiceStub> child);
+      std::shared_ptr<StorageTransferServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::storagetransfer::v1::GoogleServiceAccount>
   GetGoogleServiceAccount(
@@ -123,6 +125,7 @@ class StorageTransferServiceMetadata : public StorageTransferServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<StorageTransferServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/support/v2/internal/case_attachment_metadata_decorator.cc
+++ b/google/cloud/support/v2/internal/case_attachment_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace support_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CaseAttachmentServiceMetadata::CaseAttachmentServiceMetadata(
-    std::shared_ptr<CaseAttachmentServiceStub> child)
+    std::shared_ptr<CaseAttachmentServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void CaseAttachmentServiceMetadata::SetMetadata(
 
 void CaseAttachmentServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/support/v2/internal/case_attachment_metadata_decorator.h
+++ b/google/cloud/support/v2/internal/case_attachment_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class CaseAttachmentServiceMetadata : public CaseAttachmentServiceStub {
  public:
   ~CaseAttachmentServiceMetadata() override = default;
   explicit CaseAttachmentServiceMetadata(
-      std::shared_ptr<CaseAttachmentServiceStub> child);
+      std::shared_ptr<CaseAttachmentServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::support::v2::ListAttachmentsResponse> ListAttachments(
       grpc::ClientContext& context,
@@ -46,6 +48,7 @@ class CaseAttachmentServiceMetadata : public CaseAttachmentServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CaseAttachmentServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/support/v2/internal/case_metadata_decorator.cc
+++ b/google/cloud/support/v2/internal/case_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace support_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-CaseServiceMetadata::CaseServiceMetadata(std::shared_ptr<CaseServiceStub> child)
+CaseServiceMetadata::CaseServiceMetadata(
+    std::shared_ptr<CaseServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -101,6 +104,9 @@ void CaseServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CaseServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/support/v2/internal/case_metadata_decorator.h
+++ b/google/cloud/support/v2/internal/case_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CaseServiceMetadata : public CaseServiceStub {
  public:
   ~CaseServiceMetadata() override = default;
-  explicit CaseServiceMetadata(std::shared_ptr<CaseServiceStub> child);
+  explicit CaseServiceMetadata(
+      std::shared_ptr<CaseServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::support::v2::Case> GetCase(
       grpc::ClientContext& context,
@@ -74,6 +77,7 @@ class CaseServiceMetadata : public CaseServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CaseServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/support/v2/internal/comment_metadata_decorator.cc
+++ b/google/cloud/support/v2/internal/comment_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace support_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CommentServiceMetadata::CommentServiceMetadata(
-    std::shared_ptr<CommentServiceStub> child)
+    std::shared_ptr<CommentServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -58,6 +60,9 @@ void CommentServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CommentServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/support/v2/internal/comment_metadata_decorator.h
+++ b/google/cloud/support/v2/internal/comment_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CommentServiceMetadata : public CommentServiceStub {
  public:
   ~CommentServiceMetadata() override = default;
-  explicit CommentServiceMetadata(std::shared_ptr<CommentServiceStub> child);
+  explicit CommentServiceMetadata(
+      std::shared_ptr<CommentServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::support::v2::ListCommentsResponse> ListComments(
       grpc::ClientContext& context,
@@ -48,6 +51,7 @@ class CommentServiceMetadata : public CommentServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CommentServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/talent/v4/internal/company_metadata_decorator.cc
+++ b/google/cloud/talent/v4/internal/company_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace talent_v4_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CompanyServiceMetadata::CompanyServiceMetadata(
-    std::shared_ptr<CompanyServiceStub> child)
+    std::shared_ptr<CompanyServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -80,6 +82,9 @@ void CompanyServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CompanyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/talent/v4/internal/company_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/company_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CompanyServiceMetadata : public CompanyServiceStub {
  public:
   ~CompanyServiceMetadata() override = default;
-  explicit CompanyServiceMetadata(std::shared_ptr<CompanyServiceStub> child);
+  explicit CompanyServiceMetadata(
+      std::shared_ptr<CompanyServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::talent::v4::Company> CreateCompany(
       grpc::ClientContext& context,
@@ -60,6 +63,7 @@ class CompanyServiceMetadata : public CompanyServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CompanyServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/talent/v4/internal/completion_metadata_decorator.cc
+++ b/google/cloud/talent/v4/internal/completion_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace talent_v4_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-CompletionMetadata::CompletionMetadata(std::shared_ptr<CompletionStub> child)
+CompletionMetadata::CompletionMetadata(
+    std::shared_ptr<CompletionStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -49,6 +52,9 @@ void CompletionMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CompletionMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/talent/v4/internal/completion_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/completion_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CompletionMetadata : public CompletionStub {
  public:
   ~CompletionMetadata() override = default;
-  explicit CompletionMetadata(std::shared_ptr<CompletionStub> child);
+  explicit CompletionMetadata(
+      std::shared_ptr<CompletionStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::talent::v4::CompleteQueryResponse> CompleteQuery(
       grpc::ClientContext& context,
@@ -44,6 +47,7 @@ class CompletionMetadata : public CompletionStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CompletionStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/talent/v4/internal/event_metadata_decorator.cc
+++ b/google/cloud/talent/v4/internal/event_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace talent_v4_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 EventServiceMetadata::EventServiceMetadata(
-    std::shared_ptr<EventServiceStub> child)
+    std::shared_ptr<EventServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -50,6 +52,9 @@ void EventServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EventServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/talent/v4/internal/event_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/event_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EventServiceMetadata : public EventServiceStub {
  public:
   ~EventServiceMetadata() override = default;
-  explicit EventServiceMetadata(std::shared_ptr<EventServiceStub> child);
+  explicit EventServiceMetadata(
+      std::shared_ptr<EventServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::talent::v4::ClientEvent> CreateClientEvent(
       grpc::ClientContext& context,
@@ -45,6 +48,7 @@ class EventServiceMetadata : public EventServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<EventServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/talent/v4/internal/job_metadata_decorator.cc
+++ b/google/cloud/talent/v4/internal/job_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace talent_v4_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-JobServiceMetadata::JobServiceMetadata(std::shared_ptr<JobServiceStub> child)
+JobServiceMetadata::JobServiceMetadata(
+    std::shared_ptr<JobServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -137,6 +140,9 @@ void JobServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void JobServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/talent/v4/internal/job_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/job_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class JobServiceMetadata : public JobServiceStub {
  public:
   ~JobServiceMetadata() override = default;
-  explicit JobServiceMetadata(std::shared_ptr<JobServiceStub> child);
+  explicit JobServiceMetadata(
+      std::shared_ptr<JobServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::talent::v4::Job> CreateJob(
       grpc::ClientContext& context,
@@ -97,6 +100,7 @@ class JobServiceMetadata : public JobServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<JobServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/talent/v4/internal/tenant_metadata_decorator.cc
+++ b/google/cloud/talent/v4/internal/tenant_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace talent_v4_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TenantServiceMetadata::TenantServiceMetadata(
-    std::shared_ptr<TenantServiceStub> child)
+    std::shared_ptr<TenantServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -78,6 +80,9 @@ void TenantServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TenantServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/talent/v4/internal/tenant_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/tenant_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TenantServiceMetadata : public TenantServiceStub {
  public:
   ~TenantServiceMetadata() override = default;
-  explicit TenantServiceMetadata(std::shared_ptr<TenantServiceStub> child);
+  explicit TenantServiceMetadata(
+      std::shared_ptr<TenantServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::talent::v4::Tenant> CreateTenant(
       grpc::ClientContext& context,
@@ -60,6 +63,7 @@ class TenantServiceMetadata : public TenantServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TenantServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/tasks/v2/internal/cloud_tasks_metadata_decorator.cc
+++ b/google/cloud/tasks/v2/internal/cloud_tasks_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace tasks_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-CloudTasksMetadata::CloudTasksMetadata(std::shared_ptr<CloudTasksStub> child)
+CloudTasksMetadata::CloudTasksMetadata(
+    std::shared_ptr<CloudTasksStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -156,6 +159,9 @@ void CloudTasksMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudTasksMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/tasks/v2/internal/cloud_tasks_metadata_decorator.h
+++ b/google/cloud/tasks/v2/internal/cloud_tasks_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudTasksMetadata : public CloudTasksStub {
  public:
   ~CloudTasksMetadata() override = default;
-  explicit CloudTasksMetadata(std::shared_ptr<CloudTasksStub> child);
+  explicit CloudTasksMetadata(
+      std::shared_ptr<CloudTasksStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::tasks::v2::ListQueuesResponse> ListQueues(
       grpc::ClientContext& context,
@@ -104,6 +107,7 @@ class CloudTasksMetadata : public CloudTasksStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<CloudTasksStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/texttospeech/v1/internal/text_to_speech_metadata_decorator.cc
+++ b/google/cloud/texttospeech/v1/internal/text_to_speech_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace texttospeech_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TextToSpeechMetadata::TextToSpeechMetadata(
-    std::shared_ptr<TextToSpeechStub> child)
+    std::shared_ptr<TextToSpeechStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -58,6 +60,9 @@ void TextToSpeechMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TextToSpeechMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/texttospeech/v1/internal/text_to_speech_metadata_decorator.h
+++ b/google/cloud/texttospeech/v1/internal/text_to_speech_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TextToSpeechMetadata : public TextToSpeechStub {
  public:
   ~TextToSpeechMetadata() override = default;
-  explicit TextToSpeechMetadata(std::shared_ptr<TextToSpeechStub> child);
+  explicit TextToSpeechMetadata(
+      std::shared_ptr<TextToSpeechStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse> ListVoices(
       grpc::ClientContext& context,
@@ -51,6 +54,7 @@ class TextToSpeechMetadata : public TextToSpeechStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TextToSpeechStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/tpu/v1/internal/tpu_metadata_decorator.cc
+++ b/google/cloud/tpu/v1/internal/tpu_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace tpu_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-TpuMetadata::TpuMetadata(std::shared_ptr<TpuStub> child)
+TpuMetadata::TpuMetadata(
+    std::shared_ptr<TpuStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -143,6 +146,9 @@ void TpuMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TpuMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/tpu/v1/internal/tpu_metadata_decorator.h
+++ b/google/cloud/tpu/v1/internal/tpu_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TpuMetadata : public TpuStub {
  public:
   ~TpuMetadata() override = default;
-  explicit TpuMetadata(std::shared_ptr<TpuStub> child);
+  explicit TpuMetadata(
+      std::shared_ptr<TpuStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::tpu::v1::ListNodesResponse> ListNodes(
       grpc::ClientContext& context,
@@ -106,6 +109,7 @@ class TpuMetadata : public TpuStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TpuStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/tpu/v2/internal/tpu_metadata_decorator.cc
+++ b/google/cloud/tpu/v2/internal/tpu_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace tpu_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-TpuMetadata::TpuMetadata(std::shared_ptr<TpuStub> child)
+TpuMetadata::TpuMetadata(
+    std::shared_ptr<TpuStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -158,6 +161,9 @@ void TpuMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TpuMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/tpu/v2/internal/tpu_metadata_decorator.h
+++ b/google/cloud/tpu/v2/internal/tpu_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TpuMetadata : public TpuStub {
  public:
   ~TpuMetadata() override = default;
-  explicit TpuMetadata(std::shared_ptr<TpuStub> child);
+  explicit TpuMetadata(
+      std::shared_ptr<TpuStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::tpu::v2::ListNodesResponse> ListNodes(
       grpc::ClientContext& context,
@@ -115,6 +118,7 @@ class TpuMetadata : public TpuStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TpuStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/trace/v1/internal/trace_metadata_decorator.cc
+++ b/google/cloud/trace/v1/internal/trace_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace trace_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TraceServiceMetadata::TraceServiceMetadata(
-    std::shared_ptr<TraceServiceStub> child)
+    std::shared_ptr<TraceServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -65,6 +67,9 @@ void TraceServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TraceServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/trace/v1/internal/trace_metadata_decorator.h
+++ b/google/cloud/trace/v1/internal/trace_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TraceServiceMetadata : public TraceServiceStub {
  public:
   ~TraceServiceMetadata() override = default;
-  explicit TraceServiceMetadata(std::shared_ptr<TraceServiceStub> child);
+  explicit TraceServiceMetadata(
+      std::shared_ptr<TraceServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::devtools::cloudtrace::v1::ListTracesResponse> ListTraces(
       grpc::ClientContext& context,
@@ -54,6 +57,7 @@ class TraceServiceMetadata : public TraceServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TraceServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/trace/v2/internal/trace_metadata_decorator.cc
+++ b/google/cloud/trace/v2/internal/trace_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace trace_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TraceServiceMetadata::TraceServiceMetadata(
-    std::shared_ptr<TraceServiceStub> child)
+    std::shared_ptr<TraceServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -57,6 +59,9 @@ void TraceServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TraceServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/trace/v2/internal/trace_metadata_decorator.h
+++ b/google/cloud/trace/v2/internal/trace_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TraceServiceMetadata : public TraceServiceStub {
  public:
   ~TraceServiceMetadata() override = default;
-  explicit TraceServiceMetadata(std::shared_ptr<TraceServiceStub> child);
+  explicit TraceServiceMetadata(
+      std::shared_ptr<TraceServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   Status BatchWriteSpans(
       grpc::ClientContext& context,
@@ -49,6 +52,7 @@ class TraceServiceMetadata : public TraceServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TraceServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/translate/v3/internal/translation_metadata_decorator.cc
+++ b/google/cloud/translate/v3/internal/translation_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace translate_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TranslationServiceMetadata::TranslationServiceMetadata(
-    std::shared_ptr<TranslationServiceStub> child)
+    std::shared_ptr<TranslationServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -145,6 +147,9 @@ void TranslationServiceMetadata::SetMetadata(
 
 void TranslationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/translate/v3/internal/translation_metadata_decorator.h
+++ b/google/cloud/translate/v3/internal/translation_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class TranslationServiceMetadata : public TranslationServiceStub {
  public:
   ~TranslationServiceMetadata() override = default;
   explicit TranslationServiceMetadata(
-      std::shared_ptr<TranslationServiceStub> child);
+      std::shared_ptr<TranslationServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::translation::v3::TranslateTextResponse> TranslateText(
       grpc::ClientContext& context,
@@ -108,6 +110,7 @@ class TranslationServiceMetadata : public TranslationServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TranslationServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/video/livestream/v1/internal/livestream_metadata_decorator.cc
+++ b/google/cloud/video/livestream/v1/internal/livestream_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace video_livestream_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 LivestreamServiceMetadata::LivestreamServiceMetadata(
-    std::shared_ptr<LivestreamServiceStub> child)
+    std::shared_ptr<LivestreamServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -194,6 +196,9 @@ void LivestreamServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void LivestreamServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/video/livestream/v1/internal/livestream_metadata_decorator.h
+++ b/google/cloud/video/livestream/v1/internal/livestream_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class LivestreamServiceMetadata : public LivestreamServiceStub {
  public:
   ~LivestreamServiceMetadata() override = default;
   explicit LivestreamServiceMetadata(
-      std::shared_ptr<LivestreamServiceStub> child);
+      std::shared_ptr<LivestreamServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateChannel(
       google::cloud::CompletionQueue& cq,
@@ -140,6 +142,7 @@ class LivestreamServiceMetadata : public LivestreamServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<LivestreamServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/video/stitcher/v1/internal/video_stitcher_metadata_decorator.cc
+++ b/google/cloud/video/stitcher/v1/internal/video_stitcher_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace video_stitcher_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 VideoStitcherServiceMetadata::VideoStitcherServiceMetadata(
-    std::shared_ptr<VideoStitcherServiceStub> child)
+    std::shared_ptr<VideoStitcherServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -269,6 +271,9 @@ void VideoStitcherServiceMetadata::SetMetadata(
 
 void VideoStitcherServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/video/stitcher/v1/internal/video_stitcher_metadata_decorator.h
+++ b/google/cloud/video/stitcher/v1/internal/video_stitcher_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class VideoStitcherServiceMetadata : public VideoStitcherServiceStub {
  public:
   ~VideoStitcherServiceMetadata() override = default;
   explicit VideoStitcherServiceMetadata(
-      std::shared_ptr<VideoStitcherServiceStub> child);
+      std::shared_ptr<VideoStitcherServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateCdnKey(
       google::cloud::CompletionQueue& cq,
@@ -187,6 +189,7 @@ class VideoStitcherServiceMetadata : public VideoStitcherServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<VideoStitcherServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/video/transcoder/v1/internal/transcoder_metadata_decorator.cc
+++ b/google/cloud/video/transcoder/v1/internal/transcoder_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace video_transcoder_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TranscoderServiceMetadata::TranscoderServiceMetadata(
-    std::shared_ptr<TranscoderServiceStub> child)
+    std::shared_ptr<TranscoderServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -108,6 +110,9 @@ void TranscoderServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TranscoderServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/video/transcoder/v1/internal/transcoder_metadata_decorator.h
+++ b/google/cloud/video/transcoder/v1/internal/transcoder_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class TranscoderServiceMetadata : public TranscoderServiceStub {
  public:
   ~TranscoderServiceMetadata() override = default;
   explicit TranscoderServiceMetadata(
-      std::shared_ptr<TranscoderServiceStub> child);
+      std::shared_ptr<TranscoderServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::video::transcoder::v1::Job> CreateJob(
       grpc::ClientContext& context,
@@ -81,6 +83,7 @@ class TranscoderServiceMetadata : public TranscoderServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<TranscoderServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/videointelligence/v1/internal/video_intelligence_metadata_decorator.cc
+++ b/google/cloud/videointelligence/v1/internal/video_intelligence_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace videointelligence_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 VideoIntelligenceServiceMetadata::VideoIntelligenceServiceMetadata(
-    std::shared_ptr<VideoIntelligenceServiceStub> child)
+    std::shared_ptr<VideoIntelligenceServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -69,6 +71,9 @@ void VideoIntelligenceServiceMetadata::SetMetadata(
 void VideoIntelligenceServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/videointelligence/v1/internal/video_intelligence_metadata_decorator.h
+++ b/google/cloud/videointelligence/v1/internal/video_intelligence_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class VideoIntelligenceServiceMetadata : public VideoIntelligenceServiceStub {
  public:
   ~VideoIntelligenceServiceMetadata() override = default;
   explicit VideoIntelligenceServiceMetadata(
-      std::shared_ptr<VideoIntelligenceServiceStub> child);
+      std::shared_ptr<VideoIntelligenceServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncAnnotateVideo(
       google::cloud::CompletionQueue& cq,
@@ -58,6 +60,7 @@ class VideoIntelligenceServiceMetadata : public VideoIntelligenceServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<VideoIntelligenceServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/vision/v1/internal/image_annotator_metadata_decorator.cc
+++ b/google/cloud/vision/v1/internal/image_annotator_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace vision_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ImageAnnotatorMetadata::ImageAnnotatorMetadata(
-    std::shared_ptr<ImageAnnotatorStub> child)
+    std::shared_ptr<ImageAnnotatorStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -93,6 +95,9 @@ void ImageAnnotatorMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ImageAnnotatorMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/vision/v1/internal/image_annotator_metadata_decorator.h
+++ b/google/cloud/vision/v1/internal/image_annotator_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ImageAnnotatorMetadata : public ImageAnnotatorStub {
  public:
   ~ImageAnnotatorMetadata() override = default;
-  explicit ImageAnnotatorMetadata(std::shared_ptr<ImageAnnotatorStub> child);
+  explicit ImageAnnotatorMetadata(
+      std::shared_ptr<ImageAnnotatorStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>
   BatchAnnotateImages(
@@ -75,6 +78,7 @@ class ImageAnnotatorMetadata : public ImageAnnotatorStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ImageAnnotatorStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/vision/v1/internal/product_search_metadata_decorator.cc
+++ b/google/cloud/vision/v1/internal/product_search_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace vision_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ProductSearchMetadata::ProductSearchMetadata(
-    std::shared_ptr<ProductSearchStub> child)
+    std::shared_ptr<ProductSearchStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -208,6 +210,9 @@ void ProductSearchMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ProductSearchMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/vision/v1/internal/product_search_metadata_decorator.h
+++ b/google/cloud/vision/v1/internal/product_search_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProductSearchMetadata : public ProductSearchStub {
  public:
   ~ProductSearchMetadata() override = default;
-  explicit ProductSearchMetadata(std::shared_ptr<ProductSearchStub> child);
+  explicit ProductSearchMetadata(
+      std::shared_ptr<ProductSearchStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::vision::v1::ProductSet> CreateProductSet(
       grpc::ClientContext& context,
@@ -143,6 +146,7 @@ class ProductSearchMetadata : public ProductSearchStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ProductSearchStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/vmmigration/v1/internal/vm_migration_metadata_decorator.cc
+++ b/google/cloud/vmmigration/v1/internal/vm_migration_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace vmmigration_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-VmMigrationMetadata::VmMigrationMetadata(std::shared_ptr<VmMigrationStub> child)
+VmMigrationMetadata::VmMigrationMetadata(
+    std::shared_ptr<VmMigrationStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -465,6 +468,9 @@ void VmMigrationMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VmMigrationMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/vmmigration/v1/internal/vm_migration_metadata_decorator.h
+++ b/google/cloud/vmmigration/v1/internal/vm_migration_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VmMigrationMetadata : public VmMigrationStub {
  public:
   ~VmMigrationMetadata() override = default;
-  explicit VmMigrationMetadata(std::shared_ptr<VmMigrationStub> child);
+  explicit VmMigrationMetadata(
+      std::shared_ptr<VmMigrationStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::vmmigration::v1::ListSourcesResponse> ListSources(
       grpc::ClientContext& context,
@@ -316,6 +319,7 @@ class VmMigrationMetadata : public VmMigrationStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<VmMigrationStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/vmwareengine/v1/internal/vmware_engine_metadata_decorator.cc
+++ b/google/cloud/vmwareengine/v1/internal/vmware_engine_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace vmwareengine_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 VmwareEngineMetadata::VmwareEngineMetadata(
-    std::shared_ptr<VmwareEngineStub> child)
+    std::shared_ptr<VmwareEngineStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -420,6 +422,9 @@ void VmwareEngineMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VmwareEngineMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/vmwareengine/v1/internal/vmware_engine_metadata_decorator.h
+++ b/google/cloud/vmwareengine/v1/internal/vmware_engine_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VmwareEngineMetadata : public VmwareEngineStub {
  public:
   ~VmwareEngineMetadata() override = default;
-  explicit VmwareEngineMetadata(std::shared_ptr<VmwareEngineStub> child);
+  explicit VmwareEngineMetadata(
+      std::shared_ptr<VmwareEngineStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::vmwareengine::v1::ListPrivateCloudsResponse>
   ListPrivateClouds(
@@ -279,6 +282,7 @@ class VmwareEngineMetadata : public VmwareEngineStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<VmwareEngineStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/vpcaccess/v1/internal/vpc_access_metadata_decorator.cc
+++ b/google/cloud/vpcaccess/v1/internal/vpc_access_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace vpcaccess_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 VpcAccessServiceMetadata::VpcAccessServiceMetadata(
-    std::shared_ptr<VpcAccessServiceStub> child)
+    std::shared_ptr<VpcAccessServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -93,6 +95,9 @@ void VpcAccessServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VpcAccessServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/vpcaccess/v1/internal/vpc_access_metadata_decorator.h
+++ b/google/cloud/vpcaccess/v1/internal/vpc_access_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -34,7 +35,8 @@ class VpcAccessServiceMetadata : public VpcAccessServiceStub {
  public:
   ~VpcAccessServiceMetadata() override = default;
   explicit VpcAccessServiceMetadata(
-      std::shared_ptr<VpcAccessServiceStub> child);
+      std::shared_ptr<VpcAccessServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateConnector(
       google::cloud::CompletionQueue& cq,
@@ -74,6 +76,7 @@ class VpcAccessServiceMetadata : public VpcAccessServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<VpcAccessServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/webrisk/v1/internal/web_risk_metadata_decorator.cc
+++ b/google/cloud/webrisk/v1/internal/web_risk_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace webrisk_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 WebRiskServiceMetadata::WebRiskServiceMetadata(
-    std::shared_ptr<WebRiskServiceStub> child)
+    std::shared_ptr<WebRiskServiceStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -100,6 +102,9 @@ void WebRiskServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void WebRiskServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/webrisk/v1/internal/web_risk_metadata_decorator.h
+++ b/google/cloud/webrisk/v1/internal/web_risk_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WebRiskServiceMetadata : public WebRiskServiceStub {
  public:
   ~WebRiskServiceMetadata() override = default;
-  explicit WebRiskServiceMetadata(std::shared_ptr<WebRiskServiceStub> child);
+  explicit WebRiskServiceMetadata(
+      std::shared_ptr<WebRiskServiceStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>
   ComputeThreatListDiff(
@@ -75,6 +78,7 @@ class WebRiskServiceMetadata : public WebRiskServiceStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<WebRiskServiceStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/websecurityscanner/v1/internal/web_security_scanner_metadata_decorator.cc
+++ b/google/cloud/websecurityscanner/v1/internal/web_security_scanner_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace websecurityscanner_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 WebSecurityScannerMetadata::WebSecurityScannerMetadata(
-    std::shared_ptr<WebSecurityScannerStub> child)
+    std::shared_ptr<WebSecurityScannerStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -152,6 +154,9 @@ void WebSecurityScannerMetadata::SetMetadata(
 
 void WebSecurityScannerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/websecurityscanner/v1/internal/web_security_scanner_metadata_decorator.h
+++ b/google/cloud/websecurityscanner/v1/internal/web_security_scanner_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,8 @@ class WebSecurityScannerMetadata : public WebSecurityScannerStub {
  public:
   ~WebSecurityScannerMetadata() override = default;
   explicit WebSecurityScannerMetadata(
-      std::shared_ptr<WebSecurityScannerStub> child);
+      std::shared_ptr<WebSecurityScannerStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::websecurityscanner::v1::ScanConfig> CreateScanConfig(
       grpc::ClientContext& context,
@@ -109,6 +111,7 @@ class WebSecurityScannerMetadata : public WebSecurityScannerStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<WebSecurityScannerStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/workflows/executions/v1/internal/executions_metadata_decorator.cc
+++ b/google/cloud/workflows/executions/v1/internal/executions_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace workflows_executions_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-ExecutionsMetadata::ExecutionsMetadata(std::shared_ptr<ExecutionsStub> child)
+ExecutionsMetadata::ExecutionsMetadata(
+    std::shared_ptr<ExecutionsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -77,6 +80,9 @@ void ExecutionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ExecutionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/workflows/executions/v1/internal/executions_metadata_decorator.h
+++ b/google/cloud/workflows/executions/v1/internal/executions_metadata_decorator.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -32,7 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ExecutionsMetadata : public ExecutionsStub {
  public:
   ~ExecutionsMetadata() override = default;
-  explicit ExecutionsMetadata(std::shared_ptr<ExecutionsStub> child);
+  explicit ExecutionsMetadata(
+      std::shared_ptr<ExecutionsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::workflows::executions::v1::ListExecutionsResponse>
   ListExecutions(
@@ -61,6 +64,7 @@ class ExecutionsMetadata : public ExecutionsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<ExecutionsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/workflows/v1/internal/workflows_metadata_decorator.cc
+++ b/google/cloud/workflows/v1/internal/workflows_metadata_decorator.cc
@@ -28,8 +28,11 @@ namespace cloud {
 namespace workflows_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-WorkflowsMetadata::WorkflowsMetadata(std::shared_ptr<WorkflowsStub> child)
+WorkflowsMetadata::WorkflowsMetadata(
+    std::shared_ptr<WorkflowsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -100,6 +103,9 @@ void WorkflowsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void WorkflowsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/workflows/v1/internal/workflows_metadata_decorator.h
+++ b/google/cloud/workflows/v1/internal/workflows_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WorkflowsMetadata : public WorkflowsStub {
  public:
   ~WorkflowsMetadata() override = default;
-  explicit WorkflowsMetadata(std::shared_ptr<WorkflowsStub> child);
+  explicit WorkflowsMetadata(
+      std::shared_ptr<WorkflowsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::workflows::v1::ListWorkflowsResponse> ListWorkflows(
       grpc::ClientContext& context,
@@ -78,6 +81,7 @@ class WorkflowsMetadata : public WorkflowsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<WorkflowsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 

--- a/google/cloud/workstations/v1/internal/workstations_metadata_decorator.cc
+++ b/google/cloud/workstations/v1/internal/workstations_metadata_decorator.cc
@@ -29,8 +29,10 @@ namespace workstations_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 WorkstationsMetadata::WorkstationsMetadata(
-    std::shared_ptr<WorkstationsStub> child)
+    std::shared_ptr<WorkstationsStub> child,
+    std::unordered_map<std::string, std::string> fixed_metadata)
     : child_(std::move(child)),
+      fixed_metadata_(std::move(fixed_metadata)),
       api_client_header_(
           google::cloud::internal::ApiClientHeader("generator")) {}
 
@@ -245,6 +247,9 @@ void WorkstationsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void WorkstationsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  for (auto const& kv : fixed_metadata_) {
+    context.AddMetadata(kv.first, kv.second);
+  }
   auto const& options = internal::CurrentOptions();
   if (options.has<UserProjectOption>()) {
     context.AddMetadata("x-goog-user-project",

--- a/google/cloud/workstations/v1/internal/workstations_metadata_decorator.h
+++ b/google/cloud/workstations/v1/internal/workstations_metadata_decorator.h
@@ -24,6 +24,7 @@
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -33,7 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WorkstationsMetadata : public WorkstationsStub {
  public:
   ~WorkstationsMetadata() override = default;
-  explicit WorkstationsMetadata(std::shared_ptr<WorkstationsStub> child);
+  explicit WorkstationsMetadata(
+      std::shared_ptr<WorkstationsStub> child,
+      std::unordered_map<std::string, std::string> fixed_metadata = {});
 
   StatusOr<google::cloud::workstations::v1::WorkstationCluster>
   GetWorkstationCluster(
@@ -174,6 +177,7 @@ class WorkstationsMetadata : public WorkstationsStub {
   void SetMetadata(grpc::ClientContext& context);
 
   std::shared_ptr<WorkstationsStub> child_;
+  std::unordered_map<std::string, std::string> fixed_metadata_;
   std::string api_client_header_;
 };
 


### PR DESCRIPTION
Fixes #11823 

- I used a defaulted parameter (against @devbww's recommendation) to minimize the changes in this PR.
- I did not touch the `RestMetadataGenerator`, given that only services with handwritten stub factories can use the fixed metadata feature.
  - (currently, only `bigtable` and `spanner` care)