### PR TITLE
impl(otel): copy resource attributes

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -68,17 +68,8 @@ class KVIterable : public opentelemetry::common::KeyValueIterable {
 
 template <typename T>
 opentelemetry::nostd::span<T> MakeCompositeAttribute() {
-  T v[]{T{}, T{}};
-  return opentelemetry::nostd::span<T>(v);
-}
-
-template <>
-opentelemetry::nostd::span<opentelemetry::nostd::string_view>
-MakeCompositeAttribute() {
-  std::string s1{"s1"};
-  std::string s2{"s2"};
-  opentelemetry::nostd::string_view v[]{s1, s2};
-  return opentelemetry::nostd::span<opentelemetry::nostd::string_view>(v);
+  static auto* const kData = new T{};
+  return opentelemetry::nostd::span<T>(kData, 1);
 }
 
 Matcher<v2::AttributeValue const&> AttributeValue(bool value) {
@@ -570,10 +561,10 @@ TEST(Recordable, SetAttributeRespectsLimit) {
 TEST(Recordable, SetResourceCopiesResourceAttributes) {
   auto resource = opentelemetry::sdk::resource::Resource::Create({
       {"bool", true},
-      {"int32", std::int32_t(5)},
-      {"uint32", std::uint32_t(5)},
-      {"int64", std::int64_t(5)},
-      {"uint64", std::uint64_t(5)},
+      {"int32", std::int32_t{5}},
+      {"uint32", std::uint32_t{5}},
+      {"int64", std::int64_t{5}},
+      {"uint64", std::uint64_t{5}},
       {"double", 5.0},
       {"string", "5"},
       // Composite attributes are dropped, but let's include them to make sure


### PR DESCRIPTION
Part of the work for #11775 

Add resource attributes as span attributes. We do this because the `google::devtools::trace::v2::Span` proto does not have a concept of resources.

The work is annoying because the types are different:
- `Span`'s [AttributeValue](https://github.com/open-telemetry/opentelemetry-cpp/blob/cfcda5728e75e51215d118eccd639e21cf4fd74d/api/include/opentelemetry/common/attribute_value.h#L37-L59)
- `Resource`'s [OwnedAttributeValue](https://github.com/open-telemetry/opentelemetry-cpp/blob/cfcda5728e75e51215d118eccd639e21cf4fd74d/sdk/include/opentelemetry/sdk/common/attribute_utils.h#L30-L44)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11966)
<!-- Reviewable:end -->
