### PR TITLE
feat(generator): handle comments with 3 newlines

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -396,6 +396,17 @@ ParameterCommentSubstitution substitutions[] = {
     {R"""(`{cluster} = '-'`)""", R"""(``{cluster} = '-'``)"""},
     {R"""(`projects/<Project ID or '-'>`)""",
      R"""(``projects/<Project ID or '-'>``)"""},
+
+    // Some comments include multiple newlines in a row. We need to preserve
+    // these because they are paragraph separators. When used in `@param`
+    // commands we need to represent them as `@n` or they do more than separate
+    // the paragraph. The would terminate the `@param` comment.
+    // No comments use more than three newlines in a row at the moment.
+    {"\n\n\n", "\n @n\n"},
+    {"\n\n", "\n @n\n"},
+
+    // Finally, the next line after a newline needs to start as a comment.
+    {"\n", "\n  /// "},
 };
 
 std::string FormatApiMethodSignatureParameters(
@@ -415,12 +426,6 @@ std::string FormatApiMethodSignatureParameters(
     for (auto& sub : substitutions) {
       sub.uses += absl::StrReplaceAll({{sub.before, sub.after}}, &comment);
     }
-    absl::StrReplaceAll(
-        {
-            {"\n\n", "\n  ///  @n\n  /// "},
-            {"\n", "\n  /// "},
-        },
-        &comment);
     absl::StrAppendFormat(&parameter_comments, "  /// @param %s %s\n",
                           FieldName(parameter_descriptor), std::move(comment));
   }

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -399,9 +399,9 @@ ParameterCommentSubstitution substitutions[] = {
 
     // Some comments include multiple newlines in a row. We need to preserve
     // these because they are paragraph separators. When used in `@param`
-    // commands we need to represent them as `@n` or they do more than separate
-    // the paragraph. The would terminate the `@param` comment.
-    // No comments use more than three newlines in a row at the moment.
+    // commands we need to represent them as `@n` or they do would terminate the
+    // `@param` comment. No comments use more than three newlines in a row at
+    // the moment.
     {"\n\n\n", "\n @n\n"},
     {"\n\n", "\n @n\n"},
 

--- a/google/cloud/automl/v1/prediction_client.h
+++ b/google/cloud/automl/v1/prediction_client.h
@@ -284,7 +284,6 @@ class PredictionServiceClient {
   ///    makes predictions for a text snippet, it will only produce results
   ///    that have at least this confidence score. The default is 0.5.
   ///  @n
-  ///
   ///  AutoML Vision Classification
   ///  @n
   ///  `score_threshold`

--- a/google/cloud/iam/v2/policies_client.h
+++ b/google/cloud/iam/v2/policies_client.h
@@ -96,7 +96,6 @@ class PoliciesClient {
   ///  to list. Format:
   ///  `policies/{attachment_point}/denypolicies`
   ///  @n
-  ///
   ///  The attachment point is identified by its URL-encoded full resource name,
   ///  which means that the forward-slash character, `/`, must be written as
   ///  `%2F`. For example,
@@ -185,7 +184,6 @@ class PoliciesClient {
   /// @param name  Required. The resource name of the policy to retrieve. Format:
   ///  `policies/{attachment_point}/denypolicies/{policy_id}`
   ///  @n
-  ///
   ///  Use the URL-encoded full resource name, which means that the forward-slash
   ///  character, `/`, must be written as `%2F`. For example,
   ///  `policies/cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project/denypolicies/my-policy`.
@@ -251,7 +249,6 @@ class PoliciesClient {
   /// @param parent  Required. The resource that the policy is attached to, along with the kind of policy
   ///  to create. Format: `policies/{attachment_point}/denypolicies`
   ///  @n
-  ///
   ///  The attachment point is identified by its URL-encoded full resource name,
   ///  which means that the forward-slash character, `/`, must be written as
   ///  `%2F`. For example,
@@ -384,7 +381,6 @@ class PoliciesClient {
   /// @param name  Required. The resource name of the policy to delete. Format:
   ///  `policies/{attachment_point}/denypolicies/{policy_id}`
   ///  @n
-  ///
   ///  Use the URL-encoded full resource name, which means that the forward-slash
   ///  character, `/`, must be written as `%2F`. For example,
   ///  `policies/cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project/denypolicies/my-policy`.

--- a/google/cloud/notebooks/v1/managed_notebook_client.h
+++ b/google/cloud/notebooks/v1/managed_notebook_client.h
@@ -320,7 +320,6 @@ class ManagedNotebookServiceClient {
   ///          }
   ///      }
   ///  @n
-  ///
   ///  Currently, only the following fields can be updated:
   ///  - `software_config.kernels`
   ///  - `software_config.post_startup_script`

--- a/google/cloud/resourcemanager/v3/organizations_client.h
+++ b/google/cloud/resourcemanager/v3/organizations_client.h
@@ -157,7 +157,6 @@ class OrganizationsClient {
   /// @param query  Optional. An optional query string used to filter the Organizations to
   ///  return in the response. Query rules are case-insensitive.
   ///  @n
-  ///
   ///  ```
   ///  | Field            | Description                                |
   ///  |------------------|--------------------------------------------|

--- a/google/cloud/resourcemanager/v3/projects_client.h
+++ b/google/cloud/resourcemanager/v3/projects_client.h
@@ -275,7 +275,6 @@ class ProjectsClient {
   ///  @n
   ///  Some examples queries:
   ///  @n
-  ///
   ///  - **`name:how*`**: The project's name starts with "how".
   ///  - **`name:Howl`**: The project's name is `Howl` or `howl`.
   ///  - **`name:HOWL`**: Equivalent to above.

--- a/google/cloud/translate/v3/translation_client.h
+++ b/google/cloud/translate/v3/translation_client.h
@@ -161,7 +161,6 @@ class TranslationServiceClient {
   ///  - General (built-in) models:
   ///    `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`,
   ///  @n
-  ///
   ///  For global (non-regionalized) requests, use `location-id` `global`.
   ///  For example,
   ///  `projects/{project-number-or-id}/locations/global/models/general/nmt`.
@@ -345,7 +344,6 @@ class TranslationServiceClient {
   ///  - General (built-in) models:
   ///    `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`,
   ///  @n
-  ///
   ///  Returns languages supported by the specified model.
   ///  If missing, we get supported languages of Google general NMT model.
   /// @param display_language_code  Optional. The language to use to return localized, human readable names


### PR DESCRIPTION
We need to preserve newlines in comments as `@n` commands. We do not need (or want?) to preserve each newline because in markdown one or more act as paragraph separators.

There are no comments with 4 newlines in a row (yet).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11858)
<!-- Reviewable:end -->
