### PR TITLE
impl(otel): monitored resource mapping

### DIFF
--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(
     google_cloud_cpp_opentelemetry # cmake-format: sort
     configure_basic_tracing.cc
     configure_basic_tracing.h
+    internal/monitored_resource.cc
+    internal/monitored_resource.h
     internal/recordable.cc
     internal/recordable.h
     internal/resource_detector_impl.cc
@@ -118,8 +120,8 @@ add_subdirectory(samples)
 
 set(opentelemetry_unit_tests
     # cmake-format: sort
-    internal/recordable_test.cc internal/resource_detector_impl_test.cc
-    trace_exporter_test.cc)
+    internal/monitored_resource_test.cc internal/recordable_test.cc
+    internal/resource_detector_impl_test.cc trace_exporter_test.cc)
 
 export_list_to_bazel("opentelemetry_unit_tests.bzl" "opentelemetry_unit_tests"
                      YEAR "2023")

--- a/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry.bzl
+++ b/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry.bzl
@@ -18,6 +18,7 @@
 
 google_cloud_cpp_opentelemetry_hdrs = [
     "configure_basic_tracing.h",
+    "internal/monitored_resource.h",
     "internal/recordable.h",
     "internal/resource_detector_impl.h",
     "resource_detector.h",
@@ -26,6 +27,7 @@ google_cloud_cpp_opentelemetry_hdrs = [
 
 google_cloud_cpp_opentelemetry_srcs = [
     "configure_basic_tracing.cc",
+    "internal/monitored_resource.cc",
     "internal/recordable.cc",
     "internal/resource_detector_impl.cc",
     "resource_detector.cc",

--- a/google/cloud/opentelemetry/internal/monitored_resource.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource.cc
@@ -1,0 +1,222 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/internal/monitored_resource.h"
+#include "google/cloud/version.h"
+#include "absl/types/optional.h"
+#include "absl/types/variant.h"
+#include <opentelemetry/common/attribute_value.h>
+#include <opentelemetry/sdk/resource/resource.h>
+#include <opentelemetry/sdk/resource/semantic_conventions.h>
+#include <unordered_map>
+
+namespace google {
+namespace cloud {
+namespace otel_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+namespace sc = opentelemetry::sdk::resource::SemanticConventions;
+
+std::string AsString(
+    opentelemetry::sdk::common::OwnedAttributeValue attribute) {
+  if (absl::holds_alternative<std::string>(attribute)) {
+    return absl::get<std::string>(attribute);
+  }
+  // TODO(#11775) - convert other attribute types to strings
+  // Note that our resource detector only uses string attributes.
+  return {};
+}
+
+struct OTelKeyMatch {
+  std::vector<std::string> otel_keys;
+  absl::optional<std::string> fallback = absl::nullopt;
+};
+
+class MonitoredResourceProvider {
+ public:
+  MonitoredResourceProvider(
+      std::string type, std::unordered_map<std::string, OTelKeyMatch> lookup)
+      : type_(std::move(type)), lookup_(std::move(lookup)) {}
+
+  MonitoredResource Process(
+      opentelemetry::sdk::resource::ResourceAttributes const& attributes) {
+    MonitoredResource mr;
+    mr.type = type_;
+    for (auto const& kv : lookup_) {
+      auto found = false;
+      for (auto const& otel_key : kv.second.otel_keys) {
+        auto p = attributes.find(otel_key);
+        if (p != attributes.end()) {
+          found = true;
+          mr.labels[kv.first] = AsString(p->second);
+          break;
+        }
+      }
+      if (!found && kv.second.fallback)
+        mr.labels[kv.first] = *kv.second.fallback;
+    }
+    return mr;
+  }
+
+ private:
+  std::string type_;
+  std::unordered_map<std::string, OTelKeyMatch> lookup_;
+};
+
+MonitoredResourceProvider GceInstance() {
+  return MonitoredResourceProvider("gce_instance",
+                                   {
+                                       {"zone", {{sc::kCloudAvailabilityZone}}},
+                                       {"instance_id", {{sc::kHostId}}},
+                                   });
+}
+
+MonitoredResourceProvider K8sContainer() {
+  return MonitoredResourceProvider(
+      "k8s_container",
+      {
+          {"location", {{sc::kCloudAvailabilityZone, sc::kCloudRegion}}},
+          {"cluster_name", {{sc::kK8sClusterName}}},
+          {"namespace_name", {{sc::kK8sNamespaceName}}},
+          {"pod_name", {{sc::kK8sPodName}}},
+          {"container_name", {{sc::kK8sContainerName}}},
+      });
+}
+
+MonitoredResourceProvider K8sPod() {
+  return MonitoredResourceProvider(
+      "k8s_pod",
+      {
+          {"location", {{sc::kCloudAvailabilityZone, sc::kCloudRegion}}},
+          {"cluster_name", {{sc::kK8sClusterName}}},
+          {"namespace_name", {{sc::kK8sNamespaceName}}},
+          {"pod_name", {{sc::kK8sPodName}}},
+      });
+}
+
+MonitoredResourceProvider K8sNode() {
+  return MonitoredResourceProvider(
+      "k8s_node",
+      {
+          {"location", {{sc::kCloudAvailabilityZone, sc::kCloudRegion}}},
+          {"cluster_name", {{sc::kK8sClusterName}}},
+          {"node_name", {{sc::kK8sNodeName}}},
+      });
+}
+
+MonitoredResourceProvider K8sCluster() {
+  return MonitoredResourceProvider(
+      "k8s_cluster",
+      {
+          {"location", {{sc::kCloudAvailabilityZone, sc::kCloudRegion}}},
+          {"cluster_name", {{sc::kK8sClusterName}}},
+      });
+}
+
+MonitoredResourceProvider GaeInstance() {
+  return MonitoredResourceProvider(
+      "gae_instance",
+      {
+          {"location", {{sc::kCloudAvailabilityZone, sc::kCloudRegion}}},
+          {"module_id", {{sc::kFaasName}}},
+          {"version_id", {{sc::kFaasVersion}}},
+          {"instance_id", {{sc::kFaasInstance}}},
+      });
+}
+
+MonitoredResourceProvider AwsEc2Instance() {
+  return MonitoredResourceProvider(
+      "aws_ec2_instance",
+      {
+          {"instance_id", {{sc::kHostId}}},
+          {"region", {{sc::kCloudAvailabilityZone, sc::kCloudRegion}}},
+          {"aws_account", {{sc::kCloudAccountId}}},
+      });
+}
+
+MonitoredResourceProvider GenericTask() {
+  return MonitoredResourceProvider(
+      "generic_task",
+      {
+          {"location",
+           {{sc::kCloudAvailabilityZone, sc::kCloudRegion}, "global"}},
+          {"namespace", {{sc::kServiceNamespace}}},
+          {"job", {{sc::kServiceName}}},
+          {"task_id", {{sc::kServiceInstanceId}}},
+      });
+}
+
+MonitoredResourceProvider GenericNode() {
+  return MonitoredResourceProvider(
+      "generic_node",
+      {
+          {"location",
+           {{sc::kCloudAvailabilityZone, sc::kCloudRegion}, "global"}},
+          {"namespace", {{sc::kServiceNamespace}}},
+          {"node_id", {{sc::kHostId}}},
+      });
+}
+
+// The resource mapping logic is copied from the go implementation, at:
+//
+// https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/02fd6f23e8557907cda61ef01c94198dec4ccd71/internal/resourcemapping/resourcemapping.go
+MonitoredResourceProvider MakeProvider(
+    opentelemetry::sdk::resource::ResourceAttributes const& attributes) {
+  std::string platform;
+  auto p = attributes.find(sc::kCloudPlatform);
+  if (p != attributes.end()) platform = AsString(p->second);
+
+  if (platform == "gcp_compute_engine") {
+    return GceInstance();
+  }
+  if (platform == "gcp_kubernetes_engine") {
+    if (attributes.find(sc::kK8sContainerName) != attributes.end()) {
+      return K8sContainer();
+    }
+    if (attributes.find(sc::kK8sPodName) != attributes.end()) {
+      return K8sPod();
+    }
+    if (attributes.find(sc::kK8sNodeName) != attributes.end()) {
+      return K8sNode();
+    }
+    return K8sCluster();
+  }
+  if (platform == "gcp_app_engine") {
+    return GaeInstance();
+  }
+  if (platform == "aws_ec2") {
+    return AwsEc2Instance();
+  }
+  if ((attributes.find(sc::kServiceName) != attributes.end() &&
+       attributes.find(sc::kServiceInstanceId) != attributes.end()) ||
+      (attributes.find(sc::kFaasName) != attributes.end() &&
+       attributes.find(sc::kFaasInstance) != attributes.end())) {
+    return GenericTask();
+  }
+  return GenericNode();
+}
+
+}  // namespace
+
+MonitoredResource ToMonitoredResource(
+    opentelemetry::sdk::resource::ResourceAttributes const& attributes) {
+  auto provider = MakeProvider(attributes);
+  return provider.Process(attributes);
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/opentelemetry/internal/monitored_resource.h
+++ b/google/cloud/opentelemetry/internal/monitored_resource.h
@@ -1,0 +1,53 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_INTERNAL_MONITORED_RESOURCE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_INTERNAL_MONITORED_RESOURCE_H
+
+#include "google/cloud/version.h"
+#include <opentelemetry/sdk/resource/resource.h>
+#include <string>
+#include <unordered_map>
+
+namespace google {
+namespace cloud {
+namespace otel_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/*
+ * A struct representing a Google Cloud monitored resource.
+ *
+ * These are resources that are tracked by Cloud Monitoring. See
+ * https://cloud.google.com/monitoring/api/resources for a list of such
+ * resources.
+ */
+struct MonitoredResource {
+  // e.g. "gce_instance"
+  std::string type;
+  // e.g. {{"location", "us-central1-a"}}
+  std::unordered_map<std::string, std::string> labels;
+};
+
+/*
+ * Map the attributes to a monitored resource.
+ */
+MonitoredResource ToMonitoredResource(
+    opentelemetry::sdk::resource::ResourceAttributes const& attributes);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_INTERNAL_MONITORED_RESOURCE_H

--- a/google/cloud/opentelemetry/internal/monitored_resource_test.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource_test.cc
@@ -1,0 +1,321 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/internal/monitored_resource.h"
+#include "google/cloud/version.h"
+#include "absl/types/optional.h"
+#include <gmock/gmock.h>
+#include <opentelemetry/sdk/resource/semantic_conventions.h>
+
+namespace google {
+namespace cloud {
+namespace otel_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+namespace sc = opentelemetry::sdk::resource::SemanticConventions;
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
+
+TEST(MonitoredResource, GceInstance) {
+  auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+      {sc::kCloudPlatform, "gcp_compute_engine"},
+      {sc::kHostId, "1020304050607080900"},
+      {sc::kCloudAvailabilityZone, "us-central1-a"},
+  };
+
+  auto mr = ToMonitoredResource(attributes);
+  EXPECT_EQ(mr.type, "gce_instance");
+  EXPECT_THAT(mr.labels,
+              UnorderedElementsAre(Pair("zone", "us-central1-a"),
+                                   Pair("instance_id", "1020304050607080900")));
+}
+
+TEST(MonitoredResource, K8sContainer) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_location;
+  };
+  auto tests = std::vector<TestCase>{
+      {"us-central1-a", "us-central1", "us-central1-a"},
+      {"us-central1-a", absl::nullopt, "us-central1-a"},
+      {absl::nullopt, "us-central1", "us-central1"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kCloudPlatform, "gcp_kubernetes_engine"},
+        {sc::kK8sClusterName, "test-cluster"},
+        {sc::kK8sNamespaceName, "test-namespace"},
+        {sc::kK8sPodName, "test-pod"},
+        {sc::kK8sContainerName, "test-container"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "k8s_container");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", test.expected_location),
+                                     Pair("cluster_name", "test-cluster"),
+                                     Pair("namespace_name", "test-namespace"),
+                                     Pair("pod_name", "test-pod"),
+                                     Pair("container_name", "test-container")));
+  }
+}
+
+TEST(MonitoredResource, K8sPod) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_location;
+  };
+  auto tests = std::vector<TestCase>{
+      {"us-central1-a", "us-central1", "us-central1-a"},
+      {"us-central1-a", absl::nullopt, "us-central1-a"},
+      {absl::nullopt, "us-central1", "us-central1"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kCloudPlatform, "gcp_kubernetes_engine"},
+        {sc::kK8sClusterName, "test-cluster"},
+        {sc::kK8sNamespaceName, "test-namespace"},
+        {sc::kK8sPodName, "test-pod"},
+        //{sc::kK8sContainerName, "test-container"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "k8s_pod");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", test.expected_location),
+                                     Pair("cluster_name", "test-cluster"),
+                                     Pair("namespace_name", "test-namespace"),
+                                     Pair("pod_name", "test-pod")));
+  }
+}
+
+TEST(MonitoredResource, K8sNode) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_location;
+  };
+  auto tests = std::vector<TestCase>{
+      {"us-central1-a", "us-central1", "us-central1-a"},
+      {"us-central1-a", absl::nullopt, "us-central1-a"},
+      {absl::nullopt, "us-central1", "us-central1"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kCloudPlatform, "gcp_kubernetes_engine"},
+        {sc::kK8sClusterName, "test-cluster"},
+        {sc::kK8sNodeName, "test-node"},
+        //{sc::kK8sPodName, "test-pod"},
+        //{sc::kK8sContainerName, "test-container"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "k8s_node");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", test.expected_location),
+                                     Pair("cluster_name", "test-cluster"),
+                                     Pair("node_name", "test-node")));
+  }
+}
+
+TEST(MonitoredResource, K8sCluster) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_location;
+  };
+  auto tests = std::vector<TestCase>{
+      {"us-central1-a", "us-central1", "us-central1-a"},
+      {"us-central1-a", absl::nullopt, "us-central1-a"},
+      {absl::nullopt, "us-central1", "us-central1"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kCloudPlatform, "gcp_kubernetes_engine"},
+        {sc::kK8sClusterName, "test-cluster"},
+        //{sc::kK8sNodeName, "test-node"},
+        //{sc::kK8sPodName, "test-pod"},
+        //{sc::kK8sContainerName, "test-container"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "k8s_cluster");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", test.expected_location),
+                                     Pair("cluster_name", "test-cluster")));
+  }
+}
+
+TEST(MonitoredResource, GaeInstance) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_location;
+  };
+  auto tests = std::vector<TestCase>{
+      {"us-central1-a", "us-central1", "us-central1-a"},
+      {"us-central1-a", absl::nullopt, "us-central1-a"},
+      {absl::nullopt, "us-central1", "us-central1"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kCloudPlatform, "gcp_app_engine"},
+        {sc::kFaasName, "test-module"},
+        {sc::kFaasVersion, "test-version"},
+        {sc::kFaasInstance, "test-instance"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "gae_instance");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", test.expected_location),
+                                     Pair("module_id", "test-module"),
+                                     Pair("version_id", "test-version"),
+                                     Pair("instance_id", "test-instance")));
+  }
+}
+
+TEST(MonitoredResource, AwsEc2Instance) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_region;
+  };
+  auto tests = std::vector<TestCase>{
+      {"test-zone", "test-region", "test-zone"},
+      {"test-zone", absl::nullopt, "test-zone"},
+      {absl::nullopt, "test-region", "test-region"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kCloudPlatform, "aws_ec2"},
+        {sc::kHostId, "test-instance"},
+        {sc::kCloudAccountId, "test-account"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "aws_ec2_instance");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("instance_id", "test-instance"),
+                                     Pair("region", test.expected_region),
+                                     Pair("aws_account", "test-account")));
+  }
+}
+
+TEST(MonitoredResource, GenericTaskFaas) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_location;
+  };
+  auto tests = std::vector<TestCase>{
+      {"us-central1-a", "us-central1", "us-central1-a"},
+      {"us-central1-a", absl::nullopt, "us-central1-a"},
+      {absl::nullopt, "us-central1", "us-central1"},
+      {absl::nullopt, absl::nullopt, "global"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kFaasName, "faas-name"},
+        {sc::kFaasInstance, "faas-instance"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "generic_task");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", test.expected_location)));
+  }
+}
+
+TEST(MonitoredResource, GenericTaskService) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_location;
+  };
+  auto tests = std::vector<TestCase>{
+      {"us-central1-a", "us-central1", "us-central1-a"},
+      {"us-central1-a", absl::nullopt, "us-central1-a"},
+      {absl::nullopt, "us-central1", "us-central1"},
+      {absl::nullopt, absl::nullopt, "global"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kServiceNamespace, "test-namespace"},
+        {sc::kServiceName, "test-name"},
+        {sc::kServiceInstanceId, "test-instance"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "generic_task");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", test.expected_location),
+                                     Pair("namespace", "test-namespace"),
+                                     Pair("job", "test-name"),
+                                     Pair("task_id", "test-instance")));
+  }
+}
+
+TEST(MonitoredResource, GenericNode) {
+  struct TestCase {
+    absl::optional<std::string> zone;
+    absl::optional<std::string> region;
+    std::string expected_location;
+  };
+  auto tests = std::vector<TestCase>{
+      {"us-central1-a", "us-central1", "us-central1-a"},
+      {"us-central1-a", absl::nullopt, "us-central1-a"},
+      {absl::nullopt, "us-central1", "us-central1"},
+      {absl::nullopt, absl::nullopt, "global"},
+  };
+  for (auto const& test : tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kServiceNamespace, "test-namespace"},
+        {sc::kHostId, "test-instance"},
+    };
+    if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
+    if (test.region) attributes[sc::kCloudRegion] = *test.region;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "generic_node");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", test.expected_location),
+                                     Pair("namespace", "test-namespace"),
+                                     Pair("node_id", "test-instance")));
+  }
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/opentelemetry/internal/monitored_resource_test.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource_test.cc
@@ -91,7 +91,6 @@ TEST(MonitoredResource, K8sPod) {
         {sc::kK8sClusterName, "test-cluster"},
         {sc::kK8sNamespaceName, "test-namespace"},
         {sc::kK8sPodName, "test-pod"},
-        //{sc::kK8sContainerName, "test-container"},
     };
     if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
     if (test.region) attributes[sc::kCloudRegion] = *test.region;
