### PR TITLE
impl(generator): do not include grpc.pb.h files for REST only transport

### DIFF
--- a/generator/integration_tests/golden/v1/golden_rest_only_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/v1/golden_rest_only_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <generator/integration_tests/test2.grpc.pb.h>
+#include <generator/integration_tests/test2.pb.h>
 #include <memory>
 
 namespace google {

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -84,9 +84,10 @@ Status ClientGenerator::GenerateHeader() {
     HeaderLocalIncludes({"google/cloud/iam_updater.h"});
   }
   HeaderSystemIncludes(MethodSignatureWellKnownProtobufTypeIncludes());
-  HeaderSystemIncludes(
-      {HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
-       HasMessageWithMapField() ? "map" : "", "memory"});
+  HeaderSystemIncludes({HasGRPCLongrunningOperation()
+                            ? "google/longrunning/operations.grpc.pb.h"
+                            : "",
+                        HasMessageWithMapField() ? "map" : "", "memory"});
 
   auto result = HeaderOpenNamespaces();
   if (!result.ok()) return result;

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -68,7 +68,8 @@ Status ConnectionGenerator::GenerateHeader() {
        "google/cloud/version.h"});
   HeaderSystemIncludes(
       {vars("proto_header_path"), vars("additional_pb_header_paths"),
-       HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
+       HasGRPCLongrunningOperation() ? "google/longrunning/operations.grpc.pb.h"
+                                     : "",
        "memory"});
   switch (endpoint_location_style) {
     case ServiceConfiguration::LOCATION_DEPENDENT:

--- a/generator/internal/idempotency_policy_generator.cc
+++ b/generator/internal/idempotency_policy_generator.cc
@@ -52,7 +52,7 @@ Status IdempotencyPolicyGenerator::GenerateHeader() {
   HeaderLocalIncludes({"google/cloud/idempotency.h",
                        "google/cloud/internal/retry_policy.h",
                        "google/cloud/version.h"});
-  HeaderSystemIncludes({vars("proto_grpc_header_path"), "memory"});
+  HeaderSystemIncludes({GetPbIncludeByTransport(), "memory"});
 
   auto result = HeaderOpenNamespaces();
   if (!result.ok()) return result;

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -470,6 +470,11 @@ void ServiceCodeGenerator::SetMethods() {
   }
 }
 
+std::string ServiceCodeGenerator::GetPbIncludeByTransport() const {
+  if (HasGenerateGrpcTransport()) return vars("proto_grpc_header_path");
+  return vars("proto_header_path");
+}
+
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -208,7 +208,6 @@ class ServiceCodeGenerator : public GeneratorInterface {
   /**
    * If gRPC transport is enabled return the appropriate grpc.pb.h file.
    * Otherwise, return the appropriate pb.h file.
-   * @return
    */
   std::string GetPbIncludeByTransport() const;
 

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -205,6 +205,13 @@ class ServiceCodeGenerator : public GeneratorInterface {
   bool OmitMethodSignature(google::protobuf::MethodDescriptor const& method,
                            int method_signature_number) const;
 
+  /**
+   * If gRPC transport is enabled return the appropriate grpc.pb.h file.
+   * Otherwise, return the appropriate pb.h file.
+   * @return
+   */
+  std::string GetPbIncludeByTransport() const;
+
  private:
   void SetMethods();
 

--- a/google/cloud/compute/accelerator_types/v1/accelerator_types_connection_idempotency_policy.h
+++ b/google/cloud/compute/accelerator_types/v1/accelerator_types_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/accelerator_types/v1/accelerator_types.grpc.pb.h>
+#include <google/cloud/compute/accelerator_types/v1/accelerator_types.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/addresses/v1/addresses_client.h
+++ b/google/cloud/compute/addresses/v1/addresses_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/addresses/v1/addresses_connection.h
+++ b/google/cloud/compute/addresses/v1/addresses_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/addresses/v1/addresses.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/addresses/v1/addresses_connection_idempotency_policy.h
+++ b/google/cloud/compute/addresses/v1/addresses_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/addresses/v1/addresses.grpc.pb.h>
+#include <google/cloud/compute/addresses/v1/addresses.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/autoscalers/v1/autoscalers_client.h
+++ b/google/cloud/compute/autoscalers/v1/autoscalers_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/autoscalers/v1/autoscalers_connection.h
+++ b/google/cloud/compute/autoscalers/v1/autoscalers_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/autoscalers/v1/autoscalers.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/autoscalers/v1/autoscalers_connection_idempotency_policy.h
+++ b/google/cloud/compute/autoscalers/v1/autoscalers_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/autoscalers/v1/autoscalers.grpc.pb.h>
+#include <google/cloud/compute/autoscalers/v1/autoscalers.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/backend_buckets/v1/backend_buckets_client.h
+++ b/google/cloud/compute/backend_buckets/v1/backend_buckets_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/backend_buckets/v1/backend_buckets_connection.h
+++ b/google/cloud/compute/backend_buckets/v1/backend_buckets_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/backend_buckets/v1/backend_buckets.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/backend_buckets/v1/backend_buckets_connection_idempotency_policy.h
+++ b/google/cloud/compute/backend_buckets/v1/backend_buckets_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/backend_buckets/v1/backend_buckets.grpc.pb.h>
+#include <google/cloud/compute/backend_buckets/v1/backend_buckets.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/backend_services/v1/backend_services_client.h
+++ b/google/cloud/compute/backend_services/v1/backend_services_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/backend_services/v1/backend_services_connection.h
+++ b/google/cloud/compute/backend_services/v1/backend_services_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/backend_services/v1/backend_services.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/backend_services/v1/backend_services_connection_idempotency_policy.h
+++ b/google/cloud/compute/backend_services/v1/backend_services_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/backend_services/v1/backend_services.grpc.pb.h>
+#include <google/cloud/compute/backend_services/v1/backend_services.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/disk_types/v1/disk_types_connection_idempotency_policy.h
+++ b/google/cloud/compute/disk_types/v1/disk_types_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/disk_types/v1/disk_types.grpc.pb.h>
+#include <google/cloud/compute/disk_types/v1/disk_types.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/disks/v1/disks_client.h
+++ b/google/cloud/compute/disks/v1/disks_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/disks/v1/disks_connection.h
+++ b/google/cloud/compute/disks/v1/disks_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/disks/v1/disks.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/disks/v1/disks_connection_idempotency_policy.h
+++ b/google/cloud/compute/disks/v1/disks_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/disks/v1/disks.grpc.pb.h>
+#include <google/cloud/compute/disks/v1/disks.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways_client.h
+++ b/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways_connection.h
+++ b/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways_connection_idempotency_policy.h
+++ b/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways.grpc.pb.h>
+#include <google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/firewall_policies/v1/firewall_policies_client.h
+++ b/google/cloud/compute/firewall_policies/v1/firewall_policies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/firewall_policies/v1/firewall_policies_connection.h
+++ b/google/cloud/compute/firewall_policies/v1/firewall_policies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/firewall_policies/v1/firewall_policies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/firewall_policies/v1/firewall_policies_connection_idempotency_policy.h
+++ b/google/cloud/compute/firewall_policies/v1/firewall_policies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/firewall_policies/v1/firewall_policies.grpc.pb.h>
+#include <google/cloud/compute/firewall_policies/v1/firewall_policies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/firewalls/v1/firewalls_client.h
+++ b/google/cloud/compute/firewalls/v1/firewalls_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/firewalls/v1/firewalls_connection.h
+++ b/google/cloud/compute/firewalls/v1/firewalls_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/firewalls/v1/firewalls.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/firewalls/v1/firewalls_connection_idempotency_policy.h
+++ b/google/cloud/compute/firewalls/v1/firewalls_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/firewalls/v1/firewalls.grpc.pb.h>
+#include <google/cloud/compute/firewalls/v1/firewalls.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/forwarding_rules/v1/forwarding_rules_client.h
+++ b/google/cloud/compute/forwarding_rules/v1/forwarding_rules_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/forwarding_rules/v1/forwarding_rules_connection.h
+++ b/google/cloud/compute/forwarding_rules/v1/forwarding_rules_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/forwarding_rules/v1/forwarding_rules.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/forwarding_rules/v1/forwarding_rules_connection_idempotency_policy.h
+++ b/google/cloud/compute/forwarding_rules/v1/forwarding_rules_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/forwarding_rules/v1/forwarding_rules.grpc.pb.h>
+#include <google/cloud/compute/forwarding_rules/v1/forwarding_rules.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_addresses/v1/global_addresses_client.h
+++ b/google/cloud/compute/global_addresses/v1/global_addresses_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_addresses/v1/global_addresses_connection.h
+++ b/google/cloud/compute/global_addresses/v1/global_addresses_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/global_addresses/v1/global_addresses.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_addresses/v1/global_addresses_connection_idempotency_policy.h
+++ b/google/cloud/compute/global_addresses/v1/global_addresses_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/global_addresses/v1/global_addresses.grpc.pb.h>
+#include <google/cloud/compute/global_addresses/v1/global_addresses.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules_client.h
+++ b/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules_connection.h
+++ b/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules_connection_idempotency_policy.h
+++ b/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules.grpc.pb.h>
+#include <google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups_client.h
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups_connection.h
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups_connection_idempotency_policy.h
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups.grpc.pb.h>
+#include <google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_operations/v1/global_operations_connection_idempotency_policy.h
+++ b/google/cloud/compute/global_operations/v1/global_operations_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/global_operations/v1/global_operations.grpc.pb.h>
+#include <google/cloud/compute/global_operations/v1/global_operations.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_organization_operations/v1/global_organization_operations_connection_idempotency_policy.h
+++ b/google/cloud/compute/global_organization_operations/v1/global_organization_operations_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/global_organization_operations/v1/global_organization_operations.grpc.pb.h>
+#include <google/cloud/compute/global_organization_operations/v1/global_organization_operations.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes_client.h
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes_connection.h
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes_connection_idempotency_policy.h
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes.grpc.pb.h>
+#include <google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/health_checks/v1/health_checks_client.h
+++ b/google/cloud/compute/health_checks/v1/health_checks_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/health_checks/v1/health_checks_connection.h
+++ b/google/cloud/compute/health_checks/v1/health_checks_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/health_checks/v1/health_checks.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/health_checks/v1/health_checks_connection_idempotency_policy.h
+++ b/google/cloud/compute/health_checks/v1/health_checks_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/health_checks/v1/health_checks.grpc.pb.h>
+#include <google/cloud/compute/health_checks/v1/health_checks.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/http_health_checks/v1/http_health_checks_client.h
+++ b/google/cloud/compute/http_health_checks/v1/http_health_checks_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/http_health_checks/v1/http_health_checks_connection.h
+++ b/google/cloud/compute/http_health_checks/v1/http_health_checks_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/http_health_checks/v1/http_health_checks.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/http_health_checks/v1/http_health_checks_connection_idempotency_policy.h
+++ b/google/cloud/compute/http_health_checks/v1/http_health_checks_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/http_health_checks/v1/http_health_checks.grpc.pb.h>
+#include <google/cloud/compute/http_health_checks/v1/http_health_checks.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/https_health_checks/v1/https_health_checks_client.h
+++ b/google/cloud/compute/https_health_checks/v1/https_health_checks_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/https_health_checks/v1/https_health_checks_connection.h
+++ b/google/cloud/compute/https_health_checks/v1/https_health_checks_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/https_health_checks/v1/https_health_checks.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/https_health_checks/v1/https_health_checks_connection_idempotency_policy.h
+++ b/google/cloud/compute/https_health_checks/v1/https_health_checks_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/https_health_checks/v1/https_health_checks.grpc.pb.h>
+#include <google/cloud/compute/https_health_checks/v1/https_health_checks.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/image_family_views/v1/image_family_views_connection_idempotency_policy.h
+++ b/google/cloud/compute/image_family_views/v1/image_family_views_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/image_family_views/v1/image_family_views.grpc.pb.h>
+#include <google/cloud/compute/image_family_views/v1/image_family_views.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/images/v1/images_client.h
+++ b/google/cloud/compute/images/v1/images_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/images/v1/images_connection.h
+++ b/google/cloud/compute/images/v1/images_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/images/v1/images.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/images/v1/images_connection_idempotency_policy.h
+++ b/google/cloud/compute/images/v1/images_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/images/v1/images.grpc.pb.h>
+#include <google/cloud/compute/images/v1/images.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/instance_group_managers/v1/instance_group_managers_client.h
+++ b/google/cloud/compute/instance_group_managers/v1/instance_group_managers_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/instance_group_managers/v1/instance_group_managers_connection.h
+++ b/google/cloud/compute/instance_group_managers/v1/instance_group_managers_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/instance_group_managers/v1/instance_group_managers.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/instance_group_managers/v1/instance_group_managers_connection_idempotency_policy.h
+++ b/google/cloud/compute/instance_group_managers/v1/instance_group_managers_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/instance_group_managers/v1/instance_group_managers.grpc.pb.h>
+#include <google/cloud/compute/instance_group_managers/v1/instance_group_managers.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/instance_groups/v1/instance_groups_client.h
+++ b/google/cloud/compute/instance_groups/v1/instance_groups_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/instance_groups/v1/instance_groups_connection.h
+++ b/google/cloud/compute/instance_groups/v1/instance_groups_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/instance_groups/v1/instance_groups.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/instance_groups/v1/instance_groups_connection_idempotency_policy.h
+++ b/google/cloud/compute/instance_groups/v1/instance_groups_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/instance_groups/v1/instance_groups.grpc.pb.h>
+#include <google/cloud/compute/instance_groups/v1/instance_groups.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/instance_templates/v1/instance_templates_client.h
+++ b/google/cloud/compute/instance_templates/v1/instance_templates_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/instance_templates/v1/instance_templates_connection.h
+++ b/google/cloud/compute/instance_templates/v1/instance_templates_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/instance_templates/v1/instance_templates.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/instance_templates/v1/instance_templates_connection_idempotency_policy.h
+++ b/google/cloud/compute/instance_templates/v1/instance_templates_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/instance_templates/v1/instance_templates.grpc.pb.h>
+#include <google/cloud/compute/instance_templates/v1/instance_templates.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/instances/v1/instances_client.h
+++ b/google/cloud/compute/instances/v1/instances_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/instances/v1/instances_connection.h
+++ b/google/cloud/compute/instances/v1/instances_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/instances/v1/instances.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/instances/v1/instances_connection_idempotency_policy.h
+++ b/google/cloud/compute/instances/v1/instances_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/instances/v1/instances.grpc.pb.h>
+#include <google/cloud/compute/instances/v1/instances.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments_client.h
+++ b/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments_connection.h
+++ b/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/interconnect_attachments/v1/interconnect_attachments.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments_connection_idempotency_policy.h
+++ b/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/interconnect_attachments/v1/interconnect_attachments.grpc.pb.h>
+#include <google/cloud/compute/interconnect_attachments/v1/interconnect_attachments.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/interconnect_locations/v1/interconnect_locations_connection_idempotency_policy.h
+++ b/google/cloud/compute/interconnect_locations/v1/interconnect_locations_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/interconnect_locations/v1/interconnect_locations.grpc.pb.h>
+#include <google/cloud/compute/interconnect_locations/v1/interconnect_locations.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/interconnects/v1/interconnects_client.h
+++ b/google/cloud/compute/interconnects/v1/interconnects_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/interconnects/v1/interconnects_connection.h
+++ b/google/cloud/compute/interconnects/v1/interconnects_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/interconnects/v1/interconnects.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/interconnects/v1/interconnects_connection_idempotency_policy.h
+++ b/google/cloud/compute/interconnects/v1/interconnects_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/interconnects/v1/interconnects.grpc.pb.h>
+#include <google/cloud/compute/interconnects/v1/interconnects.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/license_codes/v1/license_codes_connection_idempotency_policy.h
+++ b/google/cloud/compute/license_codes/v1/license_codes_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/license_codes/v1/license_codes.grpc.pb.h>
+#include <google/cloud/compute/license_codes/v1/license_codes.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/licenses/v1/licenses_client.h
+++ b/google/cloud/compute/licenses/v1/licenses_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/licenses/v1/licenses_connection.h
+++ b/google/cloud/compute/licenses/v1/licenses_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/licenses/v1/licenses.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/licenses/v1/licenses_connection_idempotency_policy.h
+++ b/google/cloud/compute/licenses/v1/licenses_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/licenses/v1/licenses.grpc.pb.h>
+#include <google/cloud/compute/licenses/v1/licenses.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/machine_images/v1/machine_images_client.h
+++ b/google/cloud/compute/machine_images/v1/machine_images_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/machine_images/v1/machine_images_connection.h
+++ b/google/cloud/compute/machine_images/v1/machine_images_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/machine_images/v1/machine_images.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/machine_images/v1/machine_images_connection_idempotency_policy.h
+++ b/google/cloud/compute/machine_images/v1/machine_images_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/machine_images/v1/machine_images.grpc.pb.h>
+#include <google/cloud/compute/machine_images/v1/machine_images.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/machine_types/v1/machine_types_connection_idempotency_policy.h
+++ b/google/cloud/compute/machine_types/v1/machine_types_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/machine_types/v1/machine_types.grpc.pb.h>
+#include <google/cloud/compute/machine_types/v1/machine_types.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_attachments/v1/network_attachments_client.h
+++ b/google/cloud/compute/network_attachments/v1/network_attachments_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/network_attachments/v1/network_attachments_connection.h
+++ b/google/cloud/compute/network_attachments/v1/network_attachments_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/network_attachments/v1/network_attachments.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_attachments/v1/network_attachments_connection_idempotency_policy.h
+++ b/google/cloud/compute/network_attachments/v1/network_attachments_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/network_attachments/v1/network_attachments.grpc.pb.h>
+#include <google/cloud/compute/network_attachments/v1/network_attachments.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services_client.h
+++ b/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services_connection.h
+++ b/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/network_edge_security_services/v1/network_edge_security_services.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services_connection_idempotency_policy.h
+++ b/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/network_edge_security_services/v1/network_edge_security_services.grpc.pb.h>
+#include <google/cloud/compute/network_edge_security_services/v1/network_edge_security_services.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups_client.h
+++ b/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups_connection.h
+++ b/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups_connection_idempotency_policy.h
+++ b/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups.grpc.pb.h>
+#include <google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies_client.h
+++ b/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies_connection.h
+++ b/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/network_firewall_policies/v1/network_firewall_policies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies_connection_idempotency_policy.h
+++ b/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/network_firewall_policies/v1/network_firewall_policies.grpc.pb.h>
+#include <google/cloud/compute/network_firewall_policies/v1/network_firewall_policies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/networks/v1/networks_client.h
+++ b/google/cloud/compute/networks/v1/networks_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/networks/v1/networks_connection.h
+++ b/google/cloud/compute/networks/v1/networks_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/networks/v1/networks.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/networks/v1/networks_connection_idempotency_policy.h
+++ b/google/cloud/compute/networks/v1/networks_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/networks/v1/networks.grpc.pb.h>
+#include <google/cloud/compute/networks/v1/networks.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/node_groups/v1/node_groups_client.h
+++ b/google/cloud/compute/node_groups/v1/node_groups_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/node_groups/v1/node_groups_connection.h
+++ b/google/cloud/compute/node_groups/v1/node_groups_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/node_groups/v1/node_groups.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/node_groups/v1/node_groups_connection_idempotency_policy.h
+++ b/google/cloud/compute/node_groups/v1/node_groups_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/node_groups/v1/node_groups.grpc.pb.h>
+#include <google/cloud/compute/node_groups/v1/node_groups.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/node_templates/v1/node_templates_client.h
+++ b/google/cloud/compute/node_templates/v1/node_templates_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/node_templates/v1/node_templates_connection.h
+++ b/google/cloud/compute/node_templates/v1/node_templates_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/node_templates/v1/node_templates.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/node_templates/v1/node_templates_connection_idempotency_policy.h
+++ b/google/cloud/compute/node_templates/v1/node_templates_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/node_templates/v1/node_templates.grpc.pb.h>
+#include <google/cloud/compute/node_templates/v1/node_templates.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/node_types/v1/node_types_connection_idempotency_policy.h
+++ b/google/cloud/compute/node_types/v1/node_types_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/node_types/v1/node_types.grpc.pb.h>
+#include <google/cloud/compute/node_types/v1/node_types.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings_client.h
+++ b/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings_connection.h
+++ b/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/packet_mirrorings/v1/packet_mirrorings.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings_connection_idempotency_policy.h
+++ b/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/packet_mirrorings/v1/packet_mirrorings.grpc.pb.h>
+#include <google/cloud/compute/packet_mirrorings/v1/packet_mirrorings.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/projects/v1/projects_client.h
+++ b/google/cloud/compute/projects/v1/projects_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/projects/v1/projects_connection.h
+++ b/google/cloud/compute/projects/v1/projects_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/projects/v1/projects.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/projects/v1/projects_connection_idempotency_policy.h
+++ b/google/cloud/compute/projects/v1/projects_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/projects/v1/projects.grpc.pb.h>
+#include <google/cloud/compute/projects/v1/projects.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes_client.h
+++ b/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes_connection.h
+++ b/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes_connection_idempotency_policy.h
+++ b/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes.grpc.pb.h>
+#include <google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes_client.h
+++ b/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes_connection.h
+++ b/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes_connection_idempotency_policy.h
+++ b/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes.grpc.pb.h>
+#include <google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_autoscalers/v1/region_autoscalers_client.h
+++ b/google/cloud/compute/region_autoscalers/v1/region_autoscalers_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/region_autoscalers/v1/region_autoscalers_connection.h
+++ b/google/cloud/compute/region_autoscalers/v1/region_autoscalers_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_autoscalers/v1/region_autoscalers.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_autoscalers/v1/region_autoscalers_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_autoscalers/v1/region_autoscalers_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_autoscalers/v1/region_autoscalers.grpc.pb.h>
+#include <google/cloud/compute/region_autoscalers/v1/region_autoscalers.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_backend_services/v1/region_backend_services_client.h
+++ b/google/cloud/compute/region_backend_services/v1/region_backend_services_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/region_backend_services/v1/region_backend_services_connection.h
+++ b/google/cloud/compute/region_backend_services/v1/region_backend_services_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_backend_services/v1/region_backend_services.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_backend_services/v1/region_backend_services_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_backend_services/v1/region_backend_services_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_backend_services/v1/region_backend_services.grpc.pb.h>
+#include <google/cloud/compute/region_backend_services/v1/region_backend_services.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_commitments/v1/region_commitments_client.h
+++ b/google/cloud/compute/region_commitments/v1/region_commitments_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/region_commitments/v1/region_commitments_connection.h
+++ b/google/cloud/compute/region_commitments/v1/region_commitments_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_commitments/v1/region_commitments.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_commitments/v1/region_commitments_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_commitments/v1/region_commitments_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_commitments/v1/region_commitments.grpc.pb.h>
+#include <google/cloud/compute/region_commitments/v1/region_commitments.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_disk_types/v1/region_disk_types_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_disk_types/v1/region_disk_types_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_disk_types/v1/region_disk_types.grpc.pb.h>
+#include <google/cloud/compute/region_disk_types/v1/region_disk_types.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_disks/v1/region_disks_client.h
+++ b/google/cloud/compute/region_disks/v1/region_disks_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/region_disks/v1/region_disks_connection.h
+++ b/google/cloud/compute/region_disks/v1/region_disks_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_disks/v1/region_disks.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_disks/v1/region_disks_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_disks/v1/region_disks_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_disks/v1/region_disks.grpc.pb.h>
+#include <google/cloud/compute/region_disks/v1/region_disks.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_health_check_services/v1/region_health_check_services_client.h
+++ b/google/cloud/compute/region_health_check_services/v1/region_health_check_services_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_health_check_services/v1/region_health_check_services_connection.h
+++ b/google/cloud/compute/region_health_check_services/v1/region_health_check_services_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_health_check_services/v1/region_health_check_services.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_health_check_services/v1/region_health_check_services_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_health_check_services/v1/region_health_check_services_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_health_check_services/v1/region_health_check_services.grpc.pb.h>
+#include <google/cloud/compute/region_health_check_services/v1/region_health_check_services.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_health_checks/v1/region_health_checks_client.h
+++ b/google/cloud/compute/region_health_checks/v1/region_health_checks_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_health_checks/v1/region_health_checks_connection.h
+++ b/google/cloud/compute/region_health_checks/v1/region_health_checks_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_health_checks/v1/region_health_checks.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_health_checks/v1/region_health_checks_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_health_checks/v1/region_health_checks_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_health_checks/v1/region_health_checks.grpc.pb.h>
+#include <google/cloud/compute/region_health_checks/v1/region_health_checks.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers_client.h
+++ b/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers_connection.h
+++ b/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers.grpc.pb.h>
+#include <google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_groups/v1/region_instance_groups_client.h
+++ b/google/cloud/compute/region_instance_groups/v1/region_instance_groups_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_groups/v1/region_instance_groups_connection.h
+++ b/google/cloud/compute/region_instance_groups/v1/region_instance_groups_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_instance_groups/v1/region_instance_groups.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_groups/v1/region_instance_groups_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_instance_groups/v1/region_instance_groups_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_instance_groups/v1/region_instance_groups.grpc.pb.h>
+#include <google/cloud/compute/region_instance_groups/v1/region_instance_groups.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_templates/v1/region_instance_templates_client.h
+++ b/google/cloud/compute/region_instance_templates/v1/region_instance_templates_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_templates/v1/region_instance_templates_connection.h
+++ b/google/cloud/compute/region_instance_templates/v1/region_instance_templates_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_instance_templates/v1/region_instance_templates.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instance_templates/v1/region_instance_templates_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_instance_templates/v1/region_instance_templates_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_instance_templates/v1/region_instance_templates.grpc.pb.h>
+#include <google/cloud/compute/region_instance_templates/v1/region_instance_templates.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instances/v1/region_instances_client.h
+++ b/google/cloud/compute/region_instances/v1/region_instances_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instances/v1/region_instances_connection.h
+++ b/google/cloud/compute/region_instances/v1/region_instances_connection.h
@@ -29,7 +29,6 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_instances/v1/region_instances.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_instances/v1/region_instances_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_instances/v1/region_instances_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_instances/v1/region_instances.grpc.pb.h>
+#include <google/cloud/compute/region_instances/v1/region_instances.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups_client.h
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups_connection.h
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups.grpc.pb.h>
+#include <google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies_client.h
+++ b/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies_connection.h
+++ b/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies.grpc.pb.h>
+#include <google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints_client.h
+++ b/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints_connection.h
+++ b/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints.grpc.pb.h>
+#include <google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_operations/v1/region_operations_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_operations/v1/region_operations_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_operations/v1/region_operations.grpc.pb.h>
+#include <google/cloud/compute/region_operations/v1/region_operations.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_security_policies/v1/region_security_policies_client.h
+++ b/google/cloud/compute/region_security_policies/v1/region_security_policies_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_security_policies/v1/region_security_policies_connection.h
+++ b/google/cloud/compute/region_security_policies/v1/region_security_policies_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_security_policies/v1/region_security_policies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_security_policies/v1/region_security_policies_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_security_policies/v1/region_security_policies_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_security_policies/v1/region_security_policies.grpc.pb.h>
+#include <google/cloud/compute/region_security_policies/v1/region_security_policies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates_client.h
+++ b/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates_connection.h
+++ b/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates.grpc.pb.h>
+#include <google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies_client.h
+++ b/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies_connection.h
+++ b/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_ssl_policies/v1/region_ssl_policies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_ssl_policies/v1/region_ssl_policies.grpc.pb.h>
+#include <google/cloud/compute/region_ssl_policies/v1/region_ssl_policies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies_client.h
+++ b/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies_connection.h
+++ b/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies.grpc.pb.h>
+#include <google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies_client.h
+++ b/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies_connection.h
+++ b/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies.grpc.pb.h>
+#include <google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies_client.h
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies_connection.h
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies.grpc.pb.h>
+#include <google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_url_maps/v1/region_url_maps_client.h
+++ b/google/cloud/compute/region_url_maps/v1/region_url_maps_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_url_maps/v1/region_url_maps_connection.h
+++ b/google/cloud/compute/region_url_maps/v1/region_url_maps_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/region_url_maps/v1/region_url_maps.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/region_url_maps/v1/region_url_maps_connection_idempotency_policy.h
+++ b/google/cloud/compute/region_url_maps/v1/region_url_maps_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/region_url_maps/v1/region_url_maps.grpc.pb.h>
+#include <google/cloud/compute/region_url_maps/v1/region_url_maps.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/regions/v1/regions_connection_idempotency_policy.h
+++ b/google/cloud/compute/regions/v1/regions_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/regions/v1/regions.grpc.pb.h>
+#include <google/cloud/compute/regions/v1/regions.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/reservations/v1/reservations_client.h
+++ b/google/cloud/compute/reservations/v1/reservations_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/reservations/v1/reservations_connection.h
+++ b/google/cloud/compute/reservations/v1/reservations_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/reservations/v1/reservations.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/reservations/v1/reservations_connection_idempotency_policy.h
+++ b/google/cloud/compute/reservations/v1/reservations_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/reservations/v1/reservations.grpc.pb.h>
+#include <google/cloud/compute/reservations/v1/reservations.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/resource_policies/v1/resource_policies_client.h
+++ b/google/cloud/compute/resource_policies/v1/resource_policies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/resource_policies/v1/resource_policies_connection.h
+++ b/google/cloud/compute/resource_policies/v1/resource_policies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/resource_policies/v1/resource_policies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/resource_policies/v1/resource_policies_connection_idempotency_policy.h
+++ b/google/cloud/compute/resource_policies/v1/resource_policies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/resource_policies/v1/resource_policies.grpc.pb.h>
+#include <google/cloud/compute/resource_policies/v1/resource_policies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/routers/v1/routers_client.h
+++ b/google/cloud/compute/routers/v1/routers_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/routers/v1/routers_connection.h
+++ b/google/cloud/compute/routers/v1/routers_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/routers/v1/routers.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/routers/v1/routers_connection_idempotency_policy.h
+++ b/google/cloud/compute/routers/v1/routers_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/routers/v1/routers.grpc.pb.h>
+#include <google/cloud/compute/routers/v1/routers.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/routes/v1/routes_client.h
+++ b/google/cloud/compute/routes/v1/routes_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/routes/v1/routes_connection.h
+++ b/google/cloud/compute/routes/v1/routes_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/routes/v1/routes.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/routes/v1/routes_connection_idempotency_policy.h
+++ b/google/cloud/compute/routes/v1/routes_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/routes/v1/routes.grpc.pb.h>
+#include <google/cloud/compute/routes/v1/routes.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/security_policies/v1/security_policies_client.h
+++ b/google/cloud/compute/security_policies/v1/security_policies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/security_policies/v1/security_policies_connection.h
+++ b/google/cloud/compute/security_policies/v1/security_policies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/security_policies/v1/security_policies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/security_policies/v1/security_policies_connection_idempotency_policy.h
+++ b/google/cloud/compute/security_policies/v1/security_policies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/security_policies/v1/security_policies.grpc.pb.h>
+#include <google/cloud/compute/security_policies/v1/security_policies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/service_attachments/v1/service_attachments_client.h
+++ b/google/cloud/compute/service_attachments/v1/service_attachments_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/service_attachments/v1/service_attachments_connection.h
+++ b/google/cloud/compute/service_attachments/v1/service_attachments_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/service_attachments/v1/service_attachments.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/service_attachments/v1/service_attachments_connection_idempotency_policy.h
+++ b/google/cloud/compute/service_attachments/v1/service_attachments_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/service_attachments/v1/service_attachments.grpc.pb.h>
+#include <google/cloud/compute/service_attachments/v1/service_attachments.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/snapshots/v1/snapshots_client.h
+++ b/google/cloud/compute/snapshots/v1/snapshots_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/snapshots/v1/snapshots_connection.h
+++ b/google/cloud/compute/snapshots/v1/snapshots_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/snapshots/v1/snapshots.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/snapshots/v1/snapshots_connection_idempotency_policy.h
+++ b/google/cloud/compute/snapshots/v1/snapshots_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/snapshots/v1/snapshots.grpc.pb.h>
+#include <google/cloud/compute/snapshots/v1/snapshots.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/ssl_certificates/v1/ssl_certificates_client.h
+++ b/google/cloud/compute/ssl_certificates/v1/ssl_certificates_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/ssl_certificates/v1/ssl_certificates_connection.h
+++ b/google/cloud/compute/ssl_certificates/v1/ssl_certificates_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/ssl_certificates/v1/ssl_certificates.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/ssl_certificates/v1/ssl_certificates_connection_idempotency_policy.h
+++ b/google/cloud/compute/ssl_certificates/v1/ssl_certificates_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/ssl_certificates/v1/ssl_certificates.grpc.pb.h>
+#include <google/cloud/compute/ssl_certificates/v1/ssl_certificates.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/ssl_policies/v1/ssl_policies_client.h
+++ b/google/cloud/compute/ssl_policies/v1/ssl_policies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/ssl_policies/v1/ssl_policies_connection.h
+++ b/google/cloud/compute/ssl_policies/v1/ssl_policies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/ssl_policies/v1/ssl_policies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/ssl_policies/v1/ssl_policies_connection_idempotency_policy.h
+++ b/google/cloud/compute/ssl_policies/v1/ssl_policies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/ssl_policies/v1/ssl_policies.grpc.pb.h>
+#include <google/cloud/compute/ssl_policies/v1/ssl_policies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/subnetworks/v1/subnetworks_client.h
+++ b/google/cloud/compute/subnetworks/v1/subnetworks_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/subnetworks/v1/subnetworks_connection.h
+++ b/google/cloud/compute/subnetworks/v1/subnetworks_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/subnetworks/v1/subnetworks.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/subnetworks/v1/subnetworks_connection_idempotency_policy.h
+++ b/google/cloud/compute/subnetworks/v1/subnetworks_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/subnetworks/v1/subnetworks.grpc.pb.h>
+#include <google/cloud/compute/subnetworks/v1/subnetworks.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies_client.h
+++ b/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies_connection.h
+++ b/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies_connection_idempotency_policy.h
+++ b/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies.grpc.pb.h>
+#include <google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_http_proxies/v1/target_http_proxies_client.h
+++ b/google/cloud/compute/target_http_proxies/v1/target_http_proxies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/target_http_proxies/v1/target_http_proxies_connection.h
+++ b/google/cloud/compute/target_http_proxies/v1/target_http_proxies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/target_http_proxies/v1/target_http_proxies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_http_proxies/v1/target_http_proxies_connection_idempotency_policy.h
+++ b/google/cloud/compute/target_http_proxies/v1/target_http_proxies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/target_http_proxies/v1/target_http_proxies.grpc.pb.h>
+#include <google/cloud/compute/target_http_proxies/v1/target_http_proxies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_https_proxies/v1/target_https_proxies_client.h
+++ b/google/cloud/compute/target_https_proxies/v1/target_https_proxies_client.h
@@ -27,7 +27,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/target_https_proxies/v1/target_https_proxies_connection.h
+++ b/google/cloud/compute/target_https_proxies/v1/target_https_proxies_connection.h
@@ -31,7 +31,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/target_https_proxies/v1/target_https_proxies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_https_proxies/v1/target_https_proxies_connection_idempotency_policy.h
+++ b/google/cloud/compute/target_https_proxies/v1/target_https_proxies_connection_idempotency_policy.h
@@ -23,7 +23,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/target_https_proxies/v1/target_https_proxies.grpc.pb.h>
+#include <google/cloud/compute/target_https_proxies/v1/target_https_proxies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_instances/v1/target_instances_client.h
+++ b/google/cloud/compute/target_instances/v1/target_instances_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/target_instances/v1/target_instances_connection.h
+++ b/google/cloud/compute/target_instances/v1/target_instances_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/target_instances/v1/target_instances.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_instances/v1/target_instances_connection_idempotency_policy.h
+++ b/google/cloud/compute/target_instances/v1/target_instances_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/target_instances/v1/target_instances.grpc.pb.h>
+#include <google/cloud/compute/target_instances/v1/target_instances.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_pools/v1/target_pools_client.h
+++ b/google/cloud/compute/target_pools/v1/target_pools_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/target_pools/v1/target_pools_connection.h
+++ b/google/cloud/compute/target_pools/v1/target_pools_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/target_pools/v1/target_pools.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_pools/v1/target_pools_connection_idempotency_policy.h
+++ b/google/cloud/compute/target_pools/v1/target_pools_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/target_pools/v1/target_pools.grpc.pb.h>
+#include <google/cloud/compute/target_pools/v1/target_pools.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies_client.h
+++ b/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies_connection.h
+++ b/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies_connection_idempotency_policy.h
+++ b/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies.grpc.pb.h>
+#include <google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies_client.h
+++ b/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies_connection.h
+++ b/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies_connection_idempotency_policy.h
+++ b/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies.grpc.pb.h>
+#include <google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways_client.h
+++ b/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways_connection.h
+++ b/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways_connection_idempotency_policy.h
+++ b/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways.grpc.pb.h>
+#include <google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/url_maps/v1/url_maps_client.h
+++ b/google/cloud/compute/url_maps/v1/url_maps_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/url_maps/v1/url_maps_connection.h
+++ b/google/cloud/compute/url_maps/v1/url_maps_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/url_maps/v1/url_maps.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/url_maps/v1/url_maps_connection_idempotency_policy.h
+++ b/google/cloud/compute/url_maps/v1/url_maps_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/url_maps/v1/url_maps.grpc.pb.h>
+#include <google/cloud/compute/url_maps/v1/url_maps.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/vpn_gateways/v1/vpn_gateways_client.h
+++ b/google/cloud/compute/vpn_gateways/v1/vpn_gateways_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/vpn_gateways/v1/vpn_gateways_connection.h
+++ b/google/cloud/compute/vpn_gateways/v1/vpn_gateways_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/vpn_gateways/v1/vpn_gateways.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/vpn_gateways/v1/vpn_gateways_connection_idempotency_policy.h
+++ b/google/cloud/compute/vpn_gateways/v1/vpn_gateways_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/vpn_gateways/v1/vpn_gateways.grpc.pb.h>
+#include <google/cloud/compute/vpn_gateways/v1/vpn_gateways.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels_client.h
+++ b/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels_client.h
@@ -26,7 +26,6 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <google/longrunning/operations.grpc.pb.h>
 #include <map>
 #include <memory>
 

--- a/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels_connection.h
+++ b/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels_connection.h
@@ -30,7 +30,6 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <google/cloud/compute/vpn_tunnels/v1/vpn_tunnels.pb.h>
-#include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels_connection_idempotency_policy.h
+++ b/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/vpn_tunnels/v1/vpn_tunnels.grpc.pb.h>
+#include <google/cloud/compute/vpn_tunnels/v1/vpn_tunnels.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/zone_operations/v1/zone_operations_connection_idempotency_policy.h
+++ b/google/cloud/compute/zone_operations/v1/zone_operations_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/zone_operations/v1/zone_operations.grpc.pb.h>
+#include <google/cloud/compute/zone_operations/v1/zone_operations.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/compute/zones/v1/zones_connection_idempotency_policy.h
+++ b/google/cloud/compute/zones/v1/zones_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/compute/zones/v1/zones.grpc.pb.h>
+#include <google/cloud/compute/zones/v1/zones.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_backup_runs_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_backup_runs_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_backup_runs.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_backup_runs.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_connect_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_connect_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_connect.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_connect.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_databases_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_databases_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_databases.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_databases.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_flags_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_flags_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_flags.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_flags.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_instances_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_instances_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_instances.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_instances.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_operations_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_operations_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_operations.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_operations.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_ssl_certs_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_ssl_certs_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_ssl_certs.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_ssl_certs.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_tiers_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_tiers_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_tiers.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_tiers.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/sql/v1/sql_users_connection_idempotency_policy.h
+++ b/google/cloud/sql/v1/sql_users_connection_idempotency_policy.h
@@ -22,7 +22,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/version.h"
-#include <google/cloud/sql/v1/cloud_sql_users.grpc.pb.h>
+#include <google/cloud/sql/v1/cloud_sql_users.pb.h>
 #include <memory>
 
 namespace google {


### PR DESCRIPTION
The logic to decide which file to include is only necessary where both the gRPC and REST generated code share files. For most of the REST specific code, there are separate code generators that already include the correct pb.h or grpc.pb.h file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11910)
<!-- Reviewable:end -->
