### PR TITLE
ci: cleanup CMake flags for quickstart builds

### DIFF
--- a/ci/cloudbuild/builds/lib/quickstart.sh
+++ b/ci/cloudbuild/builds/lib/quickstart.sh
@@ -56,12 +56,9 @@ function quickstart::build_one_quickstart() {
   io::log "[ CMake ]"
   local cmake_bin_dir="${PROJECT_ROOT}/cmake-out/quickstart/cmake-${bin_dir_suffix}"
   local configure_args=(
-    # We still need to support CMake == 3.10 which does not have the -S option.
-    "-H${src_dir}"
-    "-B${cmake_bin_dir}"
+    "-S" "${src_dir}"
+    "-B" "${cmake_bin_dir}"
     -DCMAKE_PREFIX_PATH="${prefix}"
-    -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON
-    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON
   )
   if command -v /usr/local/bin/sccache >/dev/null 2>&1; then
     configure_args+=(


### PR DESCRIPTION
I missed this build in the cleanup to take advantage of CMake >= 3.13. We were also passing `-DGOOGLE_CLOUD_CPP*` flags to the quickstart builds. These have no effect because we use
`google/cloud/*/quickstart/CMakeList.txt` as the top-level CMake file in these builds, and these flags are only defined in the ./CMakeList.txt file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11990)
<!-- Reviewable:end -->
