### PR TITLE
impl(generator): un-default metadata decorator fixed headers

### DIFF
--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -189,7 +189,8 @@ BENCHMARK(BM_ClientRoundTripStubOnly);
 void BM_ClientRoundTripMetadata(benchmark::State& state) {
   auto options = Options{};
   std::shared_ptr<GoldenKitchenSinkStub> stub = std::make_shared<TestStub>();
-  stub = std::make_shared<GoldenKitchenSinkMetadata>(std::move(stub));
+  stub = std::make_shared<GoldenKitchenSinkMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   auto conn = MakeTestConnection(std::move(stub), std::move(options));
   auto client = GoldenKitchenSinkClient(std::move(conn));
 

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
  public:
   ~GoldenKitchenSinkMetadata() override = default;
-  explicit GoldenKitchenSinkMetadata(
+  GoldenKitchenSinkMetadata(
       std::shared_ptr<GoldenKitchenSinkStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
       grpc::ClientContext& context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub_factory.cc
@@ -51,7 +51,8 @@ CreateDefaultGoldenKitchenSinkStub(
     stub = std::make_shared<GoldenKitchenSinkAuth>(
         std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<GoldenKitchenSinkMetadata>(std::move(stub));
+  stub = std::make_shared<GoldenKitchenSinkMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(
       options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GoldenThingAdminMetadata : public GoldenThingAdminStub {
  public:
   ~GoldenThingAdminMetadata() override = default;
-  explicit GoldenThingAdminMetadata(
+  GoldenThingAdminMetadata(
       std::shared_ptr<GoldenThingAdminStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
       grpc::ClientContext& context,

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_stub_factory.cc
@@ -53,7 +53,8 @@ CreateDefaultGoldenThingAdminStub(
     stub = std::make_shared<GoldenThingAdminAuth>(
         std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<GoldenThingAdminMetadata>(std::move(stub));
+  stub = std::make_shared<GoldenThingAdminMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(
       options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -95,7 +95,7 @@ TEST_F(MetadataDecoratorTest, UserProject) {
         return TransientError();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   // First try without any UserProjectOption
   {
     internal::OptionsSpan span(Options{});
@@ -127,7 +127,7 @@ TEST_F(MetadataDecoratorTest, GenerateAccessToken) {
         return TransientError();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::GenerateAccessTokenRequest request;
   request.set_name("projects/-/serviceAccounts/foo@bar.com");
@@ -147,7 +147,7 @@ TEST_F(MetadataDecoratorTest, GenerateIdToken) {
         return TransientError();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::GenerateIdTokenRequest request;
   request.set_name("projects/-/serviceAccounts/foo@bar.com");
@@ -167,7 +167,7 @@ TEST_F(MetadataDecoratorTest, WriteLogEntries) {
         return TransientError();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::WriteLogEntriesRequest request;
   auto status = stub.WriteLogEntries(context, request);
@@ -185,7 +185,7 @@ TEST_F(MetadataDecoratorTest, ListLogs) {
         return TransientError();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::ListLogsRequest request;
   request.set_parent("projects/my_project");
@@ -205,7 +205,7 @@ TEST_F(MetadataDecoratorTest, ListServiceAccountKeys) {
         return TransientError();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::ListServiceAccountKeysRequest request;
   request.set_name("projects/my-project/serviceAccounts/foo@bar.com");
@@ -225,7 +225,7 @@ TEST_F(MetadataDecoratorTest, StreamingRead) {
             request);
         return mock_response;
       });
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   auto response =
       stub.StreamingRead(std::make_shared<grpc::ClientContext>(), Request{});
   EXPECT_THAT(absl::get<Status>(response->Read()), Not(IsOk()));
@@ -246,7 +246,7 @@ TEST_F(MetadataDecoratorTest, StreamingWrite) {
     return stream;
   });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
@@ -268,7 +268,7 @@ TEST_F(MetadataDecoratorTest, AsyncStreamingRead) {
         return std::make_unique<ErrorStream>(
             Status(StatusCode::kAborted, "uh-oh"));
       });
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
 
   google::cloud::CompletionQueue cq;
   auto stream = stub.AsyncStreamingRead(
@@ -293,7 +293,7 @@ TEST_F(MetadataDecoratorTest, AsyncStreamingWrite) {
         return std::make_unique<ErrorStream>(
             Status(StatusCode::kAborted, "uh-oh"));
       });
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
 
   google::cloud::CompletionQueue cq;
   auto stream =
@@ -348,7 +348,7 @@ TEST_F(MetadataDecoratorTest, ExplicitRouting) {
         return Status();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context1;
   grpc::ClientContext context2;
   // We make the same call twice. In the first call, we use `IsContextMDValid`
@@ -380,7 +380,7 @@ TEST_F(MetadataDecoratorTest, ExplicitRoutingDoesNotSendEmptyParams) {
         return Status();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context1;
   grpc::ClientContext context2;
   google::test::admin::database::v1::ExplicitRoutingRequest request;
@@ -415,7 +415,7 @@ TEST_F(MetadataDecoratorTest, ExplicitRoutingNoRegexNeeded) {
         return Status();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context1;
   grpc::ClientContext context2;
   // Note that the `app_profile_id` field is not set.
@@ -452,7 +452,7 @@ TEST_F(MetadataDecoratorTest, ExplicitRoutingNestedField) {
         return Status();
       });
 
-  GoldenKitchenSinkMetadata stub(mock_);
+  GoldenKitchenSinkMetadata stub(mock_, {});
   grpc::ClientContext context1;
   grpc::ClientContext context2;
   google::test::admin::database::v1::ExplicitRoutingRequest request;

--- a/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -71,7 +71,7 @@ TEST_F(MetadataDecoratorTest, GetDatabase) {
             return TransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(
@@ -93,7 +93,7 @@ TEST_F(MetadataDecoratorTest, ListDatabases) {
             return TransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::ListDatabasesRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
@@ -114,7 +114,7 @@ TEST_F(MetadataDecoratorTest, CreateDatabase) {
             return LongrunningTransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::test::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
@@ -137,7 +137,7 @@ TEST_F(MetadataDecoratorTest, UpdateDatabaseDdl) {
             return LongrunningTransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   request.set_database(
@@ -160,7 +160,7 @@ TEST_F(MetadataDecoratorTest, DropDatabase) {
             return TransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::DropDatabaseRequest request;
   request.set_database(
@@ -182,7 +182,7 @@ TEST_F(MetadataDecoratorTest, GetDatabaseDdl) {
             return TransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::GetDatabaseDdlRequest request;
   request.set_database(
@@ -202,7 +202,7 @@ TEST_F(MetadataDecoratorTest, SetIamPolicy) {
         return TransientError();
       });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(
@@ -222,7 +222,7 @@ TEST_F(MetadataDecoratorTest, GetIamPolicy) {
         return TransientError();
       });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(
@@ -243,7 +243,7 @@ TEST_F(MetadataDecoratorTest, TestIamPermissions) {
             return TransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(
@@ -265,7 +265,7 @@ TEST_F(MetadataDecoratorTest, CreateBackup) {
             return LongrunningTransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::test::admin::database::v1::CreateBackupRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
@@ -286,7 +286,7 @@ TEST_F(MetadataDecoratorTest, GetBackup) {
         return TransientError();
       });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::GetBackupRequest request;
   request.set_name(
@@ -308,7 +308,7 @@ TEST_F(MetadataDecoratorTest, UpdateBackup) {
             return TransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::UpdateBackupRequest request;
   request.mutable_backup()->set_name(
@@ -330,7 +330,7 @@ TEST_F(MetadataDecoratorTest, DeleteBackup) {
             return TransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::DeleteBackupRequest request;
   request.set_name(
@@ -352,7 +352,7 @@ TEST_F(MetadataDecoratorTest, ListBackups) {
             return TransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::ListBackupsRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
@@ -372,7 +372,7 @@ TEST_F(MetadataDecoratorTest, RestoreDatabase) {
         return LongrunningTransientError();
       });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
@@ -393,7 +393,7 @@ TEST_F(MetadataDecoratorTest, ListDatabaseOperations) {
         return TransientError();
       });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::ListDatabaseOperationsRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
@@ -413,7 +413,7 @@ TEST_F(MetadataDecoratorTest, ListBackupOperations) {
         return TransientError();
       });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   grpc::ClientContext context;
   google::test::admin::database::v1::ListBackupOperationsRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
@@ -436,7 +436,7 @@ TEST_F(MetadataDecoratorTest, AsyncGetDatabase) {
                     TransientError()));
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(
@@ -459,7 +459,7 @@ TEST_F(MetadataDecoratorTest, AsyncDropDatabase) {
             return make_ready_future(TransientError());
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::test::admin::database::v1::DropDatabaseRequest request;
   request.set_database(
@@ -483,7 +483,7 @@ TEST_F(MetadataDecoratorTest, LongRunningWithoutRouting) {
             return LongrunningTransientError();
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent("projects/my_project/instances/my_instance");
@@ -502,7 +502,7 @@ TEST_F(MetadataDecoratorTest, GetOperation) {
         return LongrunningTransientError();
       });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::longrunning::GetOperationRequest request;
   request.set_name("operations/my_operation");
@@ -522,7 +522,7 @@ TEST_F(MetadataDecoratorTest, CancelOperation) {
             return make_ready_future(TransientError());
           });
 
-  GoldenThingAdminMetadata stub(mock_);
+  GoldenThingAdminMetadata stub(mock_, {});
   CompletionQueue cq;
   google::longrunning::CancelOperationRequest request;
   request.set_name("operations/my_operation");

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -136,9 +136,9 @@ Status MetadataDecoratorGenerator::GenerateHeader() {
 class $metadata_class_name$ : public $stub_class_name$ {
  public:
   ~$metadata_class_name$() override = default;
-  explicit $metadata_class_name$(
+  $metadata_class_name$(
       std::shared_ptr<$stub_class_name$> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 )""");
 
   HeaderPrintPublicMethods();

--- a/generator/internal/stub_factory_generator.cc
+++ b/generator/internal/stub_factory_generator.cc
@@ -119,7 +119,8 @@ CreateDefault$stub_class_name$(
     stub = std::make_shared<$auth_class_name$>(
         std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<$metadata_class_name$>(std::move(stub));
+  stub = std::make_shared<$metadata_class_name$>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(
       options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/accessapproval/v1/internal/access_approval_metadata_decorator.h
+++ b/google/cloud/accessapproval/v1/internal/access_approval_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AccessApprovalMetadata : public AccessApprovalStub {
  public:
   ~AccessApprovalMetadata() override = default;
-  explicit AccessApprovalMetadata(
+  AccessApprovalMetadata(
       std::shared_ptr<AccessApprovalStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::accessapproval::v1::ListApprovalRequestsResponse>
   ListApprovalRequests(

--- a/google/cloud/accessapproval/v1/internal/access_approval_stub_factory.cc
+++ b/google/cloud/accessapproval/v1/internal/access_approval_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<AccessApprovalStub> CreateDefaultAccessApprovalStub(
     stub =
         std::make_shared<AccessApprovalAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AccessApprovalMetadata>(std::move(stub));
+  stub = std::make_shared<AccessApprovalMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AccessApprovalLogging>(

--- a/google/cloud/accesscontextmanager/v1/internal/access_context_manager_metadata_decorator.h
+++ b/google/cloud/accesscontextmanager/v1/internal/access_context_manager_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AccessContextManagerMetadata : public AccessContextManagerStub {
  public:
   ~AccessContextManagerMetadata() override = default;
-  explicit AccessContextManagerMetadata(
+  AccessContextManagerMetadata(
       std::shared_ptr<AccessContextManagerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<
       google::identity::accesscontextmanager::v1::ListAccessPoliciesResponse>

--- a/google/cloud/accesscontextmanager/v1/internal/access_context_manager_stub_factory.cc
+++ b/google/cloud/accesscontextmanager/v1/internal/access_context_manager_stub_factory.cc
@@ -54,7 +54,8 @@ std::shared_ptr<AccessContextManagerStub> CreateDefaultAccessContextManagerStub(
     stub = std::make_shared<AccessContextManagerAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<AccessContextManagerMetadata>(std::move(stub));
+  stub = std::make_shared<AccessContextManagerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AccessContextManagerLogging>(

--- a/google/cloud/advisorynotifications/v1/internal/advisory_notifications_metadata_decorator.h
+++ b/google/cloud/advisorynotifications/v1/internal/advisory_notifications_metadata_decorator.h
@@ -34,9 +34,9 @@ class AdvisoryNotificationsServiceMetadata
     : public AdvisoryNotificationsServiceStub {
  public:
   ~AdvisoryNotificationsServiceMetadata() override = default;
-  explicit AdvisoryNotificationsServiceMetadata(
+  AdvisoryNotificationsServiceMetadata(
       std::shared_ptr<AdvisoryNotificationsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::advisorynotifications::v1::ListNotificationsResponse>
   ListNotifications(

--- a/google/cloud/advisorynotifications/v1/internal/advisory_notifications_stub_factory.cc
+++ b/google/cloud/advisorynotifications/v1/internal/advisory_notifications_stub_factory.cc
@@ -53,8 +53,8 @@ CreateDefaultAdvisoryNotificationsServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<AdvisoryNotificationsServiceAuth>(std::move(auth),
                                                               std::move(stub));
   }
-  stub =
-      std::make_shared<AdvisoryNotificationsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AdvisoryNotificationsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AdvisoryNotificationsServiceLogging>(

--- a/google/cloud/alloydb/v1/internal/alloy_db_admin_metadata_decorator.h
+++ b/google/cloud/alloydb/v1/internal/alloy_db_admin_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AlloyDBAdminMetadata : public AlloyDBAdminStub {
  public:
   ~AlloyDBAdminMetadata() override = default;
-  explicit AlloyDBAdminMetadata(
-      std::shared_ptr<AlloyDBAdminStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AlloyDBAdminMetadata(std::shared_ptr<AlloyDBAdminStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::alloydb::v1::ListClustersResponse> ListClusters(
       grpc::ClientContext& context,

--- a/google/cloud/alloydb/v1/internal/alloy_db_admin_stub_factory.cc
+++ b/google/cloud/alloydb/v1/internal/alloy_db_admin_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<AlloyDBAdminStub> CreateDefaultAlloyDBAdminStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<AlloyDBAdminAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AlloyDBAdminMetadata>(std::move(stub));
+  stub = std::make_shared<AlloyDBAdminMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AlloyDBAdminLogging>(

--- a/google/cloud/apigateway/v1/internal/api_gateway_metadata_decorator.h
+++ b/google/cloud/apigateway/v1/internal/api_gateway_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ApiGatewayServiceMetadata : public ApiGatewayServiceStub {
  public:
   ~ApiGatewayServiceMetadata() override = default;
-  explicit ApiGatewayServiceMetadata(
+  ApiGatewayServiceMetadata(
       std::shared_ptr<ApiGatewayServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::apigateway::v1::ListGatewaysResponse> ListGateways(
       grpc::ClientContext& context,

--- a/google/cloud/apigateway/v1/internal/api_gateway_stub_factory.cc
+++ b/google/cloud/apigateway/v1/internal/api_gateway_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ApiGatewayServiceStub> CreateDefaultApiGatewayServiceStub(
     stub = std::make_shared<ApiGatewayServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<ApiGatewayServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ApiGatewayServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ApiGatewayServiceLogging>(

--- a/google/cloud/apigeeconnect/v1/internal/connection_metadata_decorator.h
+++ b/google/cloud/apigeeconnect/v1/internal/connection_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConnectionServiceMetadata : public ConnectionServiceStub {
  public:
   ~ConnectionServiceMetadata() override = default;
-  explicit ConnectionServiceMetadata(
+  ConnectionServiceMetadata(
       std::shared_ptr<ConnectionServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::apigeeconnect::v1::ListConnectionsResponse>
   ListConnections(

--- a/google/cloud/apigeeconnect/v1/internal/connection_stub_factory.cc
+++ b/google/cloud/apigeeconnect/v1/internal/connection_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<ConnectionServiceStub> CreateDefaultConnectionServiceStub(
     stub = std::make_shared<ConnectionServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<ConnectionServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ConnectionServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ConnectionServiceLogging>(

--- a/google/cloud/apikeys/v2/internal/api_keys_metadata_decorator.h
+++ b/google/cloud/apikeys/v2/internal/api_keys_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ApiKeysMetadata : public ApiKeysStub {
  public:
   ~ApiKeysMetadata() override = default;
-  explicit ApiKeysMetadata(
-      std::shared_ptr<ApiKeysStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ApiKeysMetadata(std::shared_ptr<ApiKeysStub> child,
+                  std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateKey(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/apikeys/v2/internal/api_keys_stub_factory.cc
+++ b/google/cloud/apikeys/v2/internal/api_keys_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<ApiKeysStub> CreateDefaultApiKeysStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ApiKeysAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ApiKeysMetadata>(std::move(stub));
+  stub = std::make_shared<ApiKeysMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ApiKeysLogging>(

--- a/google/cloud/appengine/v1/internal/applications_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/applications_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ApplicationsMetadata : public ApplicationsStub {
  public:
   ~ApplicationsMetadata() override = default;
-  explicit ApplicationsMetadata(
-      std::shared_ptr<ApplicationsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ApplicationsMetadata(std::shared_ptr<ApplicationsStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::appengine::v1::Application> GetApplication(
       grpc::ClientContext& context,

--- a/google/cloud/appengine/v1/internal/applications_stub_factory.cc
+++ b/google/cloud/appengine/v1/internal/applications_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<ApplicationsStub> CreateDefaultApplicationsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ApplicationsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ApplicationsMetadata>(std::move(stub));
+  stub = std::make_shared<ApplicationsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ApplicationsLogging>(

--- a/google/cloud/appengine/v1/internal/authorized_certificates_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/authorized_certificates_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AuthorizedCertificatesMetadata : public AuthorizedCertificatesStub {
  public:
   ~AuthorizedCertificatesMetadata() override = default;
-  explicit AuthorizedCertificatesMetadata(
+  AuthorizedCertificatesMetadata(
       std::shared_ptr<AuthorizedCertificatesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::appengine::v1::ListAuthorizedCertificatesResponse>
   ListAuthorizedCertificates(

--- a/google/cloud/appengine/v1/internal/authorized_certificates_stub_factory.cc
+++ b/google/cloud/appengine/v1/internal/authorized_certificates_stub_factory.cc
@@ -53,7 +53,8 @@ CreateDefaultAuthorizedCertificatesStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<AuthorizedCertificatesAuth>(std::move(auth),
                                                         std::move(stub));
   }
-  stub = std::make_shared<AuthorizedCertificatesMetadata>(std::move(stub));
+  stub = std::make_shared<AuthorizedCertificatesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AuthorizedCertificatesLogging>(

--- a/google/cloud/appengine/v1/internal/authorized_domains_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/authorized_domains_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AuthorizedDomainsMetadata : public AuthorizedDomainsStub {
  public:
   ~AuthorizedDomainsMetadata() override = default;
-  explicit AuthorizedDomainsMetadata(
+  AuthorizedDomainsMetadata(
       std::shared_ptr<AuthorizedDomainsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::appengine::v1::ListAuthorizedDomainsResponse>
   ListAuthorizedDomains(

--- a/google/cloud/appengine/v1/internal/authorized_domains_stub_factory.cc
+++ b/google/cloud/appengine/v1/internal/authorized_domains_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<AuthorizedDomainsStub> CreateDefaultAuthorizedDomainsStub(
     stub = std::make_shared<AuthorizedDomainsAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<AuthorizedDomainsMetadata>(std::move(stub));
+  stub = std::make_shared<AuthorizedDomainsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AuthorizedDomainsLogging>(

--- a/google/cloud/appengine/v1/internal/domain_mappings_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/domain_mappings_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DomainMappingsMetadata : public DomainMappingsStub {
  public:
   ~DomainMappingsMetadata() override = default;
-  explicit DomainMappingsMetadata(
+  DomainMappingsMetadata(
       std::shared_ptr<DomainMappingsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::appengine::v1::ListDomainMappingsResponse>
   ListDomainMappings(

--- a/google/cloud/appengine/v1/internal/domain_mappings_stub_factory.cc
+++ b/google/cloud/appengine/v1/internal/domain_mappings_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<DomainMappingsStub> CreateDefaultDomainMappingsStub(
     stub =
         std::make_shared<DomainMappingsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DomainMappingsMetadata>(std::move(stub));
+  stub = std::make_shared<DomainMappingsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DomainMappingsLogging>(

--- a/google/cloud/appengine/v1/internal/firewall_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/firewall_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FirewallMetadata : public FirewallStub {
  public:
   ~FirewallMetadata() override = default;
-  explicit FirewallMetadata(
-      std::shared_ptr<FirewallStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  FirewallMetadata(std::shared_ptr<FirewallStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::appengine::v1::ListIngressRulesResponse> ListIngressRules(
       grpc::ClientContext& context,

--- a/google/cloud/appengine/v1/internal/firewall_stub_factory.cc
+++ b/google/cloud/appengine/v1/internal/firewall_stub_factory.cc
@@ -49,7 +49,8 @@ std::shared_ptr<FirewallStub> CreateDefaultFirewallStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<FirewallAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<FirewallMetadata>(std::move(stub));
+  stub = std::make_shared<FirewallMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<FirewallLogging>(

--- a/google/cloud/appengine/v1/internal/instances_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/instances_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class InstancesMetadata : public InstancesStub {
  public:
   ~InstancesMetadata() override = default;
-  explicit InstancesMetadata(
-      std::shared_ptr<InstancesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  InstancesMetadata(std::shared_ptr<InstancesStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::appengine::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,

--- a/google/cloud/appengine/v1/internal/instances_stub_factory.cc
+++ b/google/cloud/appengine/v1/internal/instances_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<InstancesStub> CreateDefaultInstancesStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<InstancesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<InstancesMetadata>(std::move(stub));
+  stub = std::make_shared<InstancesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<InstancesLogging>(

--- a/google/cloud/appengine/v1/internal/services_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/services_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServicesMetadata : public ServicesStub {
  public:
   ~ServicesMetadata() override = default;
-  explicit ServicesMetadata(
-      std::shared_ptr<ServicesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ServicesMetadata(std::shared_ptr<ServicesStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::appengine::v1::ListServicesResponse> ListServices(
       grpc::ClientContext& context,

--- a/google/cloud/appengine/v1/internal/services_stub_factory.cc
+++ b/google/cloud/appengine/v1/internal/services_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<ServicesStub> CreateDefaultServicesStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ServicesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ServicesMetadata>(std::move(stub));
+  stub = std::make_shared<ServicesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ServicesLogging>(

--- a/google/cloud/appengine/v1/internal/versions_metadata_decorator.h
+++ b/google/cloud/appengine/v1/internal/versions_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VersionsMetadata : public VersionsStub {
  public:
   ~VersionsMetadata() override = default;
-  explicit VersionsMetadata(
-      std::shared_ptr<VersionsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  VersionsMetadata(std::shared_ptr<VersionsStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::appengine::v1::ListVersionsResponse> ListVersions(
       grpc::ClientContext& context,

--- a/google/cloud/appengine/v1/internal/versions_stub_factory.cc
+++ b/google/cloud/appengine/v1/internal/versions_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<VersionsStub> CreateDefaultVersionsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<VersionsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<VersionsMetadata>(std::move(stub));
+  stub = std::make_shared<VersionsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<VersionsLogging>(

--- a/google/cloud/artifactregistry/v1/internal/artifact_registry_metadata_decorator.h
+++ b/google/cloud/artifactregistry/v1/internal/artifact_registry_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ArtifactRegistryMetadata : public ArtifactRegistryStub {
  public:
   ~ArtifactRegistryMetadata() override = default;
-  explicit ArtifactRegistryMetadata(
+  ArtifactRegistryMetadata(
       std::shared_ptr<ArtifactRegistryStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::devtools::artifactregistry::v1::ListDockerImagesResponse>
   ListDockerImages(

--- a/google/cloud/artifactregistry/v1/internal/artifact_registry_stub_factory.cc
+++ b/google/cloud/artifactregistry/v1/internal/artifact_registry_stub_factory.cc
@@ -54,7 +54,8 @@ std::shared_ptr<ArtifactRegistryStub> CreateDefaultArtifactRegistryStub(
     stub = std::make_shared<ArtifactRegistryAuth>(std::move(auth),
                                                   std::move(stub));
   }
-  stub = std::make_shared<ArtifactRegistryMetadata>(std::move(stub));
+  stub = std::make_shared<ArtifactRegistryMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ArtifactRegistryLogging>(

--- a/google/cloud/asset/v1/internal/asset_metadata_decorator.h
+++ b/google/cloud/asset/v1/internal/asset_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AssetServiceMetadata : public AssetServiceStub {
  public:
   ~AssetServiceMetadata() override = default;
-  explicit AssetServiceMetadata(
-      std::shared_ptr<AssetServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AssetServiceMetadata(std::shared_ptr<AssetServiceStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncExportAssets(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/asset/v1/internal/asset_stub_factory.cc
+++ b/google/cloud/asset/v1/internal/asset_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<AssetServiceStub> CreateDefaultAssetServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<AssetServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AssetServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AssetServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AssetServiceLogging>(

--- a/google/cloud/assuredworkloads/v1/internal/assured_workloads_metadata_decorator.h
+++ b/google/cloud/assuredworkloads/v1/internal/assured_workloads_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AssuredWorkloadsServiceMetadata : public AssuredWorkloadsServiceStub {
  public:
   ~AssuredWorkloadsServiceMetadata() override = default;
-  explicit AssuredWorkloadsServiceMetadata(
+  AssuredWorkloadsServiceMetadata(
       std::shared_ptr<AssuredWorkloadsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateWorkload(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/assuredworkloads/v1/internal/assured_workloads_stub_factory.cc
+++ b/google/cloud/assuredworkloads/v1/internal/assured_workloads_stub_factory.cc
@@ -55,7 +55,8 @@ CreateDefaultAssuredWorkloadsServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<AssuredWorkloadsServiceAuth>(std::move(auth),
                                                          std::move(stub));
   }
-  stub = std::make_shared<AssuredWorkloadsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AssuredWorkloadsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AssuredWorkloadsServiceLogging>(

--- a/google/cloud/automl/v1/internal/auto_ml_metadata_decorator.h
+++ b/google/cloud/automl/v1/internal/auto_ml_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AutoMlMetadata : public AutoMlStub {
  public:
   ~AutoMlMetadata() override = default;
-  explicit AutoMlMetadata(
-      std::shared_ptr<AutoMlStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AutoMlMetadata(std::shared_ptr<AutoMlStub> child,
+                 std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDataset(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/automl/v1/internal/auto_ml_stub_factory.cc
+++ b/google/cloud/automl/v1/internal/auto_ml_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<AutoMlStub> CreateDefaultAutoMlStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<AutoMlAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AutoMlMetadata>(std::move(stub));
+  stub = std::make_shared<AutoMlMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AutoMlLogging>(

--- a/google/cloud/automl/v1/internal/prediction_metadata_decorator.h
+++ b/google/cloud/automl/v1/internal/prediction_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PredictionServiceMetadata : public PredictionServiceStub {
  public:
   ~PredictionServiceMetadata() override = default;
-  explicit PredictionServiceMetadata(
+  PredictionServiceMetadata(
       std::shared_ptr<PredictionServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::automl::v1::PredictResponse> Predict(
       grpc::ClientContext& context,

--- a/google/cloud/automl/v1/internal/prediction_stub_factory.cc
+++ b/google/cloud/automl/v1/internal/prediction_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<PredictionServiceStub> CreateDefaultPredictionServiceStub(
     stub = std::make_shared<PredictionServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<PredictionServiceMetadata>(std::move(stub));
+  stub = std::make_shared<PredictionServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PredictionServiceLogging>(

--- a/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_metadata_decorator.h
+++ b/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BareMetalSolutionMetadata : public BareMetalSolutionStub {
  public:
   ~BareMetalSolutionMetadata() override = default;
-  explicit BareMetalSolutionMetadata(
+  BareMetalSolutionMetadata(
       std::shared_ptr<BareMetalSolutionStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::baremetalsolution::v2::ListInstancesResponse>
   ListInstances(

--- a/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_stub_factory.cc
+++ b/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<BareMetalSolutionStub> CreateDefaultBareMetalSolutionStub(
     stub = std::make_shared<BareMetalSolutionAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<BareMetalSolutionMetadata>(std::move(stub));
+  stub = std::make_shared<BareMetalSolutionMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BareMetalSolutionLogging>(

--- a/google/cloud/batch/v1/internal/batch_metadata_decorator.h
+++ b/google/cloud/batch/v1/internal/batch_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BatchServiceMetadata : public BatchServiceStub {
  public:
   ~BatchServiceMetadata() override = default;
-  explicit BatchServiceMetadata(
-      std::shared_ptr<BatchServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  BatchServiceMetadata(std::shared_ptr<BatchServiceStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::batch::v1::Job> CreateJob(
       grpc::ClientContext& context,

--- a/google/cloud/batch/v1/internal/batch_stub_factory.cc
+++ b/google/cloud/batch/v1/internal/batch_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<BatchServiceStub> CreateDefaultBatchServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<BatchServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<BatchServiceMetadata>(std::move(stub));
+  stub = std::make_shared<BatchServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BatchServiceLogging>(

--- a/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_metadata_decorator.h
+++ b/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_metadata_decorator.h
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AppConnectionsServiceMetadata : public AppConnectionsServiceStub {
  public:
   ~AppConnectionsServiceMetadata() override = default;
-  explicit AppConnectionsServiceMetadata(
+  AppConnectionsServiceMetadata(
       std::shared_ptr<AppConnectionsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<
       google::cloud::beyondcorp::appconnections::v1::ListAppConnectionsResponse>

--- a/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_stub_factory.cc
+++ b/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_stub_factory.cc
@@ -55,7 +55,8 @@ CreateDefaultAppConnectionsServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<AppConnectionsServiceAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<AppConnectionsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AppConnectionsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AppConnectionsServiceLogging>(

--- a/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_metadata_decorator.h
+++ b/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AppConnectorsServiceMetadata : public AppConnectorsServiceStub {
  public:
   ~AppConnectorsServiceMetadata() override = default;
-  explicit AppConnectorsServiceMetadata(
+  AppConnectorsServiceMetadata(
       std::shared_ptr<AppConnectorsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<
       google::cloud::beyondcorp::appconnectors::v1::ListAppConnectorsResponse>

--- a/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_stub_factory.cc
+++ b/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<AppConnectorsServiceStub> CreateDefaultAppConnectorsServiceStub(
     stub = std::make_shared<AppConnectorsServiceAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<AppConnectorsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AppConnectorsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AppConnectorsServiceLogging>(

--- a/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_metadata_decorator.h
+++ b/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AppGatewaysServiceMetadata : public AppGatewaysServiceStub {
  public:
   ~AppGatewaysServiceMetadata() override = default;
-  explicit AppGatewaysServiceMetadata(
+  AppGatewaysServiceMetadata(
       std::shared_ptr<AppGatewaysServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::beyondcorp::appgateways::v1::ListAppGatewaysResponse>
   ListAppGateways(

--- a/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_stub_factory.cc
+++ b/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_stub_factory.cc
@@ -54,7 +54,8 @@ std::shared_ptr<AppGatewaysServiceStub> CreateDefaultAppGatewaysServiceStub(
     stub = std::make_shared<AppGatewaysServiceAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<AppGatewaysServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AppGatewaysServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AppGatewaysServiceLogging>(

--- a/google/cloud/beyondcorp/clientconnectorservices/v1/internal/client_connector_services_metadata_decorator.h
+++ b/google/cloud/beyondcorp/clientconnectorservices/v1/internal/client_connector_services_metadata_decorator.h
@@ -36,9 +36,9 @@ class ClientConnectorServicesServiceMetadata
     : public ClientConnectorServicesServiceStub {
  public:
   ~ClientConnectorServicesServiceMetadata() override = default;
-  explicit ClientConnectorServicesServiceMetadata(
+  ClientConnectorServicesServiceMetadata(
       std::shared_ptr<ClientConnectorServicesServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::beyondcorp::clientconnectorservices::v1::
                ListClientConnectorServicesResponse>

--- a/google/cloud/beyondcorp/clientconnectorservices/v1/internal/client_connector_services_stub_factory.cc
+++ b/google/cloud/beyondcorp/clientconnectorservices/v1/internal/client_connector_services_stub_factory.cc
@@ -55,8 +55,8 @@ CreateDefaultClientConnectorServicesServiceStub(
     stub = std::make_shared<ClientConnectorServicesServiceAuth>(
         std::move(auth), std::move(stub));
   }
-  stub =
-      std::make_shared<ClientConnectorServicesServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ClientConnectorServicesServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ClientConnectorServicesServiceLogging>(

--- a/google/cloud/beyondcorp/clientgateways/v1/internal/client_gateways_metadata_decorator.h
+++ b/google/cloud/beyondcorp/clientgateways/v1/internal/client_gateways_metadata_decorator.h
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ClientGatewaysServiceMetadata : public ClientGatewaysServiceStub {
  public:
   ~ClientGatewaysServiceMetadata() override = default;
-  explicit ClientGatewaysServiceMetadata(
+  ClientGatewaysServiceMetadata(
       std::shared_ptr<ClientGatewaysServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<
       google::cloud::beyondcorp::clientgateways::v1::ListClientGatewaysResponse>

--- a/google/cloud/beyondcorp/clientgateways/v1/internal/client_gateways_stub_factory.cc
+++ b/google/cloud/beyondcorp/clientgateways/v1/internal/client_gateways_stub_factory.cc
@@ -55,7 +55,8 @@ CreateDefaultClientGatewaysServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<ClientGatewaysServiceAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<ClientGatewaysServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ClientGatewaysServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ClientGatewaysServiceLogging>(

--- a/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_metadata_decorator.h
+++ b/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AnalyticsHubServiceMetadata : public AnalyticsHubServiceStub {
  public:
   ~AnalyticsHubServiceMetadata() override = default;
-  explicit AnalyticsHubServiceMetadata(
+  AnalyticsHubServiceMetadata(
       std::shared_ptr<AnalyticsHubServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::bigquery::analyticshub::v1::ListDataExchangesResponse>
   ListDataExchanges(

--- a/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_stub_factory.cc
+++ b/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<AnalyticsHubServiceStub> CreateDefaultAnalyticsHubServiceStub(
     stub = std::make_shared<AnalyticsHubServiceAuth>(std::move(auth),
                                                      std::move(stub));
   }
-  stub = std::make_shared<AnalyticsHubServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AnalyticsHubServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AnalyticsHubServiceLogging>(

--- a/google/cloud/bigquery/connection/v1/internal/connection_metadata_decorator.h
+++ b/google/cloud/bigquery/connection/v1/internal/connection_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConnectionServiceMetadata : public ConnectionServiceStub {
  public:
   ~ConnectionServiceMetadata() override = default;
-  explicit ConnectionServiceMetadata(
+  ConnectionServiceMetadata(
       std::shared_ptr<ConnectionServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::bigquery::connection::v1::Connection>
   CreateConnection(

--- a/google/cloud/bigquery/connection/v1/internal/connection_stub_factory.cc
+++ b/google/cloud/bigquery/connection/v1/internal/connection_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ConnectionServiceStub> CreateDefaultConnectionServiceStub(
     stub = std::make_shared<ConnectionServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<ConnectionServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ConnectionServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ConnectionServiceLogging>(

--- a/google/cloud/bigquery/datapolicies/v1/internal/data_policy_metadata_decorator.h
+++ b/google/cloud/bigquery/datapolicies/v1/internal/data_policy_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DataPolicyServiceMetadata : public DataPolicyServiceStub {
  public:
   ~DataPolicyServiceMetadata() override = default;
-  explicit DataPolicyServiceMetadata(
+  DataPolicyServiceMetadata(
       std::shared_ptr<DataPolicyServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>
   CreateDataPolicy(

--- a/google/cloud/bigquery/datapolicies/v1/internal/data_policy_stub_factory.cc
+++ b/google/cloud/bigquery/datapolicies/v1/internal/data_policy_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<DataPolicyServiceStub> CreateDefaultDataPolicyServiceStub(
     stub = std::make_shared<DataPolicyServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<DataPolicyServiceMetadata>(std::move(stub));
+  stub = std::make_shared<DataPolicyServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DataPolicyServiceLogging>(

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DataTransferServiceMetadata : public DataTransferServiceStub {
  public:
   ~DataTransferServiceMetadata() override = default;
-  explicit DataTransferServiceMetadata(
+  DataTransferServiceMetadata(
       std::shared_ptr<DataTransferServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::bigquery::datatransfer::v1::DataSource> GetDataSource(
       grpc::ClientContext& context,

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub_factory.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<DataTransferServiceStub> CreateDefaultDataTransferServiceStub(
     stub = std::make_shared<DataTransferServiceAuth>(std::move(auth),
                                                      std::move(stub));
   }
-  stub = std::make_shared<DataTransferServiceMetadata>(std::move(stub));
+  stub = std::make_shared<DataTransferServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DataTransferServiceLogging>(

--- a/google/cloud/bigquery/migration/v2/internal/migration_metadata_decorator.h
+++ b/google/cloud/bigquery/migration/v2/internal/migration_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MigrationServiceMetadata : public MigrationServiceStub {
  public:
   ~MigrationServiceMetadata() override = default;
-  explicit MigrationServiceMetadata(
+  MigrationServiceMetadata(
       std::shared_ptr<MigrationServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::bigquery::migration::v2::MigrationWorkflow>
   CreateMigrationWorkflow(

--- a/google/cloud/bigquery/migration/v2/internal/migration_stub_factory.cc
+++ b/google/cloud/bigquery/migration/v2/internal/migration_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<MigrationServiceStub> CreateDefaultMigrationServiceStub(
     stub = std::make_shared<MigrationServiceAuth>(std::move(auth),
                                                   std::move(stub));
   }
-  stub = std::make_shared<MigrationServiceMetadata>(std::move(stub));
+  stub = std::make_shared<MigrationServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<MigrationServiceLogging>(

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ReservationServiceMetadata : public ReservationServiceStub {
  public:
   ~ReservationServiceMetadata() override = default;
-  explicit ReservationServiceMetadata(
+  ReservationServiceMetadata(
       std::shared_ptr<ReservationServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::bigquery::reservation::v1::Reservation>
   CreateReservation(

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_stub_factory.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ReservationServiceStub> CreateDefaultReservationServiceStub(
     stub = std::make_shared<ReservationServiceAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<ReservationServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ReservationServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ReservationServiceLogging>(

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_metadata_decorator.h
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigQueryReadMetadata : public BigQueryReadStub {
  public:
   ~BigQueryReadMetadata() override = default;
-  explicit BigQueryReadMetadata(
-      std::shared_ptr<BigQueryReadStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  BigQueryReadMetadata(std::shared_ptr<BigQueryReadStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       grpc::ClientContext& context,

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_stub_factory.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<BigQueryReadStub> CreateDefaultBigQueryReadStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<BigQueryReadAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<BigQueryReadMetadata>(std::move(stub));
+  stub = std::make_shared<BigQueryReadMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BigQueryReadLogging>(

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_write_metadata_decorator.h
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_write_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigQueryWriteMetadata : public BigQueryWriteStub {
  public:
   ~BigQueryWriteMetadata() override = default;
-  explicit BigQueryWriteMetadata(
-      std::shared_ptr<BigQueryWriteStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  BigQueryWriteMetadata(std::shared_ptr<BigQueryWriteStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::bigquery::storage::v1::WriteStream> CreateWriteStream(
       grpc::ClientContext& context,

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_write_stub_factory.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_write_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<BigQueryWriteStub> CreateDefaultBigQueryWriteStub(
     stub =
         std::make_shared<BigQueryWriteAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<BigQueryWriteMetadata>(std::move(stub));
+  stub = std::make_shared<BigQueryWriteMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BigQueryWriteLogging>(

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigtableInstanceAdminMetadata : public BigtableInstanceAdminStub {
  public:
   ~BigtableInstanceAdminMetadata() override = default;
-  explicit BigtableInstanceAdminMetadata(
+  BigtableInstanceAdminMetadata(
       std::shared_ptr<BigtableInstanceAdminStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateInstance(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub_factory.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultBigtableInstanceAdminStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<BigtableInstanceAdminAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<BigtableInstanceAdminMetadata>(std::move(stub));
+  stub = std::make_shared<BigtableInstanceAdminMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BigtableInstanceAdminLogging>(

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigtableTableAdminMetadata : public BigtableTableAdminStub {
  public:
   ~BigtableTableAdminMetadata() override = default;
-  explicit BigtableTableAdminMetadata(
+  BigtableTableAdminMetadata(
       std::shared_ptr<BigtableTableAdminStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       grpc::ClientContext& context,

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub_factory.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<BigtableTableAdminStub> CreateDefaultBigtableTableAdminStub(
     stub = std::make_shared<BigtableTableAdminAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<BigtableTableAdminMetadata>(std::move(stub));
+  stub = std::make_shared<BigtableTableAdminMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BigtableTableAdminLogging>(

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigtableMetadata : public BigtableStub {
  public:
   ~BigtableMetadata() override = default;
-  explicit BigtableMetadata(
-      std::shared_ptr<BigtableStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  BigtableMetadata(std::shared_ptr<BigtableStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>

--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -79,7 +79,8 @@ std::shared_ptr<BigtableStub> CreateDecoratedStubs(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<BigtableAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<BigtableMetadata>(std::move(stub));
+  stub = std::make_shared<BigtableMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (google::cloud::internal::Contains(options.get<TracingComponentsOption>(),
                                         "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/billing/budgets/v1/internal/budget_metadata_decorator.h
+++ b/google/cloud/billing/budgets/v1/internal/budget_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BudgetServiceMetadata : public BudgetServiceStub {
  public:
   ~BudgetServiceMetadata() override = default;
-  explicit BudgetServiceMetadata(
-      std::shared_ptr<BudgetServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  BudgetServiceMetadata(std::shared_ptr<BudgetServiceStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::billing::budgets::v1::Budget> CreateBudget(
       grpc::ClientContext& context,

--- a/google/cloud/billing/budgets/v1/internal/budget_stub_factory.cc
+++ b/google/cloud/billing/budgets/v1/internal/budget_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<BudgetServiceStub> CreateDefaultBudgetServiceStub(
     stub =
         std::make_shared<BudgetServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<BudgetServiceMetadata>(std::move(stub));
+  stub = std::make_shared<BudgetServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BudgetServiceLogging>(

--- a/google/cloud/billing/v1/internal/cloud_billing_metadata_decorator.h
+++ b/google/cloud/billing/v1/internal/cloud_billing_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudBillingMetadata : public CloudBillingStub {
  public:
   ~CloudBillingMetadata() override = default;
-  explicit CloudBillingMetadata(
-      std::shared_ptr<CloudBillingStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CloudBillingMetadata(std::shared_ptr<CloudBillingStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::billing::v1::BillingAccount> GetBillingAccount(
       grpc::ClientContext& context,

--- a/google/cloud/billing/v1/internal/cloud_billing_stub_factory.cc
+++ b/google/cloud/billing/v1/internal/cloud_billing_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<CloudBillingStub> CreateDefaultCloudBillingStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<CloudBillingAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CloudBillingMetadata>(std::move(stub));
+  stub = std::make_shared<CloudBillingMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudBillingLogging>(

--- a/google/cloud/billing/v1/internal/cloud_catalog_metadata_decorator.h
+++ b/google/cloud/billing/v1/internal/cloud_catalog_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudCatalogMetadata : public CloudCatalogStub {
  public:
   ~CloudCatalogMetadata() override = default;
-  explicit CloudCatalogMetadata(
-      std::shared_ptr<CloudCatalogStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CloudCatalogMetadata(std::shared_ptr<CloudCatalogStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::billing::v1::ListServicesResponse> ListServices(
       grpc::ClientContext& context,

--- a/google/cloud/billing/v1/internal/cloud_catalog_stub_factory.cc
+++ b/google/cloud/billing/v1/internal/cloud_catalog_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<CloudCatalogStub> CreateDefaultCloudCatalogStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<CloudCatalogAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CloudCatalogMetadata>(std::move(stub));
+  stub = std::make_shared<CloudCatalogMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudCatalogLogging>(

--- a/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_metadata_decorator.h
+++ b/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_metadata_decorator.h
@@ -34,9 +34,9 @@ class BinauthzManagementServiceV1Metadata
     : public BinauthzManagementServiceV1Stub {
  public:
   ~BinauthzManagementServiceV1Metadata() override = default;
-  explicit BinauthzManagementServiceV1Metadata(
+  BinauthzManagementServiceV1Metadata(
       std::shared_ptr<BinauthzManagementServiceV1Stub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::binaryauthorization::v1::Policy> GetPolicy(
       grpc::ClientContext& context,

--- a/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_stub_factory.cc
+++ b/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_stub_factory.cc
@@ -53,7 +53,8 @@ CreateDefaultBinauthzManagementServiceV1Stub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<BinauthzManagementServiceV1Auth>(std::move(auth),
                                                              std::move(stub));
   }
-  stub = std::make_shared<BinauthzManagementServiceV1Metadata>(std::move(stub));
+  stub = std::make_shared<BinauthzManagementServiceV1Metadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BinauthzManagementServiceV1Logging>(

--- a/google/cloud/binaryauthorization/v1/internal/system_policy_v1_metadata_decorator.h
+++ b/google/cloud/binaryauthorization/v1/internal/system_policy_v1_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SystemPolicyV1Metadata : public SystemPolicyV1Stub {
  public:
   ~SystemPolicyV1Metadata() override = default;
-  explicit SystemPolicyV1Metadata(
+  SystemPolicyV1Metadata(
       std::shared_ptr<SystemPolicyV1Stub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::binaryauthorization::v1::Policy> GetSystemPolicy(
       grpc::ClientContext& context,

--- a/google/cloud/binaryauthorization/v1/internal/system_policy_v1_stub_factory.cc
+++ b/google/cloud/binaryauthorization/v1/internal/system_policy_v1_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<SystemPolicyV1Stub> CreateDefaultSystemPolicyV1Stub(
     stub =
         std::make_shared<SystemPolicyV1Auth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<SystemPolicyV1Metadata>(std::move(stub));
+  stub = std::make_shared<SystemPolicyV1Metadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SystemPolicyV1Logging>(

--- a/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_metadata_decorator.h
+++ b/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ValidationHelperV1Metadata : public ValidationHelperV1Stub {
  public:
   ~ValidationHelperV1Metadata() override = default;
-  explicit ValidationHelperV1Metadata(
+  ValidationHelperV1Metadata(
       std::shared_ptr<ValidationHelperV1Stub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::binaryauthorization::v1::
                ValidateAttestationOccurrenceResponse>

--- a/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_stub_factory.cc
+++ b/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ValidationHelperV1Stub> CreateDefaultValidationHelperV1Stub(
     stub = std::make_shared<ValidationHelperV1Auth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<ValidationHelperV1Metadata>(std::move(stub));
+  stub = std::make_shared<ValidationHelperV1Metadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ValidationHelperV1Logging>(

--- a/google/cloud/certificatemanager/v1/internal/certificate_manager_metadata_decorator.h
+++ b/google/cloud/certificatemanager/v1/internal/certificate_manager_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CertificateManagerMetadata : public CertificateManagerStub {
  public:
   ~CertificateManagerMetadata() override = default;
-  explicit CertificateManagerMetadata(
+  CertificateManagerMetadata(
       std::shared_ptr<CertificateManagerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::certificatemanager::v1::ListCertificatesResponse>
   ListCertificates(

--- a/google/cloud/certificatemanager/v1/internal/certificate_manager_stub_factory.cc
+++ b/google/cloud/certificatemanager/v1/internal/certificate_manager_stub_factory.cc
@@ -54,7 +54,8 @@ std::shared_ptr<CertificateManagerStub> CreateDefaultCertificateManagerStub(
     stub = std::make_shared<CertificateManagerAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<CertificateManagerMetadata>(std::move(stub));
+  stub = std::make_shared<CertificateManagerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CertificateManagerLogging>(

--- a/google/cloud/channel/v1/internal/cloud_channel_metadata_decorator.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudChannelServiceMetadata : public CloudChannelServiceStub {
  public:
   ~CloudChannelServiceMetadata() override = default;
-  explicit CloudChannelServiceMetadata(
+  CloudChannelServiceMetadata(
       std::shared_ptr<CloudChannelServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::channel::v1::ListCustomersResponse> ListCustomers(
       grpc::ClientContext& context,

--- a/google/cloud/channel/v1/internal/cloud_channel_stub_factory.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<CloudChannelServiceStub> CreateDefaultCloudChannelServiceStub(
     stub = std::make_shared<CloudChannelServiceAuth>(std::move(auth),
                                                      std::move(stub));
   }
-  stub = std::make_shared<CloudChannelServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CloudChannelServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudChannelServiceLogging>(

--- a/google/cloud/cloudbuild/v1/internal/cloud_build_metadata_decorator.h
+++ b/google/cloud/cloudbuild/v1/internal/cloud_build_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudBuildMetadata : public CloudBuildStub {
  public:
   ~CloudBuildMetadata() override = default;
-  explicit CloudBuildMetadata(
-      std::shared_ptr<CloudBuildStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CloudBuildMetadata(std::shared_ptr<CloudBuildStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBuild(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/cloudbuild/v1/internal/cloud_build_stub_factory.cc
+++ b/google/cloud/cloudbuild/v1/internal/cloud_build_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<CloudBuildStub> CreateDefaultCloudBuildStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<CloudBuildAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CloudBuildMetadata>(std::move(stub));
+  stub = std::make_shared<CloudBuildMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudBuildLogging>(

--- a/google/cloud/cloudbuild/v2/internal/repository_manager_metadata_decorator.h
+++ b/google/cloud/cloudbuild/v2/internal/repository_manager_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RepositoryManagerMetadata : public RepositoryManagerStub {
  public:
   ~RepositoryManagerMetadata() override = default;
-  explicit RepositoryManagerMetadata(
+  RepositoryManagerMetadata(
       std::shared_ptr<RepositoryManagerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateConnection(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/cloudbuild/v2/internal/repository_manager_stub_factory.cc
+++ b/google/cloud/cloudbuild/v2/internal/repository_manager_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<RepositoryManagerStub> CreateDefaultRepositoryManagerStub(
     stub = std::make_shared<RepositoryManagerAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<RepositoryManagerMetadata>(std::move(stub));
+  stub = std::make_shared<RepositoryManagerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<RepositoryManagerLogging>(

--- a/google/cloud/composer/v1/internal/environments_metadata_decorator.h
+++ b/google/cloud/composer/v1/internal/environments_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EnvironmentsMetadata : public EnvironmentsStub {
  public:
   ~EnvironmentsMetadata() override = default;
-  explicit EnvironmentsMetadata(
-      std::shared_ptr<EnvironmentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EnvironmentsMetadata(std::shared_ptr<EnvironmentsStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateEnvironment(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/composer/v1/internal/environments_stub_factory.cc
+++ b/google/cloud/composer/v1/internal/environments_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<EnvironmentsStub> CreateDefaultEnvironmentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<EnvironmentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EnvironmentsMetadata>(std::move(stub));
+  stub = std::make_shared<EnvironmentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EnvironmentsLogging>(

--- a/google/cloud/composer/v1/internal/image_versions_metadata_decorator.h
+++ b/google/cloud/composer/v1/internal/image_versions_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ImageVersionsMetadata : public ImageVersionsStub {
  public:
   ~ImageVersionsMetadata() override = default;
-  explicit ImageVersionsMetadata(
-      std::shared_ptr<ImageVersionsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ImageVersionsMetadata(std::shared_ptr<ImageVersionsStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::orchestration::airflow::service::v1::
                ListImageVersionsResponse>

--- a/google/cloud/composer/v1/internal/image_versions_stub_factory.cc
+++ b/google/cloud/composer/v1/internal/image_versions_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<ImageVersionsStub> CreateDefaultImageVersionsStub(
     stub =
         std::make_shared<ImageVersionsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ImageVersionsMetadata>(std::move(stub));
+  stub = std::make_shared<ImageVersionsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ImageVersionsLogging>(

--- a/google/cloud/confidentialcomputing/v1/internal/confidential_computing_metadata_decorator.h
+++ b/google/cloud/confidentialcomputing/v1/internal/confidential_computing_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConfidentialComputingMetadata : public ConfidentialComputingStub {
  public:
   ~ConfidentialComputingMetadata() override = default;
-  explicit ConfidentialComputingMetadata(
+  ConfidentialComputingMetadata(
       std::shared_ptr<ConfidentialComputingStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::confidentialcomputing::v1::Challenge> CreateChallenge(
       grpc::ClientContext& context,

--- a/google/cloud/confidentialcomputing/v1/internal/confidential_computing_stub_factory.cc
+++ b/google/cloud/confidentialcomputing/v1/internal/confidential_computing_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultConfidentialComputingStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<ConfidentialComputingAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<ConfidentialComputingMetadata>(std::move(stub));
+  stub = std::make_shared<ConfidentialComputingMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ConfidentialComputingLogging>(

--- a/google/cloud/connectors/v1/internal/connectors_metadata_decorator.h
+++ b/google/cloud/connectors/v1/internal/connectors_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConnectorsMetadata : public ConnectorsStub {
  public:
   ~ConnectorsMetadata() override = default;
-  explicit ConnectorsMetadata(
-      std::shared_ptr<ConnectorsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ConnectorsMetadata(std::shared_ptr<ConnectorsStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::connectors::v1::ListConnectionsResponse>
   ListConnections(grpc::ClientContext& context,

--- a/google/cloud/connectors/v1/internal/connectors_stub_factory.cc
+++ b/google/cloud/connectors/v1/internal/connectors_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<ConnectorsStub> CreateDefaultConnectorsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ConnectorsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ConnectorsMetadata>(std::move(stub));
+  stub = std::make_shared<ConnectorsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ConnectorsLogging>(

--- a/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_metadata_decorator.h
+++ b/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ContactCenterInsightsMetadata : public ContactCenterInsightsStub {
  public:
   ~ContactCenterInsightsMetadata() override = default;
-  explicit ContactCenterInsightsMetadata(
+  ContactCenterInsightsMetadata(
       std::shared_ptr<ContactCenterInsightsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
   CreateConversation(

--- a/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_stub_factory.cc
+++ b/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_stub_factory.cc
@@ -55,7 +55,8 @@ CreateDefaultContactCenterInsightsStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<ContactCenterInsightsAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<ContactCenterInsightsMetadata>(std::move(stub));
+  stub = std::make_shared<ContactCenterInsightsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ContactCenterInsightsLogging>(

--- a/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.h
+++ b/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ClusterManagerMetadata : public ClusterManagerStub {
  public:
   ~ClusterManagerMetadata() override = default;
-  explicit ClusterManagerMetadata(
+  ClusterManagerMetadata(
       std::shared_ptr<ClusterManagerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::container::v1::ListClustersResponse> ListClusters(
       grpc::ClientContext& context,

--- a/google/cloud/container/v1/internal/cluster_manager_stub_factory.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<ClusterManagerStub> CreateDefaultClusterManagerStub(
     stub =
         std::make_shared<ClusterManagerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ClusterManagerMetadata>(std::move(stub));
+  stub = std::make_shared<ClusterManagerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ClusterManagerLogging>(

--- a/google/cloud/containeranalysis/v1/internal/container_analysis_metadata_decorator.h
+++ b/google/cloud/containeranalysis/v1/internal/container_analysis_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ContainerAnalysisMetadata : public ContainerAnalysisStub {
  public:
   ~ContainerAnalysisMetadata() override = default;
-  explicit ContainerAnalysisMetadata(
+  ContainerAnalysisMetadata(
       std::shared_ptr<ContainerAnalysisStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,

--- a/google/cloud/containeranalysis/v1/internal/container_analysis_stub_factory.cc
+++ b/google/cloud/containeranalysis/v1/internal/container_analysis_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ContainerAnalysisStub> CreateDefaultContainerAnalysisStub(
     stub = std::make_shared<ContainerAnalysisAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<ContainerAnalysisMetadata>(std::move(stub));
+  stub = std::make_shared<ContainerAnalysisMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ContainerAnalysisLogging>(

--- a/google/cloud/containeranalysis/v1/internal/grafeas_metadata_decorator.h
+++ b/google/cloud/containeranalysis/v1/internal/grafeas_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GrafeasMetadata : public GrafeasStub {
  public:
   ~GrafeasMetadata() override = default;
-  explicit GrafeasMetadata(
-      std::shared_ptr<GrafeasStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  GrafeasMetadata(std::shared_ptr<GrafeasStub> child,
+                  std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<grafeas::v1::Occurrence> GetOccurrence(
       grpc::ClientContext& context,

--- a/google/cloud/containeranalysis/v1/internal/grafeas_stub_factory.cc
+++ b/google/cloud/containeranalysis/v1/internal/grafeas_stub_factory.cc
@@ -49,7 +49,8 @@ std::shared_ptr<GrafeasStub> CreateDefaultGrafeasStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<GrafeasAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<GrafeasMetadata>(std::move(stub));
+  stub = std::make_shared<GrafeasMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<GrafeasLogging>(

--- a/google/cloud/datacatalog/lineage/v1/internal/lineage_metadata_decorator.h
+++ b/google/cloud/datacatalog/lineage/v1/internal/lineage_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LineageMetadata : public LineageStub {
  public:
   ~LineageMetadata() override = default;
-  explicit LineageMetadata(
-      std::shared_ptr<LineageStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  LineageMetadata(std::shared_ptr<LineageStub> child,
+                  std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::datacatalog::lineage::v1::Process> CreateProcess(
       grpc::ClientContext& context,

--- a/google/cloud/datacatalog/lineage/v1/internal/lineage_stub_factory.cc
+++ b/google/cloud/datacatalog/lineage/v1/internal/lineage_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<LineageStub> CreateDefaultLineageStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<LineageAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<LineageMetadata>(std::move(stub));
+  stub = std::make_shared<LineageMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<LineageLogging>(

--- a/google/cloud/datacatalog/v1/internal/data_catalog_metadata_decorator.h
+++ b/google/cloud/datacatalog/v1/internal/data_catalog_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DataCatalogMetadata : public DataCatalogStub {
  public:
   ~DataCatalogMetadata() override = default;
-  explicit DataCatalogMetadata(
-      std::shared_ptr<DataCatalogStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  DataCatalogMetadata(std::shared_ptr<DataCatalogStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::datacatalog::v1::SearchCatalogResponse> SearchCatalog(
       grpc::ClientContext& context,

--- a/google/cloud/datacatalog/v1/internal/data_catalog_stub_factory.cc
+++ b/google/cloud/datacatalog/v1/internal/data_catalog_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<DataCatalogStub> CreateDefaultDataCatalogStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<DataCatalogAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DataCatalogMetadata>(std::move(stub));
+  stub = std::make_shared<DataCatalogMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DataCatalogLogging>(

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_metadata_decorator.h
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PolicyTagManagerMetadata : public PolicyTagManagerStub {
  public:
   ~PolicyTagManagerMetadata() override = default;
-  explicit PolicyTagManagerMetadata(
+  PolicyTagManagerMetadata(
       std::shared_ptr<PolicyTagManagerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> CreateTaxonomy(
       grpc::ClientContext& context,

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_metadata_decorator.h
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_metadata_decorator.h
@@ -34,9 +34,9 @@ class PolicyTagManagerSerializationMetadata
     : public PolicyTagManagerSerializationStub {
  public:
   ~PolicyTagManagerSerializationMetadata() override = default;
-  explicit PolicyTagManagerSerializationMetadata(
+  PolicyTagManagerSerializationMetadata(
       std::shared_ptr<PolicyTagManagerSerializationStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> ReplaceTaxonomy(
       grpc::ClientContext& context,

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_stub_factory.cc
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_stub_factory.cc
@@ -54,8 +54,8 @@ CreateDefaultPolicyTagManagerSerializationStub(
     stub = std::make_shared<PolicyTagManagerSerializationAuth>(std::move(auth),
                                                                std::move(stub));
   }
-  stub =
-      std::make_shared<PolicyTagManagerSerializationMetadata>(std::move(stub));
+  stub = std::make_shared<PolicyTagManagerSerializationMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PolicyTagManagerSerializationLogging>(

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_stub_factory.cc
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<PolicyTagManagerStub> CreateDefaultPolicyTagManagerStub(
     stub = std::make_shared<PolicyTagManagerAuth>(std::move(auth),
                                                   std::move(stub));
   }
-  stub = std::make_shared<PolicyTagManagerMetadata>(std::move(stub));
+  stub = std::make_shared<PolicyTagManagerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PolicyTagManagerLogging>(

--- a/google/cloud/datamigration/v1/internal/data_migration_metadata_decorator.h
+++ b/google/cloud/datamigration/v1/internal/data_migration_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DataMigrationServiceMetadata : public DataMigrationServiceStub {
  public:
   ~DataMigrationServiceMetadata() override = default;
-  explicit DataMigrationServiceMetadata(
+  DataMigrationServiceMetadata(
       std::shared_ptr<DataMigrationServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::clouddms::v1::ListMigrationJobsResponse>
   ListMigrationJobs(grpc::ClientContext& context,

--- a/google/cloud/datamigration/v1/internal/data_migration_stub_factory.cc
+++ b/google/cloud/datamigration/v1/internal/data_migration_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<DataMigrationServiceStub> CreateDefaultDataMigrationServiceStub(
     stub = std::make_shared<DataMigrationServiceAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<DataMigrationServiceMetadata>(std::move(stub));
+  stub = std::make_shared<DataMigrationServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DataMigrationServiceLogging>(

--- a/google/cloud/dataplex/v1/internal/content_metadata_decorator.h
+++ b/google/cloud/dataplex/v1/internal/content_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ContentServiceMetadata : public ContentServiceStub {
  public:
   ~ContentServiceMetadata() override = default;
-  explicit ContentServiceMetadata(
+  ContentServiceMetadata(
       std::shared_ptr<ContentServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dataplex::v1::Content> CreateContent(
       grpc::ClientContext& context,

--- a/google/cloud/dataplex/v1/internal/content_stub_factory.cc
+++ b/google/cloud/dataplex/v1/internal/content_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<ContentServiceStub> CreateDefaultContentServiceStub(
     stub =
         std::make_shared<ContentServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ContentServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ContentServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ContentServiceLogging>(

--- a/google/cloud/dataplex/v1/internal/dataplex_metadata_decorator.h
+++ b/google/cloud/dataplex/v1/internal/dataplex_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DataplexServiceMetadata : public DataplexServiceStub {
  public:
   ~DataplexServiceMetadata() override = default;
-  explicit DataplexServiceMetadata(
+  DataplexServiceMetadata(
       std::shared_ptr<DataplexServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateLake(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/dataplex/v1/internal/dataplex_stub_factory.cc
+++ b/google/cloud/dataplex/v1/internal/dataplex_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<DataplexServiceStub> CreateDefaultDataplexServiceStub(
     stub =
         std::make_shared<DataplexServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DataplexServiceMetadata>(std::move(stub));
+  stub = std::make_shared<DataplexServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DataplexServiceLogging>(

--- a/google/cloud/dataplex/v1/internal/metadata_metadata_decorator.h
+++ b/google/cloud/dataplex/v1/internal/metadata_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MetadataServiceMetadata : public MetadataServiceStub {
  public:
   ~MetadataServiceMetadata() override = default;
-  explicit MetadataServiceMetadata(
+  MetadataServiceMetadata(
       std::shared_ptr<MetadataServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dataplex::v1::Entity> CreateEntity(
       grpc::ClientContext& context,

--- a/google/cloud/dataplex/v1/internal/metadata_stub_factory.cc
+++ b/google/cloud/dataplex/v1/internal/metadata_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<MetadataServiceStub> CreateDefaultMetadataServiceStub(
     stub =
         std::make_shared<MetadataServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<MetadataServiceMetadata>(std::move(stub));
+  stub = std::make_shared<MetadataServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<MetadataServiceLogging>(

--- a/google/cloud/dataproc/v1/internal/autoscaling_policy_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/autoscaling_policy_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AutoscalingPolicyServiceMetadata : public AutoscalingPolicyServiceStub {
  public:
   ~AutoscalingPolicyServiceMetadata() override = default;
-  explicit AutoscalingPolicyServiceMetadata(
+  AutoscalingPolicyServiceMetadata(
       std::shared_ptr<AutoscalingPolicyServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
   CreateAutoscalingPolicy(

--- a/google/cloud/dataproc/v1/internal/autoscaling_policy_stub_factory.cc
+++ b/google/cloud/dataproc/v1/internal/autoscaling_policy_stub_factory.cc
@@ -53,7 +53,8 @@ CreateDefaultAutoscalingPolicyServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<AutoscalingPolicyServiceAuth>(std::move(auth),
                                                           std::move(stub));
   }
-  stub = std::make_shared<AutoscalingPolicyServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AutoscalingPolicyServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AutoscalingPolicyServiceLogging>(

--- a/google/cloud/dataproc/v1/internal/batch_controller_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/batch_controller_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BatchControllerMetadata : public BatchControllerStub {
  public:
   ~BatchControllerMetadata() override = default;
-  explicit BatchControllerMetadata(
+  BatchControllerMetadata(
       std::shared_ptr<BatchControllerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBatch(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/dataproc/v1/internal/batch_controller_stub_factory.cc
+++ b/google/cloud/dataproc/v1/internal/batch_controller_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<BatchControllerStub> CreateDefaultBatchControllerStub(
     stub =
         std::make_shared<BatchControllerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<BatchControllerMetadata>(std::move(stub));
+  stub = std::make_shared<BatchControllerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<BatchControllerLogging>(

--- a/google/cloud/dataproc/v1/internal/cluster_controller_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/cluster_controller_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ClusterControllerMetadata : public ClusterControllerStub {
  public:
   ~ClusterControllerMetadata() override = default;
-  explicit ClusterControllerMetadata(
+  ClusterControllerMetadata(
       std::shared_ptr<ClusterControllerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateCluster(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/dataproc/v1/internal/cluster_controller_stub_factory.cc
+++ b/google/cloud/dataproc/v1/internal/cluster_controller_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ClusterControllerStub> CreateDefaultClusterControllerStub(
     stub = std::make_shared<ClusterControllerAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<ClusterControllerMetadata>(std::move(stub));
+  stub = std::make_shared<ClusterControllerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ClusterControllerLogging>(

--- a/google/cloud/dataproc/v1/internal/job_controller_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/job_controller_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class JobControllerMetadata : public JobControllerStub {
  public:
   ~JobControllerMetadata() override = default;
-  explicit JobControllerMetadata(
-      std::shared_ptr<JobControllerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  JobControllerMetadata(std::shared_ptr<JobControllerStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dataproc::v1::Job> SubmitJob(
       grpc::ClientContext& context,

--- a/google/cloud/dataproc/v1/internal/job_controller_stub_factory.cc
+++ b/google/cloud/dataproc/v1/internal/job_controller_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<JobControllerStub> CreateDefaultJobControllerStub(
     stub =
         std::make_shared<JobControllerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<JobControllerMetadata>(std::move(stub));
+  stub = std::make_shared<JobControllerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<JobControllerLogging>(

--- a/google/cloud/dataproc/v1/internal/workflow_template_metadata_decorator.h
+++ b/google/cloud/dataproc/v1/internal/workflow_template_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WorkflowTemplateServiceMetadata : public WorkflowTemplateServiceStub {
  public:
   ~WorkflowTemplateServiceMetadata() override = default;
-  explicit WorkflowTemplateServiceMetadata(
+  WorkflowTemplateServiceMetadata(
       std::shared_ptr<WorkflowTemplateServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
   CreateWorkflowTemplate(

--- a/google/cloud/dataproc/v1/internal/workflow_template_stub_factory.cc
+++ b/google/cloud/dataproc/v1/internal/workflow_template_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultWorkflowTemplateServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<WorkflowTemplateServiceAuth>(std::move(auth),
                                                          std::move(stub));
   }
-  stub = std::make_shared<WorkflowTemplateServiceMetadata>(std::move(stub));
+  stub = std::make_shared<WorkflowTemplateServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<WorkflowTemplateServiceLogging>(

--- a/google/cloud/datastream/v1/internal/datastream_metadata_decorator.h
+++ b/google/cloud/datastream/v1/internal/datastream_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DatastreamMetadata : public DatastreamStub {
  public:
   ~DatastreamMetadata() override = default;
-  explicit DatastreamMetadata(
-      std::shared_ptr<DatastreamStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  DatastreamMetadata(std::shared_ptr<DatastreamStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::datastream::v1::ListConnectionProfilesResponse>
   ListConnectionProfiles(

--- a/google/cloud/datastream/v1/internal/datastream_stub_factory.cc
+++ b/google/cloud/datastream/v1/internal/datastream_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<DatastreamStub> CreateDefaultDatastreamStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<DatastreamAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DatastreamMetadata>(std::move(stub));
+  stub = std::make_shared<DatastreamMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DatastreamLogging>(

--- a/google/cloud/deploy/v1/internal/cloud_deploy_metadata_decorator.h
+++ b/google/cloud/deploy/v1/internal/cloud_deploy_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudDeployMetadata : public CloudDeployStub {
  public:
   ~CloudDeployMetadata() override = default;
-  explicit CloudDeployMetadata(
-      std::shared_ptr<CloudDeployStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CloudDeployMetadata(std::shared_ptr<CloudDeployStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::deploy::v1::ListDeliveryPipelinesResponse>
   ListDeliveryPipelines(

--- a/google/cloud/deploy/v1/internal/cloud_deploy_stub_factory.cc
+++ b/google/cloud/deploy/v1/internal/cloud_deploy_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<CloudDeployStub> CreateDefaultCloudDeployStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<CloudDeployAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CloudDeployMetadata>(std::move(stub));
+  stub = std::make_shared<CloudDeployMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudDeployLogging>(

--- a/google/cloud/dialogflow_cx/internal/agents_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/agents_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AgentsMetadata : public AgentsStub {
  public:
   ~AgentsMetadata() override = default;
-  explicit AgentsMetadata(
-      std::shared_ptr<AgentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AgentsMetadata(std::shared_ptr<AgentsStub> child,
+                 std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListAgentsResponse> ListAgents(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/agents_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/agents_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<AgentsStub> CreateDefaultAgentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<AgentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AgentsMetadata>(std::move(stub));
+  stub = std::make_shared<AgentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AgentsLogging>(

--- a/google/cloud/dialogflow_cx/internal/changelogs_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/changelogs_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ChangelogsMetadata : public ChangelogsStub {
  public:
   ~ChangelogsMetadata() override = default;
-  explicit ChangelogsMetadata(
-      std::shared_ptr<ChangelogsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ChangelogsMetadata(std::shared_ptr<ChangelogsStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListChangelogsResponse>
   ListChangelogs(grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/changelogs_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/changelogs_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<ChangelogsStub> CreateDefaultChangelogsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ChangelogsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ChangelogsMetadata>(std::move(stub));
+  stub = std::make_shared<ChangelogsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ChangelogsLogging>(

--- a/google/cloud/dialogflow_cx/internal/deployments_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/deployments_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DeploymentsMetadata : public DeploymentsStub {
  public:
   ~DeploymentsMetadata() override = default;
-  explicit DeploymentsMetadata(
-      std::shared_ptr<DeploymentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  DeploymentsMetadata(std::shared_ptr<DeploymentsStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListDeploymentsResponse>
   ListDeployments(

--- a/google/cloud/dialogflow_cx/internal/deployments_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/deployments_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<DeploymentsStub> CreateDefaultDeploymentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<DeploymentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DeploymentsMetadata>(std::move(stub));
+  stub = std::make_shared<DeploymentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DeploymentsLogging>(

--- a/google/cloud/dialogflow_cx/internal/entity_types_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/entity_types_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EntityTypesMetadata : public EntityTypesStub {
  public:
   ~EntityTypesMetadata() override = default;
-  explicit EntityTypesMetadata(
-      std::shared_ptr<EntityTypesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EntityTypesMetadata(std::shared_ptr<EntityTypesStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListEntityTypesResponse>
   ListEntityTypes(

--- a/google/cloud/dialogflow_cx/internal/entity_types_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/entity_types_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<EntityTypesStub> CreateDefaultEntityTypesStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<EntityTypesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EntityTypesMetadata>(std::move(stub));
+  stub = std::make_shared<EntityTypesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EntityTypesLogging>(

--- a/google/cloud/dialogflow_cx/internal/environments_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/environments_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EnvironmentsMetadata : public EnvironmentsStub {
  public:
   ~EnvironmentsMetadata() override = default;
-  explicit EnvironmentsMetadata(
-      std::shared_ptr<EnvironmentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EnvironmentsMetadata(std::shared_ptr<EnvironmentsStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListEnvironmentsResponse>
   ListEnvironments(

--- a/google/cloud/dialogflow_cx/internal/environments_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/environments_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<EnvironmentsStub> CreateDefaultEnvironmentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<EnvironmentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EnvironmentsMetadata>(std::move(stub));
+  stub = std::make_shared<EnvironmentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EnvironmentsLogging>(

--- a/google/cloud/dialogflow_cx/internal/experiments_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/experiments_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ExperimentsMetadata : public ExperimentsStub {
  public:
   ~ExperimentsMetadata() override = default;
-  explicit ExperimentsMetadata(
-      std::shared_ptr<ExperimentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ExperimentsMetadata(std::shared_ptr<ExperimentsStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListExperimentsResponse>
   ListExperiments(

--- a/google/cloud/dialogflow_cx/internal/experiments_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/experiments_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<ExperimentsStub> CreateDefaultExperimentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ExperimentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ExperimentsMetadata>(std::move(stub));
+  stub = std::make_shared<ExperimentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ExperimentsLogging>(

--- a/google/cloud/dialogflow_cx/internal/flows_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/flows_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FlowsMetadata : public FlowsStub {
  public:
   ~FlowsMetadata() override = default;
-  explicit FlowsMetadata(
-      std::shared_ptr<FlowsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  FlowsMetadata(std::shared_ptr<FlowsStub> child,
+                std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::Flow> CreateFlow(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/flows_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/flows_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<FlowsStub> CreateDefaultFlowsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<FlowsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<FlowsMetadata>(std::move(stub));
+  stub = std::make_shared<FlowsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<FlowsLogging>(

--- a/google/cloud/dialogflow_cx/internal/intents_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/intents_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IntentsMetadata : public IntentsStub {
  public:
   ~IntentsMetadata() override = default;
-  explicit IntentsMetadata(
-      std::shared_ptr<IntentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  IntentsMetadata(std::shared_ptr<IntentsStub> child,
+                  std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListIntentsResponse> ListIntents(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/intents_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/intents_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<IntentsStub> CreateDefaultIntentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<IntentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<IntentsMetadata>(std::move(stub));
+  stub = std::make_shared<IntentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IntentsLogging>(

--- a/google/cloud/dialogflow_cx/internal/pages_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/pages_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PagesMetadata : public PagesStub {
  public:
   ~PagesMetadata() override = default;
-  explicit PagesMetadata(
-      std::shared_ptr<PagesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  PagesMetadata(std::shared_ptr<PagesStub> child,
+                std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListPagesResponse> ListPages(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/pages_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/pages_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<PagesStub> CreateDefaultPagesStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<PagesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<PagesMetadata>(std::move(stub));
+  stub = std::make_shared<PagesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PagesLogging>(

--- a/google/cloud/dialogflow_cx/internal/security_settings_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/security_settings_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SecuritySettingsServiceMetadata : public SecuritySettingsServiceStub {
  public:
   ~SecuritySettingsServiceMetadata() override = default;
-  explicit SecuritySettingsServiceMetadata(
+  SecuritySettingsServiceMetadata(
       std::shared_ptr<SecuritySettingsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>
   CreateSecuritySettings(

--- a/google/cloud/dialogflow_cx/internal/security_settings_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/security_settings_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultSecuritySettingsServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<SecuritySettingsServiceAuth>(std::move(auth),
                                                          std::move(stub));
   }
-  stub = std::make_shared<SecuritySettingsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<SecuritySettingsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SecuritySettingsServiceLogging>(

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SessionEntityTypesMetadata : public SessionEntityTypesStub {
  public:
   ~SessionEntityTypesMetadata() override = default;
-  explicit SessionEntityTypesMetadata(
+  SessionEntityTypesMetadata(
       std::shared_ptr<SessionEntityTypesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListSessionEntityTypesResponse>
   ListSessionEntityTypes(

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<SessionEntityTypesStub> CreateDefaultSessionEntityTypesStub(
     stub = std::make_shared<SessionEntityTypesAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<SessionEntityTypesMetadata>(std::move(stub));
+  stub = std::make_shared<SessionEntityTypesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SessionEntityTypesLogging>(

--- a/google/cloud/dialogflow_cx/internal/sessions_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/sessions_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SessionsMetadata : public SessionsStub {
  public:
   ~SessionsMetadata() override = default;
-  explicit SessionsMetadata(
-      std::shared_ptr<SessionsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  SessionsMetadata(std::shared_ptr<SessionsStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::DetectIntentResponse>
   DetectIntent(grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/sessions_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/sessions_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<SessionsStub> CreateDefaultSessionsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<SessionsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<SessionsMetadata>(std::move(stub));
+  stub = std::make_shared<SessionsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SessionsLogging>(

--- a/google/cloud/dialogflow_cx/internal/test_cases_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/test_cases_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TestCasesMetadata : public TestCasesStub {
  public:
   ~TestCasesMetadata() override = default;
-  explicit TestCasesMetadata(
-      std::shared_ptr<TestCasesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  TestCasesMetadata(std::shared_ptr<TestCasesStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListTestCasesResponse>
   ListTestCases(grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/test_cases_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/test_cases_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<TestCasesStub> CreateDefaultTestCasesStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<TestCasesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<TestCasesMetadata>(std::move(stub));
+  stub = std::make_shared<TestCasesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TestCasesLogging>(

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TransitionRouteGroupsMetadata : public TransitionRouteGroupsStub {
  public:
   ~TransitionRouteGroupsMetadata() override = default;
-  explicit TransitionRouteGroupsMetadata(
+  TransitionRouteGroupsMetadata(
       std::shared_ptr<TransitionRouteGroupsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListTransitionRouteGroupsResponse>
   ListTransitionRouteGroups(

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultTransitionRouteGroupsStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<TransitionRouteGroupsAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<TransitionRouteGroupsMetadata>(std::move(stub));
+  stub = std::make_shared<TransitionRouteGroupsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TransitionRouteGroupsLogging>(

--- a/google/cloud/dialogflow_cx/internal/versions_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/versions_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VersionsMetadata : public VersionsStub {
  public:
   ~VersionsMetadata() override = default;
-  explicit VersionsMetadata(
-      std::shared_ptr<VersionsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  VersionsMetadata(std::shared_ptr<VersionsStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListVersionsResponse>
   ListVersions(grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/versions_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/versions_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<VersionsStub> CreateDefaultVersionsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<VersionsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<VersionsMetadata>(std::move(stub));
+  stub = std::make_shared<VersionsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<VersionsLogging>(

--- a/google/cloud/dialogflow_cx/internal/webhooks_metadata_decorator.h
+++ b/google/cloud/dialogflow_cx/internal/webhooks_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WebhooksMetadata : public WebhooksStub {
  public:
   ~WebhooksMetadata() override = default;
-  explicit WebhooksMetadata(
-      std::shared_ptr<WebhooksStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  WebhooksMetadata(std::shared_ptr<WebhooksStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::cx::v3::ListWebhooksResponse>
   ListWebhooks(grpc::ClientContext& context,

--- a/google/cloud/dialogflow_cx/internal/webhooks_stub_factory.cc
+++ b/google/cloud/dialogflow_cx/internal/webhooks_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<WebhooksStub> CreateDefaultWebhooksStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<WebhooksAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<WebhooksMetadata>(std::move(stub));
+  stub = std::make_shared<WebhooksMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<WebhooksLogging>(

--- a/google/cloud/dialogflow_es/internal/agents_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/agents_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AgentsMetadata : public AgentsStub {
  public:
   ~AgentsMetadata() override = default;
-  explicit AgentsMetadata(
-      std::shared_ptr<AgentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AgentsMetadata(std::shared_ptr<AgentsStub> child,
+                 std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::Agent> GetAgent(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/agents_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/agents_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<AgentsStub> CreateDefaultAgentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<AgentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AgentsMetadata>(std::move(stub));
+  stub = std::make_shared<AgentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AgentsLogging>(

--- a/google/cloud/dialogflow_es/internal/answer_records_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/answer_records_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AnswerRecordsMetadata : public AnswerRecordsStub {
  public:
   ~AnswerRecordsMetadata() override = default;
-  explicit AnswerRecordsMetadata(
-      std::shared_ptr<AnswerRecordsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AnswerRecordsMetadata(std::shared_ptr<AnswerRecordsStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListAnswerRecordsResponse>
   ListAnswerRecords(

--- a/google/cloud/dialogflow_es/internal/answer_records_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/answer_records_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<AnswerRecordsStub> CreateDefaultAnswerRecordsStub(
     stub =
         std::make_shared<AnswerRecordsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AnswerRecordsMetadata>(std::move(stub));
+  stub = std::make_shared<AnswerRecordsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AnswerRecordsLogging>(

--- a/google/cloud/dialogflow_es/internal/contexts_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/contexts_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ContextsMetadata : public ContextsStub {
  public:
   ~ContextsMetadata() override = default;
-  explicit ContextsMetadata(
-      std::shared_ptr<ContextsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ContextsMetadata(std::shared_ptr<ContextsStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListContextsResponse> ListContexts(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/contexts_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/contexts_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<ContextsStub> CreateDefaultContextsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ContextsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ContextsMetadata>(std::move(stub));
+  stub = std::make_shared<ContextsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ContextsLogging>(

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConversationDatasetsMetadata : public ConversationDatasetsStub {
  public:
   ~ConversationDatasetsMetadata() override = default;
-  explicit ConversationDatasetsMetadata(
+  ConversationDatasetsMetadata(
       std::shared_ptr<ConversationDatasetsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>>
   AsyncCreateConversationDataset(

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ConversationDatasetsStub> CreateDefaultConversationDatasetsStub(
     stub = std::make_shared<ConversationDatasetsAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<ConversationDatasetsMetadata>(std::move(stub));
+  stub = std::make_shared<ConversationDatasetsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ConversationDatasetsLogging>(

--- a/google/cloud/dialogflow_es/internal/conversation_models_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/conversation_models_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConversationModelsMetadata : public ConversationModelsStub {
  public:
   ~ConversationModelsMetadata() override = default;
-  explicit ConversationModelsMetadata(
+  ConversationModelsMetadata(
       std::shared_ptr<ConversationModelsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateConversationModel(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/dialogflow_es/internal/conversation_models_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_models_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ConversationModelsStub> CreateDefaultConversationModelsStub(
     stub = std::make_shared<ConversationModelsAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<ConversationModelsMetadata>(std::move(stub));
+  stub = std::make_shared<ConversationModelsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ConversationModelsLogging>(

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConversationProfilesMetadata : public ConversationProfilesStub {
  public:
   ~ConversationProfilesMetadata() override = default;
-  explicit ConversationProfilesMetadata(
+  ConversationProfilesMetadata(
       std::shared_ptr<ConversationProfilesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListConversationProfilesResponse>
   ListConversationProfiles(

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ConversationProfilesStub> CreateDefaultConversationProfilesStub(
     stub = std::make_shared<ConversationProfilesAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<ConversationProfilesMetadata>(std::move(stub));
+  stub = std::make_shared<ConversationProfilesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ConversationProfilesLogging>(

--- a/google/cloud/dialogflow_es/internal/conversations_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/conversations_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ConversationsMetadata : public ConversationsStub {
  public:
   ~ConversationsMetadata() override = default;
-  explicit ConversationsMetadata(
-      std::shared_ptr<ConversationsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ConversationsMetadata(std::shared_ptr<ConversationsStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::Conversation> CreateConversation(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/conversations_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/conversations_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<ConversationsStub> CreateDefaultConversationsStub(
     stub =
         std::make_shared<ConversationsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ConversationsMetadata>(std::move(stub));
+  stub = std::make_shared<ConversationsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ConversationsLogging>(

--- a/google/cloud/dialogflow_es/internal/documents_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/documents_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DocumentsMetadata : public DocumentsStub {
  public:
   ~DocumentsMetadata() override = default;
-  explicit DocumentsMetadata(
-      std::shared_ptr<DocumentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  DocumentsMetadata(std::shared_ptr<DocumentsStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListDocumentsResponse> ListDocuments(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/documents_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/documents_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<DocumentsStub> CreateDefaultDocumentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<DocumentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DocumentsMetadata>(std::move(stub));
+  stub = std::make_shared<DocumentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DocumentsLogging>(

--- a/google/cloud/dialogflow_es/internal/entity_types_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/entity_types_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EntityTypesMetadata : public EntityTypesStub {
  public:
   ~EntityTypesMetadata() override = default;
-  explicit EntityTypesMetadata(
-      std::shared_ptr<EntityTypesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EntityTypesMetadata(std::shared_ptr<EntityTypesStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListEntityTypesResponse>
   ListEntityTypes(grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/entity_types_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/entity_types_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<EntityTypesStub> CreateDefaultEntityTypesStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<EntityTypesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EntityTypesMetadata>(std::move(stub));
+  stub = std::make_shared<EntityTypesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EntityTypesLogging>(

--- a/google/cloud/dialogflow_es/internal/environments_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/environments_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EnvironmentsMetadata : public EnvironmentsStub {
  public:
   ~EnvironmentsMetadata() override = default;
-  explicit EnvironmentsMetadata(
-      std::shared_ptr<EnvironmentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EnvironmentsMetadata(std::shared_ptr<EnvironmentsStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListEnvironmentsResponse>
   ListEnvironments(grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/environments_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/environments_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<EnvironmentsStub> CreateDefaultEnvironmentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<EnvironmentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EnvironmentsMetadata>(std::move(stub));
+  stub = std::make_shared<EnvironmentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EnvironmentsLogging>(

--- a/google/cloud/dialogflow_es/internal/fulfillments_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/fulfillments_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FulfillmentsMetadata : public FulfillmentsStub {
  public:
   ~FulfillmentsMetadata() override = default;
-  explicit FulfillmentsMetadata(
-      std::shared_ptr<FulfillmentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  FulfillmentsMetadata(std::shared_ptr<FulfillmentsStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::Fulfillment> GetFulfillment(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/fulfillments_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/fulfillments_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<FulfillmentsStub> CreateDefaultFulfillmentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<FulfillmentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<FulfillmentsMetadata>(std::move(stub));
+  stub = std::make_shared<FulfillmentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<FulfillmentsLogging>(

--- a/google/cloud/dialogflow_es/internal/intents_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/intents_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IntentsMetadata : public IntentsStub {
  public:
   ~IntentsMetadata() override = default;
-  explicit IntentsMetadata(
-      std::shared_ptr<IntentsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  IntentsMetadata(std::shared_ptr<IntentsStub> child,
+                  std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListIntentsResponse> ListIntents(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/intents_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/intents_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<IntentsStub> CreateDefaultIntentsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<IntentsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<IntentsMetadata>(std::move(stub));
+  stub = std::make_shared<IntentsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IntentsLogging>(

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class KnowledgeBasesMetadata : public KnowledgeBasesStub {
  public:
   ~KnowledgeBasesMetadata() override = default;
-  explicit KnowledgeBasesMetadata(
+  KnowledgeBasesMetadata(
       std::shared_ptr<KnowledgeBasesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListKnowledgeBasesResponse>
   ListKnowledgeBases(

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<KnowledgeBasesStub> CreateDefaultKnowledgeBasesStub(
     stub =
         std::make_shared<KnowledgeBasesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<KnowledgeBasesMetadata>(std::move(stub));
+  stub = std::make_shared<KnowledgeBasesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<KnowledgeBasesLogging>(

--- a/google/cloud/dialogflow_es/internal/participants_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/participants_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ParticipantsMetadata : public ParticipantsStub {
  public:
   ~ParticipantsMetadata() override = default;
-  explicit ParticipantsMetadata(
-      std::shared_ptr<ParticipantsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ParticipantsMetadata(std::shared_ptr<ParticipantsStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::Participant> CreateParticipant(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/participants_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/participants_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<ParticipantsStub> CreateDefaultParticipantsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ParticipantsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ParticipantsMetadata>(std::move(stub));
+  stub = std::make_shared<ParticipantsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ParticipantsLogging>(

--- a/google/cloud/dialogflow_es/internal/session_entity_types_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SessionEntityTypesMetadata : public SessionEntityTypesStub {
  public:
   ~SessionEntityTypesMetadata() override = default;
-  explicit SessionEntityTypesMetadata(
+  SessionEntityTypesMetadata(
       std::shared_ptr<SessionEntityTypesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListSessionEntityTypesResponse>
   ListSessionEntityTypes(

--- a/google/cloud/dialogflow_es/internal/session_entity_types_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<SessionEntityTypesStub> CreateDefaultSessionEntityTypesStub(
     stub = std::make_shared<SessionEntityTypesAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<SessionEntityTypesMetadata>(std::move(stub));
+  stub = std::make_shared<SessionEntityTypesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SessionEntityTypesLogging>(

--- a/google/cloud/dialogflow_es/internal/sessions_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/sessions_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SessionsMetadata : public SessionsStub {
  public:
   ~SessionsMetadata() override = default;
-  explicit SessionsMetadata(
-      std::shared_ptr<SessionsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  SessionsMetadata(std::shared_ptr<SessionsStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::DetectIntentResponse> DetectIntent(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/sessions_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/sessions_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<SessionsStub> CreateDefaultSessionsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<SessionsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<SessionsMetadata>(std::move(stub));
+  stub = std::make_shared<SessionsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SessionsLogging>(

--- a/google/cloud/dialogflow_es/internal/versions_metadata_decorator.h
+++ b/google/cloud/dialogflow_es/internal/versions_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VersionsMetadata : public VersionsStub {
  public:
   ~VersionsMetadata() override = default;
-  explicit VersionsMetadata(
-      std::shared_ptr<VersionsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  VersionsMetadata(std::shared_ptr<VersionsStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::dialogflow::v2::ListVersionsResponse> ListVersions(
       grpc::ClientContext& context,

--- a/google/cloud/dialogflow_es/internal/versions_stub_factory.cc
+++ b/google/cloud/dialogflow_es/internal/versions_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<VersionsStub> CreateDefaultVersionsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<VersionsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<VersionsMetadata>(std::move(stub));
+  stub = std::make_shared<VersionsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<VersionsLogging>(

--- a/google/cloud/dlp/v2/internal/dlp_metadata_decorator.h
+++ b/google/cloud/dlp/v2/internal/dlp_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DlpServiceMetadata : public DlpServiceStub {
  public:
   ~DlpServiceMetadata() override = default;
-  explicit DlpServiceMetadata(
-      std::shared_ptr<DlpServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  DlpServiceMetadata(std::shared_ptr<DlpServiceStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::privacy::dlp::v2::InspectContentResponse> InspectContent(
       grpc::ClientContext& context,

--- a/google/cloud/dlp/v2/internal/dlp_stub_factory.cc
+++ b/google/cloud/dlp/v2/internal/dlp_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<DlpServiceStub> CreateDefaultDlpServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<DlpServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DlpServiceMetadata>(std::move(stub));
+  stub = std::make_shared<DlpServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DlpServiceLogging>(

--- a/google/cloud/documentai/v1/internal/document_processor_metadata_decorator.h
+++ b/google/cloud/documentai/v1/internal/document_processor_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DocumentProcessorServiceMetadata : public DocumentProcessorServiceStub {
  public:
   ~DocumentProcessorServiceMetadata() override = default;
-  explicit DocumentProcessorServiceMetadata(
+  DocumentProcessorServiceMetadata(
       std::shared_ptr<DocumentProcessorServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::documentai::v1::ProcessResponse> ProcessDocument(
       grpc::ClientContext& context,

--- a/google/cloud/documentai/v1/internal/document_processor_stub_factory.cc
+++ b/google/cloud/documentai/v1/internal/document_processor_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultDocumentProcessorServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<DocumentProcessorServiceAuth>(std::move(auth),
                                                           std::move(stub));
   }
-  stub = std::make_shared<DocumentProcessorServiceMetadata>(std::move(stub));
+  stub = std::make_shared<DocumentProcessorServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DocumentProcessorServiceLogging>(

--- a/google/cloud/edgecontainer/v1/internal/edge_container_metadata_decorator.h
+++ b/google/cloud/edgecontainer/v1/internal/edge_container_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EdgeContainerMetadata : public EdgeContainerStub {
  public:
   ~EdgeContainerMetadata() override = default;
-  explicit EdgeContainerMetadata(
-      std::shared_ptr<EdgeContainerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EdgeContainerMetadata(std::shared_ptr<EdgeContainerStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::edgecontainer::v1::ListClustersResponse> ListClusters(
       grpc::ClientContext& context,

--- a/google/cloud/edgecontainer/v1/internal/edge_container_stub_factory.cc
+++ b/google/cloud/edgecontainer/v1/internal/edge_container_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<EdgeContainerStub> CreateDefaultEdgeContainerStub(
     stub =
         std::make_shared<EdgeContainerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EdgeContainerMetadata>(std::move(stub));
+  stub = std::make_shared<EdgeContainerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EdgeContainerLogging>(

--- a/google/cloud/eventarc/publishing/v1/internal/publisher_metadata_decorator.h
+++ b/google/cloud/eventarc/publishing/v1/internal/publisher_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PublisherMetadata : public PublisherStub {
  public:
   ~PublisherMetadata() override = default;
-  explicit PublisherMetadata(
-      std::shared_ptr<PublisherStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  PublisherMetadata(std::shared_ptr<PublisherStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::eventarc::publishing::v1::
                PublishChannelConnectionEventsResponse>

--- a/google/cloud/eventarc/publishing/v1/internal/publisher_stub_factory.cc
+++ b/google/cloud/eventarc/publishing/v1/internal/publisher_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<PublisherStub> CreateDefaultPublisherStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<PublisherAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<PublisherMetadata>(std::move(stub));
+  stub = std::make_shared<PublisherMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PublisherLogging>(

--- a/google/cloud/eventarc/v1/internal/eventarc_metadata_decorator.h
+++ b/google/cloud/eventarc/v1/internal/eventarc_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EventarcMetadata : public EventarcStub {
  public:
   ~EventarcMetadata() override = default;
-  explicit EventarcMetadata(
-      std::shared_ptr<EventarcStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EventarcMetadata(std::shared_ptr<EventarcStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::eventarc::v1::Trigger> GetTrigger(
       grpc::ClientContext& context,

--- a/google/cloud/eventarc/v1/internal/eventarc_stub_factory.cc
+++ b/google/cloud/eventarc/v1/internal/eventarc_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<EventarcStub> CreateDefaultEventarcStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<EventarcAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EventarcMetadata>(std::move(stub));
+  stub = std::make_shared<EventarcMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EventarcLogging>(

--- a/google/cloud/filestore/v1/internal/cloud_filestore_manager_metadata_decorator.h
+++ b/google/cloud/filestore/v1/internal/cloud_filestore_manager_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudFilestoreManagerMetadata : public CloudFilestoreManagerStub {
  public:
   ~CloudFilestoreManagerMetadata() override = default;
-  explicit CloudFilestoreManagerMetadata(
+  CloudFilestoreManagerMetadata(
       std::shared_ptr<CloudFilestoreManagerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::filestore::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,

--- a/google/cloud/filestore/v1/internal/cloud_filestore_manager_stub_factory.cc
+++ b/google/cloud/filestore/v1/internal/cloud_filestore_manager_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultCloudFilestoreManagerStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<CloudFilestoreManagerAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<CloudFilestoreManagerMetadata>(std::move(stub));
+  stub = std::make_shared<CloudFilestoreManagerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudFilestoreManagerLogging>(

--- a/google/cloud/functions/v1/internal/cloud_functions_metadata_decorator.h
+++ b/google/cloud/functions/v1/internal/cloud_functions_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudFunctionsServiceMetadata : public CloudFunctionsServiceStub {
  public:
   ~CloudFunctionsServiceMetadata() override = default;
-  explicit CloudFunctionsServiceMetadata(
+  CloudFunctionsServiceMetadata(
       std::shared_ptr<CloudFunctionsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::functions::v1::ListFunctionsResponse> ListFunctions(
       grpc::ClientContext& context,

--- a/google/cloud/functions/v1/internal/cloud_functions_stub_factory.cc
+++ b/google/cloud/functions/v1/internal/cloud_functions_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultCloudFunctionsServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<CloudFunctionsServiceAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<CloudFunctionsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CloudFunctionsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudFunctionsServiceLogging>(

--- a/google/cloud/gameservices/v1/internal/game_server_clusters_metadata_decorator.h
+++ b/google/cloud/gameservices/v1/internal/game_server_clusters_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GameServerClustersServiceMetadata : public GameServerClustersServiceStub {
  public:
   ~GameServerClustersServiceMetadata() override = default;
-  explicit GameServerClustersServiceMetadata(
+  GameServerClustersServiceMetadata(
       std::shared_ptr<GameServerClustersServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::gaming::v1::ListGameServerClustersResponse>
   ListGameServerClusters(

--- a/google/cloud/gameservices/v1/internal/game_server_clusters_stub_factory.cc
+++ b/google/cloud/gameservices/v1/internal/game_server_clusters_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultGameServerClustersServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<GameServerClustersServiceAuth>(std::move(auth),
                                                            std::move(stub));
   }
-  stub = std::make_shared<GameServerClustersServiceMetadata>(std::move(stub));
+  stub = std::make_shared<GameServerClustersServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<GameServerClustersServiceLogging>(

--- a/google/cloud/gameservices/v1/internal/game_server_configs_metadata_decorator.h
+++ b/google/cloud/gameservices/v1/internal/game_server_configs_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GameServerConfigsServiceMetadata : public GameServerConfigsServiceStub {
  public:
   ~GameServerConfigsServiceMetadata() override = default;
-  explicit GameServerConfigsServiceMetadata(
+  GameServerConfigsServiceMetadata(
       std::shared_ptr<GameServerConfigsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::gaming::v1::ListGameServerConfigsResponse>
   ListGameServerConfigs(

--- a/google/cloud/gameservices/v1/internal/game_server_configs_stub_factory.cc
+++ b/google/cloud/gameservices/v1/internal/game_server_configs_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultGameServerConfigsServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<GameServerConfigsServiceAuth>(std::move(auth),
                                                           std::move(stub));
   }
-  stub = std::make_shared<GameServerConfigsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<GameServerConfigsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<GameServerConfigsServiceLogging>(

--- a/google/cloud/gameservices/v1/internal/game_server_deployments_metadata_decorator.h
+++ b/google/cloud/gameservices/v1/internal/game_server_deployments_metadata_decorator.h
@@ -35,9 +35,9 @@ class GameServerDeploymentsServiceMetadata
     : public GameServerDeploymentsServiceStub {
  public:
   ~GameServerDeploymentsServiceMetadata() override = default;
-  explicit GameServerDeploymentsServiceMetadata(
+  GameServerDeploymentsServiceMetadata(
       std::shared_ptr<GameServerDeploymentsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::gaming::v1::ListGameServerDeploymentsResponse>
   ListGameServerDeployments(

--- a/google/cloud/gameservices/v1/internal/game_server_deployments_stub_factory.cc
+++ b/google/cloud/gameservices/v1/internal/game_server_deployments_stub_factory.cc
@@ -54,8 +54,8 @@ CreateDefaultGameServerDeploymentsServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<GameServerDeploymentsServiceAuth>(std::move(auth),
                                                               std::move(stub));
   }
-  stub =
-      std::make_shared<GameServerDeploymentsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<GameServerDeploymentsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<GameServerDeploymentsServiceLogging>(

--- a/google/cloud/gameservices/v1/internal/realms_metadata_decorator.h
+++ b/google/cloud/gameservices/v1/internal/realms_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RealmsServiceMetadata : public RealmsServiceStub {
  public:
   ~RealmsServiceMetadata() override = default;
-  explicit RealmsServiceMetadata(
-      std::shared_ptr<RealmsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  RealmsServiceMetadata(std::shared_ptr<RealmsServiceStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::gaming::v1::ListRealmsResponse> ListRealms(
       grpc::ClientContext& context,

--- a/google/cloud/gameservices/v1/internal/realms_stub_factory.cc
+++ b/google/cloud/gameservices/v1/internal/realms_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<RealmsServiceStub> CreateDefaultRealmsServiceStub(
     stub =
         std::make_shared<RealmsServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<RealmsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<RealmsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<RealmsServiceLogging>(

--- a/google/cloud/gkehub/v1/internal/gke_hub_metadata_decorator.h
+++ b/google/cloud/gkehub/v1/internal/gke_hub_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GkeHubMetadata : public GkeHubStub {
  public:
   ~GkeHubMetadata() override = default;
-  explicit GkeHubMetadata(
-      std::shared_ptr<GkeHubStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  GkeHubMetadata(std::shared_ptr<GkeHubStub> child,
+                 std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::gkehub::v1::ListMembershipsResponse> ListMemberships(
       grpc::ClientContext& context,

--- a/google/cloud/gkehub/v1/internal/gke_hub_stub_factory.cc
+++ b/google/cloud/gkehub/v1/internal/gke_hub_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<GkeHubStub> CreateDefaultGkeHubStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<GkeHubAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<GkeHubMetadata>(std::move(stub));
+  stub = std::make_shared<GkeHubMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<GkeHubLogging>(

--- a/google/cloud/gkemulticloud/v1/internal/attached_clusters_metadata_decorator.h
+++ b/google/cloud/gkemulticloud/v1/internal/attached_clusters_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AttachedClustersMetadata : public AttachedClustersStub {
  public:
   ~AttachedClustersMetadata() override = default;
-  explicit AttachedClustersMetadata(
+  AttachedClustersMetadata(
       std::shared_ptr<AttachedClustersStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateAttachedCluster(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/gkemulticloud/v1/internal/attached_clusters_stub_factory.cc
+++ b/google/cloud/gkemulticloud/v1/internal/attached_clusters_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<AttachedClustersStub> CreateDefaultAttachedClustersStub(
     stub = std::make_shared<AttachedClustersAuth>(std::move(auth),
                                                   std::move(stub));
   }
-  stub = std::make_shared<AttachedClustersMetadata>(std::move(stub));
+  stub = std::make_shared<AttachedClustersMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AttachedClustersLogging>(

--- a/google/cloud/gkemulticloud/v1/internal/aws_clusters_metadata_decorator.h
+++ b/google/cloud/gkemulticloud/v1/internal/aws_clusters_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AwsClustersMetadata : public AwsClustersStub {
  public:
   ~AwsClustersMetadata() override = default;
-  explicit AwsClustersMetadata(
-      std::shared_ptr<AwsClustersStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AwsClustersMetadata(std::shared_ptr<AwsClustersStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateAwsCluster(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/gkemulticloud/v1/internal/aws_clusters_stub_factory.cc
+++ b/google/cloud/gkemulticloud/v1/internal/aws_clusters_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<AwsClustersStub> CreateDefaultAwsClustersStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<AwsClustersAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AwsClustersMetadata>(std::move(stub));
+  stub = std::make_shared<AwsClustersMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AwsClustersLogging>(

--- a/google/cloud/gkemulticloud/v1/internal/azure_clusters_metadata_decorator.h
+++ b/google/cloud/gkemulticloud/v1/internal/azure_clusters_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AzureClustersMetadata : public AzureClustersStub {
  public:
   ~AzureClustersMetadata() override = default;
-  explicit AzureClustersMetadata(
-      std::shared_ptr<AzureClustersStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AzureClustersMetadata(std::shared_ptr<AzureClustersStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateAzureClient(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/gkemulticloud/v1/internal/azure_clusters_stub_factory.cc
+++ b/google/cloud/gkemulticloud/v1/internal/azure_clusters_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<AzureClustersStub> CreateDefaultAzureClustersStub(
     stub =
         std::make_shared<AzureClustersAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AzureClustersMetadata>(std::move(stub));
+  stub = std::make_shared<AzureClustersMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AzureClustersLogging>(

--- a/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.h
+++ b/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMMetadata : public IAMStub {
  public:
   ~IAMMetadata() override = default;
-  explicit IAMMetadata(
-      std::shared_ptr<IAMStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  IAMMetadata(std::shared_ptr<IAMStub> child,
+              std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
   ListServiceAccounts(grpc::ClientContext& context,

--- a/google/cloud/iam/admin/v1/internal/iam_stub_factory.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_stub_factory.cc
@@ -49,7 +49,8 @@ std::shared_ptr<IAMStub> CreateDefaultIAMStub(google::cloud::CompletionQueue cq,
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<IAMAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<IAMMetadata>(std::move(stub));
+  stub = std::make_shared<IAMMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IAMLogging>(std::move(stub),

--- a/google/cloud/iam/credentials/v1/internal/iam_credentials_metadata_decorator.h
+++ b/google/cloud/iam/credentials/v1/internal/iam_credentials_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMCredentialsMetadata : public IAMCredentialsStub {
  public:
   ~IAMCredentialsMetadata() override = default;
-  explicit IAMCredentialsMetadata(
+  IAMCredentialsMetadata(
       std::shared_ptr<IAMCredentialsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(

--- a/google/cloud/iam/credentials/v1/internal/iam_credentials_stub_factory.cc
+++ b/google/cloud/iam/credentials/v1/internal/iam_credentials_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<IAMCredentialsStub> CreateDefaultIAMCredentialsStub(
     stub =
         std::make_shared<IAMCredentialsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<IAMCredentialsMetadata>(std::move(stub));
+  stub = std::make_shared<IAMCredentialsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IAMCredentialsLogging>(

--- a/google/cloud/iam/v1/internal/iam_policy_metadata_decorator.h
+++ b/google/cloud/iam/v1/internal/iam_policy_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMPolicyMetadata : public IAMPolicyStub {
  public:
   ~IAMPolicyMetadata() override = default;
-  explicit IAMPolicyMetadata(
-      std::shared_ptr<IAMPolicyStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  IAMPolicyMetadata(std::shared_ptr<IAMPolicyStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,

--- a/google/cloud/iam/v1/internal/iam_policy_stub_factory.cc
+++ b/google/cloud/iam/v1/internal/iam_policy_stub_factory.cc
@@ -49,7 +49,8 @@ std::shared_ptr<IAMPolicyStub> CreateDefaultIAMPolicyStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<IAMPolicyAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<IAMPolicyMetadata>(std::move(stub));
+  stub = std::make_shared<IAMPolicyMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IAMPolicyLogging>(

--- a/google/cloud/iam/v2/internal/policies_metadata_decorator.h
+++ b/google/cloud/iam/v2/internal/policies_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PoliciesMetadata : public PoliciesStub {
  public:
   ~PoliciesMetadata() override = default;
-  explicit PoliciesMetadata(
-      std::shared_ptr<PoliciesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  PoliciesMetadata(std::shared_ptr<PoliciesStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::iam::v2::ListPoliciesResponse> ListPolicies(
       grpc::ClientContext& context,

--- a/google/cloud/iam/v2/internal/policies_stub_factory.cc
+++ b/google/cloud/iam/v2/internal/policies_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<PoliciesStub> CreateDefaultPoliciesStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<PoliciesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<PoliciesMetadata>(std::move(stub));
+  stub = std::make_shared<PoliciesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PoliciesLogging>(

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_admin_metadata_decorator.h
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_admin_metadata_decorator.h
@@ -34,9 +34,9 @@ class IdentityAwareProxyAdminServiceMetadata
     : public IdentityAwareProxyAdminServiceStub {
  public:
   ~IdentityAwareProxyAdminServiceMetadata() override = default;
-  explicit IdentityAwareProxyAdminServiceMetadata(
+  IdentityAwareProxyAdminServiceMetadata(
       std::shared_ptr<IdentityAwareProxyAdminServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_admin_stub_factory.cc
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_admin_stub_factory.cc
@@ -53,8 +53,8 @@ CreateDefaultIdentityAwareProxyAdminServiceStub(
     stub = std::make_shared<IdentityAwareProxyAdminServiceAuth>(
         std::move(auth), std::move(stub));
   }
-  stub =
-      std::make_shared<IdentityAwareProxyAdminServiceMetadata>(std::move(stub));
+  stub = std::make_shared<IdentityAwareProxyAdminServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IdentityAwareProxyAdminServiceLogging>(

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_metadata_decorator.h
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_metadata_decorator.h
@@ -34,9 +34,9 @@ class IdentityAwareProxyOAuthServiceMetadata
     : public IdentityAwareProxyOAuthServiceStub {
  public:
   ~IdentityAwareProxyOAuthServiceMetadata() override = default;
-  explicit IdentityAwareProxyOAuthServiceMetadata(
+  IdentityAwareProxyOAuthServiceMetadata(
       std::shared_ptr<IdentityAwareProxyOAuthServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::iap::v1::ListBrandsResponse> ListBrands(
       grpc::ClientContext& context,

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_stub_factory.cc
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_stub_factory.cc
@@ -53,8 +53,8 @@ CreateDefaultIdentityAwareProxyOAuthServiceStub(
     stub = std::make_shared<IdentityAwareProxyOAuthServiceAuth>(
         std::move(auth), std::move(stub));
   }
-  stub =
-      std::make_shared<IdentityAwareProxyOAuthServiceMetadata>(std::move(stub));
+  stub = std::make_shared<IdentityAwareProxyOAuthServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IdentityAwareProxyOAuthServiceLogging>(

--- a/google/cloud/ids/v1/internal/ids_metadata_decorator.h
+++ b/google/cloud/ids/v1/internal/ids_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IDSMetadata : public IDSStub {
  public:
   ~IDSMetadata() override = default;
-  explicit IDSMetadata(
-      std::shared_ptr<IDSStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  IDSMetadata(std::shared_ptr<IDSStub> child,
+              std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::ids::v1::ListEndpointsResponse> ListEndpoints(
       grpc::ClientContext& context,

--- a/google/cloud/ids/v1/internal/ids_stub_factory.cc
+++ b/google/cloud/ids/v1/internal/ids_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<IDSStub> CreateDefaultIDSStub(google::cloud::CompletionQueue cq,
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<IDSAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<IDSMetadata>(std::move(stub));
+  stub = std::make_shared<IDSMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IDSLogging>(std::move(stub),

--- a/google/cloud/iot/v1/internal/device_manager_metadata_decorator.h
+++ b/google/cloud/iot/v1/internal/device_manager_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DeviceManagerMetadata : public DeviceManagerStub {
  public:
   ~DeviceManagerMetadata() override = default;
-  explicit DeviceManagerMetadata(
-      std::shared_ptr<DeviceManagerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  DeviceManagerMetadata(std::shared_ptr<DeviceManagerStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::iot::v1::DeviceRegistry> CreateDeviceRegistry(
       grpc::ClientContext& context,

--- a/google/cloud/iot/v1/internal/device_manager_stub_factory.cc
+++ b/google/cloud/iot/v1/internal/device_manager_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<DeviceManagerStub> CreateDefaultDeviceManagerStub(
     stub =
         std::make_shared<DeviceManagerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DeviceManagerMetadata>(std::move(stub));
+  stub = std::make_shared<DeviceManagerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DeviceManagerLogging>(

--- a/google/cloud/kms/inventory/v1/internal/key_dashboard_metadata_decorator.h
+++ b/google/cloud/kms/inventory/v1/internal/key_dashboard_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class KeyDashboardServiceMetadata : public KeyDashboardServiceStub {
  public:
   ~KeyDashboardServiceMetadata() override = default;
-  explicit KeyDashboardServiceMetadata(
+  KeyDashboardServiceMetadata(
       std::shared_ptr<KeyDashboardServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::kms::inventory::v1::ListCryptoKeysResponse>
   ListCryptoKeys(grpc::ClientContext& context,

--- a/google/cloud/kms/inventory/v1/internal/key_dashboard_stub_factory.cc
+++ b/google/cloud/kms/inventory/v1/internal/key_dashboard_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<KeyDashboardServiceStub> CreateDefaultKeyDashboardServiceStub(
     stub = std::make_shared<KeyDashboardServiceAuth>(std::move(auth),
                                                      std::move(stub));
   }
-  stub = std::make_shared<KeyDashboardServiceMetadata>(std::move(stub));
+  stub = std::make_shared<KeyDashboardServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<KeyDashboardServiceLogging>(

--- a/google/cloud/kms/inventory/v1/internal/key_tracking_metadata_decorator.h
+++ b/google/cloud/kms/inventory/v1/internal/key_tracking_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class KeyTrackingServiceMetadata : public KeyTrackingServiceStub {
  public:
   ~KeyTrackingServiceMetadata() override = default;
-  explicit KeyTrackingServiceMetadata(
+  KeyTrackingServiceMetadata(
       std::shared_ptr<KeyTrackingServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::kms::inventory::v1::ProtectedResourcesSummary>
   GetProtectedResourcesSummary(

--- a/google/cloud/kms/inventory/v1/internal/key_tracking_stub_factory.cc
+++ b/google/cloud/kms/inventory/v1/internal/key_tracking_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<KeyTrackingServiceStub> CreateDefaultKeyTrackingServiceStub(
     stub = std::make_shared<KeyTrackingServiceAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<KeyTrackingServiceMetadata>(std::move(stub));
+  stub = std::make_shared<KeyTrackingServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<KeyTrackingServiceLogging>(

--- a/google/cloud/kms/v1/internal/ekm_metadata_decorator.h
+++ b/google/cloud/kms/v1/internal/ekm_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EkmServiceMetadata : public EkmServiceStub {
  public:
   ~EkmServiceMetadata() override = default;
-  explicit EkmServiceMetadata(
-      std::shared_ptr<EkmServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EkmServiceMetadata(std::shared_ptr<EkmServiceStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::kms::v1::ListEkmConnectionsResponse>
   ListEkmConnections(grpc::ClientContext& context,

--- a/google/cloud/kms/v1/internal/ekm_stub_factory.cc
+++ b/google/cloud/kms/v1/internal/ekm_stub_factory.cc
@@ -49,7 +49,8 @@ std::shared_ptr<EkmServiceStub> CreateDefaultEkmServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<EkmServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EkmServiceMetadata>(std::move(stub));
+  stub = std::make_shared<EkmServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EkmServiceLogging>(

--- a/google/cloud/kms/v1/internal/key_management_metadata_decorator.h
+++ b/google/cloud/kms/v1/internal/key_management_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class KeyManagementServiceMetadata : public KeyManagementServiceStub {
  public:
   ~KeyManagementServiceMetadata() override = default;
-  explicit KeyManagementServiceMetadata(
+  KeyManagementServiceMetadata(
       std::shared_ptr<KeyManagementServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::kms::v1::ListKeyRingsResponse> ListKeyRings(
       grpc::ClientContext& context,

--- a/google/cloud/kms/v1/internal/key_management_stub_factory.cc
+++ b/google/cloud/kms/v1/internal/key_management_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<KeyManagementServiceStub> CreateDefaultKeyManagementServiceStub(
     stub = std::make_shared<KeyManagementServiceAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<KeyManagementServiceMetadata>(std::move(stub));
+  stub = std::make_shared<KeyManagementServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<KeyManagementServiceLogging>(

--- a/google/cloud/language/v1/internal/language_metadata_decorator.h
+++ b/google/cloud/language/v1/internal/language_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LanguageServiceMetadata : public LanguageServiceStub {
  public:
   ~LanguageServiceMetadata() override = default;
-  explicit LanguageServiceMetadata(
+  LanguageServiceMetadata(
       std::shared_ptr<LanguageServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
   AnalyzeSentiment(grpc::ClientContext& context,

--- a/google/cloud/language/v1/internal/language_stub_factory.cc
+++ b/google/cloud/language/v1/internal/language_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<LanguageServiceStub> CreateDefaultLanguageServiceStub(
     stub =
         std::make_shared<LanguageServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<LanguageServiceMetadata>(std::move(stub));
+  stub = std::make_shared<LanguageServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<LanguageServiceLogging>(

--- a/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.h
+++ b/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LoggingServiceV2Metadata : public LoggingServiceV2Stub {
  public:
   ~LoggingServiceV2Metadata() override = default;
-  explicit LoggingServiceV2Metadata(
+  LoggingServiceV2Metadata(
       std::shared_ptr<LoggingServiceV2Stub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   Status DeleteLog(
       grpc::ClientContext& context,

--- a/google/cloud/logging/v2/internal/logging_service_v2_stub_factory.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<LoggingServiceV2Stub> CreateDefaultLoggingServiceV2Stub(
     stub = std::make_shared<LoggingServiceV2Auth>(std::move(auth),
                                                   std::move(stub));
   }
-  stub = std::make_shared<LoggingServiceV2Metadata>(std::move(stub));
+  stub = std::make_shared<LoggingServiceV2Metadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<LoggingServiceV2Logging>(

--- a/google/cloud/managedidentities/v1/internal/managed_identities_metadata_decorator.h
+++ b/google/cloud/managedidentities/v1/internal/managed_identities_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ManagedIdentitiesServiceMetadata : public ManagedIdentitiesServiceStub {
  public:
   ~ManagedIdentitiesServiceMetadata() override = default;
-  explicit ManagedIdentitiesServiceMetadata(
+  ManagedIdentitiesServiceMetadata(
       std::shared_ptr<ManagedIdentitiesServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateMicrosoftAdDomain(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/managedidentities/v1/internal/managed_identities_stub_factory.cc
+++ b/google/cloud/managedidentities/v1/internal/managed_identities_stub_factory.cc
@@ -55,7 +55,8 @@ CreateDefaultManagedIdentitiesServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<ManagedIdentitiesServiceAuth>(std::move(auth),
                                                           std::move(stub));
   }
-  stub = std::make_shared<ManagedIdentitiesServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ManagedIdentitiesServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ManagedIdentitiesServiceLogging>(

--- a/google/cloud/memcache/v1/internal/cloud_memcache_metadata_decorator.h
+++ b/google/cloud/memcache/v1/internal/cloud_memcache_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudMemcacheMetadata : public CloudMemcacheStub {
  public:
   ~CloudMemcacheMetadata() override = default;
-  explicit CloudMemcacheMetadata(
-      std::shared_ptr<CloudMemcacheStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CloudMemcacheMetadata(std::shared_ptr<CloudMemcacheStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::memcache::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,

--- a/google/cloud/memcache/v1/internal/cloud_memcache_stub_factory.cc
+++ b/google/cloud/memcache/v1/internal/cloud_memcache_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<CloudMemcacheStub> CreateDefaultCloudMemcacheStub(
     stub =
         std::make_shared<CloudMemcacheAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CloudMemcacheMetadata>(std::move(stub));
+  stub = std::make_shared<CloudMemcacheMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudMemcacheLogging>(

--- a/google/cloud/monitoring/dashboard/v1/internal/dashboards_metadata_decorator.h
+++ b/google/cloud/monitoring/dashboard/v1/internal/dashboards_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DashboardsServiceMetadata : public DashboardsServiceStub {
  public:
   ~DashboardsServiceMetadata() override = default;
-  explicit DashboardsServiceMetadata(
+  DashboardsServiceMetadata(
       std::shared_ptr<DashboardsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::dashboard::v1::Dashboard> CreateDashboard(
       grpc::ClientContext& context,

--- a/google/cloud/monitoring/dashboard/v1/internal/dashboards_stub_factory.cc
+++ b/google/cloud/monitoring/dashboard/v1/internal/dashboards_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<DashboardsServiceStub> CreateDefaultDashboardsServiceStub(
     stub = std::make_shared<DashboardsServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<DashboardsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<DashboardsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DashboardsServiceLogging>(

--- a/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_metadata_decorator.h
+++ b/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MetricsScopesMetadata : public MetricsScopesStub {
  public:
   ~MetricsScopesMetadata() override = default;
-  explicit MetricsScopesMetadata(
-      std::shared_ptr<MetricsScopesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  MetricsScopesMetadata(std::shared_ptr<MetricsScopesStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::metricsscope::v1::MetricsScope> GetMetricsScope(
       grpc::ClientContext& context,

--- a/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_stub_factory.cc
+++ b/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<MetricsScopesStub> CreateDefaultMetricsScopesStub(
     stub =
         std::make_shared<MetricsScopesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<MetricsScopesMetadata>(std::move(stub));
+  stub = std::make_shared<MetricsScopesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<MetricsScopesLogging>(

--- a/google/cloud/monitoring/v3/internal/alert_policy_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/alert_policy_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AlertPolicyServiceMetadata : public AlertPolicyServiceStub {
  public:
   ~AlertPolicyServiceMetadata() override = default;
-  explicit AlertPolicyServiceMetadata(
+  AlertPolicyServiceMetadata(
       std::shared_ptr<AlertPolicyServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::v3::ListAlertPoliciesResponse> ListAlertPolicies(
       grpc::ClientContext& context,

--- a/google/cloud/monitoring/v3/internal/alert_policy_stub_factory.cc
+++ b/google/cloud/monitoring/v3/internal/alert_policy_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<AlertPolicyServiceStub> CreateDefaultAlertPolicyServiceStub(
     stub = std::make_shared<AlertPolicyServiceAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<AlertPolicyServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AlertPolicyServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AlertPolicyServiceLogging>(

--- a/google/cloud/monitoring/v3/internal/group_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/group_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GroupServiceMetadata : public GroupServiceStub {
  public:
   ~GroupServiceMetadata() override = default;
-  explicit GroupServiceMetadata(
-      std::shared_ptr<GroupServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  GroupServiceMetadata(std::shared_ptr<GroupServiceStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::v3::ListGroupsResponse> ListGroups(
       grpc::ClientContext& context,

--- a/google/cloud/monitoring/v3/internal/group_stub_factory.cc
+++ b/google/cloud/monitoring/v3/internal/group_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<GroupServiceStub> CreateDefaultGroupServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<GroupServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<GroupServiceMetadata>(std::move(stub));
+  stub = std::make_shared<GroupServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<GroupServiceLogging>(

--- a/google/cloud/monitoring/v3/internal/metric_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/metric_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MetricServiceMetadata : public MetricServiceStub {
  public:
   ~MetricServiceMetadata() override = default;
-  explicit MetricServiceMetadata(
-      std::shared_ptr<MetricServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  MetricServiceMetadata(std::shared_ptr<MetricServiceStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::v3::ListMonitoredResourceDescriptorsResponse>
   ListMonitoredResourceDescriptors(

--- a/google/cloud/monitoring/v3/internal/metric_stub_factory.cc
+++ b/google/cloud/monitoring/v3/internal/metric_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<MetricServiceStub> CreateDefaultMetricServiceStub(
     stub =
         std::make_shared<MetricServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<MetricServiceMetadata>(std::move(stub));
+  stub = std::make_shared<MetricServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<MetricServiceLogging>(

--- a/google/cloud/monitoring/v3/internal/notification_channel_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/notification_channel_metadata_decorator.h
@@ -34,9 +34,9 @@ class NotificationChannelServiceMetadata
     : public NotificationChannelServiceStub {
  public:
   ~NotificationChannelServiceMetadata() override = default;
-  explicit NotificationChannelServiceMetadata(
+  NotificationChannelServiceMetadata(
       std::shared_ptr<NotificationChannelServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::v3::ListNotificationChannelDescriptorsResponse>
   ListNotificationChannelDescriptors(

--- a/google/cloud/monitoring/v3/internal/notification_channel_stub_factory.cc
+++ b/google/cloud/monitoring/v3/internal/notification_channel_stub_factory.cc
@@ -53,7 +53,8 @@ CreateDefaultNotificationChannelServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<NotificationChannelServiceAuth>(std::move(auth),
                                                             std::move(stub));
   }
-  stub = std::make_shared<NotificationChannelServiceMetadata>(std::move(stub));
+  stub = std::make_shared<NotificationChannelServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<NotificationChannelServiceLogging>(

--- a/google/cloud/monitoring/v3/internal/query_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/query_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class QueryServiceMetadata : public QueryServiceStub {
  public:
   ~QueryServiceMetadata() override = default;
-  explicit QueryServiceMetadata(
-      std::shared_ptr<QueryServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  QueryServiceMetadata(std::shared_ptr<QueryServiceStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::v3::QueryTimeSeriesResponse> QueryTimeSeries(
       grpc::ClientContext& context,

--- a/google/cloud/monitoring/v3/internal/query_stub_factory.cc
+++ b/google/cloud/monitoring/v3/internal/query_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<QueryServiceStub> CreateDefaultQueryServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<QueryServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<QueryServiceMetadata>(std::move(stub));
+  stub = std::make_shared<QueryServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<QueryServiceLogging>(

--- a/google/cloud/monitoring/v3/internal/service_monitoring_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/service_monitoring_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceMonitoringServiceMetadata : public ServiceMonitoringServiceStub {
  public:
   ~ServiceMonitoringServiceMetadata() override = default;
-  explicit ServiceMonitoringServiceMetadata(
+  ServiceMonitoringServiceMetadata(
       std::shared_ptr<ServiceMonitoringServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::v3::Service> CreateService(
       grpc::ClientContext& context,

--- a/google/cloud/monitoring/v3/internal/service_monitoring_stub_factory.cc
+++ b/google/cloud/monitoring/v3/internal/service_monitoring_stub_factory.cc
@@ -53,7 +53,8 @@ CreateDefaultServiceMonitoringServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<ServiceMonitoringServiceAuth>(std::move(auth),
                                                           std::move(stub));
   }
-  stub = std::make_shared<ServiceMonitoringServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ServiceMonitoringServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ServiceMonitoringServiceLogging>(

--- a/google/cloud/monitoring/v3/internal/uptime_check_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/uptime_check_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class UptimeCheckServiceMetadata : public UptimeCheckServiceStub {
  public:
   ~UptimeCheckServiceMetadata() override = default;
-  explicit UptimeCheckServiceMetadata(
+  UptimeCheckServiceMetadata(
       std::shared_ptr<UptimeCheckServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::monitoring::v3::ListUptimeCheckConfigsResponse>
   ListUptimeCheckConfigs(

--- a/google/cloud/monitoring/v3/internal/uptime_check_stub_factory.cc
+++ b/google/cloud/monitoring/v3/internal/uptime_check_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<UptimeCheckServiceStub> CreateDefaultUptimeCheckServiceStub(
     stub = std::make_shared<UptimeCheckServiceAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<UptimeCheckServiceMetadata>(std::move(stub));
+  stub = std::make_shared<UptimeCheckServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<UptimeCheckServiceLogging>(

--- a/google/cloud/networkconnectivity/v1/internal/hub_metadata_decorator.h
+++ b/google/cloud/networkconnectivity/v1/internal/hub_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class HubServiceMetadata : public HubServiceStub {
  public:
   ~HubServiceMetadata() override = default;
-  explicit HubServiceMetadata(
-      std::shared_ptr<HubServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  HubServiceMetadata(std::shared_ptr<HubServiceStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::networkconnectivity::v1::ListHubsResponse> ListHubs(
       grpc::ClientContext& context,

--- a/google/cloud/networkconnectivity/v1/internal/hub_stub_factory.cc
+++ b/google/cloud/networkconnectivity/v1/internal/hub_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<HubServiceStub> CreateDefaultHubServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<HubServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<HubServiceMetadata>(std::move(stub));
+  stub = std::make_shared<HubServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<HubServiceLogging>(

--- a/google/cloud/networkmanagement/v1/internal/reachability_metadata_decorator.h
+++ b/google/cloud/networkmanagement/v1/internal/reachability_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ReachabilityServiceMetadata : public ReachabilityServiceStub {
  public:
   ~ReachabilityServiceMetadata() override = default;
-  explicit ReachabilityServiceMetadata(
+  ReachabilityServiceMetadata(
       std::shared_ptr<ReachabilityServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::networkmanagement::v1::ListConnectivityTestsResponse>
   ListConnectivityTests(

--- a/google/cloud/networkmanagement/v1/internal/reachability_stub_factory.cc
+++ b/google/cloud/networkmanagement/v1/internal/reachability_stub_factory.cc
@@ -54,7 +54,8 @@ std::shared_ptr<ReachabilityServiceStub> CreateDefaultReachabilityServiceStub(
     stub = std::make_shared<ReachabilityServiceAuth>(std::move(auth),
                                                      std::move(stub));
   }
-  stub = std::make_shared<ReachabilityServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ReachabilityServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ReachabilityServiceLogging>(

--- a/google/cloud/notebooks/v1/internal/managed_notebook_metadata_decorator.h
+++ b/google/cloud/notebooks/v1/internal/managed_notebook_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ManagedNotebookServiceMetadata : public ManagedNotebookServiceStub {
  public:
   ~ManagedNotebookServiceMetadata() override = default;
-  explicit ManagedNotebookServiceMetadata(
+  ManagedNotebookServiceMetadata(
       std::shared_ptr<ManagedNotebookServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::notebooks::v1::ListRuntimesResponse> ListRuntimes(
       grpc::ClientContext& context,

--- a/google/cloud/notebooks/v1/internal/managed_notebook_stub_factory.cc
+++ b/google/cloud/notebooks/v1/internal/managed_notebook_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultManagedNotebookServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<ManagedNotebookServiceAuth>(std::move(auth),
                                                         std::move(stub));
   }
-  stub = std::make_shared<ManagedNotebookServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ManagedNotebookServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ManagedNotebookServiceLogging>(

--- a/google/cloud/notebooks/v1/internal/notebook_metadata_decorator.h
+++ b/google/cloud/notebooks/v1/internal/notebook_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class NotebookServiceMetadata : public NotebookServiceStub {
  public:
   ~NotebookServiceMetadata() override = default;
-  explicit NotebookServiceMetadata(
+  NotebookServiceMetadata(
       std::shared_ptr<NotebookServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::notebooks::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,

--- a/google/cloud/notebooks/v1/internal/notebook_stub_factory.cc
+++ b/google/cloud/notebooks/v1/internal/notebook_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<NotebookServiceStub> CreateDefaultNotebookServiceStub(
     stub =
         std::make_shared<NotebookServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<NotebookServiceMetadata>(std::move(stub));
+  stub = std::make_shared<NotebookServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<NotebookServiceLogging>(

--- a/google/cloud/optimization/v1/internal/fleet_routing_metadata_decorator.h
+++ b/google/cloud/optimization/v1/internal/fleet_routing_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FleetRoutingMetadata : public FleetRoutingStub {
  public:
   ~FleetRoutingMetadata() override = default;
-  explicit FleetRoutingMetadata(
-      std::shared_ptr<FleetRoutingStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  FleetRoutingMetadata(std::shared_ptr<FleetRoutingStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::optimization::v1::OptimizeToursResponse>
   OptimizeTours(grpc::ClientContext& context,

--- a/google/cloud/optimization/v1/internal/fleet_routing_stub_factory.cc
+++ b/google/cloud/optimization/v1/internal/fleet_routing_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<FleetRoutingStub> CreateDefaultFleetRoutingStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<FleetRoutingAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<FleetRoutingMetadata>(std::move(stub));
+  stub = std::make_shared<FleetRoutingMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<FleetRoutingLogging>(

--- a/google/cloud/orgpolicy/v2/internal/org_policy_metadata_decorator.h
+++ b/google/cloud/orgpolicy/v2/internal/org_policy_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OrgPolicyMetadata : public OrgPolicyStub {
  public:
   ~OrgPolicyMetadata() override = default;
-  explicit OrgPolicyMetadata(
-      std::shared_ptr<OrgPolicyStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  OrgPolicyMetadata(std::shared_ptr<OrgPolicyStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::orgpolicy::v2::ListConstraintsResponse>
   ListConstraints(grpc::ClientContext& context,

--- a/google/cloud/orgpolicy/v2/internal/org_policy_stub_factory.cc
+++ b/google/cloud/orgpolicy/v2/internal/org_policy_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<OrgPolicyStub> CreateDefaultOrgPolicyStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<OrgPolicyAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<OrgPolicyMetadata>(std::move(stub));
+  stub = std::make_shared<OrgPolicyMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<OrgPolicyLogging>(

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_metadata_decorator.h
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AgentEndpointServiceMetadata : public AgentEndpointServiceStub {
  public:
   ~AgentEndpointServiceMetadata() override = default;
-  explicit AgentEndpointServiceMetadata(
+  AgentEndpointServiceMetadata(
       std::shared_ptr<AgentEndpointServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::cloud::osconfig::agentendpoint::v1::

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_stub_factory.cc
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<AgentEndpointServiceStub> CreateDefaultAgentEndpointServiceStub(
     stub = std::make_shared<AgentEndpointServiceAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<AgentEndpointServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AgentEndpointServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AgentEndpointServiceLogging>(

--- a/google/cloud/osconfig/v1/internal/os_config_metadata_decorator.h
+++ b/google/cloud/osconfig/v1/internal/os_config_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OsConfigServiceMetadata : public OsConfigServiceStub {
  public:
   ~OsConfigServiceMetadata() override = default;
-  explicit OsConfigServiceMetadata(
+  OsConfigServiceMetadata(
       std::shared_ptr<OsConfigServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::osconfig::v1::PatchJob> ExecutePatchJob(
       grpc::ClientContext& context,

--- a/google/cloud/osconfig/v1/internal/os_config_stub_factory.cc
+++ b/google/cloud/osconfig/v1/internal/os_config_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<OsConfigServiceStub> CreateDefaultOsConfigServiceStub(
     stub =
         std::make_shared<OsConfigServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<OsConfigServiceMetadata>(std::move(stub));
+  stub = std::make_shared<OsConfigServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<OsConfigServiceLogging>(

--- a/google/cloud/oslogin/v1/internal/os_login_metadata_decorator.h
+++ b/google/cloud/oslogin/v1/internal/os_login_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OsLoginServiceMetadata : public OsLoginServiceStub {
  public:
   ~OsLoginServiceMetadata() override = default;
-  explicit OsLoginServiceMetadata(
+  OsLoginServiceMetadata(
       std::shared_ptr<OsLoginServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::oslogin::common::SshPublicKey> CreateSshPublicKey(
       grpc::ClientContext& context,

--- a/google/cloud/oslogin/v1/internal/os_login_stub_factory.cc
+++ b/google/cloud/oslogin/v1/internal/os_login_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<OsLoginServiceStub> CreateDefaultOsLoginServiceStub(
     stub =
         std::make_shared<OsLoginServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<OsLoginServiceMetadata>(std::move(stub));
+  stub = std::make_shared<OsLoginServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<OsLoginServiceLogging>(

--- a/google/cloud/policytroubleshooter/v1/internal/iam_checker_metadata_decorator.h
+++ b/google/cloud/policytroubleshooter/v1/internal/iam_checker_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IamCheckerMetadata : public IamCheckerStub {
  public:
   ~IamCheckerMetadata() override = default;
-  explicit IamCheckerMetadata(
-      std::shared_ptr<IamCheckerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  IamCheckerMetadata(std::shared_ptr<IamCheckerStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<
       google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyResponse>

--- a/google/cloud/policytroubleshooter/v1/internal/iam_checker_stub_factory.cc
+++ b/google/cloud/policytroubleshooter/v1/internal/iam_checker_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<IamCheckerStub> CreateDefaultIamCheckerStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<IamCheckerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<IamCheckerMetadata>(std::move(stub));
+  stub = std::make_shared<IamCheckerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<IamCheckerLogging>(

--- a/google/cloud/privateca/v1/internal/certificate_authority_metadata_decorator.h
+++ b/google/cloud/privateca/v1/internal/certificate_authority_metadata_decorator.h
@@ -35,9 +35,9 @@ class CertificateAuthorityServiceMetadata
     : public CertificateAuthorityServiceStub {
  public:
   ~CertificateAuthorityServiceMetadata() override = default;
-  explicit CertificateAuthorityServiceMetadata(
+  CertificateAuthorityServiceMetadata(
       std::shared_ptr<CertificateAuthorityServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::security::privateca::v1::Certificate>
   CreateCertificate(

--- a/google/cloud/privateca/v1/internal/certificate_authority_stub_factory.cc
+++ b/google/cloud/privateca/v1/internal/certificate_authority_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultCertificateAuthorityServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<CertificateAuthorityServiceAuth>(std::move(auth),
                                                              std::move(stub));
   }
-  stub = std::make_shared<CertificateAuthorityServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CertificateAuthorityServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CertificateAuthorityServiceLogging>(

--- a/google/cloud/profiler/v2/internal/profiler_metadata_decorator.h
+++ b/google/cloud/profiler/v2/internal/profiler_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProfilerServiceMetadata : public ProfilerServiceStub {
  public:
   ~ProfilerServiceMetadata() override = default;
-  explicit ProfilerServiceMetadata(
+  ProfilerServiceMetadata(
       std::shared_ptr<ProfilerServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::devtools::cloudprofiler::v2::Profile> CreateProfile(
       grpc::ClientContext& context,

--- a/google/cloud/profiler/v2/internal/profiler_stub_factory.cc
+++ b/google/cloud/profiler/v2/internal/profiler_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<ProfilerServiceStub> CreateDefaultProfilerServiceStub(
     stub =
         std::make_shared<ProfilerServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ProfilerServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ProfilerServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ProfilerServiceLogging>(

--- a/google/cloud/pubsub/internal/publisher_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PublisherMetadata : public PublisherStub {
  public:
   ~PublisherMetadata() override = default;
-  explicit PublisherMetadata(
-      std::shared_ptr<PublisherStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  PublisherMetadata(std::shared_ptr<PublisherStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::pubsub::v1::Topic> CreateTopic(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/publisher_stub_factory.cc
+++ b/google/cloud/pubsub/internal/publisher_stub_factory.cc
@@ -34,7 +34,8 @@ std::shared_ptr<pubsub_internal::PublisherStub> DecoratePublisherStub(
     stub = std::make_shared<pubsub_internal::PublisherAuth>(std::move(auth),
                                                             std::move(stub));
   }
-  stub = std::make_shared<pubsub_internal::PublisherMetadata>(std::move(stub));
+  stub = std::make_shared<pubsub_internal::PublisherMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(opts.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::PublisherLogging>(

--- a/google/cloud/pubsub/internal/schema_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/schema_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SchemaServiceMetadata : public SchemaServiceStub {
  public:
   ~SchemaServiceMetadata() override = default;
-  explicit SchemaServiceMetadata(
-      std::shared_ptr<SchemaServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  SchemaServiceMetadata(std::shared_ptr<SchemaServiceStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::pubsub::v1::Schema> CreateSchema(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/schema_stub_factory.cc
+++ b/google/cloud/pubsub/internal/schema_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<SchemaServiceStub> CreateDefaultSchemaServiceStub(
     stub =
         std::make_shared<SchemaServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<SchemaServiceMetadata>(std::move(stub));
+  stub = std::make_shared<SchemaServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SchemaServiceLogging>(

--- a/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SubscriberMetadata : public SubscriberStub {
  public:
   ~SubscriberMetadata() override = default;
-  explicit SubscriberMetadata(
-      std::shared_ptr<SubscriberStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  SubscriberMetadata(std::shared_ptr<SubscriberStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -47,7 +47,8 @@ std::shared_ptr<pubsub_internal::SubscriberStub> DecorateSubscriberStub(
     stub = std::make_shared<pubsub_internal::SubscriberAuth>(std::move(auth),
                                                              std::move(stub));
   }
-  stub = std::make_shared<pubsub_internal::SubscriberMetadata>(std::move(stub));
+  stub = std::make_shared<pubsub_internal::SubscriberMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   auto const& tracing = opts.get<TracingComponentsOption>();
   if (internal::Contains(tracing, "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -265,7 +265,8 @@ std::shared_ptr<pubsub_internal::SubscriberStub> DecorateSubscriptionAdminStub(
     stub = std::make_shared<pubsub_internal::SubscriberAuth>(std::move(auth),
                                                              std::move(stub));
   }
-  stub = std::make_shared<pubsub_internal::SubscriberMetadata>(std::move(stub));
+  stub = std::make_shared<pubsub_internal::SubscriberMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   auto const& tracing = opts.get<TracingComponentsOption>();
   if (internal::Contains(tracing, "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/pubsublite/internal/admin_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/admin_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AdminServiceMetadata : public AdminServiceStub {
  public:
   ~AdminServiceMetadata() override = default;
-  explicit AdminServiceMetadata(
-      std::shared_ptr<AdminServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  AdminServiceMetadata(std::shared_ptr<AdminServiceStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       grpc::ClientContext& context,

--- a/google/cloud/pubsublite/internal/admin_stub_factory.cc
+++ b/google/cloud/pubsublite/internal/admin_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<AdminServiceStub> CreateDefaultAdminServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<AdminServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<AdminServiceMetadata>(std::move(stub));
+  stub = std::make_shared<AdminServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<AdminServiceLogging>(

--- a/google/cloud/pubsublite/internal/cursor_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/cursor_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CursorServiceMetadata : public CursorServiceStub {
  public:
   ~CursorServiceMetadata() override = default;
-  explicit CursorServiceMetadata(
-      std::shared_ptr<CursorServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CursorServiceMetadata(std::shared_ptr<CursorServiceStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::pubsublite::v1::StreamingCommitCursorRequest,

--- a/google/cloud/pubsublite/internal/cursor_stub_factory.cc
+++ b/google/cloud/pubsublite/internal/cursor_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<CursorServiceStub> CreateDefaultCursorServiceStub(
     stub =
         std::make_shared<CursorServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CursorServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CursorServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CursorServiceLogging>(

--- a/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.h
@@ -34,9 +34,9 @@ class PartitionAssignmentServiceMetadata
     : public PartitionAssignmentServiceStub {
  public:
   ~PartitionAssignmentServiceMetadata() override = default;
-  explicit PartitionAssignmentServiceMetadata(
+  PartitionAssignmentServiceMetadata(
       std::shared_ptr<PartitionAssignmentServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::pubsublite::v1::PartitionAssignmentRequest,

--- a/google/cloud/pubsublite/internal/partition_assignment_stub_factory.cc
+++ b/google/cloud/pubsublite/internal/partition_assignment_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultPartitionAssignmentServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<PartitionAssignmentServiceAuth>(std::move(auth),
                                                             std::move(stub));
   }
-  stub = std::make_shared<PartitionAssignmentServiceMetadata>(std::move(stub));
+  stub = std::make_shared<PartitionAssignmentServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PartitionAssignmentServiceLogging>(

--- a/google/cloud/pubsublite/internal/publisher_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/publisher_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PublisherServiceMetadata : public PublisherServiceStub {
  public:
   ~PublisherServiceMetadata() override = default;
-  explicit PublisherServiceMetadata(
+  PublisherServiceMetadata(
       std::shared_ptr<PublisherServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::pubsublite::v1::PublishRequest,

--- a/google/cloud/pubsublite/internal/publisher_stub_factory.cc
+++ b/google/cloud/pubsublite/internal/publisher_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<PublisherServiceStub> CreateDefaultPublisherServiceStub(
     stub = std::make_shared<PublisherServiceAuth>(std::move(auth),
                                                   std::move(stub));
   }
-  stub = std::make_shared<PublisherServiceMetadata>(std::move(stub));
+  stub = std::make_shared<PublisherServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PublisherServiceLogging>(

--- a/google/cloud/pubsublite/internal/subscriber_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/subscriber_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SubscriberServiceMetadata : public SubscriberServiceStub {
  public:
   ~SubscriberServiceMetadata() override = default;
-  explicit SubscriberServiceMetadata(
+  SubscriberServiceMetadata(
       std::shared_ptr<SubscriberServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::pubsublite::v1::SubscribeRequest,

--- a/google/cloud/pubsublite/internal/subscriber_stub_factory.cc
+++ b/google/cloud/pubsublite/internal/subscriber_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<SubscriberServiceStub> CreateDefaultSubscriberServiceStub(
     stub = std::make_shared<SubscriberServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<SubscriberServiceMetadata>(std::move(stub));
+  stub = std::make_shared<SubscriberServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SubscriberServiceLogging>(

--- a/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TopicStatsServiceMetadata : public TopicStatsServiceStub {
  public:
   ~TopicStatsServiceMetadata() override = default;
-  explicit TopicStatsServiceMetadata(
+  TopicStatsServiceMetadata(
       std::shared_ptr<TopicStatsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>
   ComputeMessageStats(

--- a/google/cloud/pubsublite/internal/topic_stats_stub_factory.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<TopicStatsServiceStub> CreateDefaultTopicStatsServiceStub(
     stub = std::make_shared<TopicStatsServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<TopicStatsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<TopicStatsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TopicStatsServiceLogging>(

--- a/google/cloud/recommender/v1/internal/recommender_metadata_decorator.h
+++ b/google/cloud/recommender/v1/internal/recommender_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RecommenderMetadata : public RecommenderStub {
  public:
   ~RecommenderMetadata() override = default;
-  explicit RecommenderMetadata(
-      std::shared_ptr<RecommenderStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  RecommenderMetadata(std::shared_ptr<RecommenderStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::recommender::v1::ListInsightsResponse> ListInsights(
       grpc::ClientContext& context,

--- a/google/cloud/recommender/v1/internal/recommender_stub_factory.cc
+++ b/google/cloud/recommender/v1/internal/recommender_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<RecommenderStub> CreateDefaultRecommenderStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<RecommenderAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<RecommenderMetadata>(std::move(stub));
+  stub = std::make_shared<RecommenderMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<RecommenderLogging>(

--- a/google/cloud/redis/v1/internal/cloud_redis_metadata_decorator.h
+++ b/google/cloud/redis/v1/internal/cloud_redis_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudRedisMetadata : public CloudRedisStub {
  public:
   ~CloudRedisMetadata() override = default;
-  explicit CloudRedisMetadata(
-      std::shared_ptr<CloudRedisStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CloudRedisMetadata(std::shared_ptr<CloudRedisStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::redis::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,

--- a/google/cloud/redis/v1/internal/cloud_redis_stub_factory.cc
+++ b/google/cloud/redis/v1/internal/cloud_redis_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<CloudRedisStub> CreateDefaultCloudRedisStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<CloudRedisAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CloudRedisMetadata>(std::move(stub));
+  stub = std::make_shared<CloudRedisMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudRedisLogging>(

--- a/google/cloud/resourcemanager/v3/internal/folders_metadata_decorator.h
+++ b/google/cloud/resourcemanager/v3/internal/folders_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FoldersMetadata : public FoldersStub {
  public:
   ~FoldersMetadata() override = default;
-  explicit FoldersMetadata(
-      std::shared_ptr<FoldersStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  FoldersMetadata(std::shared_ptr<FoldersStub> child,
+                  std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::resourcemanager::v3::Folder> GetFolder(
       grpc::ClientContext& context,

--- a/google/cloud/resourcemanager/v3/internal/folders_stub_factory.cc
+++ b/google/cloud/resourcemanager/v3/internal/folders_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<FoldersStub> CreateDefaultFoldersStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<FoldersAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<FoldersMetadata>(std::move(stub));
+  stub = std::make_shared<FoldersMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<FoldersLogging>(

--- a/google/cloud/resourcemanager/v3/internal/organizations_metadata_decorator.h
+++ b/google/cloud/resourcemanager/v3/internal/organizations_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OrganizationsMetadata : public OrganizationsStub {
  public:
   ~OrganizationsMetadata() override = default;
-  explicit OrganizationsMetadata(
-      std::shared_ptr<OrganizationsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  OrganizationsMetadata(std::shared_ptr<OrganizationsStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::resourcemanager::v3::Organization> GetOrganization(
       grpc::ClientContext& context,

--- a/google/cloud/resourcemanager/v3/internal/organizations_stub_factory.cc
+++ b/google/cloud/resourcemanager/v3/internal/organizations_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<OrganizationsStub> CreateDefaultOrganizationsStub(
     stub =
         std::make_shared<OrganizationsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<OrganizationsMetadata>(std::move(stub));
+  stub = std::make_shared<OrganizationsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<OrganizationsLogging>(

--- a/google/cloud/resourcemanager/v3/internal/projects_metadata_decorator.h
+++ b/google/cloud/resourcemanager/v3/internal/projects_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProjectsMetadata : public ProjectsStub {
  public:
   ~ProjectsMetadata() override = default;
-  explicit ProjectsMetadata(
-      std::shared_ptr<ProjectsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ProjectsMetadata(std::shared_ptr<ProjectsStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::resourcemanager::v3::Project> GetProject(
       grpc::ClientContext& context,

--- a/google/cloud/resourcemanager/v3/internal/projects_stub_factory.cc
+++ b/google/cloud/resourcemanager/v3/internal/projects_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<ProjectsStub> CreateDefaultProjectsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ProjectsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ProjectsMetadata>(std::move(stub));
+  stub = std::make_shared<ProjectsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ProjectsLogging>(

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ResourceSettingsServiceMetadata : public ResourceSettingsServiceStub {
  public:
   ~ResourceSettingsServiceMetadata() override = default;
-  explicit ResourceSettingsServiceMetadata(
+  ResourceSettingsServiceMetadata(
       std::shared_ptr<ResourceSettingsServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::resourcesettings::v1::ListSettingsResponse>
   ListSettings(grpc::ClientContext& context,

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_stub_factory.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultResourceSettingsServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<ResourceSettingsServiceAuth>(std::move(auth),
                                                          std::move(stub));
   }
-  stub = std::make_shared<ResourceSettingsServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ResourceSettingsServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ResourceSettingsServiceLogging>(

--- a/google/cloud/retail/v2/internal/catalog_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/catalog_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CatalogServiceMetadata : public CatalogServiceStub {
  public:
   ~CatalogServiceMetadata() override = default;
-  explicit CatalogServiceMetadata(
+  CatalogServiceMetadata(
       std::shared_ptr<CatalogServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::retail::v2::ListCatalogsResponse> ListCatalogs(
       grpc::ClientContext& context,

--- a/google/cloud/retail/v2/internal/catalog_stub_factory.cc
+++ b/google/cloud/retail/v2/internal/catalog_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<CatalogServiceStub> CreateDefaultCatalogServiceStub(
     stub =
         std::make_shared<CatalogServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CatalogServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CatalogServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CatalogServiceLogging>(

--- a/google/cloud/retail/v2/internal/completion_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/completion_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CompletionServiceMetadata : public CompletionServiceStub {
  public:
   ~CompletionServiceMetadata() override = default;
-  explicit CompletionServiceMetadata(
+  CompletionServiceMetadata(
       std::shared_ptr<CompletionServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::retail::v2::CompleteQueryResponse> CompleteQuery(
       grpc::ClientContext& context,

--- a/google/cloud/retail/v2/internal/completion_stub_factory.cc
+++ b/google/cloud/retail/v2/internal/completion_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<CompletionServiceStub> CreateDefaultCompletionServiceStub(
     stub = std::make_shared<CompletionServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<CompletionServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CompletionServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CompletionServiceLogging>(

--- a/google/cloud/retail/v2/internal/prediction_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/prediction_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PredictionServiceMetadata : public PredictionServiceStub {
  public:
   ~PredictionServiceMetadata() override = default;
-  explicit PredictionServiceMetadata(
+  PredictionServiceMetadata(
       std::shared_ptr<PredictionServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::retail::v2::PredictResponse> Predict(
       grpc::ClientContext& context,

--- a/google/cloud/retail/v2/internal/prediction_stub_factory.cc
+++ b/google/cloud/retail/v2/internal/prediction_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<PredictionServiceStub> CreateDefaultPredictionServiceStub(
     stub = std::make_shared<PredictionServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<PredictionServiceMetadata>(std::move(stub));
+  stub = std::make_shared<PredictionServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PredictionServiceLogging>(

--- a/google/cloud/retail/v2/internal/product_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/product_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProductServiceMetadata : public ProductServiceStub {
  public:
   ~ProductServiceMetadata() override = default;
-  explicit ProductServiceMetadata(
+  ProductServiceMetadata(
       std::shared_ptr<ProductServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::retail::v2::Product> CreateProduct(
       grpc::ClientContext& context,

--- a/google/cloud/retail/v2/internal/product_stub_factory.cc
+++ b/google/cloud/retail/v2/internal/product_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ProductServiceStub> CreateDefaultProductServiceStub(
     stub =
         std::make_shared<ProductServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ProductServiceMetadata>(std::move(stub));
+  stub = std::make_shared<ProductServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ProductServiceLogging>(

--- a/google/cloud/retail/v2/internal/search_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/search_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SearchServiceMetadata : public SearchServiceStub {
  public:
   ~SearchServiceMetadata() override = default;
-  explicit SearchServiceMetadata(
-      std::shared_ptr<SearchServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  SearchServiceMetadata(std::shared_ptr<SearchServiceStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::retail::v2::SearchResponse> Search(
       grpc::ClientContext& context,

--- a/google/cloud/retail/v2/internal/search_stub_factory.cc
+++ b/google/cloud/retail/v2/internal/search_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<SearchServiceStub> CreateDefaultSearchServiceStub(
     stub =
         std::make_shared<SearchServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<SearchServiceMetadata>(std::move(stub));
+  stub = std::make_shared<SearchServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SearchServiceLogging>(

--- a/google/cloud/retail/v2/internal/user_event_metadata_decorator.h
+++ b/google/cloud/retail/v2/internal/user_event_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class UserEventServiceMetadata : public UserEventServiceStub {
  public:
   ~UserEventServiceMetadata() override = default;
-  explicit UserEventServiceMetadata(
+  UserEventServiceMetadata(
       std::shared_ptr<UserEventServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::retail::v2::UserEvent> WriteUserEvent(
       grpc::ClientContext& context,

--- a/google/cloud/retail/v2/internal/user_event_stub_factory.cc
+++ b/google/cloud/retail/v2/internal/user_event_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<UserEventServiceStub> CreateDefaultUserEventServiceStub(
     stub = std::make_shared<UserEventServiceAuth>(std::move(auth),
                                                   std::move(stub));
   }
-  stub = std::make_shared<UserEventServiceMetadata>(std::move(stub));
+  stub = std::make_shared<UserEventServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<UserEventServiceLogging>(

--- a/google/cloud/run/v2/internal/revisions_metadata_decorator.h
+++ b/google/cloud/run/v2/internal/revisions_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RevisionsMetadata : public RevisionsStub {
  public:
   ~RevisionsMetadata() override = default;
-  explicit RevisionsMetadata(
-      std::shared_ptr<RevisionsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  RevisionsMetadata(std::shared_ptr<RevisionsStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::run::v2::Revision> GetRevision(
       grpc::ClientContext& context,

--- a/google/cloud/run/v2/internal/revisions_stub_factory.cc
+++ b/google/cloud/run/v2/internal/revisions_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<RevisionsStub> CreateDefaultRevisionsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<RevisionsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<RevisionsMetadata>(std::move(stub));
+  stub = std::make_shared<RevisionsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<RevisionsLogging>(

--- a/google/cloud/run/v2/internal/services_metadata_decorator.h
+++ b/google/cloud/run/v2/internal/services_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServicesMetadata : public ServicesStub {
  public:
   ~ServicesMetadata() override = default;
-  explicit ServicesMetadata(
-      std::shared_ptr<ServicesStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ServicesMetadata(std::shared_ptr<ServicesStub> child,
+                   std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateService(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/run/v2/internal/services_stub_factory.cc
+++ b/google/cloud/run/v2/internal/services_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<ServicesStub> CreateDefaultServicesStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ServicesAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ServicesMetadata>(std::move(stub));
+  stub = std::make_shared<ServicesMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ServicesLogging>(

--- a/google/cloud/scheduler/v1/internal/cloud_scheduler_metadata_decorator.h
+++ b/google/cloud/scheduler/v1/internal/cloud_scheduler_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudSchedulerMetadata : public CloudSchedulerStub {
  public:
   ~CloudSchedulerMetadata() override = default;
-  explicit CloudSchedulerMetadata(
+  CloudSchedulerMetadata(
       std::shared_ptr<CloudSchedulerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::scheduler::v1::ListJobsResponse> ListJobs(
       grpc::ClientContext& context,

--- a/google/cloud/scheduler/v1/internal/cloud_scheduler_stub_factory.cc
+++ b/google/cloud/scheduler/v1/internal/cloud_scheduler_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<CloudSchedulerStub> CreateDefaultCloudSchedulerStub(
     stub =
         std::make_shared<CloudSchedulerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CloudSchedulerMetadata>(std::move(stub));
+  stub = std::make_shared<CloudSchedulerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudSchedulerLogging>(

--- a/google/cloud/secretmanager/v1/internal/secret_manager_metadata_decorator.h
+++ b/google/cloud/secretmanager/v1/internal/secret_manager_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SecretManagerServiceMetadata : public SecretManagerServiceStub {
  public:
   ~SecretManagerServiceMetadata() override = default;
-  explicit SecretManagerServiceMetadata(
+  SecretManagerServiceMetadata(
       std::shared_ptr<SecretManagerServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::secretmanager::v1::ListSecretsResponse> ListSecrets(
       grpc::ClientContext& context,

--- a/google/cloud/secretmanager/v1/internal/secret_manager_stub_factory.cc
+++ b/google/cloud/secretmanager/v1/internal/secret_manager_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<SecretManagerServiceStub> CreateDefaultSecretManagerServiceStub(
     stub = std::make_shared<SecretManagerServiceAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<SecretManagerServiceMetadata>(std::move(stub));
+  stub = std::make_shared<SecretManagerServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SecretManagerServiceLogging>(

--- a/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SecurityCenterMetadata : public SecurityCenterStub {
  public:
   ~SecurityCenterMetadata() override = default;
-  explicit SecurityCenterMetadata(
+  SecurityCenterMetadata(
       std::shared_ptr<SecurityCenterStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncBulkMuteFindings(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/securitycenter/v1/internal/security_center_stub_factory.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<SecurityCenterStub> CreateDefaultSecurityCenterStub(
     stub =
         std::make_shared<SecurityCenterAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<SecurityCenterMetadata>(std::move(stub));
+  stub = std::make_shared<SecurityCenterMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SecurityCenterLogging>(

--- a/google/cloud/servicecontrol/v1/internal/quota_controller_metadata_decorator.h
+++ b/google/cloud/servicecontrol/v1/internal/quota_controller_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class QuotaControllerMetadata : public QuotaControllerStub {
  public:
   ~QuotaControllerMetadata() override = default;
-  explicit QuotaControllerMetadata(
+  QuotaControllerMetadata(
       std::shared_ptr<QuotaControllerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>
   AllocateQuota(grpc::ClientContext& context,

--- a/google/cloud/servicecontrol/v1/internal/quota_controller_stub_factory.cc
+++ b/google/cloud/servicecontrol/v1/internal/quota_controller_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<QuotaControllerStub> CreateDefaultQuotaControllerStub(
     stub =
         std::make_shared<QuotaControllerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<QuotaControllerMetadata>(std::move(stub));
+  stub = std::make_shared<QuotaControllerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<QuotaControllerLogging>(

--- a/google/cloud/servicecontrol/v1/internal/service_controller_metadata_decorator.h
+++ b/google/cloud/servicecontrol/v1/internal/service_controller_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceControllerMetadata : public ServiceControllerStub {
  public:
   ~ServiceControllerMetadata() override = default;
-  explicit ServiceControllerMetadata(
+  ServiceControllerMetadata(
       std::shared_ptr<ServiceControllerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::api::servicecontrol::v1::CheckResponse> Check(
       grpc::ClientContext& context,

--- a/google/cloud/servicecontrol/v1/internal/service_controller_stub_factory.cc
+++ b/google/cloud/servicecontrol/v1/internal/service_controller_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<ServiceControllerStub> CreateDefaultServiceControllerStub(
     stub = std::make_shared<ServiceControllerAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<ServiceControllerMetadata>(std::move(stub));
+  stub = std::make_shared<ServiceControllerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ServiceControllerLogging>(

--- a/google/cloud/servicecontrol/v2/internal/service_controller_metadata_decorator.h
+++ b/google/cloud/servicecontrol/v2/internal/service_controller_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceControllerMetadata : public ServiceControllerStub {
  public:
   ~ServiceControllerMetadata() override = default;
-  explicit ServiceControllerMetadata(
+  ServiceControllerMetadata(
       std::shared_ptr<ServiceControllerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::api::servicecontrol::v2::CheckResponse> Check(
       grpc::ClientContext& context,

--- a/google/cloud/servicecontrol/v2/internal/service_controller_stub_factory.cc
+++ b/google/cloud/servicecontrol/v2/internal/service_controller_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<ServiceControllerStub> CreateDefaultServiceControllerStub(
     stub = std::make_shared<ServiceControllerAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<ServiceControllerMetadata>(std::move(stub));
+  stub = std::make_shared<ServiceControllerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ServiceControllerLogging>(

--- a/google/cloud/servicedirectory/v1/internal/lookup_metadata_decorator.h
+++ b/google/cloud/servicedirectory/v1/internal/lookup_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LookupServiceMetadata : public LookupServiceStub {
  public:
   ~LookupServiceMetadata() override = default;
-  explicit LookupServiceMetadata(
-      std::shared_ptr<LookupServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  LookupServiceMetadata(std::shared_ptr<LookupServiceStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>
   ResolveService(

--- a/google/cloud/servicedirectory/v1/internal/lookup_stub_factory.cc
+++ b/google/cloud/servicedirectory/v1/internal/lookup_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<LookupServiceStub> CreateDefaultLookupServiceStub(
     stub =
         std::make_shared<LookupServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<LookupServiceMetadata>(std::move(stub));
+  stub = std::make_shared<LookupServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<LookupServiceLogging>(

--- a/google/cloud/servicedirectory/v1/internal/registration_metadata_decorator.h
+++ b/google/cloud/servicedirectory/v1/internal/registration_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RegistrationServiceMetadata : public RegistrationServiceStub {
  public:
   ~RegistrationServiceMetadata() override = default;
-  explicit RegistrationServiceMetadata(
+  RegistrationServiceMetadata(
       std::shared_ptr<RegistrationServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::servicedirectory::v1::Namespace> CreateNamespace(
       grpc::ClientContext& context,

--- a/google/cloud/servicedirectory/v1/internal/registration_stub_factory.cc
+++ b/google/cloud/servicedirectory/v1/internal/registration_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<RegistrationServiceStub> CreateDefaultRegistrationServiceStub(
     stub = std::make_shared<RegistrationServiceAuth>(std::move(auth),
                                                      std::move(stub));
   }
-  stub = std::make_shared<RegistrationServiceMetadata>(std::move(stub));
+  stub = std::make_shared<RegistrationServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<RegistrationServiceLogging>(

--- a/google/cloud/servicemanagement/v1/internal/service_manager_metadata_decorator.h
+++ b/google/cloud/servicemanagement/v1/internal/service_manager_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceManagerMetadata : public ServiceManagerStub {
  public:
   ~ServiceManagerMetadata() override = default;
-  explicit ServiceManagerMetadata(
+  ServiceManagerMetadata(
       std::shared_ptr<ServiceManagerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::api::servicemanagement::v1::ListServicesResponse>
   ListServices(grpc::ClientContext& context,

--- a/google/cloud/servicemanagement/v1/internal/service_manager_stub_factory.cc
+++ b/google/cloud/servicemanagement/v1/internal/service_manager_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ServiceManagerStub> CreateDefaultServiceManagerStub(
     stub =
         std::make_shared<ServiceManagerAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ServiceManagerMetadata>(std::move(stub));
+  stub = std::make_shared<ServiceManagerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ServiceManagerLogging>(

--- a/google/cloud/serviceusage/v1/internal/service_usage_metadata_decorator.h
+++ b/google/cloud/serviceusage/v1/internal/service_usage_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceUsageMetadata : public ServiceUsageStub {
  public:
   ~ServiceUsageMetadata() override = default;
-  explicit ServiceUsageMetadata(
-      std::shared_ptr<ServiceUsageStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ServiceUsageMetadata(std::shared_ptr<ServiceUsageStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncEnableService(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/serviceusage/v1/internal/service_usage_stub_factory.cc
+++ b/google/cloud/serviceusage/v1/internal/service_usage_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<ServiceUsageStub> CreateDefaultServiceUsageStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ServiceUsageAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ServiceUsageMetadata>(std::move(stub));
+  stub = std::make_shared<ServiceUsageMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ServiceUsageLogging>(

--- a/google/cloud/shell/v1/internal/cloud_shell_metadata_decorator.h
+++ b/google/cloud/shell/v1/internal/cloud_shell_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudShellServiceMetadata : public CloudShellServiceStub {
  public:
   ~CloudShellServiceMetadata() override = default;
-  explicit CloudShellServiceMetadata(
+  CloudShellServiceMetadata(
       std::shared_ptr<CloudShellServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::shell::v1::Environment> GetEnvironment(
       grpc::ClientContext& context,

--- a/google/cloud/shell/v1/internal/cloud_shell_stub_factory.cc
+++ b/google/cloud/shell/v1/internal/cloud_shell_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<CloudShellServiceStub> CreateDefaultCloudShellServiceStub(
     stub = std::make_shared<CloudShellServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<CloudShellServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CloudShellServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudShellServiceLogging>(

--- a/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.h
+++ b/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DatabaseAdminMetadata : public DatabaseAdminStub {
  public:
   ~DatabaseAdminMetadata() override = default;
-  explicit DatabaseAdminMetadata(
-      std::shared_ptr<DatabaseAdminStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  DatabaseAdminMetadata(std::shared_ptr<DatabaseAdminStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::spanner::admin::database::v1::ListDatabasesResponse>
   ListDatabases(

--- a/google/cloud/spanner/admin/internal/database_admin_stub_factory.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
     stub =
         std::make_shared<DatabaseAdminAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<DatabaseAdminMetadata>(std::move(stub));
+  stub = std::make_shared<DatabaseAdminMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<DatabaseAdminLogging>(

--- a/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.h
+++ b/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class InstanceAdminMetadata : public InstanceAdminStub {
  public:
   ~InstanceAdminMetadata() override = default;
-  explicit InstanceAdminMetadata(
-      std::shared_ptr<InstanceAdminStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  InstanceAdminMetadata(std::shared_ptr<InstanceAdminStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::spanner::admin::instance::v1::ListInstanceConfigsResponse>
   ListInstanceConfigs(

--- a/google/cloud/spanner/admin/internal/instance_admin_stub_factory.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
     stub =
         std::make_shared<InstanceAdminAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<InstanceAdminMetadata>(std::move(stub));
+  stub = std::make_shared<InstanceAdminMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<InstanceAdminLogging>(

--- a/google/cloud/speech/v1/internal/speech_metadata_decorator.h
+++ b/google/cloud/speech/v1/internal/speech_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SpeechMetadata : public SpeechStub {
  public:
   ~SpeechMetadata() override = default;
-  explicit SpeechMetadata(
-      std::shared_ptr<SpeechStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  SpeechMetadata(std::shared_ptr<SpeechStub> child,
+                 std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::speech::v1::RecognizeResponse> Recognize(
       grpc::ClientContext& context,

--- a/google/cloud/speech/v1/internal/speech_stub_factory.cc
+++ b/google/cloud/speech/v1/internal/speech_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<SpeechStub> CreateDefaultSpeechStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<SpeechAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<SpeechMetadata>(std::move(stub));
+  stub = std::make_shared<SpeechMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SpeechLogging>(

--- a/google/cloud/speech/v2/internal/speech_metadata_decorator.h
+++ b/google/cloud/speech/v2/internal/speech_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SpeechMetadata : public SpeechStub {
  public:
   ~SpeechMetadata() override = default;
-  explicit SpeechMetadata(
-      std::shared_ptr<SpeechStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  SpeechMetadata(std::shared_ptr<SpeechStub> child,
+                 std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateRecognizer(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/speech/v2/internal/speech_stub_factory.cc
+++ b/google/cloud/speech/v2/internal/speech_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<SpeechStub> CreateDefaultSpeechStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<SpeechAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<SpeechMetadata>(std::move(stub));
+  stub = std::make_shared<SpeechMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SpeechLogging>(

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class StorageMetadata : public StorageStub {
  public:
   ~StorageMetadata() override = default;
-  explicit StorageMetadata(
-      std::shared_ptr<StorageStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  StorageMetadata(std::shared_ptr<StorageStub> child,
+                  std::multimap<std::string, std::string> fixed_metadata);
 
   Status DeleteBucket(
       grpc::ClientContext& context,

--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -73,7 +73,8 @@ CreateDecoratedStubs(google::cloud::CompletionQueue cq, Options const& options,
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<StorageAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<StorageMetadata>(std::move(stub));
+  stub = std::make_shared<StorageMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (google::cloud::internal::Contains(options.get<TracingComponentsOption>(),
                                         "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/storageinsights/v1/internal/storage_insights_metadata_decorator.h
+++ b/google/cloud/storageinsights/v1/internal/storage_insights_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class StorageInsightsMetadata : public StorageInsightsStub {
  public:
   ~StorageInsightsMetadata() override = default;
-  explicit StorageInsightsMetadata(
+  StorageInsightsMetadata(
       std::shared_ptr<StorageInsightsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::storageinsights::v1::ListReportConfigsResponse>
   ListReportConfigs(

--- a/google/cloud/storageinsights/v1/internal/storage_insights_stub_factory.cc
+++ b/google/cloud/storageinsights/v1/internal/storage_insights_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<StorageInsightsStub> CreateDefaultStorageInsightsStub(
     stub =
         std::make_shared<StorageInsightsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<StorageInsightsMetadata>(std::move(stub));
+  stub = std::make_shared<StorageInsightsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<StorageInsightsLogging>(

--- a/google/cloud/storagetransfer/v1/internal/storage_transfer_metadata_decorator.h
+++ b/google/cloud/storagetransfer/v1/internal/storage_transfer_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class StorageTransferServiceMetadata : public StorageTransferServiceStub {
  public:
   ~StorageTransferServiceMetadata() override = default;
-  explicit StorageTransferServiceMetadata(
+  StorageTransferServiceMetadata(
       std::shared_ptr<StorageTransferServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::storagetransfer::v1::GoogleServiceAccount>
   GetGoogleServiceAccount(

--- a/google/cloud/storagetransfer/v1/internal/storage_transfer_stub_factory.cc
+++ b/google/cloud/storagetransfer/v1/internal/storage_transfer_stub_factory.cc
@@ -54,7 +54,8 @@ CreateDefaultStorageTransferServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<StorageTransferServiceAuth>(std::move(auth),
                                                         std::move(stub));
   }
-  stub = std::make_shared<StorageTransferServiceMetadata>(std::move(stub));
+  stub = std::make_shared<StorageTransferServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<StorageTransferServiceLogging>(

--- a/google/cloud/support/v2/internal/case_attachment_metadata_decorator.h
+++ b/google/cloud/support/v2/internal/case_attachment_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CaseAttachmentServiceMetadata : public CaseAttachmentServiceStub {
  public:
   ~CaseAttachmentServiceMetadata() override = default;
-  explicit CaseAttachmentServiceMetadata(
+  CaseAttachmentServiceMetadata(
       std::shared_ptr<CaseAttachmentServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::support::v2::ListAttachmentsResponse> ListAttachments(
       grpc::ClientContext& context,

--- a/google/cloud/support/v2/internal/case_attachment_stub_factory.cc
+++ b/google/cloud/support/v2/internal/case_attachment_stub_factory.cc
@@ -53,7 +53,8 @@ CreateDefaultCaseAttachmentServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<CaseAttachmentServiceAuth>(std::move(auth),
                                                        std::move(stub));
   }
-  stub = std::make_shared<CaseAttachmentServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CaseAttachmentServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CaseAttachmentServiceLogging>(

--- a/google/cloud/support/v2/internal/case_metadata_decorator.h
+++ b/google/cloud/support/v2/internal/case_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CaseServiceMetadata : public CaseServiceStub {
  public:
   ~CaseServiceMetadata() override = default;
-  explicit CaseServiceMetadata(
-      std::shared_ptr<CaseServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CaseServiceMetadata(std::shared_ptr<CaseServiceStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::support::v2::Case> GetCase(
       grpc::ClientContext& context,

--- a/google/cloud/support/v2/internal/case_stub_factory.cc
+++ b/google/cloud/support/v2/internal/case_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<CaseServiceStub> CreateDefaultCaseServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<CaseServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CaseServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CaseServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CaseServiceLogging>(

--- a/google/cloud/support/v2/internal/comment_metadata_decorator.h
+++ b/google/cloud/support/v2/internal/comment_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CommentServiceMetadata : public CommentServiceStub {
  public:
   ~CommentServiceMetadata() override = default;
-  explicit CommentServiceMetadata(
+  CommentServiceMetadata(
       std::shared_ptr<CommentServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::support::v2::ListCommentsResponse> ListComments(
       grpc::ClientContext& context,

--- a/google/cloud/support/v2/internal/comment_stub_factory.cc
+++ b/google/cloud/support/v2/internal/comment_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<CommentServiceStub> CreateDefaultCommentServiceStub(
     stub =
         std::make_shared<CommentServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CommentServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CommentServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CommentServiceLogging>(

--- a/google/cloud/talent/v4/internal/company_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/company_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CompanyServiceMetadata : public CompanyServiceStub {
  public:
   ~CompanyServiceMetadata() override = default;
-  explicit CompanyServiceMetadata(
+  CompanyServiceMetadata(
       std::shared_ptr<CompanyServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::talent::v4::Company> CreateCompany(
       grpc::ClientContext& context,

--- a/google/cloud/talent/v4/internal/company_stub_factory.cc
+++ b/google/cloud/talent/v4/internal/company_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<CompanyServiceStub> CreateDefaultCompanyServiceStub(
     stub =
         std::make_shared<CompanyServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CompanyServiceMetadata>(std::move(stub));
+  stub = std::make_shared<CompanyServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CompanyServiceLogging>(

--- a/google/cloud/talent/v4/internal/completion_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/completion_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CompletionMetadata : public CompletionStub {
  public:
   ~CompletionMetadata() override = default;
-  explicit CompletionMetadata(
-      std::shared_ptr<CompletionStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CompletionMetadata(std::shared_ptr<CompletionStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::talent::v4::CompleteQueryResponse> CompleteQuery(
       grpc::ClientContext& context,

--- a/google/cloud/talent/v4/internal/completion_stub_factory.cc
+++ b/google/cloud/talent/v4/internal/completion_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<CompletionStub> CreateDefaultCompletionStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<CompletionAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CompletionMetadata>(std::move(stub));
+  stub = std::make_shared<CompletionMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CompletionLogging>(

--- a/google/cloud/talent/v4/internal/event_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/event_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EventServiceMetadata : public EventServiceStub {
  public:
   ~EventServiceMetadata() override = default;
-  explicit EventServiceMetadata(
-      std::shared_ptr<EventServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  EventServiceMetadata(std::shared_ptr<EventServiceStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::talent::v4::ClientEvent> CreateClientEvent(
       grpc::ClientContext& context,

--- a/google/cloud/talent/v4/internal/event_stub_factory.cc
+++ b/google/cloud/talent/v4/internal/event_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<EventServiceStub> CreateDefaultEventServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<EventServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<EventServiceMetadata>(std::move(stub));
+  stub = std::make_shared<EventServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<EventServiceLogging>(

--- a/google/cloud/talent/v4/internal/job_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/job_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class JobServiceMetadata : public JobServiceStub {
  public:
   ~JobServiceMetadata() override = default;
-  explicit JobServiceMetadata(
-      std::shared_ptr<JobServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  JobServiceMetadata(std::shared_ptr<JobServiceStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::talent::v4::Job> CreateJob(
       grpc::ClientContext& context,

--- a/google/cloud/talent/v4/internal/job_stub_factory.cc
+++ b/google/cloud/talent/v4/internal/job_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<JobServiceStub> CreateDefaultJobServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<JobServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<JobServiceMetadata>(std::move(stub));
+  stub = std::make_shared<JobServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<JobServiceLogging>(

--- a/google/cloud/talent/v4/internal/tenant_metadata_decorator.h
+++ b/google/cloud/talent/v4/internal/tenant_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TenantServiceMetadata : public TenantServiceStub {
  public:
   ~TenantServiceMetadata() override = default;
-  explicit TenantServiceMetadata(
-      std::shared_ptr<TenantServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  TenantServiceMetadata(std::shared_ptr<TenantServiceStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::talent::v4::Tenant> CreateTenant(
       grpc::ClientContext& context,

--- a/google/cloud/talent/v4/internal/tenant_stub_factory.cc
+++ b/google/cloud/talent/v4/internal/tenant_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<TenantServiceStub> CreateDefaultTenantServiceStub(
     stub =
         std::make_shared<TenantServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<TenantServiceMetadata>(std::move(stub));
+  stub = std::make_shared<TenantServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TenantServiceLogging>(

--- a/google/cloud/tasks/v2/internal/cloud_tasks_metadata_decorator.h
+++ b/google/cloud/tasks/v2/internal/cloud_tasks_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudTasksMetadata : public CloudTasksStub {
  public:
   ~CloudTasksMetadata() override = default;
-  explicit CloudTasksMetadata(
-      std::shared_ptr<CloudTasksStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  CloudTasksMetadata(std::shared_ptr<CloudTasksStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::tasks::v2::ListQueuesResponse> ListQueues(
       grpc::ClientContext& context,

--- a/google/cloud/tasks/v2/internal/cloud_tasks_stub_factory.cc
+++ b/google/cloud/tasks/v2/internal/cloud_tasks_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<CloudTasksStub> CreateDefaultCloudTasksStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<CloudTasksAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<CloudTasksMetadata>(std::move(stub));
+  stub = std::make_shared<CloudTasksMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<CloudTasksLogging>(

--- a/google/cloud/texttospeech/v1/internal/text_to_speech_metadata_decorator.h
+++ b/google/cloud/texttospeech/v1/internal/text_to_speech_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TextToSpeechMetadata : public TextToSpeechStub {
  public:
   ~TextToSpeechMetadata() override = default;
-  explicit TextToSpeechMetadata(
-      std::shared_ptr<TextToSpeechStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  TextToSpeechMetadata(std::shared_ptr<TextToSpeechStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse> ListVoices(
       grpc::ClientContext& context,

--- a/google/cloud/texttospeech/v1/internal/text_to_speech_stub_factory.cc
+++ b/google/cloud/texttospeech/v1/internal/text_to_speech_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<TextToSpeechStub> CreateDefaultTextToSpeechStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<TextToSpeechAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<TextToSpeechMetadata>(std::move(stub));
+  stub = std::make_shared<TextToSpeechMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TextToSpeechLogging>(

--- a/google/cloud/timeseriesinsights/v1/internal/timeseries_insights_controller_metadata_decorator.h
+++ b/google/cloud/timeseriesinsights/v1/internal/timeseries_insights_controller_metadata_decorator.h
@@ -34,9 +34,9 @@ class TimeseriesInsightsControllerMetadata
     : public TimeseriesInsightsControllerStub {
  public:
   ~TimeseriesInsightsControllerMetadata() override = default;
-  explicit TimeseriesInsightsControllerMetadata(
+  TimeseriesInsightsControllerMetadata(
       std::shared_ptr<TimeseriesInsightsControllerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::timeseriesinsights::v1::ListDataSetsResponse>
   ListDataSets(grpc::ClientContext& context,

--- a/google/cloud/timeseriesinsights/v1/internal/timeseries_insights_controller_stub_factory.cc
+++ b/google/cloud/timeseriesinsights/v1/internal/timeseries_insights_controller_stub_factory.cc
@@ -53,8 +53,8 @@ CreateDefaultTimeseriesInsightsControllerStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<TimeseriesInsightsControllerAuth>(std::move(auth),
                                                               std::move(stub));
   }
-  stub =
-      std::make_shared<TimeseriesInsightsControllerMetadata>(std::move(stub));
+  stub = std::make_shared<TimeseriesInsightsControllerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TimeseriesInsightsControllerLogging>(

--- a/google/cloud/tpu/v1/internal/tpu_metadata_decorator.h
+++ b/google/cloud/tpu/v1/internal/tpu_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TpuMetadata : public TpuStub {
  public:
   ~TpuMetadata() override = default;
-  explicit TpuMetadata(
-      std::shared_ptr<TpuStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  TpuMetadata(std::shared_ptr<TpuStub> child,
+              std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::tpu::v1::ListNodesResponse> ListNodes(
       grpc::ClientContext& context,

--- a/google/cloud/tpu/v1/internal/tpu_stub_factory.cc
+++ b/google/cloud/tpu/v1/internal/tpu_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<TpuStub> CreateDefaultTpuStub(google::cloud::CompletionQueue cq,
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<TpuAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<TpuMetadata>(std::move(stub));
+  stub = std::make_shared<TpuMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TpuLogging>(std::move(stub),

--- a/google/cloud/tpu/v2/internal/tpu_metadata_decorator.h
+++ b/google/cloud/tpu/v2/internal/tpu_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TpuMetadata : public TpuStub {
  public:
   ~TpuMetadata() override = default;
-  explicit TpuMetadata(
-      std::shared_ptr<TpuStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  TpuMetadata(std::shared_ptr<TpuStub> child,
+              std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::tpu::v2::ListNodesResponse> ListNodes(
       grpc::ClientContext& context,

--- a/google/cloud/tpu/v2/internal/tpu_stub_factory.cc
+++ b/google/cloud/tpu/v2/internal/tpu_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<TpuStub> CreateDefaultTpuStub(google::cloud::CompletionQueue cq,
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<TpuAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<TpuMetadata>(std::move(stub));
+  stub = std::make_shared<TpuMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TpuLogging>(std::move(stub),

--- a/google/cloud/trace/v1/internal/trace_metadata_decorator.h
+++ b/google/cloud/trace/v1/internal/trace_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TraceServiceMetadata : public TraceServiceStub {
  public:
   ~TraceServiceMetadata() override = default;
-  explicit TraceServiceMetadata(
-      std::shared_ptr<TraceServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  TraceServiceMetadata(std::shared_ptr<TraceServiceStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::devtools::cloudtrace::v1::ListTracesResponse> ListTraces(
       grpc::ClientContext& context,

--- a/google/cloud/trace/v1/internal/trace_stub_factory.cc
+++ b/google/cloud/trace/v1/internal/trace_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<TraceServiceStub> CreateDefaultTraceServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<TraceServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<TraceServiceMetadata>(std::move(stub));
+  stub = std::make_shared<TraceServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TraceServiceLogging>(

--- a/google/cloud/trace/v2/internal/trace_metadata_decorator.h
+++ b/google/cloud/trace/v2/internal/trace_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TraceServiceMetadata : public TraceServiceStub {
  public:
   ~TraceServiceMetadata() override = default;
-  explicit TraceServiceMetadata(
-      std::shared_ptr<TraceServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  TraceServiceMetadata(std::shared_ptr<TraceServiceStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   Status BatchWriteSpans(
       grpc::ClientContext& context,

--- a/google/cloud/trace/v2/internal/trace_stub_factory.cc
+++ b/google/cloud/trace/v2/internal/trace_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<TraceServiceStub> CreateDefaultTraceServiceStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<TraceServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<TraceServiceMetadata>(std::move(stub));
+  stub = std::make_shared<TraceServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TraceServiceLogging>(

--- a/google/cloud/translate/v3/internal/translation_metadata_decorator.h
+++ b/google/cloud/translate/v3/internal/translation_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TranslationServiceMetadata : public TranslationServiceStub {
  public:
   ~TranslationServiceMetadata() override = default;
-  explicit TranslationServiceMetadata(
+  TranslationServiceMetadata(
       std::shared_ptr<TranslationServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::translation::v3::TranslateTextResponse> TranslateText(
       grpc::ClientContext& context,

--- a/google/cloud/translate/v3/internal/translation_stub_factory.cc
+++ b/google/cloud/translate/v3/internal/translation_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<TranslationServiceStub> CreateDefaultTranslationServiceStub(
     stub = std::make_shared<TranslationServiceAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<TranslationServiceMetadata>(std::move(stub));
+  stub = std::make_shared<TranslationServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TranslationServiceLogging>(

--- a/google/cloud/video/livestream/v1/internal/livestream_metadata_decorator.h
+++ b/google/cloud/video/livestream/v1/internal/livestream_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LivestreamServiceMetadata : public LivestreamServiceStub {
  public:
   ~LivestreamServiceMetadata() override = default;
-  explicit LivestreamServiceMetadata(
+  LivestreamServiceMetadata(
       std::shared_ptr<LivestreamServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateChannel(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/video/livestream/v1/internal/livestream_stub_factory.cc
+++ b/google/cloud/video/livestream/v1/internal/livestream_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<LivestreamServiceStub> CreateDefaultLivestreamServiceStub(
     stub = std::make_shared<LivestreamServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<LivestreamServiceMetadata>(std::move(stub));
+  stub = std::make_shared<LivestreamServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<LivestreamServiceLogging>(

--- a/google/cloud/video/stitcher/v1/internal/video_stitcher_metadata_decorator.h
+++ b/google/cloud/video/stitcher/v1/internal/video_stitcher_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VideoStitcherServiceMetadata : public VideoStitcherServiceStub {
  public:
   ~VideoStitcherServiceMetadata() override = default;
-  explicit VideoStitcherServiceMetadata(
+  VideoStitcherServiceMetadata(
       std::shared_ptr<VideoStitcherServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateCdnKey(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/video/stitcher/v1/internal/video_stitcher_stub_factory.cc
+++ b/google/cloud/video/stitcher/v1/internal/video_stitcher_stub_factory.cc
@@ -54,7 +54,8 @@ std::shared_ptr<VideoStitcherServiceStub> CreateDefaultVideoStitcherServiceStub(
     stub = std::make_shared<VideoStitcherServiceAuth>(std::move(auth),
                                                       std::move(stub));
   }
-  stub = std::make_shared<VideoStitcherServiceMetadata>(std::move(stub));
+  stub = std::make_shared<VideoStitcherServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<VideoStitcherServiceLogging>(

--- a/google/cloud/video/transcoder/v1/internal/transcoder_metadata_decorator.h
+++ b/google/cloud/video/transcoder/v1/internal/transcoder_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TranscoderServiceMetadata : public TranscoderServiceStub {
  public:
   ~TranscoderServiceMetadata() override = default;
-  explicit TranscoderServiceMetadata(
+  TranscoderServiceMetadata(
       std::shared_ptr<TranscoderServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::video::transcoder::v1::Job> CreateJob(
       grpc::ClientContext& context,

--- a/google/cloud/video/transcoder/v1/internal/transcoder_stub_factory.cc
+++ b/google/cloud/video/transcoder/v1/internal/transcoder_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<TranscoderServiceStub> CreateDefaultTranscoderServiceStub(
     stub = std::make_shared<TranscoderServiceAuth>(std::move(auth),
                                                    std::move(stub));
   }
-  stub = std::make_shared<TranscoderServiceMetadata>(std::move(stub));
+  stub = std::make_shared<TranscoderServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<TranscoderServiceLogging>(

--- a/google/cloud/videointelligence/v1/internal/video_intelligence_metadata_decorator.h
+++ b/google/cloud/videointelligence/v1/internal/video_intelligence_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VideoIntelligenceServiceMetadata : public VideoIntelligenceServiceStub {
  public:
   ~VideoIntelligenceServiceMetadata() override = default;
-  explicit VideoIntelligenceServiceMetadata(
+  VideoIntelligenceServiceMetadata(
       std::shared_ptr<VideoIntelligenceServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncAnnotateVideo(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/videointelligence/v1/internal/video_intelligence_stub_factory.cc
+++ b/google/cloud/videointelligence/v1/internal/video_intelligence_stub_factory.cc
@@ -55,7 +55,8 @@ CreateDefaultVideoIntelligenceServiceStub(google::cloud::CompletionQueue cq,
     stub = std::make_shared<VideoIntelligenceServiceAuth>(std::move(auth),
                                                           std::move(stub));
   }
-  stub = std::make_shared<VideoIntelligenceServiceMetadata>(std::move(stub));
+  stub = std::make_shared<VideoIntelligenceServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<VideoIntelligenceServiceLogging>(

--- a/google/cloud/vision/v1/internal/image_annotator_metadata_decorator.h
+++ b/google/cloud/vision/v1/internal/image_annotator_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ImageAnnotatorMetadata : public ImageAnnotatorStub {
  public:
   ~ImageAnnotatorMetadata() override = default;
-  explicit ImageAnnotatorMetadata(
+  ImageAnnotatorMetadata(
       std::shared_ptr<ImageAnnotatorStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>
   BatchAnnotateImages(

--- a/google/cloud/vision/v1/internal/image_annotator_stub_factory.cc
+++ b/google/cloud/vision/v1/internal/image_annotator_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ImageAnnotatorStub> CreateDefaultImageAnnotatorStub(
     stub =
         std::make_shared<ImageAnnotatorAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ImageAnnotatorMetadata>(std::move(stub));
+  stub = std::make_shared<ImageAnnotatorMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ImageAnnotatorLogging>(

--- a/google/cloud/vision/v1/internal/product_search_metadata_decorator.h
+++ b/google/cloud/vision/v1/internal/product_search_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProductSearchMetadata : public ProductSearchStub {
  public:
   ~ProductSearchMetadata() override = default;
-  explicit ProductSearchMetadata(
-      std::shared_ptr<ProductSearchStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ProductSearchMetadata(std::shared_ptr<ProductSearchStub> child,
+                        std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::vision::v1::ProductSet> CreateProductSet(
       grpc::ClientContext& context,

--- a/google/cloud/vision/v1/internal/product_search_stub_factory.cc
+++ b/google/cloud/vision/v1/internal/product_search_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<ProductSearchStub> CreateDefaultProductSearchStub(
     stub =
         std::make_shared<ProductSearchAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ProductSearchMetadata>(std::move(stub));
+  stub = std::make_shared<ProductSearchMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ProductSearchLogging>(

--- a/google/cloud/vmmigration/v1/internal/vm_migration_metadata_decorator.h
+++ b/google/cloud/vmmigration/v1/internal/vm_migration_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VmMigrationMetadata : public VmMigrationStub {
  public:
   ~VmMigrationMetadata() override = default;
-  explicit VmMigrationMetadata(
-      std::shared_ptr<VmMigrationStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  VmMigrationMetadata(std::shared_ptr<VmMigrationStub> child,
+                      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::vmmigration::v1::ListSourcesResponse> ListSources(
       grpc::ClientContext& context,

--- a/google/cloud/vmmigration/v1/internal/vm_migration_stub_factory.cc
+++ b/google/cloud/vmmigration/v1/internal/vm_migration_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<VmMigrationStub> CreateDefaultVmMigrationStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<VmMigrationAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<VmMigrationMetadata>(std::move(stub));
+  stub = std::make_shared<VmMigrationMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<VmMigrationLogging>(

--- a/google/cloud/vmwareengine/v1/internal/vmware_engine_metadata_decorator.h
+++ b/google/cloud/vmwareengine/v1/internal/vmware_engine_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VmwareEngineMetadata : public VmwareEngineStub {
  public:
   ~VmwareEngineMetadata() override = default;
-  explicit VmwareEngineMetadata(
-      std::shared_ptr<VmwareEngineStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  VmwareEngineMetadata(std::shared_ptr<VmwareEngineStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::vmwareengine::v1::ListPrivateCloudsResponse>
   ListPrivateClouds(

--- a/google/cloud/vmwareengine/v1/internal/vmware_engine_stub_factory.cc
+++ b/google/cloud/vmwareengine/v1/internal/vmware_engine_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<VmwareEngineStub> CreateDefaultVmwareEngineStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<VmwareEngineAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<VmwareEngineMetadata>(std::move(stub));
+  stub = std::make_shared<VmwareEngineMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<VmwareEngineLogging>(

--- a/google/cloud/vpcaccess/v1/internal/vpc_access_metadata_decorator.h
+++ b/google/cloud/vpcaccess/v1/internal/vpc_access_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VpcAccessServiceMetadata : public VpcAccessServiceStub {
  public:
   ~VpcAccessServiceMetadata() override = default;
-  explicit VpcAccessServiceMetadata(
+  VpcAccessServiceMetadata(
       std::shared_ptr<VpcAccessServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateConnector(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/vpcaccess/v1/internal/vpc_access_stub_factory.cc
+++ b/google/cloud/vpcaccess/v1/internal/vpc_access_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<VpcAccessServiceStub> CreateDefaultVpcAccessServiceStub(
     stub = std::make_shared<VpcAccessServiceAuth>(std::move(auth),
                                                   std::move(stub));
   }
-  stub = std::make_shared<VpcAccessServiceMetadata>(std::move(stub));
+  stub = std::make_shared<VpcAccessServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<VpcAccessServiceLogging>(

--- a/google/cloud/webrisk/v1/internal/web_risk_metadata_decorator.h
+++ b/google/cloud/webrisk/v1/internal/web_risk_metadata_decorator.h
@@ -34,9 +34,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WebRiskServiceMetadata : public WebRiskServiceStub {
  public:
   ~WebRiskServiceMetadata() override = default;
-  explicit WebRiskServiceMetadata(
+  WebRiskServiceMetadata(
       std::shared_ptr<WebRiskServiceStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>
   ComputeThreatListDiff(

--- a/google/cloud/webrisk/v1/internal/web_risk_stub_factory.cc
+++ b/google/cloud/webrisk/v1/internal/web_risk_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<WebRiskServiceStub> CreateDefaultWebRiskServiceStub(
     stub =
         std::make_shared<WebRiskServiceAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<WebRiskServiceMetadata>(std::move(stub));
+  stub = std::make_shared<WebRiskServiceMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<WebRiskServiceLogging>(

--- a/google/cloud/websecurityscanner/v1/internal/web_security_scanner_metadata_decorator.h
+++ b/google/cloud/websecurityscanner/v1/internal/web_security_scanner_metadata_decorator.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WebSecurityScannerMetadata : public WebSecurityScannerStub {
  public:
   ~WebSecurityScannerMetadata() override = default;
-  explicit WebSecurityScannerMetadata(
+  WebSecurityScannerMetadata(
       std::shared_ptr<WebSecurityScannerStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+      std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::websecurityscanner::v1::ScanConfig> CreateScanConfig(
       grpc::ClientContext& context,

--- a/google/cloud/websecurityscanner/v1/internal/web_security_scanner_stub_factory.cc
+++ b/google/cloud/websecurityscanner/v1/internal/web_security_scanner_stub_factory.cc
@@ -53,7 +53,8 @@ std::shared_ptr<WebSecurityScannerStub> CreateDefaultWebSecurityScannerStub(
     stub = std::make_shared<WebSecurityScannerAuth>(std::move(auth),
                                                     std::move(stub));
   }
-  stub = std::make_shared<WebSecurityScannerMetadata>(std::move(stub));
+  stub = std::make_shared<WebSecurityScannerMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<WebSecurityScannerLogging>(

--- a/google/cloud/workflows/executions/v1/internal/executions_metadata_decorator.h
+++ b/google/cloud/workflows/executions/v1/internal/executions_metadata_decorator.h
@@ -33,9 +33,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ExecutionsMetadata : public ExecutionsStub {
  public:
   ~ExecutionsMetadata() override = default;
-  explicit ExecutionsMetadata(
-      std::shared_ptr<ExecutionsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  ExecutionsMetadata(std::shared_ptr<ExecutionsStub> child,
+                     std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::workflows::executions::v1::ListExecutionsResponse>
   ListExecutions(

--- a/google/cloud/workflows/executions/v1/internal/executions_stub_factory.cc
+++ b/google/cloud/workflows/executions/v1/internal/executions_stub_factory.cc
@@ -50,7 +50,8 @@ std::shared_ptr<ExecutionsStub> CreateDefaultExecutionsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<ExecutionsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<ExecutionsMetadata>(std::move(stub));
+  stub = std::make_shared<ExecutionsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<ExecutionsLogging>(

--- a/google/cloud/workflows/v1/internal/workflows_metadata_decorator.h
+++ b/google/cloud/workflows/v1/internal/workflows_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WorkflowsMetadata : public WorkflowsStub {
  public:
   ~WorkflowsMetadata() override = default;
-  explicit WorkflowsMetadata(
-      std::shared_ptr<WorkflowsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  WorkflowsMetadata(std::shared_ptr<WorkflowsStub> child,
+                    std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::workflows::v1::ListWorkflowsResponse> ListWorkflows(
       grpc::ClientContext& context,

--- a/google/cloud/workflows/v1/internal/workflows_stub_factory.cc
+++ b/google/cloud/workflows/v1/internal/workflows_stub_factory.cc
@@ -51,7 +51,8 @@ std::shared_ptr<WorkflowsStub> CreateDefaultWorkflowsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<WorkflowsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<WorkflowsMetadata>(std::move(stub));
+  stub = std::make_shared<WorkflowsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<WorkflowsLogging>(

--- a/google/cloud/workstations/v1/internal/workstations_metadata_decorator.h
+++ b/google/cloud/workstations/v1/internal/workstations_metadata_decorator.h
@@ -34,9 +34,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WorkstationsMetadata : public WorkstationsStub {
  public:
   ~WorkstationsMetadata() override = default;
-  explicit WorkstationsMetadata(
-      std::shared_ptr<WorkstationsStub> child,
-      std::multimap<std::string, std::string> fixed_metadata = {});
+  WorkstationsMetadata(std::shared_ptr<WorkstationsStub> child,
+                       std::multimap<std::string, std::string> fixed_metadata);
 
   StatusOr<google::cloud::workstations::v1::WorkstationCluster>
   GetWorkstationCluster(

--- a/google/cloud/workstations/v1/internal/workstations_stub_factory.cc
+++ b/google/cloud/workstations/v1/internal/workstations_stub_factory.cc
@@ -52,7 +52,8 @@ std::shared_ptr<WorkstationsStub> CreateDefaultWorkstationsStub(
   if (auth->RequiresConfigureContext()) {
     stub = std::make_shared<WorkstationsAuth>(std::move(auth), std::move(stub));
   }
-  stub = std::make_shared<WorkstationsMetadata>(std::move(stub));
+  stub = std::make_shared<WorkstationsMetadata>(
+      std::move(stub), std::multimap<std::string, std::string>{});
   if (internal::Contains(options.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<WorkstationsLogging>(


### PR DESCRIPTION
Followup to #11828 where metadata-decorator users specify their
fixed headers even when they are empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11853)
<!-- Reviewable:end -->