@@ -122,8 +121,6 @@ TEST(MonitoredResource, K8sNode) {
         {sc::kCloudPlatform, "gcp_kubernetes_engine"},
         {sc::kK8sClusterName, "test-cluster"},
         {sc::kK8sNodeName, "test-node"},
-        //{sc::kK8sPodName, "test-pod"},
-        //{sc::kK8sContainerName, "test-container"},
     };
     if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
     if (test.region) attributes[sc::kCloudRegion] = *test.region;
@@ -152,9 +149,6 @@ TEST(MonitoredResource, K8sCluster) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
         {sc::kCloudPlatform, "gcp_kubernetes_engine"},
         {sc::kK8sClusterName, "test-cluster"},
-        //{sc::kK8sNodeName, "test-node"},
-        //{sc::kK8sPodName, "test-pod"},
-        //{sc::kK8sContainerName, "test-container"},
     };
     if (test.zone) attributes[sc::kCloudAvailabilityZone] = *test.zone;
     if (test.region) attributes[sc::kCloudRegion] = *test.region;

--- a/google/cloud/opentelemetry/opentelemetry_unit_tests.bzl
+++ b/google/cloud/opentelemetry/opentelemetry_unit_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 opentelemetry_unit_tests = [
+    "internal/monitored_resource_test.cc",
     "internal/recordable_test.cc",
     "internal/resource_detector_impl_test.cc",
     "trace_exporter_test.cc",


### PR DESCRIPTION
Part of the work for #11775 

Add support for mapping OTel attributes to GCP [Monitored Resources](https://cloud.google.com/monitoring/api/resources).

This is a whole lot of if statements, copied from: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/02fd6f23e8557907cda61ef01c94198dec4ccd71/internal/resourcemapping/resourcemapping.go#L165

(If you are wondering how we keep the logic up to date, there is an end-to-end test suite written by google's OpenTelemetry team. It does things like test the resource detector on GCE/GKE/Cloud Run/etc. It verifies mapping logic like in this PR. It seems like a lot of set up work. I will consider whether it should be required for C++)

---

I considered code like:

```cc
bool PlatformIsGce(std::string const& platform) {
  return platform == "gcp_compute_engine";
}
//etc.

MonitoredResourceProvider MakeProvider(
    opentelemetry::sdk::resource::ResourceAttributes const& attributes) {
  std::string platform;
  auto p = attributes.find(sc::kCloudPlatform);
  if (p != attributes.end()) platform = AsString(p->second);

  if (PlatformIsGce(platform)) return GceInstance();
  if (PlatformIsGke(platform)) {
    if (GkeIsContainer(attributes)) return GkeContainer();
    if (GkeIsPod(attributes)) return GkePod();
    if (GkeIsNode(attributes)) return GkeNode();
    return GkeCluster();
  }
  if (PlatformIsAwsEc2(platform)) return AwsEc2Instance();
  if (IsGenericTask(attributes)) return GenericTask();
  return GenericNode();
```

but I preferred to see the conditionals inline.

---

Also there are some:
```cc
if (foo) {
  WouldHaveFitOnOneLine();
}
```

I thought they looked worse on one line. :shrug:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11952)
<!-- Reviewable:end -->
