### PR TITLE
feat(spanner): implement at-least-once Commit

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -304,6 +304,16 @@ StatusOr<CommitResult> Client::Commit(Transaction transaction,
                         CommitOptions(internal::CurrentOptions())});
 }
 
+StatusOr<CommitResult> Client::CommitAtLeastOnce(
+    Transaction::ReadWriteOptions transaction_options, Mutations mutations,
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), opts_));
+  return conn_->Commit({spanner_internal::MakeSingleUseCommitTransaction(
+                            std::move(transaction_options)),
+                        std::move(mutations),
+                        CommitOptions(internal::CurrentOptions())});
+}
+
 Status Client::Rollback(Transaction transaction, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), opts_));
   return conn_->Rollback({std::move(transaction)});

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -184,7 +184,7 @@ class Client {
    * @copydoc Read
    *
    * @param transaction_options Execute this read in a single-use transaction
-   * with these options.
+   *     with these options.
    */
   RowStream Read(Transaction::SingleUseOptions transaction_options,
                  std::string table, KeySet keys,
@@ -593,8 +593,8 @@ class Client {
    *
    * @param transaction The transaction to commit.
    * @param mutations The mutations to be executed when this transaction
-   *     commits. All mutations are applied atomically, in the order they appear
-   *     in this list.
+   *     commits. All mutations are applied atomically, in the order they
+   *     appear in this list.
    * @param opts (optional) The options to use for this call.
    *
    * @return A `StatusOr` containing the result of the commit or error status
@@ -602,6 +602,34 @@ class Client {
    */
   StatusOr<CommitResult> Commit(Transaction transaction, Mutations mutations,
                                 Options opts = {});
+
+  /**
+   * Commits a write transaction with at-least-once semantics.
+   *
+   * Apply the given mutations atomically, using a single RPC, and therefore
+   * without replay protection.  That is, it is possible that the mutations
+   * will be applied more than once. If the mutations are not idempotent, this
+   * may lead to a failure (for example, an insert may fail with "already
+   * exists" even though the row did not exist before the call was made).
+   * Accordingly, this call may only be appropriate for idempotent, latency-
+   * sensitive and/or high-throughput blind writing.
+   *
+   * @note Prefer the `Commit` overloads if you want exactly-once semantics
+   *     or want to reapply mutations after a `kAborted` error.
+   *
+   * @param transaction_options Execute the commit in a temporary transaction
+   *     with these options.
+   * @param mutations The mutations to be executed when this transaction
+   *     commits. All mutations are applied atomically, in the order they
+   *     appear in this list.
+   * @param opts (optional) The options to use for this call.
+   *
+   * @return A `StatusOr` containing the result of the commit or error status
+   *     on failure.
+   */
+  StatusOr<CommitResult> CommitAtLeastOnce(
+      Transaction::ReadWriteOptions transaction_options, Mutations mutations,
+      Options opts = {});
 
   /**
    * Rolls back a read-write transaction, releasing any locks it holds.

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -124,6 +124,15 @@ Transaction::Transaction(SingleUseOptions opts) {
       std::move(selector), route_to_leader, std::string());
 }
 
+Transaction::Transaction(ReadWriteOptions opts, SingleUseCommitTag) {
+  google::spanner::v1::TransactionSelector selector;
+  *selector.mutable_single_use() = MakeOpts(std::move(opts.rw_opts_));
+  auto const route_to_leader = true;  // write
+  impl_ = std::make_shared<spanner_internal::TransactionImpl>(
+      std::move(selector), route_to_leader,
+      std::move(opts.tag_).value_or(std::string()));
+}
+
 Transaction::Transaction(std::string session_id, std::string transaction_id,
                          bool route_to_leader, std::string transaction_tag) {
   google::spanner::v1::TransactionSelector selector;


### PR DESCRIPTION
Add a new operation, `spanner::Client::CommitAtLeastOnce()`, with all its caveats, that exposes the single-RPC, temporary-transaction commit support.

Fixes #4890.