### PR TITLE
cleanup: use `-S` option to configure CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ From the top-level directory of `google-cloud-cpp` run these commands:
 ```shell
 git -C $HOME clone https://github.com/microsoft/vcpkg.git
 env VCPKG_ROOT=$HOME/vcpkg $HOME/vcpkg/bootstrap-vcpkg.sh
-cmake -H. -Bcmake-out/ -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+cmake -S . -B cmake-out/ -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
 cmake --build cmake-out -- -j $(nproc)
 ```
 

--- a/ci/cloudbuild/builds/clang-7.0.sh
+++ b/ci/cloudbuild/builds/clang-7.0.sh
@@ -26,7 +26,7 @@ source module ci/lib/io.sh
 export CC=clang
 export CXX=clang++
 
-io::run cmake -GNinja -H. -Bcmake-out \
+io::run cmake -GNinja -S . -B cmake-out \
   -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)" \
   -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON \

--- a/ci/cloudbuild/builds/demo-install.sh
+++ b/ci/cloudbuild/builds/demo-install.sh
@@ -40,7 +40,7 @@ cmake_config_testing_details=(
 ## [BEGIN packaging.md]
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   "${cmake_config_testing_details[@]}" \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \

--- a/ci/cloudbuild/builds/gcc-7.3.sh
+++ b/ci/cloudbuild/builds/gcc-7.3.sh
@@ -25,7 +25,7 @@ source module ci/lib/io.sh
 export CC=gcc
 export CXX=g++
 
-io::run cmake -GNinja -H. -Bcmake-out \
+io::run cmake -GNinja -S . -B cmake-out \
   -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)" \
   -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON \

--- a/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
@@ -176,7 +176,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.9.
         -DWITH_ABSEIL=ON \
         -DBUILD_TESTING=OFF \
         -DOPENTELEMETRY_INSTALL=ON \
-        -H. -Bcmake-out -GNinja && \
+        -GNinja -S . -B cmake-out && \
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 

--- a/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
@@ -121,7 +121,7 @@ RUN curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig

--- a/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
@@ -132,7 +132,7 @@ RUN curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
@@ -119,7 +119,7 @@ RUN curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -122,7 +122,7 @@ RUN curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
@@ -50,7 +50,7 @@ RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230125.3.tar.gz | 
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \
       -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out && \
+      -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -70,7 +70,7 @@ RUN curl -fsSL https://github.com/protocolbuffers/protobuf/archive/v23.3.tar.gz 
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Dprotobuf_ABSL_PROVIDER=package \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -87,7 +87,7 @@ RUN curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -113,7 +113,7 @@ RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.56.0.tar.gz | \
         -DgRPC_RE2_PROVIDER=package \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -134,7 +134,7 @@ RUN curl -fsSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
         -DCRC32C_BUILD_TESTS=OFF \
         -DCRC32C_BUILD_BENCHMARKS=OFF \
         -DCRC32C_USE_GLOG=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -156,7 +156,7 @@ RUN curl -fsSL https://github.com/nlohmann/json/archive/v3.11.2.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -DJSON_BuildTests=OFF \
-      -H. -Bcmake-out && \
+      -S . -B cmake-out && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
@@ -90,7 +90,7 @@ RUN curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig

--- a/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
@@ -199,7 +199,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.9.
         -DWITH_ABSEIL=ON \
         -DBUILD_TESTING=OFF \
         -DOPENTELEMETRY_INSTALL=ON \
-        -H. -Bcmake-out -GNinja && \
+        -S . -B cmake-out -GNinja && \
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 

--- a/ci/cloudbuild/dockerfiles/fedora-37-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cxx14.Dockerfile
@@ -68,7 +68,7 @@ RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230125.3.tar.gz | 
       -DCMAKE_BUILD_TYPE="Release" \
       -DABSL_BUILD_TESTING=OFF \
       -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out/abseil && \
+      -S . -B cmake-out/abseil && \
     cmake --build cmake-out/abseil --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
@@ -82,7 +82,7 @@ RUN curl -fsSL https://github.com/google/googletest/archive/v1.13.0.tar.gz | \
       -DCMAKE_CXX_STANDARD=14 \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out/googletest && \
+      -S . -B cmake-out/googletest && \
     cmake --build cmake-out/googletest --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
