### PR TITLE
fix: re-enable essentialcontacts test (#11922)

### DIFF
--- a/google/cloud/essentialcontacts/CMakeLists.txt
+++ b/google/cloud/essentialcontacts/CMakeLists.txt
@@ -125,9 +125,8 @@ if (BUILD_TESTING)
         COMMAND
             cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
             $<TARGET_FILE:essentialcontacts_quickstart> GOOGLE_CLOUD_PROJECT)
-    set_tests_properties(
-        essentialcontacts_quickstart PROPERTIES DISABLED TRUE LABELS
-                                                "integration-test;quickstart")
+    set_tests_properties(essentialcontacts_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.


### PR DESCRIPTION
This reverts commit 61c66e961d29e2e38c5bd01e37a491a4981de8a2.

Tested that the service is now working
`gcloud essential-contacts list --project=alevenb-test
API [essentialcontacts.googleapis.com] not enabled on project [1029569578106]. Would you
like to enable and retry (this will take a few minutes)? (y/N)?  y

Enabling service [essentialcontacts.googleapis.com] on project [1029569578106]...
Operation "operations/acat.p2-1029569578106-a128f3b7-b0db-4743-8524-10ba93625675" finished successfully.
Listed 0 items.`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11931)
<!-- Reviewable:end -->
