### PR TITLE
test(bigquery): include `v2/` in coverage results

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,15 @@ coverage:
 
 # Ignore generated code that lives with handcrafted code.
 ignore:
+  - "google/cloud/bigquery/analyticshub"
+  - "google/cloud/bigquery/biglake"
+  - "google/cloud/bigquery/connection"
+  - "google/cloud/bigquery/datapolicies"
+  - "google/cloud/bigquery/datatransfer"
+  - "google/cloud/bigquery/migration"
+  - "google/cloud/bigquery/reservation"
+  - "google/cloud/bigquery/samples"
+  - "google/cloud/bigquery/storage"
   - "google/cloud/bigtable/internal/*_decorator.cc"
   - "google/cloud/bigtable/internal/*_decorator.h"
   - "google/cloud/bigtable/internal/*_stub.cc"

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -36,6 +36,7 @@ instrumented_patterns=(
   "/google/cloud/pubsublite[/:]"
   "/google/cloud/spanner[/:]"
   "/google/cloud/storage[/:]"
+  "/google/cloud/bigquery/v2[/:]"
 )
 instrumentation_filter="$(printf ",%s" "${instrumented_patterns[@]}")"
 instrumentation_filter="${instrumentation_filter:1}"

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -36,7 +36,7 @@ instrumented_patterns=(
   "/google/cloud/pubsublite[/:]"
   "/google/cloud/spanner[/:]"
   "/google/cloud/storage[/:]"
-  "/google/cloud/bigquery/v2[/:]"
+  "/google/cloud/bigquery[/:]"
 )
 instrumentation_filter="$(printf ",%s" "${instrumented_patterns[@]}")"
 instrumentation_filter="${instrumentation_filter:1}"


### PR DESCRIPTION
We only report code coverage for hand-crafted code, as the generated code is not tested directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12019)
<!-- Reviewable:end -->
