### PR TITLE
impl(bigtable): reverse scan internals

### DIFF
--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -185,8 +185,9 @@ void AsyncRowReader::OnStreamFinished(Status status) {
     // We've returned some rows and need to make sure we don't
     // request them again.
     if (reverse_) {
-      row_set_ =
-          row_set_.Intersect(bigtable::RowRange::Open("", last_read_row_key_));
+      google::bigtable::v2::RowRange range;
+      range.set_end_key_open(last_read_row_key_);
+      row_set_ = row_set_.Intersect(bigtable::RowRange(std::move(range)));
     } else {
       row_set_ =
           row_set_.Intersect(bigtable::RowRange::Open(last_read_row_key_, ""));

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -57,13 +57,13 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
                      std::string app_profile_id, std::string table_name,
                      RowFunctor on_row, FinishFunctor on_finish,
                      bigtable::RowSet row_set, std::int64_t rows_limit,
-                     bigtable::Filter filter,
+                     bigtable::Filter filter, bool reverse,
                      std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                      std::unique_ptr<BackoffPolicy> backoff_policy) {
     auto reader = std::shared_ptr<AsyncRowReader>(new AsyncRowReader(
         std::move(cq), std::move(stub), std::move(app_profile_id),
         std::move(table_name), std::move(on_row), std::move(on_finish),
-        std::move(row_set), rows_limit, std::move(filter),
+        std::move(row_set), rows_limit, std::move(filter), reverse,
         std::move(retry_policy), std::move(backoff_policy)));
     reader->MakeRequest();
   }
@@ -73,7 +73,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
                  std::string app_profile_id, std::string table_name,
                  RowFunctor on_row, FinishFunctor on_finish,
                  bigtable::RowSet row_set, std::int64_t rows_limit,
-                 bigtable::Filter filter,
+                 bigtable::Filter filter, bool reverse,
                  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                  std::unique_ptr<BackoffPolicy> backoff_policy)
       : cq_(std::move(cq)),
@@ -85,6 +85,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
         row_set_(std::move(row_set)),
         rows_limit_(rows_limit),
         filter_(std::move(filter)),
+        reverse_(std::move(reverse)),
         retry_policy_(std::move(retry_policy)),
         backoff_policy_(std::move(backoff_policy)) {}
 
@@ -129,6 +130,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
   bigtable::RowSet row_set_;
   std::int64_t rows_limit_;
   bigtable::Filter filter_;
+  bool reverse_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   std::unique_ptr<bigtable::internal::ReadRowsParser> parser_;

--- a/google/cloud/bigtable/internal/async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/async_row_reader_test.cc
@@ -150,8 +150,8 @@ TEST(AsyncRowReaderTest, Success) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify that reading works when the futures are not immediately
@@ -218,8 +218,8 @@ TEST(AsyncRowReaderTest, SuccessDelayedFuture) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 
   // Satisfy the futures
   p1.set_value(true);
