### PR TITLE
ci: increase timeout for macOS builds

### DIFF
--- a/ci/kokoro/macos/bazel-presubmit.cfg
+++ b/ci/kokoro/macos/bazel-presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout_mins: 480

--- a/ci/kokoro/macos/bazel.cfg
+++ b/ci/kokoro/macos/bazel.cfg
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout_mins: 480

--- a/ci/kokoro/macos/quickstart-bazel-presubmit.cfg
+++ b/ci/kokoro/macos/quickstart-bazel-presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout_mins: 480

--- a/ci/kokoro/macos/quickstart-bazel.cfg
+++ b/ci/kokoro/macos/quickstart-bazel.cfg
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout_mins: 480


### PR DESCRIPTION
We know that a build with a cold cache will take more than 4h (240m). We also know we have a few of these builds every month. Increase the timeout to 8h. This should be enough as we never need a second build for these sporadic timeouts.

This is not without tradeoffs. We also get broken builds from time to time that simply stall without any progress. To minimize the impact of these, this PR only increases the timeout for the builds that have timed out while still making progress.

Part of the work for #10272

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11965)
<!-- Reviewable:end -->