@@ -96,7 +96,7 @@ RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.0.tar.gz | \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
         -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out/benchmark && \
+        -S . -B cmake-out/benchmark && \
     cmake --build cmake-out/benchmark --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
@@ -111,7 +111,7 @@ RUN curl -fsSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
       -DCRC32C_BUILD_TESTS=OFF \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
-      -H. -Bcmake-out/crc32c && \
+      -S . -B cmake-out/crc32c && \
     cmake --build cmake-out/crc32c --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
@@ -125,7 +125,7 @@ RUN curl -fsSL https://github.com/nlohmann/json/archive/v3.11.2.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -DJSON_BuildTests=OFF \
-      -H. -Bcmake-out/nlohmann/json && \
+      -S . -B cmake-out/nlohmann/json && \
     cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
@@ -139,7 +139,7 @@ RUN curl -fsSL https://github.com/protocolbuffers/protobuf/archive/v23.3.tar.gz 
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Dprotobuf_ABSL_PROVIDER=package \
-        -H. -Bcmake-out -GNinja && \
+        -S . -B cmake-out -GNinja && \
     cmake --build cmake-out --target install && \
     ldconfig && \
     cd /var/tmp && rm -fr build
@@ -173,7 +173,7 @@ RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.56.0.tar.gz | \
         -DgRPC_RE2_PROVIDER=package \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
-        -H. -Bcmake-out -GNinja && \
+        -S . -B cmake-out -GNinja && \
     cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
@@ -190,7 +190,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.9.
         -DWITH_ABSEIL=ON \
         -DBUILD_TESTING=OFF \
         -DOPENTELEMETRY_INSTALL=ON \
-        -H. -Bcmake-out -GNinja && \
+        -S . -B cmake-out -GNinja && \
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 

--- a/ci/cloudbuild/dockerfiles/fedora-37-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cxx20.Dockerfile
@@ -191,7 +191,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.9.
         -DWITH_ABSEIL=ON \
         -DBUILD_TESTING=OFF \
         -DOPENTELEMETRY_INSTALL=ON \
-        -H. -Bcmake-out -GNinja && \
+        -S . -B cmake-out -GNinja && \
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -51,7 +51,7 @@ CMake support files, then compiling and installing the libraries
 requires two commands:
 
 ```bash
-cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+cmake -S . -B cmake-out -DBUILD_TESTING=OFF -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out --target install
 ```
 
@@ -205,7 +205,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -303,7 +303,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -479,7 +479,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -630,7 +630,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -718,7 +718,7 @@ curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -799,7 +799,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -847,7 +847,7 @@ curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230125.3.tar.gz | \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \
       -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out && \
+      -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -867,7 +867,7 @@ curl -fsSL https://github.com/protocolbuffers/protobuf/archive/v23.3.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Dprotobuf_ABSL_PROVIDER=package \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -884,7 +884,7 @@ curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -910,7 +910,7 @@ curl -fsSL https://github.com/grpc/grpc/archive/v1.56.0.tar.gz | \
         -DgRPC_RE2_PROVIDER=package \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -931,7 +931,7 @@ curl -fsSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
         -DCRC32C_BUILD_TESTS=OFF \
         -DCRC32C_BUILD_BENCHMARKS=OFF \
         -DCRC32C_USE_GLOG=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -953,7 +953,7 @@ curl -fsSL https://github.com/nlohmann/json/archive/v3.11.2.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -DJSON_BuildTests=OFF \
