### PR TITLE
cleanup(ci): make the "ctcache stats" banner consistent

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -57,7 +57,7 @@ if [[ "${TRIGGER_TYPE}" != "manual" ]]; then
 fi
 
 if [[ "${TRIGGER_TYPE}" != "manual" || "${VERBOSE_FLAG}" == "true" ]]; then
-  io::log_h2 "ctcache stats"
+  io::log "===> ctcache stats"
   printf "%s: %s\n" "total size" "$(du -sh "${CTCACHE_DIR}")"
   printf "%s: %s\n" " num files" "$(find "${CTCACHE_DIR}" | wc -l)"
   echo


### PR DESCRIPTION
Make the "ctcache stats" banner look like the "sccache stats" one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/11995)
<!-- Reviewable:end -->
