### PR TITLE
cleanup: only install bazelisk if needed

### DIFF
--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -49,7 +49,3 @@ RUN pip3 install black==22.3.0
 RUN pip3 install mdformat-gfm==0.3.5 \
                  mdformat-frontmatter==0.4.1 \
                  mdformat-footnote==0.1.1
-
-RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH}" && \
-    chmod +x /usr/bin/bazelisk && \
-    ln -s /usr/bin/bazelisk /usr/bin/bazel

--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -49,3 +49,7 @@ RUN pip3 install black==22.3.0
 RUN pip3 install mdformat-gfm==0.3.5 \
                  mdformat-frontmatter==0.4.1 \
                  mdformat-footnote==0.1.1
+
+RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH}" && \
+    chmod +x /usr/bin/bazelisk && \
+    ln -s /usr/bin/bazelisk /usr/bin/bazel

--- a/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
@@ -240,11 +240,6 @@ RUN /var/tmp/ci/install-cloud-sdk.sh
 ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
 
-# The check-api build uses bazelisk
-RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH}" && \
-    chmod +x /usr/bin/bazelisk && \
-    ln -s /usr/bin/bazelisk /usr/bin/bazel
-
 WORKDIR /var/tmp/sccache
 RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | \
     tar -zxf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-37-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cxx14.Dockerfile
@@ -212,7 +212,3 @@ RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccac
 
 # Update the ld.conf cache in case any libraries were installed in /usr/local/lib*
 RUN ldconfig /usr/local/lib*
-
-RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH}" && \
-    chmod +x /usr/bin/bazelisk && \
-    ln -s /usr/bin/bazelisk /usr/bin/bazel

--- a/ci/cloudbuild/dockerfiles/fedora-37-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cxx20.Dockerfile
@@ -213,7 +213,3 @@ RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccac
 
 # Update the ld.conf cache in case any libraries were installed in /usr/local/lib*
 RUN ldconfig /usr/local/lib*
-
-RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH}" && \
-    chmod +x /usr/bin/bazelisk && \
-    ln -s /usr/bin/bazelisk /usr/bin/bazel

--- a/ci/cloudbuild/triggers/integration-production-ci.yaml
+++ b/ci/cloudbuild/triggers/integration-production-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: integration-production-ci
 substitutions:
   _BUILD_NAME: integration-production
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/integration-production-pr.yaml
+++ b/ci/cloudbuild/triggers/integration-production-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: integration-production-pr
 substitutions:
   _BUILD_NAME: integration-production
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-37-bazel
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:


### PR DESCRIPTION
The Docker images used exclusively in CMake-based builds should have no need to install bazelisk, so don't install it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11991)
<!-- Reviewable:end -->
