### PR TITLE
cleanup(pubsub): use double-quote include syntax

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/samples/pubsub_samples_common.h"
+#include "google/cloud/pubsub/samples/testdata/schema.pb.h"
 #include "google/cloud/pubsub/schema.h"
 #include "google/cloud/pubsub/schema_client.h"
 #include "google/cloud/pubsub/subscriber.h"
@@ -24,7 +25,6 @@
 #include "google/cloud/project.h"
 #include "google/cloud/status.h"
 #include "google/cloud/testing_util/example_driver.h"
-#include <google/cloud/pubsub/samples/testdata/schema.pb.h>
 #include <google/protobuf/text_format.h>
 #include <chrono>
 #include <condition_variable>


### PR DESCRIPTION
Use `#include "..."` for in-project headers, the goal being to eliminate a special-case transformation used during the Google import, that recently displayed its fragility.