@@ -276,8 +276,8 @@ TEST(AsyncRowReaderTest, ResponseInMultipleChunks) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify that parser fails if the stream finishes prematurely.
@@ -327,8 +327,8 @@ TEST(AsyncRowReaderTest, ParserEofFailsOnUnfinishedRow) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 /// @test Check that we ignore HandleEndOfStream errors if enough rows were read
@@ -381,10 +381,11 @@ TEST(AsyncRowReaderTest, ParserEofDoesntFailOnUnfinishedRowIfRowLimit) {
   internal::OptionsSpan span(
       Options{}.set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
 
-  AsyncRowReader::Create(
-      cq, mock, kAppProfile, kTableName, on_row.AsStdFunction(),
-      on_finish.AsStdFunction(), bigtable::RowSet(), 1,
-      bigtable::Filter::PassAllFilter(), std::move(retry), std::move(mock_b));
+  AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
+                         on_row.AsStdFunction(), on_finish.AsStdFunction(),
+                         bigtable::RowSet(), 1,
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify that permanent errors are not retried and properly passed.
@@ -427,8 +428,8 @@ TEST(AsyncRowReaderTest, PermanentFailure) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 TEST(AsyncRowReaderTest, RetryPolicyExhausted) {
@@ -479,8 +480,8 @@ TEST(AsyncRowReaderTest, RetryPolicyExhausted) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify that retries do not ask for rows we have already read.
@@ -563,7 +564,7 @@ TEST(AsyncRowReaderTest, RetrySkipsReadRows) {
       cq, mock, kAppProfile, kTableName, on_row.AsStdFunction(),
       on_finish.AsStdFunction(), bigtable::RowSet("r1", "r2"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      std::move(retry), std::move(mock_b));
+      false, std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify that we do not retry at all if the rowset will be empty.
@@ -619,7 +620,7 @@ TEST(AsyncRowReaderTest, NoRetryIfRowSetIsEmpty) {
       cq, mock, kAppProfile, kTableName, on_row.AsStdFunction(),
       on_finish.AsStdFunction(), bigtable::RowSet("r1"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      std::move(retry), std::move(mock_b));
+      false, std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify that the last scanned row is respected.
@@ -708,7 +709,7 @@ TEST(AsyncRowReaderTest, LastScannedRowKeyIsRespected) {
       cq, mock, kAppProfile, kTableName, on_row.AsStdFunction(),
       on_finish.AsStdFunction(), bigtable::RowSet("r1", "r2", "r3"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      std::move(retry), std::move(mock_b));
+      false, std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify proper handling of bogus responses from the service.
@@ -762,8 +763,8 @@ TEST(AsyncRowReaderTest, ParserFailsOnOutOfOrderRowKeys) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify canceling the stream by satisfying the futures with false
@@ -856,8 +857,8 @@ TEST_P(AsyncRowReaderExceptionTest, CancelMidStream) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -923,8 +924,8 @@ TEST(AsyncRowReaderTest, CancelAfterStreamFinish) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 /// @test Verify that the recursion described in TryGiveRowToUser is bounded.
@@ -997,8 +998,8 @@ TEST(AsyncRowReaderTest, DeepStack) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 TEST(AsyncRowReaderTest, TimerErrorEndsLoop) {
@@ -1055,8 +1056,8 @@ TEST(AsyncRowReaderTest, TimerErrorEndsLoop) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 }
 
 TEST(AsyncRowReaderTest, CurrentOptionsContinuedOnRetries) {
@@ -1110,13 +1111,209 @@ TEST(AsyncRowReaderTest, CurrentOptionsContinuedOnRetries) {
   AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
                          on_row.AsStdFunction(), on_finish.AsStdFunction(),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 
   // Simulate the timer being satisfied in a thread with different prevailing
   // options than the calling thread.
   internal::OptionsSpan clear(Options{});
   timer_promise.set_value(make_status_or(std::chrono::system_clock::now()));
+}
+
+TEST(AsyncRowReaderTest, ReverseScanSuccess) {
+  CompletionQueue cq;
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncReadRows)
+      .WillOnce([](Unused, Unused, v2::ReadRowsRequest const& request) {
+        EXPECT_TRUE(request.reversed());
+        auto stream = std::make_unique<MockAsyncReadRowsStream>();
+        ::testing::InSequence s;
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([] {
+              return make_ready_future(
+                  MakeResponse({{"r2", true}, {"r1", true}}));
+            })
+            .WillOnce([] { return make_ready_future(EndOfStream()); });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(Status{});
+        });
+        return stream;
+      });
+
+  MockFunction<future<bool>(bigtable::Row const&)> on_row;
+  EXPECT_CALL(on_row, Call)
+      .WillOnce([](bigtable::Row const& row) {
+        EXPECT_EQ("r2", row.row_key());
+        return make_ready_future(true);
+      })
+      .WillOnce([](bigtable::Row const& row) {
+        EXPECT_EQ("r1", row.row_key());
+        return make_ready_future(true);
+      });
+
+  MockFunction<void(Status const&)> on_finish;
+  EXPECT_CALL(on_finish, Call).WillOnce([](Status const& status) {
+    EXPECT_STATUS_OK(status);
+  });
+
+  auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).Times(0);
+
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(1);
+  internal::OptionsSpan span(
+      Options{}.set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
+
+  AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
+                         on_row.AsStdFunction(), on_finish.AsStdFunction(),
+                         bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
+                         bigtable::Filter::PassAllFilter(), true,
+                         std::move(retry), std::move(mock_b));
+}
+
+TEST(AsyncRowReaderTest, ReverseScanFailsOnIncreasingRowKeyOrder) {
+  CompletionQueue cq;
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncReadRows)
+      .WillOnce([](Unused, Unused, v2::ReadRowsRequest const& request) {
+        EXPECT_TRUE(request.reversed());
+        auto stream = std::make_unique<MockAsyncReadRowsStream>();
+        ::testing::InSequence s;
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Read).WillOnce([] {
+          // The rows should be returned out of order for a reverse scan.
+          return make_ready_future(MakeResponse({{"r1", true}, {"r2", true}}));
+        });
+        EXPECT_CALL(*stream, Cancel);
+        EXPECT_CALL(*stream, Read).WillOnce([] {
+          return make_ready_future(EndOfStream());
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(Status{});
+        });
+        return stream;
+      });
+
+  MockFunction<future<bool>(bigtable::Row const&)> on_row;
+  EXPECT_CALL(on_row, Call).WillOnce([](bigtable::Row const& row) {
+    EXPECT_EQ("r1", row.row_key());
+    return make_ready_future(true);
+  });
+
+  MockFunction<void(Status const&)> on_finish;
+  EXPECT_CALL(on_finish, Call).WillOnce([](Status const& status) {
+    EXPECT_THAT(status, StatusIs(StatusCode::kInternal));
+  });
+
+  auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).Times(0);
+
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(1);
+  internal::OptionsSpan span(
+      Options{}.set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
+
+  AsyncRowReader::Create(cq, mock, kAppProfile, kTableName,
+                         on_row.AsStdFunction(), on_finish.AsStdFunction(),
+                         bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
+                         bigtable::Filter::PassAllFilter(), true,
+                         std::move(retry), std::move(mock_b));
+}
+
+TEST(AsyncRowReaderTest, ReverseScanResumption) {
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer).WillOnce([] {
+    return make_ready_future(make_status_or(std::chrono::system_clock::now()));
+  });
+  CompletionQueue cq(mock_cq);
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncReadRows)
+      .WillOnce([](Unused, Unused, v2::ReadRowsRequest const& request) {
+        EXPECT_TRUE(request.reversed());
+        // The initial row set contains three rows: "r1", "r2", and "r3".
+        EXPECT_THAT(request.rows().row_keys(), ElementsAre("r1", "r2", "r3"));
+        auto stream = std::make_unique<MockAsyncReadRowsStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Read)
+            // The service will return "r3". But it will also tell us that "r2"
+            // has been scanned, before failing with a transient error.
+            .WillOnce([] {
+              return make_ready_future(MakeResponse({{"r3", true}}));
+            })
+            .WillOnce([] {
+              v2::ReadRowsResponse r;
+              r.set_last_scanned_row_key("r2");
+              return make_ready_future(absl::make_optional(r));
+            })
+            .WillOnce([] { return make_ready_future(EndOfStream()); });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(TransientError());
+        });
+        return stream;
+      })
+      .WillOnce([](Unused, Unused, v2::ReadRowsRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        // Because the service has scanned up to "r2", we should not ask for
+        // "r2" again. The row set for this call should only contain: "r1".
+        EXPECT_THAT(request.rows().row_keys(), ElementsAre("r1"));
+        auto stream = std::make_unique<MockAsyncReadRowsStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([] {
+              return make_ready_future(MakeResponse({{"r1", true}}));
+            })
+            .WillOnce([] { return make_ready_future(EndOfStream()); });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(TransientError());
+        });
+        return stream;
+      });
+
+  MockFunction<future<bool>(bigtable::Row const&)> on_row;
+  EXPECT_CALL(on_row, Call)
+      .WillOnce([](bigtable::Row const& row) {
+        EXPECT_EQ("r3", row.row_key());
+        return make_ready_future(true);
+      })
+      .WillOnce([](bigtable::Row const& row) {
+        EXPECT_EQ("r1", row.row_key());
+        return make_ready_future(true);
+      });
+
+  MockFunction<void(Status const&)> on_finish;
+  EXPECT_CALL(on_finish, Call).WillOnce([](Status const& status) {
+    ASSERT_STATUS_OK(status);
+  });
+
+  auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).WillOnce(Return(ms(0)));
+
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(2);
+  internal::OptionsSpan span(
+      Options{}.set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
+
+  AsyncRowReader::Create(
+      cq, mock, kAppProfile, kTableName, on_row.AsStdFunction(),
+      on_finish.AsStdFunction(), bigtable::RowSet("r1", "r2", "r3"),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      true, std::move(retry), std::move(mock_b));
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
@@ -1149,8 +1346,8 @@ TEST(AsyncRowReaderTest, TracedBackoff) {
   AsyncRowReader::Create(background.cq(), mock, kAppProfile, kTableName,
                          std::move(on_row), std::move(on_finish),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 
   // Block until the async call has completed.
   p.get_future().get();
@@ -1185,8 +1382,8 @@ TEST(AsyncRowReaderTest, CallSpanActiveThroughout) {
   AsyncRowReader::Create(background.cq(), mock, kAppProfile, kTableName,
                          std::move(on_row), std::move(on_finish),
                          bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-                         bigtable::Filter::PassAllFilter(), std::move(retry),
-                         std::move(mock_b));
+                         bigtable::Filter::PassAllFilter(), false,
+                         std::move(retry), std::move(mock_b));
 
   // Block until the async call has completed.
   p.get_future().get();

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -178,7 +178,7 @@ bigtable::RowReader DataConnectionImpl::ReadRowsFull(
   auto impl = std::make_shared<DefaultRowReader>(
       stub_, std::move(params.app_profile_id), std::move(params.table_name),
       std::move(params.row_set), params.rows_limit, std::move(params.filter),
-      retry_policy(), backoff_policy());
+      false, retry_policy(), backoff_policy());
   return MakeRowReader(std::move(impl));
 }
 
@@ -374,10 +374,11 @@ void DataConnectionImpl::AsyncReadRows(
     std::function<future<bool>(bigtable::Row)> on_row,
     std::function<void(Status)> on_finish, bigtable::RowSet row_set,
     std::int64_t rows_limit, bigtable::Filter filter) {
+  auto reverse = false;
   bigtable_internal::AsyncRowReader::Create(
       background_->cq(), stub_, app_profile_id(), table_name, std::move(on_row),
       std::move(on_finish), std::move(row_set), rows_limit, std::move(filter),
-      retry_policy(), backoff_policy());
+      reverse, retry_policy(), backoff_policy());
 }
 
 future<StatusOr<std::pair<bool, bigtable::Row>>>

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -692,6 +692,7 @@ TEST(DataConnectionTest, ReadRows) {
         EXPECT_EQ(42, request.rows_limit());
         EXPECT_THAT(request, HasTestRowSet());
         EXPECT_THAT(request.filter(), IsTestFilter());
+        EXPECT_FALSE(request.reversed());
 
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));
@@ -715,6 +716,7 @@ TEST(DataConnectionTest, ReadRowsFull) {
         EXPECT_EQ(42, request.rows_limit());
         EXPECT_THAT(request, HasTestRowSet());
         EXPECT_THAT(request.filter(), IsTestFilter());
+        EXPECT_FALSE(request.reversed());
 
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));

