### PR TITLE
docs: use c.g.com/cpp mocking guide

### DIFF
--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -78,7 +78,7 @@ function (google_cloud_cpp_doxygen_targets_impl library)
     list(
         APPEND
         DOXYGEN_ALIASES
-        "googleapis_dev_link{2}=\"https://googleapis.dev/cpp/google-cloud-\\1/${VERSION}/\\2\""
+        "cloud_cpp_docs_link{2}=\"https://cloud.google.com/cpp/docs/reference/\\1/${VERSION}/\\2\""
     )
     set(DOXYGEN_INLINE_INHERITED_MEMB YES)
     set(DOXYGEN_JAVADOC_AUTOBRIEF YES)

--- a/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGoldenKitchenSinkConnection : public golden_v1::GoldenKitchenSinkConnection {
  public:

--- a/generator/integration_tests/golden/v1/mocks/mock_golden_rest_only_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_golden_rest_only_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGoldenRestOnlyConnection : public golden_v1::GoldenRestOnlyConnection {
  public:

--- a/generator/integration_tests/golden/v1/mocks/mock_golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_golden_thing_admin_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGoldenThingAdminConnection : public golden_v1::GoldenThingAdminConnection {
  public:

--- a/generator/internal/mock_connection_generator.cc
+++ b/generator/internal/mock_connection_generator.cc
@@ -69,7 +69,7 @@ Status MockConnectionGenerator::GenerateHeader() {
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class $mock_connection_class_name$ : public $product_namespace$::$connection_class_name$ {
  public:

--- a/google/cloud/accessapproval/v1/mocks/mock_access_approval_connection.h
+++ b/google/cloud/accessapproval/v1/mocks/mock_access_approval_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAccessApprovalConnection
     : public accessapproval_v1::AccessApprovalConnection {

--- a/google/cloud/accesscontextmanager/v1/mocks/mock_access_context_manager_connection.h
+++ b/google/cloud/accesscontextmanager/v1/mocks/mock_access_context_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAccessContextManagerConnection
     : public accesscontextmanager_v1::AccessContextManagerConnection {

--- a/google/cloud/advisorynotifications/v1/mocks/mock_advisory_notifications_connection.h
+++ b/google/cloud/advisorynotifications/v1/mocks/mock_advisory_notifications_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAdvisoryNotificationsServiceConnection
     : public advisorynotifications_v1::AdvisoryNotificationsServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_dataset_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_dataset_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDatasetServiceConnection
     : public aiplatform_v1::DatasetServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_endpoint_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_endpoint_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEndpointServiceConnection
     : public aiplatform_v1::EndpointServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_featurestore_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_featurestore_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFeaturestoreServiceConnection
     : public aiplatform_v1::FeaturestoreServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_featurestore_online_serving_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_featurestore_online_serving_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFeaturestoreOnlineServingServiceConnection
     : public aiplatform_v1::FeaturestoreOnlineServingServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_index_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_index_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIndexServiceConnection
     : public aiplatform_v1::IndexServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_index_endpoint_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_index_endpoint_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIndexEndpointServiceConnection
     : public aiplatform_v1::IndexEndpointServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_job_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_job_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
  public:

--- a/google/cloud/aiplatform/v1/mocks/mock_match_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_match_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMatchServiceConnection
     : public aiplatform_v1::MatchServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_metadata_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_metadata_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMetadataServiceConnection
     : public aiplatform_v1::MetadataServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_migration_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_migration_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMigrationServiceConnection
     : public aiplatform_v1::MigrationServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_model_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_model_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockModelServiceConnection
     : public aiplatform_v1::ModelServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_model_garden_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_model_garden_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockModelGardenServiceConnection
     : public aiplatform_v1::ModelGardenServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_pipeline_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_pipeline_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPipelineServiceConnection
     : public aiplatform_v1::PipelineServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_prediction_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_prediction_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPredictionServiceConnection
     : public aiplatform_v1::PredictionServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_specialist_pool_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_specialist_pool_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSpecialistPoolServiceConnection
     : public aiplatform_v1::SpecialistPoolServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_tensorboard_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_tensorboard_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTensorboardServiceConnection
     : public aiplatform_v1::TensorboardServiceConnection {

--- a/google/cloud/aiplatform/v1/mocks/mock_vizier_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_vizier_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVizierServiceConnection
     : public aiplatform_v1::VizierServiceConnection {

--- a/google/cloud/alloydb/v1/mocks/mock_alloy_db_admin_connection.h
+++ b/google/cloud/alloydb/v1/mocks/mock_alloy_db_admin_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAlloyDBAdminConnection : public alloydb_v1::AlloyDBAdminConnection {
  public:

--- a/google/cloud/apigateway/v1/mocks/mock_api_gateway_connection.h
+++ b/google/cloud/apigateway/v1/mocks/mock_api_gateway_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockApiGatewayServiceConnection
     : public apigateway_v1::ApiGatewayServiceConnection {

--- a/google/cloud/apigeeconnect/v1/mocks/mock_connection_connection.h
+++ b/google/cloud/apigeeconnect/v1/mocks/mock_connection_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockConnectionServiceConnection
     : public apigeeconnect_v1::ConnectionServiceConnection {

--- a/google/cloud/apikeys/v2/mocks/mock_api_keys_connection.h
+++ b/google/cloud/apikeys/v2/mocks/mock_api_keys_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockApiKeysConnection : public apikeys_v2::ApiKeysConnection {
  public:

--- a/google/cloud/appengine/v1/mocks/mock_applications_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_applications_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockApplicationsConnection : public appengine_v1::ApplicationsConnection {
  public:

--- a/google/cloud/appengine/v1/mocks/mock_authorized_certificates_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_authorized_certificates_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAuthorizedCertificatesConnection
     : public appengine_v1::AuthorizedCertificatesConnection {

--- a/google/cloud/appengine/v1/mocks/mock_authorized_domains_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_authorized_domains_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAuthorizedDomainsConnection
     : public appengine_v1::AuthorizedDomainsConnection {

--- a/google/cloud/appengine/v1/mocks/mock_domain_mappings_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_domain_mappings_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDomainMappingsConnection
     : public appengine_v1::DomainMappingsConnection {

--- a/google/cloud/appengine/v1/mocks/mock_firewall_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_firewall_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFirewallConnection : public appengine_v1::FirewallConnection {
  public:

--- a/google/cloud/appengine/v1/mocks/mock_instances_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_instances_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInstancesConnection : public appengine_v1::InstancesConnection {
  public:

--- a/google/cloud/appengine/v1/mocks/mock_services_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_services_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockServicesConnection : public appengine_v1::ServicesConnection {
  public:

--- a/google/cloud/appengine/v1/mocks/mock_versions_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_versions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVersionsConnection : public appengine_v1::VersionsConnection {
  public:

--- a/google/cloud/artifactregistry/v1/mocks/mock_artifact_registry_connection.h
+++ b/google/cloud/artifactregistry/v1/mocks/mock_artifact_registry_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockArtifactRegistryConnection
     : public artifactregistry_v1::ArtifactRegistryConnection {

--- a/google/cloud/asset/v1/mocks/mock_asset_connection.h
+++ b/google/cloud/asset/v1/mocks/mock_asset_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAssetServiceConnection : public asset_v1::AssetServiceConnection {
  public:

--- a/google/cloud/assuredworkloads/v1/mocks/mock_assured_workloads_connection.h
+++ b/google/cloud/assuredworkloads/v1/mocks/mock_assured_workloads_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAssuredWorkloadsServiceConnection
     : public assuredworkloads_v1::AssuredWorkloadsServiceConnection {

--- a/google/cloud/automl/v1/mocks/mock_auto_ml_connection.h
+++ b/google/cloud/automl/v1/mocks/mock_auto_ml_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAutoMlConnection : public automl_v1::AutoMlConnection {
  public:

--- a/google/cloud/automl/v1/mocks/mock_prediction_connection.h
+++ b/google/cloud/automl/v1/mocks/mock_prediction_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPredictionServiceConnection
     : public automl_v1::PredictionServiceConnection {

--- a/google/cloud/baremetalsolution/v2/mocks/mock_bare_metal_solution_connection.h
+++ b/google/cloud/baremetalsolution/v2/mocks/mock_bare_metal_solution_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBareMetalSolutionConnection
     : public baremetalsolution_v2::BareMetalSolutionConnection {

--- a/google/cloud/batch/v1/mocks/mock_batch_connection.h
+++ b/google/cloud/batch/v1/mocks/mock_batch_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBatchServiceConnection : public batch_v1::BatchServiceConnection {
  public:

--- a/google/cloud/beyondcorp/appconnections/v1/mocks/mock_app_connections_connection.h
+++ b/google/cloud/beyondcorp/appconnections/v1/mocks/mock_app_connections_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAppConnectionsServiceConnection
     : public beyondcorp_appconnections_v1::AppConnectionsServiceConnection {

--- a/google/cloud/beyondcorp/appconnectors/v1/mocks/mock_app_connectors_connection.h
+++ b/google/cloud/beyondcorp/appconnectors/v1/mocks/mock_app_connectors_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAppConnectorsServiceConnection
     : public beyondcorp_appconnectors_v1::AppConnectorsServiceConnection {

--- a/google/cloud/beyondcorp/appgateways/v1/mocks/mock_app_gateways_connection.h
+++ b/google/cloud/beyondcorp/appgateways/v1/mocks/mock_app_gateways_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAppGatewaysServiceConnection
     : public beyondcorp_appgateways_v1::AppGatewaysServiceConnection {

--- a/google/cloud/beyondcorp/clientconnectorservices/v1/mocks/mock_client_connector_services_connection.h
+++ b/google/cloud/beyondcorp/clientconnectorservices/v1/mocks/mock_client_connector_services_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockClientConnectorServicesServiceConnection
     : public beyondcorp_clientconnectorservices_v1::

--- a/google/cloud/beyondcorp/clientgateways/v1/mocks/mock_client_gateways_connection.h
+++ b/google/cloud/beyondcorp/clientgateways/v1/mocks/mock_client_gateways_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockClientGatewaysServiceConnection
     : public beyondcorp_clientgateways_v1::ClientGatewaysServiceConnection {

--- a/google/cloud/bigquery/analyticshub/v1/mocks/mock_analytics_hub_connection.h
+++ b/google/cloud/bigquery/analyticshub/v1/mocks/mock_analytics_hub_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAnalyticsHubServiceConnection
     : public bigquery_analyticshub_v1::AnalyticsHubServiceConnection {

--- a/google/cloud/bigquery/connection/v1/mocks/mock_connection_connection.h
+++ b/google/cloud/bigquery/connection/v1/mocks/mock_connection_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockConnectionServiceConnection
     : public bigquery_connection_v1::ConnectionServiceConnection {

--- a/google/cloud/bigquery/datapolicies/v1/mocks/mock_data_policy_connection.h
+++ b/google/cloud/bigquery/datapolicies/v1/mocks/mock_data_policy_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDataPolicyServiceConnection
     : public bigquery_datapolicies_v1::DataPolicyServiceConnection {

--- a/google/cloud/bigquery/datatransfer/v1/mocks/mock_data_transfer_connection.h
+++ b/google/cloud/bigquery/datatransfer/v1/mocks/mock_data_transfer_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDataTransferServiceConnection
     : public bigquery_datatransfer_v1::DataTransferServiceConnection {

--- a/google/cloud/bigquery/migration/v2/mocks/mock_migration_connection.h
+++ b/google/cloud/bigquery/migration/v2/mocks/mock_migration_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMigrationServiceConnection
     : public bigquery_migration_v2::MigrationServiceConnection {

--- a/google/cloud/bigquery/reservation/v1/mocks/mock_reservation_connection.h
+++ b/google/cloud/bigquery/reservation/v1/mocks/mock_reservation_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockReservationServiceConnection
     : public bigquery_reservation_v1::ReservationServiceConnection {

--- a/google/cloud/bigquery/storage/v1/mocks/mock_bigquery_read_connection.h
+++ b/google/cloud/bigquery/storage/v1/mocks/mock_bigquery_read_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBigQueryReadConnection
     : public bigquery_storage_v1::BigQueryReadConnection {

--- a/google/cloud/bigquery/storage/v1/mocks/mock_bigquery_write_connection.h
+++ b/google/cloud/bigquery/storage/v1/mocks/mock_bigquery_write_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBigQueryWriteConnection
     : public bigquery_storage_v1::BigQueryWriteConnection {

--- a/google/cloud/bigtable/admin/mocks/mock_bigtable_instance_admin_connection.h
+++ b/google/cloud/bigtable/admin/mocks/mock_bigtable_instance_admin_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBigtableInstanceAdminConnection
     : public bigtable_admin::BigtableInstanceAdminConnection {

--- a/google/cloud/bigtable/admin/mocks/mock_bigtable_table_admin_connection.h
+++ b/google/cloud/bigtable/admin/mocks/mock_bigtable_table_admin_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBigtableTableAdminConnection
     : public bigtable_admin::BigtableTableAdminConnection {

--- a/google/cloud/billing/budgets/v1/mocks/mock_budget_connection.h
+++ b/google/cloud/billing/budgets/v1/mocks/mock_budget_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBudgetServiceConnection
     : public billing_budgets_v1::BudgetServiceConnection {

--- a/google/cloud/billing/v1/mocks/mock_cloud_billing_connection.h
+++ b/google/cloud/billing/v1/mocks/mock_cloud_billing_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudBillingConnection : public billing_v1::CloudBillingConnection {
  public:

--- a/google/cloud/billing/v1/mocks/mock_cloud_catalog_connection.h
+++ b/google/cloud/billing/v1/mocks/mock_cloud_catalog_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudCatalogConnection : public billing_v1::CloudCatalogConnection {
  public:

--- a/google/cloud/binaryauthorization/v1/mocks/mock_binauthz_management_service_v1_connection.h
+++ b/google/cloud/binaryauthorization/v1/mocks/mock_binauthz_management_service_v1_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBinauthzManagementServiceV1Connection
     : public binaryauthorization_v1::BinauthzManagementServiceV1Connection {

--- a/google/cloud/binaryauthorization/v1/mocks/mock_system_policy_v1_connection.h
+++ b/google/cloud/binaryauthorization/v1/mocks/mock_system_policy_v1_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSystemPolicyV1Connection
     : public binaryauthorization_v1::SystemPolicyV1Connection {

--- a/google/cloud/binaryauthorization/v1/mocks/mock_validation_helper_v1_connection.h
+++ b/google/cloud/binaryauthorization/v1/mocks/mock_validation_helper_v1_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockValidationHelperV1Connection
     : public binaryauthorization_v1::ValidationHelperV1Connection {

--- a/google/cloud/certificatemanager/v1/mocks/mock_certificate_manager_connection.h
+++ b/google/cloud/certificatemanager/v1/mocks/mock_certificate_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCertificateManagerConnection
     : public certificatemanager_v1::CertificateManagerConnection {

--- a/google/cloud/channel/v1/mocks/mock_cloud_channel_connection.h
+++ b/google/cloud/channel/v1/mocks/mock_cloud_channel_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudChannelServiceConnection
     : public channel_v1::CloudChannelServiceConnection {

--- a/google/cloud/cloudbuild/v1/mocks/mock_cloud_build_connection.h
+++ b/google/cloud/cloudbuild/v1/mocks/mock_cloud_build_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudBuildConnection : public cloudbuild_v1::CloudBuildConnection {
  public:

--- a/google/cloud/cloudbuild/v2/mocks/mock_repository_manager_connection.h
+++ b/google/cloud/cloudbuild/v2/mocks/mock_repository_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRepositoryManagerConnection
     : public cloudbuild_v2::RepositoryManagerConnection {

--- a/google/cloud/composer/v1/mocks/mock_environments_connection.h
+++ b/google/cloud/composer/v1/mocks/mock_environments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEnvironmentsConnection : public composer_v1::EnvironmentsConnection {
  public:

--- a/google/cloud/composer/v1/mocks/mock_image_versions_connection.h
+++ b/google/cloud/composer/v1/mocks/mock_image_versions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockImageVersionsConnection
     : public composer_v1::ImageVersionsConnection {

--- a/google/cloud/compute/accelerator_types/v1/mocks/mock_accelerator_types_connection.h
+++ b/google/cloud/compute/accelerator_types/v1/mocks/mock_accelerator_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAcceleratorTypesConnection
     : public compute_accelerator_types_v1::AcceleratorTypesConnection {

--- a/google/cloud/compute/addresses/v1/mocks/mock_addresses_connection.h
+++ b/google/cloud/compute/addresses/v1/mocks/mock_addresses_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAddressesConnection
     : public compute_addresses_v1::AddressesConnection {

--- a/google/cloud/compute/autoscalers/v1/mocks/mock_autoscalers_connection.h
+++ b/google/cloud/compute/autoscalers/v1/mocks/mock_autoscalers_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAutoscalersConnection
     : public compute_autoscalers_v1::AutoscalersConnection {

--- a/google/cloud/compute/backend_buckets/v1/mocks/mock_backend_buckets_connection.h
+++ b/google/cloud/compute/backend_buckets/v1/mocks/mock_backend_buckets_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBackendBucketsConnection
     : public compute_backend_buckets_v1::BackendBucketsConnection {

--- a/google/cloud/compute/backend_services/v1/mocks/mock_backend_services_connection.h
+++ b/google/cloud/compute/backend_services/v1/mocks/mock_backend_services_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBackendServicesConnection
     : public compute_backend_services_v1::BackendServicesConnection {

--- a/google/cloud/compute/disk_types/v1/mocks/mock_disk_types_connection.h
+++ b/google/cloud/compute/disk_types/v1/mocks/mock_disk_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDiskTypesConnection
     : public compute_disk_types_v1::DiskTypesConnection {

--- a/google/cloud/compute/disks/v1/mocks/mock_disks_connection.h
+++ b/google/cloud/compute/disks/v1/mocks/mock_disks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDisksConnection : public compute_disks_v1::DisksConnection {
  public:

--- a/google/cloud/compute/external_vpn_gateways/v1/mocks/mock_external_vpn_gateways_connection.h
+++ b/google/cloud/compute/external_vpn_gateways/v1/mocks/mock_external_vpn_gateways_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockExternalVpnGatewaysConnection
     : public compute_external_vpn_gateways_v1::ExternalVpnGatewaysConnection {

--- a/google/cloud/compute/firewall_policies/v1/mocks/mock_firewall_policies_connection.h
+++ b/google/cloud/compute/firewall_policies/v1/mocks/mock_firewall_policies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFirewallPoliciesConnection
     : public compute_firewall_policies_v1::FirewallPoliciesConnection {

--- a/google/cloud/compute/firewalls/v1/mocks/mock_firewalls_connection.h
+++ b/google/cloud/compute/firewalls/v1/mocks/mock_firewalls_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFirewallsConnection
     : public compute_firewalls_v1::FirewallsConnection {

--- a/google/cloud/compute/forwarding_rules/v1/mocks/mock_forwarding_rules_connection.h
+++ b/google/cloud/compute/forwarding_rules/v1/mocks/mock_forwarding_rules_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockForwardingRulesConnection
     : public compute_forwarding_rules_v1::ForwardingRulesConnection {

--- a/google/cloud/compute/global_addresses/v1/mocks/mock_global_addresses_connection.h
+++ b/google/cloud/compute/global_addresses/v1/mocks/mock_global_addresses_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGlobalAddressesConnection
     : public compute_global_addresses_v1::GlobalAddressesConnection {

--- a/google/cloud/compute/global_forwarding_rules/v1/mocks/mock_global_forwarding_rules_connection.h
+++ b/google/cloud/compute/global_forwarding_rules/v1/mocks/mock_global_forwarding_rules_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGlobalForwardingRulesConnection
     : public compute_global_forwarding_rules_v1::

--- a/google/cloud/compute/global_network_endpoint_groups/v1/mocks/mock_global_network_endpoint_groups_connection.h
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/mocks/mock_global_network_endpoint_groups_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGlobalNetworkEndpointGroupsConnection
     : public compute_global_network_endpoint_groups_v1::

--- a/google/cloud/compute/global_operations/v1/mocks/mock_global_operations_connection.h
+++ b/google/cloud/compute/global_operations/v1/mocks/mock_global_operations_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGlobalOperationsConnection
     : public compute_global_operations_v1::GlobalOperationsConnection {

--- a/google/cloud/compute/global_organization_operations/v1/mocks/mock_global_organization_operations_connection.h
+++ b/google/cloud/compute/global_organization_operations/v1/mocks/mock_global_organization_operations_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGlobalOrganizationOperationsConnection
     : public compute_global_organization_operations_v1::

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/mocks/mock_global_public_delegated_prefixes_connection.h
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/mocks/mock_global_public_delegated_prefixes_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGlobalPublicDelegatedPrefixesConnection
     : public compute_global_public_delegated_prefixes_v1::

--- a/google/cloud/compute/health_checks/v1/mocks/mock_health_checks_connection.h
+++ b/google/cloud/compute/health_checks/v1/mocks/mock_health_checks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockHealthChecksConnection
     : public compute_health_checks_v1::HealthChecksConnection {

--- a/google/cloud/compute/http_health_checks/v1/mocks/mock_http_health_checks_connection.h
+++ b/google/cloud/compute/http_health_checks/v1/mocks/mock_http_health_checks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockHttpHealthChecksConnection
     : public compute_http_health_checks_v1::HttpHealthChecksConnection {

--- a/google/cloud/compute/https_health_checks/v1/mocks/mock_https_health_checks_connection.h
+++ b/google/cloud/compute/https_health_checks/v1/mocks/mock_https_health_checks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockHttpsHealthChecksConnection
     : public compute_https_health_checks_v1::HttpsHealthChecksConnection {

--- a/google/cloud/compute/image_family_views/v1/mocks/mock_image_family_views_connection.h
+++ b/google/cloud/compute/image_family_views/v1/mocks/mock_image_family_views_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockImageFamilyViewsConnection
     : public compute_image_family_views_v1::ImageFamilyViewsConnection {

--- a/google/cloud/compute/images/v1/mocks/mock_images_connection.h
+++ b/google/cloud/compute/images/v1/mocks/mock_images_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockImagesConnection : public compute_images_v1::ImagesConnection {
  public:

--- a/google/cloud/compute/instance_group_managers/v1/mocks/mock_instance_group_managers_connection.h
+++ b/google/cloud/compute/instance_group_managers/v1/mocks/mock_instance_group_managers_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInstanceGroupManagersConnection
     : public compute_instance_group_managers_v1::

--- a/google/cloud/compute/instance_groups/v1/mocks/mock_instance_groups_connection.h
+++ b/google/cloud/compute/instance_groups/v1/mocks/mock_instance_groups_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInstanceGroupsConnection
     : public compute_instance_groups_v1::InstanceGroupsConnection {

--- a/google/cloud/compute/instance_templates/v1/mocks/mock_instance_templates_connection.h
+++ b/google/cloud/compute/instance_templates/v1/mocks/mock_instance_templates_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInstanceTemplatesConnection
     : public compute_instance_templates_v1::InstanceTemplatesConnection {

--- a/google/cloud/compute/instances/v1/mocks/mock_instances_connection.h
+++ b/google/cloud/compute/instances/v1/mocks/mock_instances_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInstancesConnection
     : public compute_instances_v1::InstancesConnection {

--- a/google/cloud/compute/interconnect_attachments/v1/mocks/mock_interconnect_attachments_connection.h
+++ b/google/cloud/compute/interconnect_attachments/v1/mocks/mock_interconnect_attachments_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInterconnectAttachmentsConnection
     : public compute_interconnect_attachments_v1::

--- a/google/cloud/compute/interconnect_locations/v1/mocks/mock_interconnect_locations_connection.h
+++ b/google/cloud/compute/interconnect_locations/v1/mocks/mock_interconnect_locations_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInterconnectLocationsConnection
     : public compute_interconnect_locations_v1::

--- a/google/cloud/compute/interconnects/v1/mocks/mock_interconnects_connection.h
+++ b/google/cloud/compute/interconnects/v1/mocks/mock_interconnects_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInterconnectsConnection
     : public compute_interconnects_v1::InterconnectsConnection {

--- a/google/cloud/compute/license_codes/v1/mocks/mock_license_codes_connection.h
+++ b/google/cloud/compute/license_codes/v1/mocks/mock_license_codes_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockLicenseCodesConnection
     : public compute_license_codes_v1::LicenseCodesConnection {

--- a/google/cloud/compute/licenses/v1/mocks/mock_licenses_connection.h
+++ b/google/cloud/compute/licenses/v1/mocks/mock_licenses_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockLicensesConnection : public compute_licenses_v1::LicensesConnection {
  public:

--- a/google/cloud/compute/machine_images/v1/mocks/mock_machine_images_connection.h
+++ b/google/cloud/compute/machine_images/v1/mocks/mock_machine_images_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMachineImagesConnection
     : public compute_machine_images_v1::MachineImagesConnection {

--- a/google/cloud/compute/machine_types/v1/mocks/mock_machine_types_connection.h
+++ b/google/cloud/compute/machine_types/v1/mocks/mock_machine_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMachineTypesConnection
     : public compute_machine_types_v1::MachineTypesConnection {

--- a/google/cloud/compute/network_attachments/v1/mocks/mock_network_attachments_connection.h
+++ b/google/cloud/compute/network_attachments/v1/mocks/mock_network_attachments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNetworkAttachmentsConnection
     : public compute_network_attachments_v1::NetworkAttachmentsConnection {

--- a/google/cloud/compute/network_edge_security_services/v1/mocks/mock_network_edge_security_services_connection.h
+++ b/google/cloud/compute/network_edge_security_services/v1/mocks/mock_network_edge_security_services_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNetworkEdgeSecurityServicesConnection
     : public compute_network_edge_security_services_v1::

--- a/google/cloud/compute/network_endpoint_groups/v1/mocks/mock_network_endpoint_groups_connection.h
+++ b/google/cloud/compute/network_endpoint_groups/v1/mocks/mock_network_endpoint_groups_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNetworkEndpointGroupsConnection
     : public compute_network_endpoint_groups_v1::

--- a/google/cloud/compute/network_firewall_policies/v1/mocks/mock_network_firewall_policies_connection.h
+++ b/google/cloud/compute/network_firewall_policies/v1/mocks/mock_network_firewall_policies_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNetworkFirewallPoliciesConnection
     : public compute_network_firewall_policies_v1::

--- a/google/cloud/compute/networks/v1/mocks/mock_networks_connection.h
+++ b/google/cloud/compute/networks/v1/mocks/mock_networks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNetworksConnection : public compute_networks_v1::NetworksConnection {
  public:

--- a/google/cloud/compute/node_groups/v1/mocks/mock_node_groups_connection.h
+++ b/google/cloud/compute/node_groups/v1/mocks/mock_node_groups_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNodeGroupsConnection
     : public compute_node_groups_v1::NodeGroupsConnection {

--- a/google/cloud/compute/node_templates/v1/mocks/mock_node_templates_connection.h
+++ b/google/cloud/compute/node_templates/v1/mocks/mock_node_templates_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNodeTemplatesConnection
     : public compute_node_templates_v1::NodeTemplatesConnection {

--- a/google/cloud/compute/node_types/v1/mocks/mock_node_types_connection.h
+++ b/google/cloud/compute/node_types/v1/mocks/mock_node_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNodeTypesConnection
     : public compute_node_types_v1::NodeTypesConnection {

--- a/google/cloud/compute/packet_mirrorings/v1/mocks/mock_packet_mirrorings_connection.h
+++ b/google/cloud/compute/packet_mirrorings/v1/mocks/mock_packet_mirrorings_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPacketMirroringsConnection
     : public compute_packet_mirrorings_v1::PacketMirroringsConnection {

--- a/google/cloud/compute/projects/v1/mocks/mock_projects_connection.h
+++ b/google/cloud/compute/projects/v1/mocks/mock_projects_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockProjectsConnection : public compute_projects_v1::ProjectsConnection {
  public:

--- a/google/cloud/compute/public_advertised_prefixes/v1/mocks/mock_public_advertised_prefixes_connection.h
+++ b/google/cloud/compute/public_advertised_prefixes/v1/mocks/mock_public_advertised_prefixes_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPublicAdvertisedPrefixesConnection
     : public compute_public_advertised_prefixes_v1::

--- a/google/cloud/compute/public_delegated_prefixes/v1/mocks/mock_public_delegated_prefixes_connection.h
+++ b/google/cloud/compute/public_delegated_prefixes/v1/mocks/mock_public_delegated_prefixes_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPublicDelegatedPrefixesConnection
     : public compute_public_delegated_prefixes_v1::

--- a/google/cloud/compute/region_autoscalers/v1/mocks/mock_region_autoscalers_connection.h
+++ b/google/cloud/compute/region_autoscalers/v1/mocks/mock_region_autoscalers_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionAutoscalersConnection
     : public compute_region_autoscalers_v1::RegionAutoscalersConnection {

--- a/google/cloud/compute/region_backend_services/v1/mocks/mock_region_backend_services_connection.h
+++ b/google/cloud/compute/region_backend_services/v1/mocks/mock_region_backend_services_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionBackendServicesConnection
     : public compute_region_backend_services_v1::

--- a/google/cloud/compute/region_commitments/v1/mocks/mock_region_commitments_connection.h
+++ b/google/cloud/compute/region_commitments/v1/mocks/mock_region_commitments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionCommitmentsConnection
     : public compute_region_commitments_v1::RegionCommitmentsConnection {

--- a/google/cloud/compute/region_disk_types/v1/mocks/mock_region_disk_types_connection.h
+++ b/google/cloud/compute/region_disk_types/v1/mocks/mock_region_disk_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionDiskTypesConnection
     : public compute_region_disk_types_v1::RegionDiskTypesConnection {

--- a/google/cloud/compute/region_disks/v1/mocks/mock_region_disks_connection.h
+++ b/google/cloud/compute/region_disks/v1/mocks/mock_region_disks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionDisksConnection
     : public compute_region_disks_v1::RegionDisksConnection {

--- a/google/cloud/compute/region_health_check_services/v1/mocks/mock_region_health_check_services_connection.h
+++ b/google/cloud/compute/region_health_check_services/v1/mocks/mock_region_health_check_services_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionHealthCheckServicesConnection
     : public compute_region_health_check_services_v1::

--- a/google/cloud/compute/region_health_checks/v1/mocks/mock_region_health_checks_connection.h
+++ b/google/cloud/compute/region_health_checks/v1/mocks/mock_region_health_checks_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionHealthChecksConnection
     : public compute_region_health_checks_v1::RegionHealthChecksConnection {

--- a/google/cloud/compute/region_instance_group_managers/v1/mocks/mock_region_instance_group_managers_connection.h
+++ b/google/cloud/compute/region_instance_group_managers/v1/mocks/mock_region_instance_group_managers_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionInstanceGroupManagersConnection
     : public compute_region_instance_group_managers_v1::

--- a/google/cloud/compute/region_instance_groups/v1/mocks/mock_region_instance_groups_connection.h
+++ b/google/cloud/compute/region_instance_groups/v1/mocks/mock_region_instance_groups_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionInstanceGroupsConnection
     : public compute_region_instance_groups_v1::RegionInstanceGroupsConnection {

--- a/google/cloud/compute/region_instance_templates/v1/mocks/mock_region_instance_templates_connection.h
+++ b/google/cloud/compute/region_instance_templates/v1/mocks/mock_region_instance_templates_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionInstanceTemplatesConnection
     : public compute_region_instance_templates_v1::

--- a/google/cloud/compute/region_instances/v1/mocks/mock_region_instances_connection.h
+++ b/google/cloud/compute/region_instances/v1/mocks/mock_region_instances_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionInstancesConnection
     : public compute_region_instances_v1::RegionInstancesConnection {

--- a/google/cloud/compute/region_network_endpoint_groups/v1/mocks/mock_region_network_endpoint_groups_connection.h
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/mocks/mock_region_network_endpoint_groups_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionNetworkEndpointGroupsConnection
     : public compute_region_network_endpoint_groups_v1::

--- a/google/cloud/compute/region_network_firewall_policies/v1/mocks/mock_region_network_firewall_policies_connection.h
+++ b/google/cloud/compute/region_network_firewall_policies/v1/mocks/mock_region_network_firewall_policies_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionNetworkFirewallPoliciesConnection
     : public compute_region_network_firewall_policies_v1::

--- a/google/cloud/compute/region_notification_endpoints/v1/mocks/mock_region_notification_endpoints_connection.h
+++ b/google/cloud/compute/region_notification_endpoints/v1/mocks/mock_region_notification_endpoints_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionNotificationEndpointsConnection
     : public compute_region_notification_endpoints_v1::

--- a/google/cloud/compute/region_operations/v1/mocks/mock_region_operations_connection.h
+++ b/google/cloud/compute/region_operations/v1/mocks/mock_region_operations_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionOperationsConnection
     : public compute_region_operations_v1::RegionOperationsConnection {

--- a/google/cloud/compute/region_security_policies/v1/mocks/mock_region_security_policies_connection.h
+++ b/google/cloud/compute/region_security_policies/v1/mocks/mock_region_security_policies_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionSecurityPoliciesConnection
     : public compute_region_security_policies_v1::

--- a/google/cloud/compute/region_ssl_certificates/v1/mocks/mock_region_ssl_certificates_connection.h
+++ b/google/cloud/compute/region_ssl_certificates/v1/mocks/mock_region_ssl_certificates_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionSslCertificatesConnection
     : public compute_region_ssl_certificates_v1::

--- a/google/cloud/compute/region_ssl_policies/v1/mocks/mock_region_ssl_policies_connection.h
+++ b/google/cloud/compute/region_ssl_policies/v1/mocks/mock_region_ssl_policies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionSslPoliciesConnection
     : public compute_region_ssl_policies_v1::RegionSslPoliciesConnection {

--- a/google/cloud/compute/region_target_http_proxies/v1/mocks/mock_region_target_http_proxies_connection.h
+++ b/google/cloud/compute/region_target_http_proxies/v1/mocks/mock_region_target_http_proxies_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionTargetHttpProxiesConnection
     : public compute_region_target_http_proxies_v1::

--- a/google/cloud/compute/region_target_https_proxies/v1/mocks/mock_region_target_https_proxies_connection.h
+++ b/google/cloud/compute/region_target_https_proxies/v1/mocks/mock_region_target_https_proxies_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionTargetHttpsProxiesConnection
     : public compute_region_target_https_proxies_v1::

--- a/google/cloud/compute/region_target_tcp_proxies/v1/mocks/mock_region_target_tcp_proxies_connection.h
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/mocks/mock_region_target_tcp_proxies_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionTargetTcpProxiesConnection
     : public compute_region_target_tcp_proxies_v1::

--- a/google/cloud/compute/region_url_maps/v1/mocks/mock_region_url_maps_connection.h
+++ b/google/cloud/compute/region_url_maps/v1/mocks/mock_region_url_maps_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionUrlMapsConnection
     : public compute_region_url_maps_v1::RegionUrlMapsConnection {

--- a/google/cloud/compute/regions/v1/mocks/mock_regions_connection.h
+++ b/google/cloud/compute/regions/v1/mocks/mock_regions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegionsConnection : public compute_regions_v1::RegionsConnection {
  public:

--- a/google/cloud/compute/reservations/v1/mocks/mock_reservations_connection.h
+++ b/google/cloud/compute/reservations/v1/mocks/mock_reservations_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockReservationsConnection
     : public compute_reservations_v1::ReservationsConnection {

--- a/google/cloud/compute/resource_policies/v1/mocks/mock_resource_policies_connection.h
+++ b/google/cloud/compute/resource_policies/v1/mocks/mock_resource_policies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockResourcePoliciesConnection
     : public compute_resource_policies_v1::ResourcePoliciesConnection {

--- a/google/cloud/compute/routers/v1/mocks/mock_routers_connection.h
+++ b/google/cloud/compute/routers/v1/mocks/mock_routers_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRoutersConnection : public compute_routers_v1::RoutersConnection {
  public:

--- a/google/cloud/compute/routes/v1/mocks/mock_routes_connection.h
+++ b/google/cloud/compute/routes/v1/mocks/mock_routes_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRoutesConnection : public compute_routes_v1::RoutesConnection {
  public:

--- a/google/cloud/compute/security_policies/v1/mocks/mock_security_policies_connection.h
+++ b/google/cloud/compute/security_policies/v1/mocks/mock_security_policies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSecurityPoliciesConnection
     : public compute_security_policies_v1::SecurityPoliciesConnection {

--- a/google/cloud/compute/service_attachments/v1/mocks/mock_service_attachments_connection.h
+++ b/google/cloud/compute/service_attachments/v1/mocks/mock_service_attachments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockServiceAttachmentsConnection
     : public compute_service_attachments_v1::ServiceAttachmentsConnection {

--- a/google/cloud/compute/snapshots/v1/mocks/mock_snapshots_connection.h
+++ b/google/cloud/compute/snapshots/v1/mocks/mock_snapshots_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSnapshotsConnection
     : public compute_snapshots_v1::SnapshotsConnection {

--- a/google/cloud/compute/ssl_certificates/v1/mocks/mock_ssl_certificates_connection.h
+++ b/google/cloud/compute/ssl_certificates/v1/mocks/mock_ssl_certificates_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSslCertificatesConnection
     : public compute_ssl_certificates_v1::SslCertificatesConnection {

--- a/google/cloud/compute/ssl_policies/v1/mocks/mock_ssl_policies_connection.h
+++ b/google/cloud/compute/ssl_policies/v1/mocks/mock_ssl_policies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSslPoliciesConnection
     : public compute_ssl_policies_v1::SslPoliciesConnection {

--- a/google/cloud/compute/subnetworks/v1/mocks/mock_subnetworks_connection.h
+++ b/google/cloud/compute/subnetworks/v1/mocks/mock_subnetworks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSubnetworksConnection
     : public compute_subnetworks_v1::SubnetworksConnection {

--- a/google/cloud/compute/target_grpc_proxies/v1/mocks/mock_target_grpc_proxies_connection.h
+++ b/google/cloud/compute/target_grpc_proxies/v1/mocks/mock_target_grpc_proxies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTargetGrpcProxiesConnection
     : public compute_target_grpc_proxies_v1::TargetGrpcProxiesConnection {

--- a/google/cloud/compute/target_http_proxies/v1/mocks/mock_target_http_proxies_connection.h
+++ b/google/cloud/compute/target_http_proxies/v1/mocks/mock_target_http_proxies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTargetHttpProxiesConnection
     : public compute_target_http_proxies_v1::TargetHttpProxiesConnection {

--- a/google/cloud/compute/target_https_proxies/v1/mocks/mock_target_https_proxies_connection.h
+++ b/google/cloud/compute/target_https_proxies/v1/mocks/mock_target_https_proxies_connection.h
@@ -41,7 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTargetHttpsProxiesConnection
     : public compute_target_https_proxies_v1::TargetHttpsProxiesConnection {

--- a/google/cloud/compute/target_instances/v1/mocks/mock_target_instances_connection.h
+++ b/google/cloud/compute/target_instances/v1/mocks/mock_target_instances_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTargetInstancesConnection
     : public compute_target_instances_v1::TargetInstancesConnection {

--- a/google/cloud/compute/target_pools/v1/mocks/mock_target_pools_connection.h
+++ b/google/cloud/compute/target_pools/v1/mocks/mock_target_pools_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTargetPoolsConnection
     : public compute_target_pools_v1::TargetPoolsConnection {

--- a/google/cloud/compute/target_ssl_proxies/v1/mocks/mock_target_ssl_proxies_connection.h
+++ b/google/cloud/compute/target_ssl_proxies/v1/mocks/mock_target_ssl_proxies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTargetSslProxiesConnection
     : public compute_target_ssl_proxies_v1::TargetSslProxiesConnection {

--- a/google/cloud/compute/target_tcp_proxies/v1/mocks/mock_target_tcp_proxies_connection.h
+++ b/google/cloud/compute/target_tcp_proxies/v1/mocks/mock_target_tcp_proxies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTargetTcpProxiesConnection
     : public compute_target_tcp_proxies_v1::TargetTcpProxiesConnection {

--- a/google/cloud/compute/target_vpn_gateways/v1/mocks/mock_target_vpn_gateways_connection.h
+++ b/google/cloud/compute/target_vpn_gateways/v1/mocks/mock_target_vpn_gateways_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTargetVpnGatewaysConnection
     : public compute_target_vpn_gateways_v1::TargetVpnGatewaysConnection {

--- a/google/cloud/compute/url_maps/v1/mocks/mock_url_maps_connection.h
+++ b/google/cloud/compute/url_maps/v1/mocks/mock_url_maps_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockUrlMapsConnection : public compute_url_maps_v1::UrlMapsConnection {
  public:

--- a/google/cloud/compute/vpn_gateways/v1/mocks/mock_vpn_gateways_connection.h
+++ b/google/cloud/compute/vpn_gateways/v1/mocks/mock_vpn_gateways_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVpnGatewaysConnection
     : public compute_vpn_gateways_v1::VpnGatewaysConnection {

--- a/google/cloud/compute/vpn_tunnels/v1/mocks/mock_vpn_tunnels_connection.h
+++ b/google/cloud/compute/vpn_tunnels/v1/mocks/mock_vpn_tunnels_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVpnTunnelsConnection
     : public compute_vpn_tunnels_v1::VpnTunnelsConnection {

--- a/google/cloud/compute/zone_operations/v1/mocks/mock_zone_operations_connection.h
+++ b/google/cloud/compute/zone_operations/v1/mocks/mock_zone_operations_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockZoneOperationsConnection
     : public compute_zone_operations_v1::ZoneOperationsConnection {

--- a/google/cloud/compute/zones/v1/mocks/mock_zones_connection.h
+++ b/google/cloud/compute/zones/v1/mocks/mock_zones_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockZonesConnection : public compute_zones_v1::ZonesConnection {
  public:

--- a/google/cloud/confidentialcomputing/v1/mocks/mock_confidential_computing_connection.h
+++ b/google/cloud/confidentialcomputing/v1/mocks/mock_confidential_computing_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockConfidentialComputingConnection
     : public confidentialcomputing_v1::ConfidentialComputingConnection {

--- a/google/cloud/connectors/v1/mocks/mock_connectors_connection.h
+++ b/google/cloud/connectors/v1/mocks/mock_connectors_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockConnectorsConnection : public connectors_v1::ConnectorsConnection {
  public:

--- a/google/cloud/contactcenterinsights/v1/mocks/mock_contact_center_insights_connection.h
+++ b/google/cloud/contactcenterinsights/v1/mocks/mock_contact_center_insights_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockContactCenterInsightsConnection
     : public contactcenterinsights_v1::ContactCenterInsightsConnection {

--- a/google/cloud/container/v1/mocks/mock_cluster_manager_connection.h
+++ b/google/cloud/container/v1/mocks/mock_cluster_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockClusterManagerConnection
     : public container_v1::ClusterManagerConnection {

--- a/google/cloud/containeranalysis/v1/mocks/mock_container_analysis_connection.h
+++ b/google/cloud/containeranalysis/v1/mocks/mock_container_analysis_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockContainerAnalysisConnection
     : public containeranalysis_v1::ContainerAnalysisConnection {

--- a/google/cloud/containeranalysis/v1/mocks/mock_grafeas_connection.h
+++ b/google/cloud/containeranalysis/v1/mocks/mock_grafeas_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGrafeasConnection : public containeranalysis_v1::GrafeasConnection {
  public:

--- a/google/cloud/datacatalog/lineage/v1/mocks/mock_lineage_connection.h
+++ b/google/cloud/datacatalog/lineage/v1/mocks/mock_lineage_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockLineageConnection : public datacatalog_lineage_v1::LineageConnection {
  public:

--- a/google/cloud/datacatalog/v1/mocks/mock_data_catalog_connection.h
+++ b/google/cloud/datacatalog/v1/mocks/mock_data_catalog_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDataCatalogConnection : public datacatalog_v1::DataCatalogConnection {
  public:

--- a/google/cloud/datacatalog/v1/mocks/mock_policy_tag_manager_connection.h
+++ b/google/cloud/datacatalog/v1/mocks/mock_policy_tag_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPolicyTagManagerConnection
     : public datacatalog_v1::PolicyTagManagerConnection {

--- a/google/cloud/datacatalog/v1/mocks/mock_policy_tag_manager_serialization_connection.h
+++ b/google/cloud/datacatalog/v1/mocks/mock_policy_tag_manager_serialization_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPolicyTagManagerSerializationConnection
     : public datacatalog_v1::PolicyTagManagerSerializationConnection {

--- a/google/cloud/datamigration/v1/mocks/mock_data_migration_connection.h
+++ b/google/cloud/datamigration/v1/mocks/mock_data_migration_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDataMigrationServiceConnection
     : public datamigration_v1::DataMigrationServiceConnection {

--- a/google/cloud/dataplex/v1/mocks/mock_content_connection.h
+++ b/google/cloud/dataplex/v1/mocks/mock_content_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockContentServiceConnection
     : public dataplex_v1::ContentServiceConnection {

--- a/google/cloud/dataplex/v1/mocks/mock_dataplex_connection.h
+++ b/google/cloud/dataplex/v1/mocks/mock_dataplex_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDataplexServiceConnection
     : public dataplex_v1::DataplexServiceConnection {

--- a/google/cloud/dataplex/v1/mocks/mock_metadata_connection.h
+++ b/google/cloud/dataplex/v1/mocks/mock_metadata_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMetadataServiceConnection
     : public dataplex_v1::MetadataServiceConnection {

--- a/google/cloud/dataproc/v1/mocks/mock_autoscaling_policy_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_autoscaling_policy_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAutoscalingPolicyServiceConnection
     : public dataproc_v1::AutoscalingPolicyServiceConnection {

--- a/google/cloud/dataproc/v1/mocks/mock_batch_controller_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_batch_controller_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockBatchControllerConnection
     : public dataproc_v1::BatchControllerConnection {

--- a/google/cloud/dataproc/v1/mocks/mock_cluster_controller_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_cluster_controller_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockClusterControllerConnection
     : public dataproc_v1::ClusterControllerConnection {

--- a/google/cloud/dataproc/v1/mocks/mock_job_controller_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_job_controller_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockJobControllerConnection
     : public dataproc_v1::JobControllerConnection {

--- a/google/cloud/dataproc/v1/mocks/mock_workflow_template_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_workflow_template_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockWorkflowTemplateServiceConnection
     : public dataproc_v1::WorkflowTemplateServiceConnection {

--- a/google/cloud/datastream/v1/mocks/mock_datastream_connection.h
+++ b/google/cloud/datastream/v1/mocks/mock_datastream_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDatastreamConnection : public datastream_v1::DatastreamConnection {
  public:

--- a/google/cloud/deploy/v1/mocks/mock_cloud_deploy_connection.h
+++ b/google/cloud/deploy/v1/mocks/mock_cloud_deploy_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_agents_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_agents_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAgentsConnection : public dialogflow_cx::AgentsConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_changelogs_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_changelogs_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockChangelogsConnection : public dialogflow_cx::ChangelogsConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_deployments_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_deployments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDeploymentsConnection : public dialogflow_cx::DeploymentsConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_entity_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEntityTypesConnection : public dialogflow_cx::EntityTypesConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_environments_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_environments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEnvironmentsConnection
     : public dialogflow_cx::EnvironmentsConnection {

--- a/google/cloud/dialogflow_cx/mocks/mock_experiments_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_experiments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockExperimentsConnection : public dialogflow_cx::ExperimentsConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_flows_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_flows_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFlowsConnection : public dialogflow_cx::FlowsConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_intents_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_intents_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIntentsConnection : public dialogflow_cx::IntentsConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_pages_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_pages_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPagesConnection : public dialogflow_cx::PagesConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_security_settings_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_security_settings_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSecuritySettingsServiceConnection
     : public dialogflow_cx::SecuritySettingsServiceConnection {

--- a/google/cloud/dialogflow_cx/mocks/mock_session_entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_session_entity_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSessionEntityTypesConnection
     : public dialogflow_cx::SessionEntityTypesConnection {

--- a/google/cloud/dialogflow_cx/mocks/mock_sessions_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_sessions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSessionsConnection : public dialogflow_cx::SessionsConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_test_cases_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_test_cases_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTestCasesConnection : public dialogflow_cx::TestCasesConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_transition_route_groups_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_transition_route_groups_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTransitionRouteGroupsConnection
     : public dialogflow_cx::TransitionRouteGroupsConnection {

--- a/google/cloud/dialogflow_cx/mocks/mock_versions_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_versions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVersionsConnection : public dialogflow_cx::VersionsConnection {
  public:

--- a/google/cloud/dialogflow_cx/mocks/mock_webhooks_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_webhooks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockWebhooksConnection : public dialogflow_cx::WebhooksConnection {
  public:

--- a/google/cloud/dialogflow_es/mocks/mock_agents_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_agents_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAgentsConnection : public dialogflow_es::AgentsConnection {
  public:

--- a/google/cloud/dialogflow_es/mocks/mock_answer_records_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_answer_records_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAnswerRecordsConnection
     : public dialogflow_es::AnswerRecordsConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_contexts_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_contexts_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockContextsConnection : public dialogflow_es::ContextsConnection {
  public:

--- a/google/cloud/dialogflow_es/mocks/mock_conversation_datasets_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_conversation_datasets_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockConversationDatasetsConnection
     : public dialogflow_es::ConversationDatasetsConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_conversation_models_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_conversation_models_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockConversationModelsConnection
     : public dialogflow_es::ConversationModelsConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_conversation_profiles_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_conversation_profiles_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockConversationProfilesConnection
     : public dialogflow_es::ConversationProfilesConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_conversations_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_conversations_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockConversationsConnection
     : public dialogflow_es::ConversationsConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_documents_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_documents_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDocumentsConnection : public dialogflow_es::DocumentsConnection {
  public:

--- a/google/cloud/dialogflow_es/mocks/mock_entity_types_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_entity_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEntityTypesConnection : public dialogflow_es::EntityTypesConnection {
  public:

--- a/google/cloud/dialogflow_es/mocks/mock_environments_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_environments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEnvironmentsConnection
     : public dialogflow_es::EnvironmentsConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_fulfillments_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_fulfillments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFulfillmentsConnection
     : public dialogflow_es::FulfillmentsConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_intents_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_intents_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIntentsConnection : public dialogflow_es::IntentsConnection {
  public:

--- a/google/cloud/dialogflow_es/mocks/mock_knowledge_bases_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_knowledge_bases_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockKnowledgeBasesConnection
     : public dialogflow_es::KnowledgeBasesConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_participants_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_participants_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockParticipantsConnection
     : public dialogflow_es::ParticipantsConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_session_entity_types_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_session_entity_types_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSessionEntityTypesConnection
     : public dialogflow_es::SessionEntityTypesConnection {

--- a/google/cloud/dialogflow_es/mocks/mock_sessions_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_sessions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSessionsConnection : public dialogflow_es::SessionsConnection {
  public:

--- a/google/cloud/dialogflow_es/mocks/mock_versions_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_versions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVersionsConnection : public dialogflow_es::VersionsConnection {
  public:

--- a/google/cloud/dlp/v2/mocks/mock_dlp_connection.h
+++ b/google/cloud/dlp/v2/mocks/mock_dlp_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
  public:

--- a/google/cloud/documentai/v1/mocks/mock_document_processor_connection.h
+++ b/google/cloud/documentai/v1/mocks/mock_document_processor_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDocumentProcessorServiceConnection
     : public documentai_v1::DocumentProcessorServiceConnection {

--- a/google/cloud/domains/v1/mocks/mock_domains_connection.h
+++ b/google/cloud/domains/v1/mocks/mock_domains_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDomainsConnection : public domains_v1::DomainsConnection {
  public:

--- a/google/cloud/edgecontainer/v1/mocks/mock_edge_container_connection.h
+++ b/google/cloud/edgecontainer/v1/mocks/mock_edge_container_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEdgeContainerConnection
     : public edgecontainer_v1::EdgeContainerConnection {

--- a/google/cloud/essentialcontacts/v1/mocks/mock_essential_contacts_connection.h
+++ b/google/cloud/essentialcontacts/v1/mocks/mock_essential_contacts_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEssentialContactsServiceConnection
     : public essentialcontacts_v1::EssentialContactsServiceConnection {

--- a/google/cloud/eventarc/publishing/v1/mocks/mock_publisher_connection.h
+++ b/google/cloud/eventarc/publishing/v1/mocks/mock_publisher_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPublisherConnection
     : public eventarc_publishing_v1::PublisherConnection {

--- a/google/cloud/eventarc/v1/mocks/mock_eventarc_connection.h
+++ b/google/cloud/eventarc/v1/mocks/mock_eventarc_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEventarcConnection : public eventarc_v1::EventarcConnection {
  public:

--- a/google/cloud/filestore/v1/mocks/mock_cloud_filestore_manager_connection.h
+++ b/google/cloud/filestore/v1/mocks/mock_cloud_filestore_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudFilestoreManagerConnection
     : public filestore_v1::CloudFilestoreManagerConnection {

--- a/google/cloud/functions/v1/mocks/mock_cloud_functions_connection.h
+++ b/google/cloud/functions/v1/mocks/mock_cloud_functions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudFunctionsServiceConnection
     : public functions_v1::CloudFunctionsServiceConnection {

--- a/google/cloud/gameservices/v1/mocks/mock_game_server_clusters_connection.h
+++ b/google/cloud/gameservices/v1/mocks/mock_game_server_clusters_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGameServerClustersServiceConnection
     : public gameservices_v1::GameServerClustersServiceConnection {

--- a/google/cloud/gameservices/v1/mocks/mock_game_server_configs_connection.h
+++ b/google/cloud/gameservices/v1/mocks/mock_game_server_configs_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGameServerConfigsServiceConnection
     : public gameservices_v1::GameServerConfigsServiceConnection {

--- a/google/cloud/gameservices/v1/mocks/mock_game_server_deployments_connection.h
+++ b/google/cloud/gameservices/v1/mocks/mock_game_server_deployments_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGameServerDeploymentsServiceConnection
     : public gameservices_v1::GameServerDeploymentsServiceConnection {

--- a/google/cloud/gameservices/v1/mocks/mock_realms_connection.h
+++ b/google/cloud/gameservices/v1/mocks/mock_realms_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRealmsServiceConnection
     : public gameservices_v1::RealmsServiceConnection {

--- a/google/cloud/gkehub/v1/mocks/mock_gke_hub_connection.h
+++ b/google/cloud/gkehub/v1/mocks/mock_gke_hub_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGkeHubConnection : public gkehub_v1::GkeHubConnection {
  public:

--- a/google/cloud/gkemulticloud/v1/mocks/mock_attached_clusters_connection.h
+++ b/google/cloud/gkemulticloud/v1/mocks/mock_attached_clusters_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAttachedClustersConnection
     : public gkemulticloud_v1::AttachedClustersConnection {

--- a/google/cloud/gkemulticloud/v1/mocks/mock_aws_clusters_connection.h
+++ b/google/cloud/gkemulticloud/v1/mocks/mock_aws_clusters_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAwsClustersConnection
     : public gkemulticloud_v1::AwsClustersConnection {

--- a/google/cloud/gkemulticloud/v1/mocks/mock_azure_clusters_connection.h
+++ b/google/cloud/gkemulticloud/v1/mocks/mock_azure_clusters_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAzureClustersConnection
     : public gkemulticloud_v1::AzureClustersConnection {

--- a/google/cloud/iam/admin/v1/mocks/mock_iam_connection.h
+++ b/google/cloud/iam/admin/v1/mocks/mock_iam_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIAMConnection : public iam_admin_v1::IAMConnection {
  public:

--- a/google/cloud/iam/credentials/v1/mocks/mock_iam_credentials_connection.h
+++ b/google/cloud/iam/credentials/v1/mocks/mock_iam_credentials_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIAMCredentialsConnection
     : public iam_credentials_v1::IAMCredentialsConnection {

--- a/google/cloud/iam/v1/mocks/mock_iam_policy_connection.h
+++ b/google/cloud/iam/v1/mocks/mock_iam_policy_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIAMPolicyConnection : public iam_v1::IAMPolicyConnection {
  public:

--- a/google/cloud/iam/v2/mocks/mock_policies_connection.h
+++ b/google/cloud/iam/v2/mocks/mock_policies_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPoliciesConnection : public iam_v2::PoliciesConnection {
  public:

--- a/google/cloud/iap/v1/mocks/mock_identity_aware_proxy_admin_connection.h
+++ b/google/cloud/iap/v1/mocks/mock_identity_aware_proxy_admin_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIdentityAwareProxyAdminServiceConnection
     : public iap_v1::IdentityAwareProxyAdminServiceConnection {

--- a/google/cloud/iap/v1/mocks/mock_identity_aware_proxy_o_auth_connection.h
+++ b/google/cloud/iap/v1/mocks/mock_identity_aware_proxy_o_auth_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIdentityAwareProxyOAuthServiceConnection
     : public iap_v1::IdentityAwareProxyOAuthServiceConnection {

--- a/google/cloud/ids/v1/mocks/mock_ids_connection.h
+++ b/google/cloud/ids/v1/mocks/mock_ids_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIDSConnection : public ids_v1::IDSConnection {
  public:

--- a/google/cloud/iot/v1/mocks/mock_device_manager_connection.h
+++ b/google/cloud/iot/v1/mocks/mock_device_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDeviceManagerConnection : public iot_v1::DeviceManagerConnection {
  public:

--- a/google/cloud/kms/inventory/v1/mocks/mock_key_dashboard_connection.h
+++ b/google/cloud/kms/inventory/v1/mocks/mock_key_dashboard_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockKeyDashboardServiceConnection
     : public kms_inventory_v1::KeyDashboardServiceConnection {

--- a/google/cloud/kms/inventory/v1/mocks/mock_key_tracking_connection.h
+++ b/google/cloud/kms/inventory/v1/mocks/mock_key_tracking_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockKeyTrackingServiceConnection
     : public kms_inventory_v1::KeyTrackingServiceConnection {

--- a/google/cloud/kms/v1/mocks/mock_ekm_connection.h
+++ b/google/cloud/kms/v1/mocks/mock_ekm_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEkmServiceConnection : public kms_v1::EkmServiceConnection {
  public:

--- a/google/cloud/kms/v1/mocks/mock_key_management_connection.h
+++ b/google/cloud/kms/v1/mocks/mock_key_management_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockKeyManagementServiceConnection
     : public kms_v1::KeyManagementServiceConnection {

--- a/google/cloud/language/v1/mocks/mock_language_connection.h
+++ b/google/cloud/language/v1/mocks/mock_language_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockLanguageServiceConnection
     : public language_v1::LanguageServiceConnection {

--- a/google/cloud/logging/v2/mocks/mock_logging_service_v2_connection.h
+++ b/google/cloud/logging/v2/mocks/mock_logging_service_v2_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockLoggingServiceV2Connection
     : public logging_v2::LoggingServiceV2Connection {

--- a/google/cloud/managedidentities/v1/mocks/mock_managed_identities_connection.h
+++ b/google/cloud/managedidentities/v1/mocks/mock_managed_identities_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockManagedIdentitiesServiceConnection
     : public managedidentities_v1::ManagedIdentitiesServiceConnection {

--- a/google/cloud/memcache/v1/mocks/mock_cloud_memcache_connection.h
+++ b/google/cloud/memcache/v1/mocks/mock_cloud_memcache_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudMemcacheConnection
     : public memcache_v1::CloudMemcacheConnection {

--- a/google/cloud/monitoring/dashboard/v1/mocks/mock_dashboards_connection.h
+++ b/google/cloud/monitoring/dashboard/v1/mocks/mock_dashboards_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDashboardsServiceConnection
     : public monitoring_dashboard_v1::DashboardsServiceConnection {

--- a/google/cloud/monitoring/metricsscope/v1/mocks/mock_metrics_scopes_connection.h
+++ b/google/cloud/monitoring/metricsscope/v1/mocks/mock_metrics_scopes_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMetricsScopesConnection
     : public monitoring_metricsscope_v1::MetricsScopesConnection {

--- a/google/cloud/monitoring/v3/mocks/mock_alert_policy_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_alert_policy_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAlertPolicyServiceConnection
     : public monitoring_v3::AlertPolicyServiceConnection {

--- a/google/cloud/monitoring/v3/mocks/mock_group_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_group_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockGroupServiceConnection
     : public monitoring_v3::GroupServiceConnection {

--- a/google/cloud/monitoring/v3/mocks/mock_metric_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_metric_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockMetricServiceConnection
     : public monitoring_v3::MetricServiceConnection {

--- a/google/cloud/monitoring/v3/mocks/mock_notification_channel_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_notification_channel_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNotificationChannelServiceConnection
     : public monitoring_v3::NotificationChannelServiceConnection {

--- a/google/cloud/monitoring/v3/mocks/mock_query_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_query_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockQueryServiceConnection
     : public monitoring_v3::QueryServiceConnection {

--- a/google/cloud/monitoring/v3/mocks/mock_service_monitoring_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_service_monitoring_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockServiceMonitoringServiceConnection
     : public monitoring_v3::ServiceMonitoringServiceConnection {

--- a/google/cloud/monitoring/v3/mocks/mock_uptime_check_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_uptime_check_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockUptimeCheckServiceConnection
     : public monitoring_v3::UptimeCheckServiceConnection {

--- a/google/cloud/networkconnectivity/v1/mocks/mock_hub_connection.h
+++ b/google/cloud/networkconnectivity/v1/mocks/mock_hub_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockHubServiceConnection
     : public networkconnectivity_v1::HubServiceConnection {

--- a/google/cloud/networkmanagement/v1/mocks/mock_reachability_connection.h
+++ b/google/cloud/networkmanagement/v1/mocks/mock_reachability_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockReachabilityServiceConnection
     : public networkmanagement_v1::ReachabilityServiceConnection {

--- a/google/cloud/networkservices/v1/mocks/mock_network_services_connection.h
+++ b/google/cloud/networkservices/v1/mocks/mock_network_services_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNetworkServicesConnection
     : public networkservices_v1::NetworkServicesConnection {

--- a/google/cloud/notebooks/v1/mocks/mock_managed_notebook_connection.h
+++ b/google/cloud/notebooks/v1/mocks/mock_managed_notebook_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockManagedNotebookServiceConnection
     : public notebooks_v1::ManagedNotebookServiceConnection {

--- a/google/cloud/notebooks/v1/mocks/mock_notebook_connection.h
+++ b/google/cloud/notebooks/v1/mocks/mock_notebook_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockNotebookServiceConnection
     : public notebooks_v1::NotebookServiceConnection {

--- a/google/cloud/optimization/v1/mocks/mock_fleet_routing_connection.h
+++ b/google/cloud/optimization/v1/mocks/mock_fleet_routing_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFleetRoutingConnection
     : public optimization_v1::FleetRoutingConnection {

--- a/google/cloud/orgpolicy/v2/mocks/mock_org_policy_connection.h
+++ b/google/cloud/orgpolicy/v2/mocks/mock_org_policy_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockOrgPolicyConnection : public orgpolicy_v2::OrgPolicyConnection {
  public:

--- a/google/cloud/osconfig/agentendpoint/v1/mocks/mock_agent_endpoint_connection.h
+++ b/google/cloud/osconfig/agentendpoint/v1/mocks/mock_agent_endpoint_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAgentEndpointServiceConnection
     : public osconfig_agentendpoint_v1::AgentEndpointServiceConnection {

--- a/google/cloud/osconfig/v1/mocks/mock_os_config_connection.h
+++ b/google/cloud/osconfig/v1/mocks/mock_os_config_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockOsConfigServiceConnection
     : public osconfig_v1::OsConfigServiceConnection {

--- a/google/cloud/oslogin/v1/mocks/mock_os_login_connection.h
+++ b/google/cloud/oslogin/v1/mocks/mock_os_login_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockOsLoginServiceConnection
     : public oslogin_v1::OsLoginServiceConnection {

--- a/google/cloud/policytroubleshooter/v1/mocks/mock_iam_checker_connection.h
+++ b/google/cloud/policytroubleshooter/v1/mocks/mock_iam_checker_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockIamCheckerConnection
     : public policytroubleshooter_v1::IamCheckerConnection {

--- a/google/cloud/privateca/v1/mocks/mock_certificate_authority_connection.h
+++ b/google/cloud/privateca/v1/mocks/mock_certificate_authority_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCertificateAuthorityServiceConnection
     : public privateca_v1::CertificateAuthorityServiceConnection {

--- a/google/cloud/profiler/v2/mocks/mock_profiler_connection.h
+++ b/google/cloud/profiler/v2/mocks/mock_profiler_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockProfilerServiceConnection
     : public profiler_v2::ProfilerServiceConnection {

--- a/google/cloud/pubsub/mocks/mock_schema_connection.h
+++ b/google/cloud/pubsub/mocks/mock_schema_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSchemaServiceConnection : public pubsub::SchemaServiceConnection {
  public:

--- a/google/cloud/pubsublite/mocks/mock_admin_connection.h
+++ b/google/cloud/pubsublite/mocks/mock_admin_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockAdminServiceConnection : public pubsublite::AdminServiceConnection {
  public:

--- a/google/cloud/pubsublite/mocks/mock_topic_stats_connection.h
+++ b/google/cloud/pubsublite/mocks/mock_topic_stats_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTopicStatsServiceConnection
     : public pubsublite::TopicStatsServiceConnection {

--- a/google/cloud/recommender/v1/mocks/mock_recommender_connection.h
+++ b/google/cloud/recommender/v1/mocks/mock_recommender_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRecommenderConnection : public recommender_v1::RecommenderConnection {
  public:

--- a/google/cloud/redis/v1/mocks/mock_cloud_redis_connection.h
+++ b/google/cloud/redis/v1/mocks/mock_cloud_redis_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudRedisConnection : public redis_v1::CloudRedisConnection {
  public:

--- a/google/cloud/resourcemanager/v3/mocks/mock_folders_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_folders_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockFoldersConnection : public resourcemanager_v3::FoldersConnection {
  public:

--- a/google/cloud/resourcemanager/v3/mocks/mock_organizations_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_organizations_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockOrganizationsConnection
     : public resourcemanager_v3::OrganizationsConnection {

--- a/google/cloud/resourcemanager/v3/mocks/mock_projects_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_projects_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockProjectsConnection : public resourcemanager_v3::ProjectsConnection {
  public:

--- a/google/cloud/resourcesettings/v1/mocks/mock_resource_settings_connection.h
+++ b/google/cloud/resourcesettings/v1/mocks/mock_resource_settings_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockResourceSettingsServiceConnection
     : public resourcesettings_v1::ResourceSettingsServiceConnection {

--- a/google/cloud/retail/v2/mocks/mock_catalog_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_catalog_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCatalogServiceConnection
     : public retail_v2::CatalogServiceConnection {

--- a/google/cloud/retail/v2/mocks/mock_completion_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_completion_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCompletionServiceConnection
     : public retail_v2::CompletionServiceConnection {

--- a/google/cloud/retail/v2/mocks/mock_prediction_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_prediction_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockPredictionServiceConnection
     : public retail_v2::PredictionServiceConnection {

--- a/google/cloud/retail/v2/mocks/mock_product_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_product_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockProductServiceConnection
     : public retail_v2::ProductServiceConnection {

--- a/google/cloud/retail/v2/mocks/mock_search_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_search_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSearchServiceConnection : public retail_v2::SearchServiceConnection {
  public:

--- a/google/cloud/retail/v2/mocks/mock_user_event_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_user_event_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockUserEventServiceConnection
     : public retail_v2::UserEventServiceConnection {

--- a/google/cloud/run/v2/mocks/mock_revisions_connection.h
+++ b/google/cloud/run/v2/mocks/mock_revisions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRevisionsConnection : public run_v2::RevisionsConnection {
  public:

--- a/google/cloud/run/v2/mocks/mock_services_connection.h
+++ b/google/cloud/run/v2/mocks/mock_services_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockServicesConnection : public run_v2::ServicesConnection {
  public:

--- a/google/cloud/scheduler/v1/mocks/mock_cloud_scheduler_connection.h
+++ b/google/cloud/scheduler/v1/mocks/mock_cloud_scheduler_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudSchedulerConnection
     : public scheduler_v1::CloudSchedulerConnection {

--- a/google/cloud/secretmanager/v1/mocks/mock_secret_manager_connection.h
+++ b/google/cloud/secretmanager/v1/mocks/mock_secret_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSecretManagerServiceConnection
     : public secretmanager_v1::SecretManagerServiceConnection {

--- a/google/cloud/securitycenter/v1/mocks/mock_security_center_connection.h
+++ b/google/cloud/securitycenter/v1/mocks/mock_security_center_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSecurityCenterConnection
     : public securitycenter_v1::SecurityCenterConnection {

--- a/google/cloud/servicecontrol/v1/mocks/mock_quota_controller_connection.h
+++ b/google/cloud/servicecontrol/v1/mocks/mock_quota_controller_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockQuotaControllerConnection
     : public servicecontrol_v1::QuotaControllerConnection {

--- a/google/cloud/servicecontrol/v1/mocks/mock_service_controller_connection.h
+++ b/google/cloud/servicecontrol/v1/mocks/mock_service_controller_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockServiceControllerConnection
     : public servicecontrol_v1::ServiceControllerConnection {

--- a/google/cloud/servicecontrol/v2/mocks/mock_service_controller_connection.h
+++ b/google/cloud/servicecontrol/v2/mocks/mock_service_controller_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockServiceControllerConnection
     : public servicecontrol_v2::ServiceControllerConnection {

--- a/google/cloud/servicedirectory/v1/mocks/mock_lookup_connection.h
+++ b/google/cloud/servicedirectory/v1/mocks/mock_lookup_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockLookupServiceConnection
     : public servicedirectory_v1::LookupServiceConnection {

--- a/google/cloud/servicedirectory/v1/mocks/mock_registration_connection.h
+++ b/google/cloud/servicedirectory/v1/mocks/mock_registration_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockRegistrationServiceConnection
     : public servicedirectory_v1::RegistrationServiceConnection {

--- a/google/cloud/servicemanagement/v1/mocks/mock_service_manager_connection.h
+++ b/google/cloud/servicemanagement/v1/mocks/mock_service_manager_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockServiceManagerConnection
     : public servicemanagement_v1::ServiceManagerConnection {

--- a/google/cloud/serviceusage/v1/mocks/mock_service_usage_connection.h
+++ b/google/cloud/serviceusage/v1/mocks/mock_service_usage_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockServiceUsageConnection
     : public serviceusage_v1::ServiceUsageConnection {

--- a/google/cloud/shell/v1/mocks/mock_cloud_shell_connection.h
+++ b/google/cloud/shell/v1/mocks/mock_cloud_shell_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudShellServiceConnection
     : public shell_v1::CloudShellServiceConnection {

--- a/google/cloud/spanner/admin/mocks/mock_database_admin_connection.h
+++ b/google/cloud/spanner/admin/mocks/mock_database_admin_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockDatabaseAdminConnection
     : public spanner_admin::DatabaseAdminConnection {

--- a/google/cloud/spanner/admin/mocks/mock_instance_admin_connection.h
+++ b/google/cloud/spanner/admin/mocks/mock_instance_admin_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockInstanceAdminConnection
     : public spanner_admin::InstanceAdminConnection {

--- a/google/cloud/speech/v1/mocks/mock_speech_connection.h
+++ b/google/cloud/speech/v1/mocks/mock_speech_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSpeechConnection : public speech_v1::SpeechConnection {
  public:

--- a/google/cloud/speech/v2/mocks/mock_speech_connection.h
+++ b/google/cloud/speech/v2/mocks/mock_speech_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSpeechConnection : public speech_v2::SpeechConnection {
  public:

--- a/google/cloud/sql/v1/mocks/mock_sql_backup_runs_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_backup_runs_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlBackupRunsServiceConnection
     : public sql_v1::SqlBackupRunsServiceConnection {

--- a/google/cloud/sql/v1/mocks/mock_sql_connect_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_connect_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlConnectServiceConnection
     : public sql_v1::SqlConnectServiceConnection {

--- a/google/cloud/sql/v1/mocks/mock_sql_databases_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_databases_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlDatabasesServiceConnection
     : public sql_v1::SqlDatabasesServiceConnection {

--- a/google/cloud/sql/v1/mocks/mock_sql_flags_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_flags_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlFlagsServiceConnection : public sql_v1::SqlFlagsServiceConnection {
  public:

--- a/google/cloud/sql/v1/mocks/mock_sql_instances_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_instances_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlInstancesServiceConnection
     : public sql_v1::SqlInstancesServiceConnection {

--- a/google/cloud/sql/v1/mocks/mock_sql_operations_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_operations_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlOperationsServiceConnection
     : public sql_v1::SqlOperationsServiceConnection {

--- a/google/cloud/sql/v1/mocks/mock_sql_ssl_certs_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_ssl_certs_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlSslCertsServiceConnection
     : public sql_v1::SqlSslCertsServiceConnection {

--- a/google/cloud/sql/v1/mocks/mock_sql_tiers_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_tiers_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlTiersServiceConnection : public sql_v1::SqlTiersServiceConnection {
  public:

--- a/google/cloud/sql/v1/mocks/mock_sql_users_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_users_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockSqlUsersServiceConnection : public sql_v1::SqlUsersServiceConnection {
  public:

--- a/google/cloud/storageinsights/v1/mocks/mock_storage_insights_connection.h
+++ b/google/cloud/storageinsights/v1/mocks/mock_storage_insights_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockStorageInsightsConnection
     : public storageinsights_v1::StorageInsightsConnection {

--- a/google/cloud/storagetransfer/v1/mocks/mock_storage_transfer_connection.h
+++ b/google/cloud/storagetransfer/v1/mocks/mock_storage_transfer_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockStorageTransferServiceConnection
     : public storagetransfer_v1::StorageTransferServiceConnection {

--- a/google/cloud/support/v2/mocks/mock_case_attachment_connection.h
+++ b/google/cloud/support/v2/mocks/mock_case_attachment_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCaseAttachmentServiceConnection
     : public support_v2::CaseAttachmentServiceConnection {

--- a/google/cloud/support/v2/mocks/mock_case_connection.h
+++ b/google/cloud/support/v2/mocks/mock_case_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCaseServiceConnection : public support_v2::CaseServiceConnection {
  public:

--- a/google/cloud/support/v2/mocks/mock_comment_connection.h
+++ b/google/cloud/support/v2/mocks/mock_comment_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCommentServiceConnection
     : public support_v2::CommentServiceConnection {

--- a/google/cloud/talent/v4/mocks/mock_company_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_company_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCompanyServiceConnection
     : public talent_v4::CompanyServiceConnection {

--- a/google/cloud/talent/v4/mocks/mock_completion_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_completion_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCompletionConnection : public talent_v4::CompletionConnection {
  public:

--- a/google/cloud/talent/v4/mocks/mock_event_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_event_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockEventServiceConnection : public talent_v4::EventServiceConnection {
  public:

--- a/google/cloud/talent/v4/mocks/mock_job_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_job_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockJobServiceConnection : public talent_v4::JobServiceConnection {
  public:

--- a/google/cloud/talent/v4/mocks/mock_tenant_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_tenant_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTenantServiceConnection : public talent_v4::TenantServiceConnection {
  public:

--- a/google/cloud/tasks/v2/mocks/mock_cloud_tasks_connection.h
+++ b/google/cloud/tasks/v2/mocks/mock_cloud_tasks_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockCloudTasksConnection : public tasks_v2::CloudTasksConnection {
  public:

--- a/google/cloud/texttospeech/v1/mocks/mock_text_to_speech_connection.h
+++ b/google/cloud/texttospeech/v1/mocks/mock_text_to_speech_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTextToSpeechConnection
     : public texttospeech_v1::TextToSpeechConnection {

--- a/google/cloud/timeseriesinsights/v1/mocks/mock_timeseries_insights_controller_connection.h
+++ b/google/cloud/timeseriesinsights/v1/mocks/mock_timeseries_insights_controller_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTimeseriesInsightsControllerConnection
     : public timeseriesinsights_v1::TimeseriesInsightsControllerConnection {

--- a/google/cloud/tpu/v1/mocks/mock_tpu_connection.h
+++ b/google/cloud/tpu/v1/mocks/mock_tpu_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTpuConnection : public tpu_v1::TpuConnection {
  public:

--- a/google/cloud/tpu/v2/mocks/mock_tpu_connection.h
+++ b/google/cloud/tpu/v2/mocks/mock_tpu_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTpuConnection : public tpu_v2::TpuConnection {
  public:

--- a/google/cloud/trace/v1/mocks/mock_trace_connection.h
+++ b/google/cloud/trace/v1/mocks/mock_trace_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTraceServiceConnection : public trace_v1::TraceServiceConnection {
  public:

--- a/google/cloud/trace/v2/mocks/mock_trace_connection.h
+++ b/google/cloud/trace/v2/mocks/mock_trace_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTraceServiceConnection : public trace_v2::TraceServiceConnection {
  public:

--- a/google/cloud/translate/v3/mocks/mock_translation_connection.h
+++ b/google/cloud/translate/v3/mocks/mock_translation_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTranslationServiceConnection
     : public translate_v3::TranslationServiceConnection {

--- a/google/cloud/video/livestream/v1/mocks/mock_livestream_connection.h
+++ b/google/cloud/video/livestream/v1/mocks/mock_livestream_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockLivestreamServiceConnection
     : public video_livestream_v1::LivestreamServiceConnection {

--- a/google/cloud/video/stitcher/v1/mocks/mock_video_stitcher_connection.h
+++ b/google/cloud/video/stitcher/v1/mocks/mock_video_stitcher_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVideoStitcherServiceConnection
     : public video_stitcher_v1::VideoStitcherServiceConnection {

--- a/google/cloud/video/transcoder/v1/mocks/mock_transcoder_connection.h
+++ b/google/cloud/video/transcoder/v1/mocks/mock_transcoder_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockTranscoderServiceConnection
     : public video_transcoder_v1::TranscoderServiceConnection {

--- a/google/cloud/videointelligence/v1/mocks/mock_video_intelligence_connection.h
+++ b/google/cloud/videointelligence/v1/mocks/mock_video_intelligence_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVideoIntelligenceServiceConnection
     : public videointelligence_v1::VideoIntelligenceServiceConnection {

--- a/google/cloud/vision/v1/mocks/mock_image_annotator_connection.h
+++ b/google/cloud/vision/v1/mocks/mock_image_annotator_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockImageAnnotatorConnection
     : public vision_v1::ImageAnnotatorConnection {

--- a/google/cloud/vision/v1/mocks/mock_product_search_connection.h
+++ b/google/cloud/vision/v1/mocks/mock_product_search_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockProductSearchConnection : public vision_v1::ProductSearchConnection {
  public:

--- a/google/cloud/vmmigration/v1/mocks/mock_vm_migration_connection.h
+++ b/google/cloud/vmmigration/v1/mocks/mock_vm_migration_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
  public:

--- a/google/cloud/vmwareengine/v1/mocks/mock_vmware_engine_connection.h
+++ b/google/cloud/vmwareengine/v1/mocks/mock_vmware_engine_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVmwareEngineConnection
     : public vmwareengine_v1::VmwareEngineConnection {

--- a/google/cloud/vpcaccess/v1/mocks/mock_vpc_access_connection.h
+++ b/google/cloud/vpcaccess/v1/mocks/mock_vpc_access_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockVpcAccessServiceConnection
     : public vpcaccess_v1::VpcAccessServiceConnection {

--- a/google/cloud/webrisk/v1/mocks/mock_web_risk_connection.h
+++ b/google/cloud/webrisk/v1/mocks/mock_web_risk_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockWebRiskServiceConnection
     : public webrisk_v1::WebRiskServiceConnection {

--- a/google/cloud/websecurityscanner/v1/mocks/mock_web_security_scanner_connection.h
+++ b/google/cloud/websecurityscanner/v1/mocks/mock_web_security_scanner_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockWebSecurityScannerConnection
     : public websecurityscanner_v1::WebSecurityScannerConnection {

--- a/google/cloud/workflows/executions/v1/mocks/mock_executions_connection.h
+++ b/google/cloud/workflows/executions/v1/mocks/mock_executions_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockExecutionsConnection
     : public workflows_executions_v1::ExecutionsConnection {

--- a/google/cloud/workflows/v1/mocks/mock_workflows_connection.h
+++ b/google/cloud/workflows/v1/mocks/mock_workflows_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockWorkflowsConnection : public workflows_v1::WorkflowsConnection {
  public:

--- a/google/cloud/workstations/v1/mocks/mock_workstations_connection.h
+++ b/google/cloud/workstations/v1/mocks/mock_workstations_connection.h
@@ -40,7 +40,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * While the example showcases types from the BigQuery library, the underlying
  * principles apply for any pair of `*Client` and `*Connection`.
  *
- * [bq-mock]: @googleapis_dev_link{bigquery,bigquery-read-mock.html}
+ * [bq-mock]: @cloud_cpp_docs_link{bigquery,bigquery-read-mock}
  */
 class MockWorkstationsConnection
     : public workstations_v1::WorkstationsConnection {


### PR DESCRIPTION
Fixes #11868 

Prefer cloud.google.com/cpp over googlapis.dev/cpp

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11869)
<!-- Reviewable:end -->
