### PR TITLE
cleanup(otel): unnecessary wrapper

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -273,13 +273,10 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept {
 void Recordable::SetInstrumentationScope(
     opentelemetry::sdk::instrumentationscope::InstrumentationScope const&
         instrumentation_scope) noexcept {
-  valid_ = valid_ && internal::NoExceptAction([&] {
-             SetAttribute("otel.scope.name", instrumentation_scope.GetName());
-             if (!instrumentation_scope.GetVersion().empty()) {
-               SetAttribute("otel.scope.version",
-                            instrumentation_scope.GetVersion());
-             }
-           });
+  SetAttribute("otel.scope.name", instrumentation_scope.GetName());
+  if (!instrumentation_scope.GetVersion().empty()) {
+    SetAttribute("otel.scope.version", instrumentation_scope.GetVersion());
+  }
 }
 
 void Recordable::SetIdentityImpl(


### PR DESCRIPTION
`SetAttribute(...)` already has a noexcept wrapper. So this one was unnecessary.

https://github.com/googleapis/google-cloud-cpp/blob/1145a8ccff7f8ce7fcebc0256efe6b3093e8e21a/google/cloud/opentelemetry/internal/recordable.cc#L204-L207

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11886)
<!-- Reviewable:end -->
