### PR TITLE
impl(otel): monitored resources in trace exporter

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -150,6 +150,7 @@ class Recordable final : public opentelemetry::sdk::trace::Recordable {
                    opentelemetry::common::KeyValueIterable const& attributes);
   void SetStatusImpl(opentelemetry::trace::StatusCode code,
                      opentelemetry::nostd::string_view description);
+  void SetResourceImpl(opentelemetry::sdk::resource::Resource const& resource);
 
   Project project_;
   google::devtools::cloudtrace::v2::Span span_;


### PR DESCRIPTION
Part of the work for #11775

If we recognize the `opentelemetry::sdk::resource::Resource` as a GCP Monitored Resource, add attributes representing the monitored resource.

Copying attributes is [involved](https://github.com/dbolduc/google-cloud-cpp/commit/220d6178ebd21c8221e3ecbd255c7f19ee12a866) enough for its own PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11963)
<!-- Reviewable:end -->
