### PR TITLE
impl(bigquery): Idempotency policy for cancel job

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
@@ -43,6 +43,10 @@ Idempotency BigQueryJobIdempotencyPolicy::InsertJob(InsertJobRequest const&) {
   return Idempotency::kNonIdempotent;
 }
 
+Idempotency BigQueryJobIdempotencyPolicy::CancelJob(CancelJobRequest const&) {
+  return Idempotency::kNonIdempotent;
+}
+
 std::unique_ptr<BigQueryJobIdempotencyPolicy>
 MakeDefaultBigQueryJobIdempotencyPolicy() {
   return std::make_unique<BigQueryJobIdempotencyPolicy>();

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
@@ -39,6 +39,8 @@ class BigQueryJobIdempotencyPolicy {
   virtual google::cloud::Idempotency ListJobs(ListJobsRequest const& request);
 
   virtual google::cloud::Idempotency InsertJob(InsertJobRequest const& request);
+
+  virtual google::cloud::Idempotency CancelJob(CancelJobRequest const& request);
 };
 
 std::unique_ptr<BigQueryJobIdempotencyPolicy>

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy_test.cc
@@ -46,6 +46,14 @@ TEST(JobIdempotencyPolicytTest, InsertJob) {
   EXPECT_EQ(actual->InsertJob(request), expected);
 }
 
+TEST(JobIdempotencyPolicytTest, CancelJob) {
+  auto actual = MakeDefaultBigQueryJobIdempotencyPolicy();
+  auto expected = Idempotency::kNonIdempotent;
+
+  CancelJobRequest request;
+  EXPECT_EQ(actual->CancelJob(request), expected);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud


### PR DESCRIPTION
This PR defines the Idempotency policy for the CancelJob api

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11975)
<!-- Reviewable:end -->