-      -H. -Bcmake-out && \
+      -S . -B cmake-out && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
@@ -965,7 +965,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -1084,7 +1084,7 @@ curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1121,7 +1121,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -1251,7 +1251,7 @@ curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1288,7 +1288,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -1405,7 +1405,7 @@ curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1486,7 +1486,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -1606,7 +1606,7 @@ curl -fsSL https://github.com/google/re2/archive/2023-06-02.tar.gz | \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1690,7 +1690,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
@@ -1895,7 +1895,7 @@ We can now compile and install `google-cloud-cpp`:
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -H. -Bcmake-out \
+cmake -S . -B cmake-out \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -1053,7 +1053,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $$HOME/google-cloud-cpp/google/cloud/$library$/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/accessapproval/quickstart/README.md
+++ b/google/cloud/accessapproval/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/accessapproval/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/accesscontextmanager/quickstart/README.md
+++ b/google/cloud/accesscontextmanager/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/accesscontextmanager/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/advisorynotifications/quickstart/README.md
+++ b/google/cloud/advisorynotifications/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/advisorynotifications/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/aiplatform/quickstart/README.md
+++ b/google/cloud/aiplatform/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/aiplatform/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/alloydb/quickstart/README.md
+++ b/google/cloud/alloydb/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/alloydb/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/apigateway/quickstart/README.md
+++ b/google/cloud/apigateway/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/apigateway/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/apigeeconnect/quickstart/README.md
+++ b/google/cloud/apigeeconnect/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/apigeeconnect/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/apikeys/quickstart/README.md
+++ b/google/cloud/apikeys/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/apikeys/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/appengine/quickstart/README.md
+++ b/google/cloud/appengine/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/appengine/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/artifactregistry/quickstart/README.md
+++ b/google/cloud/artifactregistry/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/artifactregistry/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/asset/quickstart/README.md
+++ b/google/cloud/asset/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/asset/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/assuredworkloads/quickstart/README.md
+++ b/google/cloud/assuredworkloads/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/assuredworkloads/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/automl/quickstart/README.md
+++ b/google/cloud/automl/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/automl/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/baremetalsolution/quickstart/README.md
+++ b/google/cloud/baremetalsolution/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/baremetalsolution/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/batch/quickstart/README.md
+++ b/google/cloud/batch/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/batch/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/beyondcorp/quickstart/README.md
+++ b/google/cloud/beyondcorp/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/beyondcorp/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/bigquery/quickstart/README.md
+++ b/google/cloud/bigquery/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/bigquery/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/bigtable/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/billing/quickstart/README.md
+++ b/google/cloud/billing/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/billing/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/binaryauthorization/quickstart/README.md
+++ b/google/cloud/binaryauthorization/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/binaryauthorization/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/certificatemanager/quickstart/README.md
+++ b/google/cloud/certificatemanager/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/certificatemanager/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/channel/quickstart/README.md
+++ b/google/cloud/channel/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/channel/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/cloudbuild/quickstart/README.md
+++ b/google/cloud/cloudbuild/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/cloudbuild/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/composer/quickstart/README.md
+++ b/google/cloud/composer/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/composer/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/compute/quickstart/README.md
+++ b/google/cloud/compute/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/compute/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/confidentialcomputing/quickstart/README.md
+++ b/google/cloud/confidentialcomputing/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/confidentialcomputing/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/connectors/quickstart/README.md
+++ b/google/cloud/connectors/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/connectors/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/contactcenterinsights/quickstart/README.md
+++ b/google/cloud/contactcenterinsights/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/contactcenterinsights/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/container/quickstart/README.md
+++ b/google/cloud/container/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/container/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/containeranalysis/quickstart/README.md
+++ b/google/cloud/containeranalysis/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/containeranalysis/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/contentwarehouse/quickstart/README.md
+++ b/google/cloud/contentwarehouse/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/contentwarehouse/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/datacatalog/quickstart/README.md
+++ b/google/cloud/datacatalog/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/datacatalog/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/datafusion/quickstart/README.md
+++ b/google/cloud/datafusion/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/datafusion/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/datamigration/quickstart/README.md
+++ b/google/cloud/datamigration/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/datamigration/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/dataplex/quickstart/README.md
+++ b/google/cloud/dataplex/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/dataplex/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/dataproc/quickstart/README.md
+++ b/google/cloud/dataproc/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/dataproc/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/datastream/quickstart/README.md
+++ b/google/cloud/datastream/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/datastream/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/deploy/quickstart/README.md
+++ b/google/cloud/deploy/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/deploy/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/dialogflow_cx/quickstart/README.md
+++ b/google/cloud/dialogflow_cx/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/dialogflow_cx/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/dialogflow_es/quickstart/README.md
+++ b/google/cloud/dialogflow_es/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/dialogflow_es/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/dlp/quickstart/README.md
+++ b/google/cloud/dlp/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/dlp/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/documentai/quickstart/README.md
+++ b/google/cloud/documentai/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/documentai/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/domains/quickstart/README.md
+++ b/google/cloud/domains/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/domains/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/edgecontainer/quickstart/README.md
+++ b/google/cloud/edgecontainer/quickstart/README.md
@@ -107,7 +107,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/edgecontainer/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/essentialcontacts/quickstart/README.md
+++ b/google/cloud/essentialcontacts/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/essentialcontacts/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/eventarc/quickstart/README.md
+++ b/google/cloud/eventarc/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/eventarc/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/filestore/quickstart/README.md
+++ b/google/cloud/filestore/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/filestore/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/functions/quickstart/README.md
+++ b/google/cloud/functions/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/functions/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/gameservices/quickstart/README.md
+++ b/google/cloud/gameservices/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/gameservices/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/gkebackup/quickstart/README.md
+++ b/google/cloud/gkebackup/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/gkebackup/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/gkehub/quickstart/README.md
+++ b/google/cloud/gkehub/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/gkehub/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/gkemulticloud/quickstart/README.md
+++ b/google/cloud/gkemulticloud/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/gkemulticloud/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/iam/quickstart/README.md
+++ b/google/cloud/iam/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/iam/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/iap/quickstart/README.md
+++ b/google/cloud/iap/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/iap/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/ids/quickstart/README.md
+++ b/google/cloud/ids/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/ids/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/iot/quickstart/README.md
+++ b/google/cloud/iot/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/iot/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/kms/quickstart/README.md
+++ b/google/cloud/kms/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/kms/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/language/quickstart/README.md
+++ b/google/cloud/language/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/language/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/logging/quickstart/README.md
+++ b/google/cloud/logging/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/logging/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/managedidentities/quickstart/README.md
+++ b/google/cloud/managedidentities/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/managedidentities/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/memcache/quickstart/README.md
+++ b/google/cloud/memcache/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/memcache/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/metastore/quickstart/README.md
+++ b/google/cloud/metastore/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/metastore/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/monitoring/quickstart/README.md
+++ b/google/cloud/monitoring/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/monitoring/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/networkconnectivity/quickstart/README.md
+++ b/google/cloud/networkconnectivity/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/networkconnectivity/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/networkmanagement/quickstart/README.md
+++ b/google/cloud/networkmanagement/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/networkmanagement/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/networksecurity/quickstart/README.md
+++ b/google/cloud/networksecurity/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/networksecurity/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/networkservices/quickstart/README.md
+++ b/google/cloud/networkservices/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/networkservices/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/notebooks/quickstart/README.md
+++ b/google/cloud/notebooks/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/notebooks/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/opentelemetry/quickstart/README.md
+++ b/google/cloud/opentelemetry/quickstart/README.md
@@ -134,7 +134,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.9.
         -DWITH_ABSEIL=ON \
         -DBUILD_TESTING=OFF \
         -DOPENTELEMETRY_INSTALL=ON \
