### PR TITLE
fix(common): pagination must support empty pages

### DIFF
--- a/google/cloud/internal/pagination_range.h
+++ b/google/cloud/internal/pagination_range.h
@@ -102,8 +102,8 @@ class PagedStreamReader {
       page_ = extractor_(*std::move(response));
       current_ = page_.begin();
     }
-    if (current_ != page_.end()) return std::move(*current_++);
-    return Status{};
+    if (current_ == page_.end()) return Status{};
+    return std::move(*current_++);
   }
 
  private:


### PR DESCRIPTION
Some services return empty pages with a non-empty pagination token. Our code would stop such iterations immediately. The correct behavior is to retrieve the next page until some non-empty range is returned.

Fixes #11936

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11937)
<!-- Reviewable:end -->
