### PR TITLE
impl(bigquery): Fixes CancelJob api url in request and tests

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -247,11 +247,11 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(
     return internal::InvalidArgumentError(
         "Invalid CancelJobRequest: Job Id is empty", GCP_ERROR_INFO());
   }
+
   // Builds CancelJob request path based on endpoint provided.
   std::string endpoint = GetBaseEndpoint(opts);
-
   std::string path = absl::StrCat(endpoint, "/projects/", r.project_id(),
-                                  "/jobs/", r.job_id());
+                                  "/jobs/", r.job_id(), "/cancel");
   request.SetPath(std::move(path));
 
   // Add query params.

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -981,7 +981,7 @@ TEST(CancelJobRequestTest, SuccessWithLocation) {
 
   rest_internal::RestRequest expected;
   expected.SetPath(
-      "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs/2");
+      "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs/2/cancel");
   expected.AddQueryParameter("location", "useast");
   EXPECT_EQ(expected, *actual);
 }
@@ -996,7 +996,7 @@ TEST(CancelJobRequestTest, SuccessWithoutLocation) {
 
   rest_internal::RestRequest expected;
   expected.SetPath(
-      "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs/2");
+      "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs/2/cancel");
   EXPECT_EQ(expected, *actual);
 }
 
@@ -1008,13 +1008,13 @@ TEST(CancelJobRequestTest, SuccessWithDifferentEndpoints) {
     std::string expected;
   } cases[] = {
       {"https://myendpoint.google.com",
-       "https://myendpoint.google.com/bigquery/v2/projects/1/jobs/2"},
+       "https://myendpoint.google.com/bigquery/v2/projects/1/jobs/2/cancel"},
       {"http://myendpoint.google.com",
-       "http://myendpoint.google.com/bigquery/v2/projects/1/jobs/2"},
+       "http://myendpoint.google.com/bigquery/v2/projects/1/jobs/2/cancel"},
       {"myendpoint.google.com",
-       "https://myendpoint.google.com/bigquery/v2/projects/1/jobs/2"},
+       "https://myendpoint.google.com/bigquery/v2/projects/1/jobs/2/cancel"},
       {"https://myendpoint.google.com/",
-       "https://myendpoint.google.com/bigquery/v2/projects/1/jobs/2"},
+       "https://myendpoint.google.com/bigquery/v2/projects/1/jobs/2/cancel"},
   };
 
   for (auto const& test : cases) {


### PR DESCRIPTION
Fixes the CancelJob request url as per 

https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/cancel#http-request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11993)
<!-- Reviewable:end -->