-        -H. -Bcmake-out && \
+        -S . -B cmake-out && \
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 ```

--- a/google/cloud/optimization/quickstart/README.md
+++ b/google/cloud/optimization/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/optimization/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/orgpolicy/quickstart/README.md
+++ b/google/cloud/orgpolicy/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/orgpolicy/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/osconfig/quickstart/README.md
+++ b/google/cloud/osconfig/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/osconfig/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/oslogin/quickstart/README.md
+++ b/google/cloud/oslogin/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/oslogin/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/policytroubleshooter/quickstart/README.md
+++ b/google/cloud/policytroubleshooter/quickstart/README.md
@@ -101,7 +101,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/policytroubleshooter/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/privateca/quickstart/README.md
+++ b/google/cloud/privateca/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/privateca/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/profiler/quickstart/README.md
+++ b/google/cloud/profiler/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/profiler/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/pubsub/quickstart/README.md
+++ b/google/cloud/pubsub/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/pubsub/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/pubsublite/quickstart/README.md
+++ b/google/cloud/pubsublite/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/pubsublite/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/recaptchaenterprise/quickstart/README.md
+++ b/google/cloud/recaptchaenterprise/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/recaptchaenterprise/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/recommender/quickstart/README.md
+++ b/google/cloud/recommender/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/recommender/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/redis/quickstart/README.md
+++ b/google/cloud/redis/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/redis/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/resourcemanager/quickstart/README.md
+++ b/google/cloud/resourcemanager/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/resourcemanager/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/resourcesettings/quickstart/README.md
+++ b/google/cloud/resourcesettings/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/resourcesettings/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/retail/quickstart/README.md
+++ b/google/cloud/retail/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/retail/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/run/quickstart/README.md
+++ b/google/cloud/run/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/run/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/scheduler/quickstart/README.md
+++ b/google/cloud/scheduler/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/scheduler/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/secretmanager/quickstart/README.md
+++ b/google/cloud/secretmanager/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/secretmanager/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/securitycenter/quickstart/README.md
+++ b/google/cloud/securitycenter/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/securitycenter/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/servicecontrol/quickstart/README.md
+++ b/google/cloud/servicecontrol/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/servicecontrol/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/servicedirectory/quickstart/README.md
+++ b/google/cloud/servicedirectory/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/servicedirectory/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/servicemanagement/quickstart/README.md
+++ b/google/cloud/servicemanagement/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/servicemanagement/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/serviceusage/quickstart/README.md
+++ b/google/cloud/serviceusage/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/serviceusage/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/shell/quickstart/README.md
+++ b/google/cloud/shell/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/shell/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/spanner/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/speech/quickstart/README.md
+++ b/google/cloud/speech/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/speech/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/sql/quickstart/README.md
+++ b/google/cloud/sql/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/sql/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/storage/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 
@@ -142,7 +142,7 @@ to your CMake configuration step. Using the previous example:
 
 ```sh
 cd $HOME/google-cloud-cpp/google/cloud/storage/quickstart
