### PR TITLE
cleanup(pubsub): revert PR #11940

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/samples/pubsub_samples_common.h"
-#include "google/cloud/pubsub/samples/testdata/schema.pb.h"
 #include "google/cloud/pubsub/schema.h"
 #include "google/cloud/pubsub/schema_client.h"
 #include "google/cloud/pubsub/subscriber.h"
@@ -25,6 +24,7 @@
 #include "google/cloud/project.h"
 #include "google/cloud/status.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <google/cloud/pubsub/samples/testdata/schema.pb.h>
 #include <google/protobuf/text_format.h>
 #include <chrono>
 #include <condition_variable>


### PR DESCRIPTION
Just like #10139 reverted a similar change from #10135, we now relearn the lesson for #11940.  Contrary to the promise, the change in `#include` form does not eliminate a special-case transformation used during the Google import.  I'll leave a breadcrumb elsewhere in the hope of having to not re-relearn in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11947)
<!-- Reviewable:end -->
