### PR TITLE
chore(deps): update benchmark to v1.8.1

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -44,11 +44,11 @@ def google_cloud_cpp_development_deps(name = None):
         http_archive,
         name = "com_google_benchmark",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_benchmark/v1.8.0.tar.gz",
-            "https://github.com/google/benchmark/archive/v1.8.0.tar.gz",
+            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_benchmark/v1.8.1.tar.gz",
+            "https://github.com/google/benchmark/archive/v1.8.1.tar.gz",
         ],
-        sha256 = "ea2e94c24ddf6594d15c711c06ccd4486434d9cf3eca954e2af8a20c88f9f172",
-        strip_prefix = "benchmark-1.8.0",
+        sha256 = "e9ff65cecfed4f60c893a1e8a1ba94221fad3b27075f2f80f47eb424b0f8c9bd",
+        strip_prefix = "benchmark-1.8.1",
     )
 
     # PugiXML, this is only used in the docfx internal tool.

--- a/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
@@ -154,7 +154,7 @@ RUN curl -fsSL https://github.com/google/googletest/archive/v1.13.0.tar.gz | \
 
 # Download and compile Google microbenchmark support library:
 WORKDIR /var/tmp/build
-RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.0.tar.gz | \
+RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \

--- a/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cmake.Dockerfile
@@ -106,7 +106,7 @@ RUN curl -fsSL https://github.com/google/googletest/archive/v1.13.0.tar.gz | \
     ldconfig && cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build
-RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.0.tar.gz | \
+RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \

--- a/ci/cloudbuild/dockerfiles/fedora-37-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cxx14.Dockerfile
@@ -89,7 +89,7 @@ RUN curl -fsSL https://github.com/google/googletest/archive/v1.13.0.tar.gz | \
 
 # Download and compile Google microbenchmark support library:
 WORKDIR /var/tmp/build
-RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.0.tar.gz | \
+RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_CXX_STANDARD=14 \

--- a/ci/cloudbuild/dockerfiles/fedora-37-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-37-cxx20.Dockerfile
@@ -90,7 +90,7 @@ RUN curl -fsSL https://github.com/google/googletest/archive/v1.13.0.tar.gz | \
 
 # Download and compile Google microbenchmark support library:
 WORKDIR /var/tmp/build
-RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.0.tar.gz | \
+RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_CXX_STANDARD=20 \

--- a/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
@@ -82,7 +82,7 @@ RUN curl -fsSL https://github.com/google/googletest/archive/v1.13.0.tar.gz | \
     cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build/benchmark
-RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.0.tar.gz | \
+RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \

