### PR TITLE
doc(spanner): update the description of the "DataBoost" feature

### DIFF
--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -308,8 +308,8 @@ struct PartitionsMaximumOption {
  * partitions returned from `Client::PartitionRead()` or `PartitionQuery()`.
  *
  * If true, the requests from the subsequent partitioned `Client::Read()`
- * and `Client::ExecuteQuery()` requests will be executed via Spanner-
- * independent compute resources.
+ * and `Client::ExecuteQuery()` calls will be executed using the independent
+ * compute resources of Cloud Spanner Data Boost.
  *
  * @ingroup spanner-options
  */

--- a/google/cloud/spanner/partition_options.h
+++ b/google/cloud/spanner/partition_options.h
@@ -59,8 +59,8 @@ struct PartitionOptions {
    * Use "data boost" in the returned partitions.
    *
    * If true, the requests from the subsequent partitioned `Client::Read()`
-   * and `Client::ExecuteQuery()` requests will be executed via Spanner-
-   * independent compute resources.
+   * and `Client::ExecuteQuery()` calls will be executed using the independent
+   * compute resources of Cloud Spanner Data Boost.
    */
   bool data_boost = false;
 };

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -83,8 +83,8 @@ StatusOr<QueryPartition> DeserializeQueryPartition(
  * Instances of `QueryPartition` are created by `Client::PartitionQuery`. Once
  * created, `QueryPartition` objects can be serialized, transmitted to separate
  * processes, and used to read data in parallel using `Client::ExecuteQuery`.
- * If `data_boost` is set, those requests will be executed via Spanner-
- * independent compute resources.
+ * If `data_boost` is set, those requests will be executed using the
+ * independent compute resources of Cloud Spanner Data Boost.
  */
 class QueryPartition {
  public:

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -84,8 +84,8 @@ StatusOr<ReadPartition> DeserializeReadPartition(
  * Instances of `ReadPartition` are created by `Client::PartitionRead`.
  * Once created, `ReadPartition` objects can be serialized, transmitted to
  * separate processes, and used to read data in parallel using `Client::Read`.
- * If `data_boost` is set, those requests will be executed via Spanner-
- * independent compute resources.
+ * If `data_boost` is set, those requests will be executed using the
+ * independent compute resources of Cloud Spanner Data Boost.
  */
 class ReadPartition {
  public:


### PR DESCRIPTION
I finally received word from the writers of how they want to describe this parameter, most importantly by saying "Cloud Spanner Data Boost". See #11345.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11913)
<!-- Reviewable:end -->