-cmake -H. -B.build -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON \
+cmake -S . -B .build -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON \
     -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
 cmake --build .build --target quickstart_grpc
 ```

--- a/google/cloud/storageinsights/quickstart/README.md
+++ b/google/cloud/storageinsights/quickstart/README.md
@@ -105,7 +105,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/storageinsights/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/storagetransfer/quickstart/README.md
+++ b/google/cloud/storagetransfer/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/storagetransfer/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/support/quickstart/README.md
+++ b/google/cloud/support/quickstart/README.md
@@ -104,7 +104,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/support/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/talent/quickstart/README.md
+++ b/google/cloud/talent/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/talent/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/tasks/quickstart/README.md
+++ b/google/cloud/tasks/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/tasks/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/texttospeech/quickstart/README.md
+++ b/google/cloud/texttospeech/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/texttospeech/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/timeseriesinsights/quickstart/README.md
+++ b/google/cloud/timeseriesinsights/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/timeseriesinsights/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/tpu/quickstart/README.md
+++ b/google/cloud/tpu/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/tpu/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/trace/quickstart/README.md
+++ b/google/cloud/trace/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/trace/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/translate/quickstart/README.md
+++ b/google/cloud/translate/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/translate/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/video/quickstart/README.md
+++ b/google/cloud/video/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/video/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/videointelligence/quickstart/README.md
+++ b/google/cloud/videointelligence/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/videointelligence/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/vision/quickstart/README.md
+++ b/google/cloud/vision/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/vision/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/vmmigration/quickstart/README.md
+++ b/google/cloud/vmmigration/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/vmmigration/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/vmwareengine/quickstart/README.md
+++ b/google/cloud/vmwareengine/quickstart/README.md
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/vmwareengine/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/vpcaccess/quickstart/README.md
+++ b/google/cloud/vpcaccess/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/vpcaccess/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/webrisk/quickstart/README.md
+++ b/google/cloud/webrisk/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/webrisk/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/websecurityscanner/quickstart/README.md
+++ b/google/cloud/websecurityscanner/quickstart/README.md
@@ -100,7 +100,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/websecurityscanner/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/workflows/quickstart/README.md
+++ b/google/cloud/workflows/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/workflows/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 

--- a/google/cloud/workstations/quickstart/README.md
+++ b/google/cloud/workstations/quickstart/README.md
@@ -103,7 +103,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/google-cloud-cpp/google/cloud/workstations/quickstart
-   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
    cmake --build .build
    ```
 


### PR DESCRIPTION
Since we now require CMake >= 3.13 we can use the `-S` option to configure the source directory.  FWIW, `-H.` worked, but was undocumented and basically a bit of a hack.

Part of the work for #11781

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11969)
<!-- Reviewable:end -->