--- a/google/cloud/completion_queue_benchmark.cc
+++ b/google/cloud/completion_queue_benchmark.cc
@@ -90,7 +90,7 @@ void BM_Baseline(benchmark::State& state) {
 
   for (auto _ : state) {
     auto unused = runner(state.range(1));
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
   state.SetComplexityN(state.range(1));
 }
@@ -117,7 +117,7 @@ void BM_CompletionQueueRunAsync(benchmark::State& state) {
 
   for (auto _ : state) {
     auto unused = runner(state.range(1));
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
   state.SetComplexityN(state.range(1));
   cq.Shutdown();

--- a/google/cloud/options_benchmark.cc
+++ b/google/cloud/options_benchmark.cc
@@ -46,7 +46,7 @@ void BM_OptionsOneElementDefault(benchmark::State& state) {
       "You will do foolish things, but do them with enthusiasm.");
   for (auto _ : state) {
     auto unused = opts.get<StringOptionDefault>();
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_OptionsOneElementDefault);
@@ -56,7 +56,7 @@ void BM_OptionsOneElementPresent(benchmark::State& state) {
       "You will do foolish things, but do them with enthusiasm.");
   for (auto _ : state) {
     auto unused = opts.get<StringOptionPresent>();
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_OptionsOneElementPresent);

--- a/google/cloud/spanner/bytes_benchmark.cc
+++ b/google/cloud/spanner/bytes_benchmark.cc
@@ -66,7 +66,7 @@ std::string const kText = R"""(
 void BM_BytesCtor(benchmark::State& state) {
   for (auto _ : state) {
     auto unused = Bytes(kText);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
   state.SetBytesProcessed(state.iterations() * kText.size());
 }
@@ -76,7 +76,7 @@ void BM_BytesGet(benchmark::State& state) {
   Bytes b(kText);
   for (auto _ : state) {
     auto unused = b.get<std::string>();
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
   state.SetBytesProcessed(state.iterations() *
                           spanner_internal::BytesToBase64(b).size());

--- a/google/cloud/spanner/internal/merge_chunk_benchmark.cc
+++ b/google/cloud/spanner/internal/merge_chunk_benchmark.cc
@@ -76,7 +76,7 @@ void BM_MergeChunkStrings(benchmark::State& state) {
     auto value = a;
     auto chunk = b;
     auto unused = MergeChunk(value, std::move(chunk));
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_MergeChunkStrings);
@@ -88,7 +88,7 @@ void BM_MergeChunkListOfInts(benchmark::State& state) {
     auto value = a;
     auto chunk = b;
     auto unused = MergeChunk(value, std::move(chunk));
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_MergeChunkListOfInts);
@@ -100,7 +100,7 @@ void BM_MergeChunkListOfStrings(benchmark::State& state) {
     auto value = a;
     auto chunk = b;
     auto unused = MergeChunk(value, std::move(chunk));
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_MergeChunkListOfStrings);
@@ -114,7 +114,7 @@ void BM_MergeChunkListsOfListOfString(benchmark::State& state) {
     auto value = a;
     auto chunk = b;
     auto unused = MergeChunk(value, std::move(chunk));
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_MergeChunkListsOfListOfString);

--- a/google/cloud/spanner/numeric_benchmark.cc
+++ b/google/cloud/spanner/numeric_benchmark.cc
@@ -48,7 +48,7 @@ void BM_NumericFromStringCanonical(benchmark::State& state) {
   std::string s = "99999999999999999999999999999.999999999";
   for (auto _ : state) {
     auto unused = MakeNumeric(s);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericFromStringCanonical);
@@ -57,7 +57,7 @@ void BM_NumericFromString(benchmark::State& state) {
   std::string s = "+9999999999999999999999999999.9999999999e1";
   for (auto _ : state) {
     auto unused = MakeNumeric(s);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericFromString);
@@ -66,7 +66,7 @@ void BM_NumericFromDouble(benchmark::State& state) {
   double d = 9.999999999999999e+28;
   for (auto _ : state) {
     auto unused = MakeNumeric(d);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericFromDouble);
@@ -75,7 +75,7 @@ void BM_NumericFromUnsigned(benchmark::State& state) {
   auto u = std::numeric_limits<std::uint64_t>::max();
   for (auto _ : state) {
     auto unused = MakeNumeric(u);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericFromUnsigned);
@@ -84,7 +84,7 @@ void BM_NumericFromInteger(benchmark::State& state) {
   auto i = std::numeric_limits<std::int64_t>::min();
   for (auto _ : state) {
     auto unused = MakeNumeric(i);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericFromInteger);
@@ -94,7 +94,7 @@ void BM_NumericToString(benchmark::State& state) {
   Numeric n = MakeNumeric(s).value();
   for (auto _ : state) {
     auto unused = n.ToString();
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericToString);
@@ -104,7 +104,7 @@ void BM_NumericToDouble(benchmark::State& state) {
   Numeric n = MakeNumeric(d).value();
   for (auto _ : state) {
     auto unused = ToDouble(n);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericToDouble);
@@ -114,7 +114,7 @@ void BM_NumericToUnsigned(benchmark::State& state) {
   Numeric n = MakeNumeric(u).value();
   for (auto _ : state) {
     auto unused = ToInteger<std::uint64_t>(n);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericToUnsigned);
@@ -124,7 +124,7 @@ void BM_NumericToInteger(benchmark::State& state) {
   Numeric n = MakeNumeric(i).value();
   for (auto _ : state) {
     auto unused = ToInteger<std::int64_t>(n);
-    benchmark::DoNotOptimize(unused);
+    benchmark::DoNotOptimize(std::move(unused));
   }
 }
 BENCHMARK(BM_NumericToInteger);

--- a/google/cloud/spanner/row_benchmark.cc
+++ b/google/cloud/spanner/row_benchmark.cc
@@ -39,11 +39,11 @@ void BM_RowGetByPosition(benchmark::State& state) {
   Row row = spanner_mocks::MakeRow(1, "blah", true);
   for (auto _ : state) {
     auto unused_0 = row.get(0);
-    benchmark::DoNotOptimize(unused_0);
+    benchmark::DoNotOptimize(std::move(unused_0));
     auto unused_1 = row.get(1);
-    benchmark::DoNotOptimize(unused_1);
+    benchmark::DoNotOptimize(std::move(unused_1));
     auto unused_2 = row.get(2);
-    benchmark::DoNotOptimize(unused_2);
+    benchmark::DoNotOptimize(std::move(unused_2));
   }
 }
 BENCHMARK(BM_RowGetByPosition);
@@ -56,11 +56,11 @@ void BM_RowGetByColumnName(benchmark::State& state) {
   });
   for (auto _ : state) {
     auto unused_a = row.get("a");
-    benchmark::DoNotOptimize(unused_a);
+    benchmark::DoNotOptimize(std::move(unused_a));
     auto unused_b = row.get("b");
-    benchmark::DoNotOptimize(unused_b);
+    benchmark::DoNotOptimize(std::move(unused_b));
     auto unused_c = row.get("c");
-    benchmark::DoNotOptimize(unused_c);
+    benchmark::DoNotOptimize(std::move(unused_c));
   }
 }
 BENCHMARK(BM_RowGetByColumnName);

--- a/google/cloud/storage/internal/crc32c_benchmark.cc
+++ b/google/cloud/storage/internal/crc32c_benchmark.cc
@@ -48,14 +48,14 @@ void BM_Crc32cDuplicateNonAbseil(benchmark::State& state) {
       for (std::size_t m = 0; m < kWriteSize; m += kMessage) {
         auto w = absl::string_view{buffer}.substr(m, kMessage);
         auto c = crc32c::Crc32c(w.data(), w.size());
-        benchmark::DoNotOptimize(c);
+        benchmark::DoNotOptimize(std::move(c));
       }
       crc = crc32c::Extend(crc,
                            reinterpret_cast<std::uint8_t const*>(buffer.data()),
                            buffer.size());
     }
   }
-  benchmark::DoNotOptimize(crc);
+  benchmark::DoNotOptimize(std::move(crc));
 }
 BENCHMARK(BM_Crc32cDuplicateNonAbseil);
 
@@ -67,12 +67,12 @@ void BM_Crc32cDuplicate(benchmark::State& state) {
       for (std::size_t m = 0; m < kWriteSize; m += kMessage) {
         auto w = absl::string_view{buffer}.substr(m, kMessage);
         auto c = Crc32c(w);
-        benchmark::DoNotOptimize(c);
+        benchmark::DoNotOptimize(std::move(c));
       }
       crc = ExtendCrc32c(crc, buffer);
     }
   }
-  benchmark::DoNotOptimize(crc);
+  benchmark::DoNotOptimize(std::move(crc));
 }
 BENCHMARK(BM_Crc32cDuplicate);
 
@@ -88,7 +88,7 @@ void BM_Crc32cConcat(benchmark::State& state) {
       }
     }
   }
-  benchmark::DoNotOptimize(crc);
+  benchmark::DoNotOptimize(std::move(crc));
 }
 BENCHMARK(BM_Crc32cConcat);
 


### PR DESCRIPTION
Requires some concurrent edits because `benchmark::DoNotOptimize(T const&)` has been deprecated with "The const-ref version of this method can permit undesired compiler optimizations in benchmarks".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12015)
<!-- Reviewable:end -->
