### PR TITLE
chore(storage): fixed ctype=CORD workarounds url

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ option(
     [==[Enable the workarounds for [ctype = CORD] when using Protobuf < v23.
 More details at
 
-https://github.com/googleapis/google-cloud-cpp/blob/main/doc/ctype-cord-workaround.md
+https://github.com/googleapis/google-cloud-cpp/blob/main/doc/ctype-cord-workarounds.md
 ]==]
     OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)

--- a/google/cloud/storage/internal/grpc_ctype_cord_workaround.h
+++ b/google/cloud/storage/internal/grpc_ctype_cord_workaround.h
@@ -60,7 +60,7 @@ static_assert(!HasPublicContent<google::storage::v2::ChecksummedData>::value,
               "The workarounds for [ctype = CORD] are enabled, but not needed."
               "\nPlease disable these workarounds as described in:"
               "\n    https://github.com/googleapis/google-cloud-cpp"
-              "/blob/main/doc/ctype-cord-workaround.md"
+              "/blob/main/doc/ctype-cord-workarounds.md"
               "\n");
 
 static_assert(std::is_same<std::string, ContentType>::value,
@@ -68,7 +68,7 @@ static_assert(std::is_same<std::string, ContentType>::value,
               "\nThis will result in compile-time errors."
               "\nPlease disable these workarounds as described in:"
               "\n    https://github.com/googleapis/google-cloud-cpp"
-              "/blob/main/doc/ctype-cord-workaround.md"
+              "/blob/main/doc/ctype-cord-workarounds.md"
               "\n");
 
 // Workaround for older Protobuf versions without `[ctype = CORD]` support.
@@ -119,7 +119,7 @@ static_assert(
     "\nThis will result in compile-time errors"
     "\nPlease enable these workarounds as described in:"
     "\n    https://github.com/googleapis/google-cloud-cpp"
-    "/blob/main/doc/ctype-cord-workaround.md"
+    "/blob/main/doc/ctype-cord-workarounds.md"
     "\n");
 
 // The OSS version of [ctype = CORD] will not support `mutable_content()`. That


### PR DESCRIPTION
Minor change to fix the urls pointing to the workaround.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11879)
<!-- Reviewable:end -->
