### PR TITLE
fix(generator): tidy up `stub_rest_generator` output

### DIFF
--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -153,6 +153,12 @@ void SetHttpGetQueryParameters(
                                         i.first, i.first));
             return;
           }
+          if (i.second == protobuf::FieldDescriptor::CPPTYPE_BOOL) {
+            out->append(absl::StrFormat(
+                R"""(std::make_pair("%s", request.%s() ? "1" : "0"))""",
+                i.first, i.first));
+            return;
+          }
           out->append(absl::StrFormat(
               "std::make_pair(\"%s\", std::to_string(request.%s()))", i.first,
               i.first));

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -133,6 +133,7 @@ char const* const kServiceProto =
     "  int32 page_size = 1;\n"
     "  string page_token = 2;\n"
     "  string name = 3;\n"
+    "  bool include_foo = 4;\n"
     "}\n"
     "// Leading comments about message PaginatedOutput.\n"
     "message PaginatedOutput {\n"
@@ -389,9 +390,8 @@ TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersGet) {
       service_file_descriptor->service(0)->method(4);
   VarsDictionary vars;
   SetHttpGetQueryParameters(ParseHttpExtension(*method), *method, vars);
-  EXPECT_THAT(vars.at("method_http_query_parameters"),
-              Eq(",\n      {std::make_pair(\"not_used_anymore\", "
-                 "request.not_used_anymore())}"));
+  EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(R"""(,
+      {std::make_pair("not_used_anymore", request.not_used_anymore())})"""));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersGetPaginated) {
@@ -401,11 +401,11 @@ TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersGetPaginated) {
       service_file_descriptor->service(0)->method(3);
   VarsDictionary vars;
   SetHttpGetQueryParameters(ParseHttpExtension(*method), *method, vars);
-  EXPECT_THAT(vars.at("method_http_query_parameters"),
-              Eq(",\n      {std::make_pair(\"page_size\", "
-                 "std::to_string(request.page_size())),\n       "
-                 "std::make_pair(\"page_token\", request.page_token()),\n      "
-                 " std::make_pair(\"name\", request.name())}"));
+  EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(R"""(,
+      {std::make_pair("page_size", std::to_string(request.page_size())),
+       std::make_pair("page_token", request.page_token()),
+       std::make_pair("name", request.name()),
+       std::make_pair("include_foo", request.include_foo() ? "1" : "0")})"""));
 }
 
 TEST_F(HttpOptionUtilsTest, HasHttpAnnotationRoutingHeaderSuccess) {

--- a/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub.cc
+++ b/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub.cc
@@ -51,12 +51,12 @@ DefaultAcceleratorTypesRestStub::AggregatedListAcceleratorTypes(
                    "/aggregated/acceleratorTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::AcceleratorType>
@@ -89,7 +89,7 @@ DefaultAcceleratorTypesRestStub::ListAcceleratorTypes(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/addresses/v1/internal/addresses_rest_stub.cc
+++ b/google/cloud/compute/addresses/v1/internal/addresses_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultAddressesRestStub::AggregatedListAddresses(
                    "/aggregated/addresses"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -141,7 +141,7 @@ DefaultAddressesRestStub::ListAddresses(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub.cc
+++ b/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultAutoscalersRestStub::AggregatedListAutoscalers(
                    "/aggregated/autoscalers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -141,7 +141,7 @@ DefaultAutoscalersRestStub::ListAutoscalers(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
+++ b/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
@@ -169,7 +169,7 @@ DefaultBackendBucketsRestStub::ListBackendBuckets(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
+++ b/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
@@ -81,12 +81,12 @@ DefaultBackendServicesRestStub::AggregatedListBackendServices(
                    "/aggregated/backendServices"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -220,7 +220,7 @@ DefaultBackendServicesRestStub::ListBackendServices(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub.cc
+++ b/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub.cc
@@ -50,12 +50,12 @@ DefaultDiskTypesRestStub::AggregatedListDiskTypes(
                    "/aggregated/diskTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::DiskType>
@@ -86,7 +86,7 @@ DefaultDiskTypesRestStub::ListDiskTypes(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
+++ b/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
@@ -82,12 +82,12 @@ DefaultDisksRestStub::AggregatedListDisks(
                    "/aggregated/disks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -204,7 +204,7 @@ DefaultDisksRestStub::ListDisks(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub.cc
@@ -125,7 +125,7 @@ DefaultExternalVpnGatewaysRestStub::ListExternalVpnGateways(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
@@ -233,7 +233,7 @@ DefaultFirewallPoliciesRestStub::ListFirewallPolicies(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("parent_id", request.parent_id()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<

--- a/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub.cc
+++ b/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub.cc
@@ -118,7 +118,7 @@ DefaultFirewallsRestStub::ListFirewalls(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub.cc
+++ b/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultForwardingRulesRestStub::AggregatedListForwardingRules(
                    "/aggregated/forwardingRules"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -144,7 +144,7 @@ DefaultForwardingRulesRestStub::ListForwardingRules(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub.cc
+++ b/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub.cc
@@ -118,7 +118,7 @@ DefaultGlobalAddressesRestStub::ListGlobalAddresses(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub.cc
+++ b/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub.cc
@@ -122,7 +122,7 @@ DefaultGlobalForwardingRulesRestStub::ListGlobalForwardingRules(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
@@ -184,7 +184,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::ListGlobalNetworkEndpointGroups(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<

--- a/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub.cc
+++ b/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub.cc
@@ -51,12 +51,12 @@ DefaultGlobalOperationsRestStub::AggregatedListGlobalOperations(
                    "/aggregated/operations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 Status DefaultGlobalOperationsRestStub::DeleteGlobalOperations(
@@ -95,7 +95,7 @@ DefaultGlobalOperationsRestStub::ListGlobalOperations(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>

--- a/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
+++ b/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
@@ -78,7 +78,7 @@ DefaultGlobalOrganizationOperationsRestStub::ListGlobalOrganizationOperations(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("parent_id", request.parent_id()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub.cc
@@ -128,7 +128,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::ListGlobalPublicDelegatedPrefixes(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub.cc
+++ b/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultHealthChecksRestStub::AggregatedListHealthChecks(
                    "/aggregated/healthChecks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -139,7 +139,7 @@ DefaultHealthChecksRestStub::ListHealthChecks(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub.cc
+++ b/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub.cc
@@ -122,7 +122,7 @@ DefaultHttpHealthChecksRestStub::ListHttpHealthChecks(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub.cc
+++ b/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub.cc
@@ -122,7 +122,7 @@ DefaultHttpsHealthChecksRestStub::ListHttpsHealthChecks(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/images/v1/internal/images_rest_stub.cc
+++ b/google/cloud/compute/images/v1/internal/images_rest_stub.cc
@@ -167,7 +167,7 @@ DefaultImagesRestStub::ListImages(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
@@ -86,12 +86,12 @@ DefaultInstanceGroupManagersRestStub::AggregatedListInstanceGroupManagers(
                    "/aggregated/instanceGroupManagers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -288,7 +288,7 @@ DefaultInstanceGroupManagersRestStub::ListInstanceGroupManagers(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<
@@ -309,7 +309,7 @@ DefaultInstanceGroupManagersRestStub::ListErrors(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success())),
+                      request.return_partial_success() ? "1" : "0"),
        std::make_pair("zone", request.zone())});
 }
 

--- a/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub.cc
+++ b/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub.cc
@@ -82,12 +82,12 @@ DefaultInstanceGroupsRestStub::AggregatedListInstanceGroups(
                    "/aggregated/instanceGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -168,7 +168,7 @@ DefaultInstanceGroupsRestStub::ListInstanceGroups(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::InstanceGroupsListInstances>

--- a/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub.cc
+++ b/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultInstanceTemplatesRestStub::AggregatedListInstanceTemplates(
                    "/aggregated/instanceTemplates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -158,7 +158,7 @@ DefaultInstanceTemplatesRestStub::ListInstanceTemplates(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
+++ b/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
@@ -107,12 +107,12 @@ DefaultInstancesRestStub::AggregatedListInstances(
                    "/aggregated/instances"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -388,7 +388,7 @@ DefaultInstancesRestStub::ListInstances(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::InstanceListReferrers>
@@ -408,7 +408,7 @@ DefaultInstancesRestStub::ListReferrers(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success())),
+                      request.return_partial_success() ? "1" : "0"),
        std::make_pair("zone", request.zone())});
 }
 

--- a/google/cloud/compute/integration_tests/compute_integration_test.cc
+++ b/google/cloud/compute/integration_tests/compute_integration_test.cc
@@ -32,8 +32,6 @@ using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::Eq;
 using ::testing::HasSubstr;
-using ::testing::IsEmpty;
-using ::testing::Not;
 
 class ComputeIntegrationTest
     : public ::google::cloud::testing_util::IntegrationTest {

--- a/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub.cc
+++ b/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub.cc
@@ -58,12 +58,12 @@ DefaultInterconnectAttachmentsRestStub::AggregatedListInterconnectAttachments(
                    "/aggregated/interconnectAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -149,7 +149,7 @@ DefaultInterconnectAttachmentsRestStub::ListInterconnectAttachments(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub.cc
+++ b/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub.cc
@@ -69,7 +69,7 @@ DefaultInterconnectLocationsRestStub::ListInterconnectLocations(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub.cc
+++ b/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub.cc
@@ -133,7 +133,7 @@ DefaultInterconnectsRestStub::ListInterconnects(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/licenses/v1/internal/licenses_rest_stub.cc
+++ b/google/cloud/compute/licenses/v1/internal/licenses_rest_stub.cc
@@ -134,7 +134,7 @@ DefaultLicensesRestStub::ListLicenses(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub.cc
+++ b/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub.cc
@@ -135,7 +135,7 @@ DefaultMachineImagesRestStub::ListMachineImages(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub.cc
+++ b/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub.cc
@@ -50,12 +50,12 @@ DefaultMachineTypesRestStub::AggregatedListMachineTypes(
                    "/aggregated/machineTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::MachineType>
@@ -87,7 +87,7 @@ DefaultMachineTypesRestStub::ListMachineTypes(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub.cc
+++ b/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultNetworkAttachmentsRestStub::AggregatedListNetworkAttachments(
                    "/aggregated/networkAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -163,7 +163,7 @@ DefaultNetworkAttachmentsRestStub::ListNetworkAttachments(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub.cc
+++ b/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub.cc
@@ -61,12 +61,12 @@ DefaultNetworkEdgeSecurityServicesRestStub::
                    "/aggregated/networkEdgeSecurityServices"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub.cc
@@ -58,12 +58,12 @@ DefaultNetworkEndpointGroupsRestStub::AggregatedListNetworkEndpointGroups(
                    "/aggregated/networkEndpointGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -203,7 +203,7 @@ DefaultNetworkEndpointGroupsRestStub::ListNetworkEndpointGroups(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<

--- a/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
@@ -245,7 +245,7 @@ DefaultNetworkFirewallPoliciesRestStub::ListNetworkFirewallPolicies(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
+++ b/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
@@ -158,7 +158,7 @@ DefaultNetworksRestStub::ListNetworks(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::ExchangedPeeringRoutesList>
@@ -181,7 +181,7 @@ DefaultNetworksRestStub::ListPeeringRoutes(
        std::make_pair("project", request.project()),
        std::make_pair("region", request.region()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
+++ b/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
@@ -82,12 +82,12 @@ DefaultNodeGroupsRestStub::AggregatedListNodeGroups(
                    "/aggregated/nodeGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -210,7 +210,7 @@ DefaultNodeGroupsRestStub::ListNodeGroups(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::NodeGroupsListNodes>

--- a/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub.cc
+++ b/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultNodeTemplatesRestStub::AggregatedListNodeTemplates(
                    "/aggregated/nodeTemplates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -159,7 +159,7 @@ DefaultNodeTemplatesRestStub::ListNodeTemplates(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/node_types/v1/internal/node_types_rest_stub.cc
+++ b/google/cloud/compute/node_types/v1/internal/node_types_rest_stub.cc
@@ -50,12 +50,12 @@ DefaultNodeTypesRestStub::AggregatedListNodeTypes(
                    "/aggregated/nodeTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::NodeType>
@@ -86,7 +86,7 @@ DefaultNodeTypesRestStub::ListNodeTypes(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub.cc
+++ b/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultPacketMirroringsRestStub::AggregatedListPacketMirrorings(
                    "/aggregated/packetMirrorings"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -146,7 +146,7 @@ DefaultPacketMirroringsRestStub::ListPacketMirrorings(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
+++ b/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
@@ -178,7 +178,7 @@ DefaultProjectsRestStub::GetXpnResources(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::XpnHostList>

--- a/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
@@ -126,7 +126,7 @@ DefaultPublicAdvertisedPrefixesRestStub::ListPublicAdvertisedPrefixes(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
@@ -58,12 +58,12 @@ DefaultPublicDelegatedPrefixesRestStub::AggregatedListPublicDelegatedPrefixes(
                    "/aggregated/publicDelegatedPrefixes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -149,7 +149,7 @@ DefaultPublicDelegatedPrefixesRestStub::ListPublicDelegatedPrefixes(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub.cc
+++ b/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub.cc
@@ -123,7 +123,7 @@ DefaultRegionAutoscalersRestStub::ListRegionAutoscalers(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub.cc
+++ b/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub.cc
@@ -156,7 +156,7 @@ DefaultRegionBackendServicesRestStub::ListRegionBackendServices(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub.cc
+++ b/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultRegionCommitmentsRestStub::AggregatedListRegionCommitments(
                    "/aggregated/commitments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Commitment>
@@ -117,7 +117,7 @@ DefaultRegionCommitmentsRestStub::ListRegionCommitments(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub.cc
+++ b/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub.cc
@@ -67,7 +67,7 @@ DefaultRegionDiskTypesRestStub::ListRegionDiskTypes(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
+++ b/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
@@ -189,7 +189,7 @@ DefaultRegionDisksRestStub::ListRegionDisks(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub.cc
+++ b/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub.cc
@@ -130,7 +130,7 @@ DefaultRegionHealthCheckServicesRestStub::ListRegionHealthCheckServices(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub.cc
+++ b/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub.cc
@@ -124,7 +124,7 @@ DefaultRegionHealthChecksRestStub::ListRegionHealthChecks(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
@@ -273,7 +273,7 @@ DefaultRegionInstanceGroupManagersRestStub::ListRegionInstanceGroupManagers(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -295,7 +295,7 @@ DefaultRegionInstanceGroupManagersRestStub::ListErrors(
        std::make_pair("project", request.project()),
        std::make_pair("region", request.region()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::

--- a/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub.cc
+++ b/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub.cc
@@ -76,7 +76,7 @@ DefaultRegionInstanceGroupsRestStub::ListRegionInstanceGroups(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::RegionInstanceGroupsListInstances>

--- a/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub.cc
+++ b/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub.cc
@@ -127,7 +127,7 @@ DefaultRegionInstanceTemplatesRestStub::ListRegionInstanceTemplates(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
@@ -132,7 +132,7 @@ DefaultRegionNetworkEndpointGroupsRestStub::ListRegionNetworkEndpointGroups(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
@@ -275,7 +275,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::ListRegionNetworkFirewallPolicies(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub.cc
+++ b/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub.cc
@@ -132,7 +132,7 @@ DefaultRegionNotificationEndpointsRestStub::ListRegionNotificationEndpoints(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub.cc
+++ b/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub.cc
@@ -77,7 +77,7 @@ DefaultRegionOperationsRestStub::ListRegionOperations(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>

--- a/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
+++ b/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
@@ -127,7 +127,7 @@ DefaultRegionSecurityPoliciesRestStub::ListRegionSecurityPolicies(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub.cc
+++ b/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub.cc
@@ -126,7 +126,7 @@ DefaultRegionSslCertificatesRestStub::ListRegionSslCertificates(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub.cc
+++ b/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub.cc
@@ -122,7 +122,7 @@ DefaultRegionSslPoliciesRestStub::ListRegionSslPolicies(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<
@@ -142,7 +142,7 @@ DefaultRegionSslPoliciesRestStub::ListAvailableFeatures(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub.cc
@@ -127,7 +127,7 @@ DefaultRegionTargetHttpProxiesRestStub::ListRegionTargetHttpProxies(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub.cc
@@ -128,7 +128,7 @@ DefaultRegionTargetHttpsProxiesRestStub::ListRegionTargetHttpsProxies(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub.cc
@@ -127,7 +127,7 @@ DefaultRegionTargetTcpProxiesRestStub::ListRegionTargetTcpProxies(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub.cc
+++ b/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub.cc
@@ -121,7 +121,7 @@ DefaultRegionUrlMapsRestStub::ListRegionUrlMaps(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/regions/v1/internal/regions_rest_stub.cc
+++ b/google/cloud/compute/regions/v1/internal/regions_rest_stub.cc
@@ -63,7 +63,7 @@ DefaultRegionsRestStub::ListRegions(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/reservations/v1/internal/reservations_rest_stub.cc
+++ b/google/cloud/compute/reservations/v1/internal/reservations_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultReservationsRestStub::AggregatedListReservations(
                    "/aggregated/reservations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -158,7 +158,7 @@ DefaultReservationsRestStub::ListReservations(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub.cc
+++ b/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultResourcePoliciesRestStub::AggregatedListResourcePolicies(
                    "/aggregated/resourcePolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -163,7 +163,7 @@ DefaultResourcePoliciesRestStub::ListResourcePolicies(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/routers/v1/internal/routers_rest_stub.cc
+++ b/google/cloud/compute/routers/v1/internal/routers_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultRoutersRestStub::AggregatedListRouters(
                    "/aggregated/routers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -120,7 +120,7 @@ DefaultRoutersRestStub::GetNatMappingInfo(
        std::make_pair("project", request.project()),
        std::make_pair("region", request.region()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::RouterStatusResponse>
@@ -177,7 +177,7 @@ DefaultRoutersRestStub::ListRouters(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/routes/v1/internal/routes_rest_stub.cc
+++ b/google/cloud/compute/routes/v1/internal/routes_rest_stub.cc
@@ -116,7 +116,7 @@ DefaultRoutesRestStub::ListRoutes(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
+++ b/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
@@ -83,12 +83,12 @@ DefaultSecurityPoliciesRestStub::AggregatedListSecurityPolicies(
                    "/aggregated/securityPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -182,7 +182,7 @@ DefaultSecurityPoliciesRestStub::ListSecurityPolicies(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -202,7 +202,7 @@ DefaultSecurityPoliciesRestStub::ListPreconfiguredExpressionSets(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub.cc
+++ b/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultServiceAttachmentsRestStub::AggregatedListServiceAttachments(
                    "/aggregated/serviceAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -163,7 +163,7 @@ DefaultServiceAttachmentsRestStub::ListServiceAttachments(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub.cc
+++ b/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub.cc
@@ -133,7 +133,7 @@ DefaultSnapshotsRestStub::ListSnapshots(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub.cc
+++ b/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultSslCertificatesRestStub::AggregatedListSslCertificates(
                    "/aggregated/sslCertificates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -140,7 +140,7 @@ DefaultSslCertificatesRestStub::ListSslCertificates(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub.cc
+++ b/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultSslPoliciesRestStub::AggregatedListSslPolicies(
                    "/aggregated/sslPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -139,7 +139,7 @@ DefaultSslPoliciesRestStub::ListSslPolicies(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<
@@ -158,7 +158,7 @@ DefaultSslPoliciesRestStub::ListAvailableFeatures(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub.cc
+++ b/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultSubnetworksRestStub::AggregatedListSubnetworks(
                    "/aggregated/subnetworks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -184,7 +184,7 @@ DefaultSubnetworksRestStub::ListSubnetworks(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::UsableSubnetworksAggregatedList>
@@ -202,7 +202,7 @@ DefaultSubnetworksRestStub::ListUsable(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub.cc
@@ -122,7 +122,7 @@ DefaultTargetGrpcProxiesRestStub::ListTargetGrpcProxies(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultTargetHttpProxiesRestStub::AggregatedListTargetHttpProxies(
                    "/aggregated/targetHttpProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -142,7 +142,7 @@ DefaultTargetHttpProxiesRestStub::ListTargetHttpProxies(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub.cc
@@ -58,12 +58,12 @@ DefaultTargetHttpsProxiesRestStub::AggregatedListTargetHttpsProxies(
                    "/aggregated/targetHttpsProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -143,7 +143,7 @@ DefaultTargetHttpsProxiesRestStub::ListTargetHttpsProxies(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub.cc
+++ b/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultTargetInstancesRestStub::AggregatedListTargetInstances(
                    "/aggregated/targetInstances"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -143,7 +143,7 @@ DefaultTargetInstancesRestStub::ListTargetInstances(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub.cc
+++ b/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub.cc
@@ -108,12 +108,12 @@ DefaultTargetPoolsRestStub::AggregatedListTargetPools(
                    "/aggregated/targetPools"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -207,7 +207,7 @@ DefaultTargetPoolsRestStub::ListTargetPools(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub.cc
@@ -121,7 +121,7 @@ DefaultTargetSslProxiesRestStub::ListTargetSslProxies(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultTargetTcpProxiesRestStub::AggregatedListTargetTcpProxies(
                    "/aggregated/targetTcpProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -141,7 +141,7 @@ DefaultTargetTcpProxiesRestStub::ListTargetTcpProxies(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub.cc
@@ -57,12 +57,12 @@ DefaultTargetVpnGatewaysRestStub::AggregatedListTargetVpnGateways(
                    "/aggregated/targetVpnGateways"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -146,7 +146,7 @@ DefaultTargetVpnGatewaysRestStub::ListTargetVpnGateways(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub.cc
+++ b/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultUrlMapsRestStub::AggregatedListUrlMaps(
                    "/aggregated/urlMaps"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -164,7 +164,7 @@ DefaultUrlMapsRestStub::ListUrlMaps(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultVpnGatewaysRestStub::AggregatedListVpnGateways(
                    "/aggregated/vpnGateways"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -157,7 +157,7 @@ DefaultVpnGatewaysRestStub::ListVpnGateways(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub.cc
+++ b/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub.cc
@@ -56,12 +56,12 @@ DefaultVpnTunnelsRestStub::AggregatedListVpnTunnels(
                    "/aggregated/vpnTunnels"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
-                      std::to_string(request.include_all_scopes())),
+                      request.include_all_scopes() ? "1" : "0"),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -141,7 +141,7 @@ DefaultVpnTunnelsRestStub::ListVpnTunnels(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub.cc
+++ b/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub.cc
@@ -76,7 +76,7 @@ DefaultZoneOperationsRestStub::ListZoneOperations(
        std::make_pair("page_token", request.page_token()),
        std::make_pair("project", request.project()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>

--- a/google/cloud/compute/zones/v1/internal/zones_rest_stub.cc
+++ b/google/cloud/compute/zones/v1/internal/zones_rest_stub.cc
@@ -60,7 +60,7 @@ DefaultZonesRestStub::ListZones(
        std::make_pair("order_by", request.order_by()),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("return_partial_success",
-                      std::to_string(request.return_partial_success()))});
+                      request.return_partial_success() ? "1" : "0")});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
clang-tidy did not like the implicit conversion from `bool` to `int` forced by `std::to_string(... some bool ...)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11943)
<!-- Reviewable:end -->
