### PR TITLE
cleanup: `ValidateMetadataFixture` doc nits

### DIFF
--- a/google/cloud/testing_util/validate_metadata.h
+++ b/google/cloud/testing_util/validate_metadata.h
@@ -60,11 +60,11 @@ class ValidateMetadataFixture {
    * Verify that the metadata in the context is appropriate for a gRPC method.
    *
    * `ClientContext` should instruct gRPC to set a `x-goog-request-params` HTTP
-   * header with a value dictated by a `google.api.http` option in the gRPC
-   * service specification. This function checks if the header is set and
-   * whether it has a valid value.
+   * header with a value determined by the `google.api.routing` or
+   * `google.api.http` option in the gRPC service specification. This function
+   * checks if the header is set and whether it has a valid value.
    *
-   * @note A `grpc::ClientContext` can be used in only one gRPC. The caller
+   * @note A `grpc::ClientContext` can be used in only one RPC. The caller
    *   cannot reuse @p context for other RPCs or other calls to this function.
    *
    * @param context the context to validate
@@ -73,8 +73,6 @@ class ValidateMetadataFixture {
    *     header.
    * @param resource_prefix_header if specified, this is the expected value for
    *     the google-cloud-resource-prefix metadata header.
-   *
-   * @return an OK status if the `context` is properly set up
    */
   void IsContextMDValid(
       grpc::ClientContext& context, std::string const& method_name,


### PR DESCRIPTION
Documentation nits for an internal testing helper. I forgot to update the documentation when I refactored the class a year ago.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12012)
<!-- Reviewable:end -->
