### PR TITLE
impl(bigquery): CancelJob stub and decorator changes

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
@@ -71,6 +71,19 @@ StatusOr<InsertJobResponse> BigQueryJobLogging::InsertJob(
       tracing_options_);
 }
 
+StatusOr<CancelJobResponse> BigQueryJobLogging::CancelJob(
+    rest_internal::RestContext& rest_context, CancelJobRequest const& request) {
+  return LogWrapper(
+      [this](rest_internal::RestContext& rest_context,
+             CancelJobRequest const& request) {
+        return child_->CancelJob(rest_context, request);
+      },
+      rest_context, request, __func__,
+      "google.cloud.bigquery.v2.minimal.internal.CancelJobRequest",
+      "google.cloud.bigquery.v2.minimal.internal.CancelJobResponse",
+      tracing_options_);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.h
@@ -42,6 +42,9 @@ class BigQueryJobLogging : public BigQueryJobRestStub {
   StatusOr<InsertJobResponse> InsertJob(
       rest_internal::RestContext& rest_context,
       InsertJobRequest const& request) override;
+  StatusOr<CancelJobResponse> CancelJob(
+      rest_internal::RestContext& rest_context,
+      CancelJobRequest const& request) override;
 
  private:
   std::shared_ptr<BigQueryJobRestStub> child_;

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
@@ -215,6 +215,65 @@ TEST(JobLoggingClientTest, InsertJob) {
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
 }
 
+TEST(JobLoggingClientTest, CancelJob) {
+  ScopedLog log;
+
+  auto mock_stub = std::make_shared<MockBigQueryJobRestStub>();
+  auto constexpr kExpectedPayload =
+      R"({"kind":"cancel-job",
+          "job":{"kind": "jkind",
+          "etag": "jtag",
+          "id": "j123",
+          "self_link": "jselfLink",
+          "user_email": "juserEmail",
+          "status": {"state": "DONE"},
+          "reference": {"project_id": "p123", "job_id": "j123"},
+          "configuration": {
+            "job_type": "QUERY",
+            "query_config": {"query": "select 1;"}
+          }}})";
+
+  EXPECT_CALL(*mock_stub, CancelJob)
+      .WillOnce(
+          [&](rest_internal::RestContext&,
+              CancelJobRequest const& request) -> StatusOr<CancelJobResponse> {
+            EXPECT_THAT(request.project_id(), Not(IsEmpty()));
+            EXPECT_THAT(request.job_id(), Not(IsEmpty()));
+            BigQueryHttpResponse http_response;
+            http_response.payload = kExpectedPayload;
+            return CancelJobResponse::BuildFromHttpResponse(
+                std::move(http_response));
+          });
+
+  auto client = CreateMockJobLogging(std::move(mock_stub));
+
+  CancelJobRequest request("p123", "j123");
+
+  rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
+
+  client->CancelJob(context, request);
+
+  auto actual_lines = log.ExtractLines();
+
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(" << ")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(CancelJobRequest)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(job_id: "j123")")).Times(2));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(project_id: "p123")")).Times(2));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(CancelJobResponse)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(state: "DONE")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(id: "j123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "jkind")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(etag: "jtag")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
@@ -51,6 +51,12 @@ StatusOr<InsertJobResponse> BigQueryJobMetadata::InsertJob(
   return child_->InsertJob(context, request);
 }
 
+StatusOr<CancelJobResponse> BigQueryJobMetadata::CancelJob(
+    rest_internal::RestContext& context, CancelJobRequest const& request) {
+  SetMetadata(context);
+  return child_->CancelJob(context, request);
+}
+
 void BigQueryJobMetadata::SetMetadata(rest_internal::RestContext& rest_context,
                                       std::vector<std::string> const& params) {
   rest_context.AddHeader("x-goog-api-client", api_client_header_);

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
@@ -39,6 +39,9 @@ class BigQueryJobMetadata : public BigQueryJobRestStub {
   StatusOr<InsertJobResponse> InsertJob(
       rest_internal::RestContext& rest_context,
       InsertJobRequest const& request) override;
+  StatusOr<CancelJobResponse> CancelJob(
+      rest_internal::RestContext& rest_context,
+      CancelJobRequest const& request) override;
 
  private:
   void SetMetadata(rest_internal::RestContext& context,

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -71,6 +71,24 @@ StatusOr<InsertJobResponse> DefaultBigQueryJobRestStub::InsertJob(
                        {absl::MakeConstSpan(json_payload.dump())}));
 }
 
+StatusOr<CancelJobResponse> DefaultBigQueryJobRestStub::CancelJob(
+    rest_internal::RestContext& rest_context, CancelJobRequest const& request) {
+  // Prepare the RestRequest from CancelJobRequest.
+  auto rest_request =
+      PrepareRestRequest<CancelJobRequest>(rest_context, request);
+
+  rest_request->AddHeader("Content-Type", "application/json");
+
+  // For cancel jobs, request body is empty:
+  // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/cancel#request-body
+  absl::Span<char const> empty_span = absl::MakeConstSpan("");
+
+  // Call the rest stub and parse the RestResponse.
+  rest_internal::RestContext context;
+  return ParseFromRestResponse<CancelJobResponse>(
+      rest_stub_->Post(context, std::move(*rest_request), {empty_span}));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -42,6 +42,9 @@ class BigQueryJobRestStub {
   virtual StatusOr<InsertJobResponse> InsertJob(
       rest_internal::RestContext& rest_context,
       InsertJobRequest const& request) = 0;
+  virtual StatusOr<CancelJobResponse> CancelJob(
+      rest_internal::RestContext& rest_context,
+      CancelJobRequest const& request) = 0;
 };
 
 class DefaultBigQueryJobRestStub : public BigQueryJobRestStub {
@@ -58,6 +61,9 @@ class DefaultBigQueryJobRestStub : public BigQueryJobRestStub {
   StatusOr<InsertJobResponse> InsertJob(
       rest_internal::RestContext& rest_context,
       InsertJobRequest const& request) override;
+  StatusOr<CancelJobResponse> CancelJob(
+      rest_internal::RestContext& rest_context,
+      CancelJobRequest const& request) override;
 
  private:
   std::unique_ptr<rest_internal::RestClient> rest_stub_;

--- a/google/cloud/bigquery/v2/minimal/testing/mock_job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/testing/mock_job_rest_stub.h
@@ -40,6 +40,11 @@ class MockBigQueryJobRestStub
               (rest_internal::RestContext & rest_context,
                bigquery_v2_minimal_internal::InsertJobRequest const& request),
               (override));
+  MOCK_METHOD(StatusOr<bigquery_v2_minimal_internal::CancelJobResponse>,
+              CancelJob,
+              (rest_internal::RestContext & rest_context,
+               bigquery_v2_minimal_internal::CancelJobRequest const& request),
+              (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
This PR implements the rest stub, decorator and mock changes for CancelJob api

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11979)
<!-- Reviewable:end -->