--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -110,8 +110,9 @@ absl::variant<Status, bigtable::Row> DefaultRowReader::Advance() {
       // We've returned some rows and need to make sure we don't
       // request them again.
       if (reverse_) {
-        row_set_ = row_set_.Intersect(
-            bigtable::RowRange::Open("", last_read_row_key_));
+        google::bigtable::v2::RowRange range;
+        range.set_end_key_open(last_read_row_key_);
+        row_set_ = row_set_.Intersect(bigtable::RowRange(std::move(range)));
       } else {
         row_set_ = row_set_.Intersect(
             bigtable::RowRange::Open(last_read_row_key_, ""));

--- a/google/cloud/bigtable/internal/default_row_reader.h
+++ b/google/cloud/bigtable/internal/default_row_reader.h
@@ -45,7 +45,7 @@ class DefaultRowReader : public RowReaderImpl {
   DefaultRowReader(std::shared_ptr<BigtableStub> stub,
                    std::string app_profile_id, std::string table_name,
                    bigtable::RowSet row_set, std::int64_t rows_limit,
-                   bigtable::Filter filter,
+                   bigtable::Filter filter, bool reverse,
                    std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                    std::unique_ptr<BackoffPolicy> backoff_policy);
 
@@ -89,6 +89,7 @@ class DefaultRowReader : public RowReaderImpl {
   bigtable::RowSet row_set_;
   std::int64_t rows_limit_;
   bigtable::Filter filter_;
+  bool reverse_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
 

--- a/google/cloud/bigtable/internal/legacy_async_row_reader.cc
+++ b/google/cloud/bigtable/internal/legacy_async_row_reader.cc
@@ -36,7 +36,7 @@ void LegacyAsyncRowReader::MakeRequest() {
   if (rows_limit_ != NO_ROWS_LIMIT) {
     request.set_rows_limit(rows_limit_ - rows_count_);
   }
-  parser_ = parser_factory_->Create();
+  parser_ = parser_factory_->Create(false);
 
   auto context = std::make_unique<grpc::ClientContext>();
   rpc_retry_policy_->Setup(*context);

--- a/google/cloud/bigtable/internal/legacy_row_reader.cc
+++ b/google/cloud/bigtable/internal/legacy_row_reader.cc
@@ -81,7 +81,7 @@ void LegacyRowReader::MakeRequest() {
   stream_ = client_->ReadRows(context_.get(), request);
   stream_is_open_ = true;
 
-  parser_ = parser_factory_->Create();
+  parser_ = parser_factory_->Create(false);
 }
 
 bool LegacyRowReader::NextChunk() {

--- a/google/cloud/bigtable/internal/legacy_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/legacy_row_reader_test.cc
@@ -53,6 +53,8 @@ using ::testing::SetArgReferee;
 
 class ReadRowsParserMock : public bigtable::internal::ReadRowsParser {
  public:
+  explicit ReadRowsParserMock() : ReadRowsParser(false) {}
+
   MOCK_METHOD(void, HandleChunkHook,
               (ReadRowsResponse_CellChunk chunk, grpc::Status& status));
   void HandleChunk(ReadRowsResponse_CellChunk chunk,
@@ -93,10 +95,10 @@ class ReadRowsParserMockFactory
   void AddParser(ParserPtr parser) { parsers_.emplace_back(std::move(parser)); }
 
   MOCK_METHOD(void, CreateHook, ());
-  ParserPtr Create() override {
+  ParserPtr Create(bool reverse) override {
     CreateHook();
     if (parsers_.empty()) {
-      return std::make_unique<bigtable::internal::ReadRowsParser>();
+      return std::make_unique<bigtable::internal::ReadRowsParser>(reverse);
     }
     ParserPtr parser = std::move(parsers_.front());
     parsers_.pop_front();

--- a/google/cloud/bigtable/internal/readrowsparser.h
+++ b/google/cloud/bigtable/internal/readrowsparser.h
@@ -27,6 +27,7 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+
 /**
  * Transforms a stream of chunks as returned by the ReadRows streaming
  * RPC into a sequence of rows.
@@ -51,7 +52,7 @@ namespace internal {
  */
 class ReadRowsParser {
  public:
-  ReadRowsParser() = default;
+  explicit ReadRowsParser(bool reverse) : reverse_(reverse) {}
 
   virtual ~ReadRowsParser() = default;
 
@@ -90,6 +91,9 @@ class ReadRowsParser {
     std::vector<std::string> labels;
   };
 
+  /// If true, we expect row keys in reverse order.
+  bool reverse_;
+
   /**
    * Moves partial results into a Cell class.
    *
@@ -127,10 +131,11 @@ class ReadRowsParserFactory {
   virtual ~ReadRowsParserFactory() = default;
 
   /// Returns a newly created parser instance.
-  virtual std::unique_ptr<ReadRowsParser> Create() {
-    return std::make_unique<ReadRowsParser>();
+  virtual std::unique_ptr<ReadRowsParser> Create(bool reverse) {
+    return std::make_unique<ReadRowsParser>(reverse);
   }
 };
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/readrowsparser_test.cc
+++ b/google/cloud/bigtable/internal/readrowsparser_test.cc
@@ -36,7 +36,7 @@ using ::testing::Not;
 
 TEST(ReadRowsParserTest, NoChunksNoRowsSucceeds) {
   grpc::Status status;
-  ReadRowsParser parser;
+  ReadRowsParser parser(false);
 
   EXPECT_FALSE(parser.HasNext());
   parser.HandleEndOfStream(status);
@@ -45,7 +45,7 @@ TEST(ReadRowsParserTest, NoChunksNoRowsSucceeds) {
 }
 
 TEST(ReadRowsParserTest, HandleEndOfStreamCalledTwiceThrows) {
-  ReadRowsParser parser;
+  ReadRowsParser parser(false);
   grpc::Status status;
   EXPECT_FALSE(parser.HasNext());
   parser.HandleEndOfStream(status);
@@ -55,7 +55,7 @@ TEST(ReadRowsParserTest, HandleEndOfStreamCalledTwiceThrows) {
 }
 
 TEST(ReadRowsParserTest, HandleChunkAfterEndOfStreamThrows) {
-  ReadRowsParser parser;
+  ReadRowsParser parser(false);
   ReadRowsResponse_CellChunk chunk;
   grpc::Status status;
   chunk.set_value_size(1);
@@ -70,7 +70,7 @@ TEST(ReadRowsParserTest, HandleChunkAfterEndOfStreamThrows) {
 
 TEST(ReadRowsParserTest, SingleChunkSucceeds) {
   using ::google::protobuf::TextFormat;
-  ReadRowsParser parser;
+  ReadRowsParser parser(false);
   ReadRowsResponse_CellChunk chunk;
   std::string chunk1 = R"(
     row_key: "RK"
@@ -105,7 +105,7 @@ TEST(ReadRowsParserTest, SingleChunkSucceeds) {
 
 TEST(ReadRowsParserTest, NextAfterEndOfStreamSucceeds) {
   using ::google::protobuf::TextFormat;
-  ReadRowsParser parser;
+  ReadRowsParser parser(false);
   ReadRowsResponse_CellChunk chunk;
   std::string chunk1 = R"(
     row_key: "RK"
@@ -130,7 +130,7 @@ TEST(ReadRowsParserTest, NextAfterEndOfStreamSucceeds) {
 }
 
 TEST(ReadRowsParserTest, NextWithNoDataThrows) {
-  ReadRowsParser parser;
+  ReadRowsParser parser(false);
   grpc::Status status;
   EXPECT_FALSE(parser.HasNext());
   parser.HandleEndOfStream(status);
@@ -214,7 +214,7 @@ class AcceptanceTest : public ::testing::Test {
   }
 
  private:
-  ReadRowsParser parser_;
+  ReadRowsParser parser_{false};
   std::vector<google::cloud::bigtable::Row> rows_;
 };
 


### PR DESCRIPTION
Part of the work for #12010 

- Have sync/async row readers set the `reversed` flag
- Teach sync/async row readers how to resume a reverse scan
- Teach the row parser about reverse row orders

The diff might have been prettier had I defaulted the `bool reverse` used to initialize a `ReadRowsParser`. I know at least one person on the team who does not like to use defaulted arguments for internal-only APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12013)
<!-- Reviewable:end -->
