### PR TITLE
cleanup: simplify some benchmark::DoNotOptimize() calls

### DIFF
--- a/google/cloud/completion_queue_benchmark.cc
+++ b/google/cloud/completion_queue_benchmark.cc
@@ -89,8 +89,7 @@ void BM_Baseline(benchmark::State& state) {
   };
 
   for (auto _ : state) {
-    auto unused = runner(state.range(1));
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(runner(state.range(1)));
   }
   state.SetComplexityN(state.range(1));
 }
@@ -116,8 +115,7 @@ void BM_CompletionQueueRunAsync(benchmark::State& state) {
   };
 
   for (auto _ : state) {
-    auto unused = runner(state.range(1));
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(runner(state.range(1)));
   }
   state.SetComplexityN(state.range(1));
   cq.Shutdown();

--- a/google/cloud/spanner/bytes_benchmark.cc
+++ b/google/cloud/spanner/bytes_benchmark.cc
@@ -65,8 +65,7 @@ std::string const kText = R"""(
 
 void BM_BytesCtor(benchmark::State& state) {
   for (auto _ : state) {
-    auto unused = Bytes(kText);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(Bytes(kText));
   }
   state.SetBytesProcessed(state.iterations() * kText.size());
 }
@@ -75,8 +74,7 @@ BENCHMARK(BM_BytesCtor);
 void BM_BytesGet(benchmark::State& state) {
   Bytes b(kText);
   for (auto _ : state) {
-    auto unused = b.get<std::string>();
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(b.get<std::string>());
   }
   state.SetBytesProcessed(state.iterations() *
                           spanner_internal::BytesToBase64(b).size());

--- a/google/cloud/spanner/internal/merge_chunk_benchmark.cc
+++ b/google/cloud/spanner/internal/merge_chunk_benchmark.cc
@@ -75,8 +75,7 @@ void BM_MergeChunkStrings(benchmark::State& state) {
   for (auto _ : state) {
     auto value = a;
     auto chunk = b;
-    auto unused = MergeChunk(value, std::move(chunk));
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MergeChunk(value, std::move(chunk)));
   }
 }
 BENCHMARK(BM_MergeChunkStrings);
@@ -87,8 +86,7 @@ void BM_MergeChunkListOfInts(benchmark::State& state) {
   for (auto _ : state) {
     auto value = a;
     auto chunk = b;
-    auto unused = MergeChunk(value, std::move(chunk));
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MergeChunk(value, std::move(chunk)));
   }
 }
 BENCHMARK(BM_MergeChunkListOfInts);
@@ -99,8 +97,7 @@ void BM_MergeChunkListOfStrings(benchmark::State& state) {
   for (auto _ : state) {
     auto value = a;
     auto chunk = b;
-    auto unused = MergeChunk(value, std::move(chunk));
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MergeChunk(value, std::move(chunk)));
   }
 }
 BENCHMARK(BM_MergeChunkListOfStrings);
@@ -113,8 +110,7 @@ void BM_MergeChunkListsOfListOfString(benchmark::State& state) {
   for (auto _ : state) {
     auto value = a;
     auto chunk = b;
-    auto unused = MergeChunk(value, std::move(chunk));
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MergeChunk(value, std::move(chunk)));
   }
 }
 BENCHMARK(BM_MergeChunkListsOfListOfString);

--- a/google/cloud/spanner/numeric_benchmark.cc
+++ b/google/cloud/spanner/numeric_benchmark.cc
@@ -47,8 +47,7 @@ namespace {
 void BM_NumericFromStringCanonical(benchmark::State& state) {
   std::string s = "99999999999999999999999999999.999999999";
   for (auto _ : state) {
-    auto unused = MakeNumeric(s);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MakeNumeric(s));
   }
 }
 BENCHMARK(BM_NumericFromStringCanonical);
@@ -56,8 +55,7 @@ BENCHMARK(BM_NumericFromStringCanonical);
 void BM_NumericFromString(benchmark::State& state) {
   std::string s = "+9999999999999999999999999999.9999999999e1";
   for (auto _ : state) {
-    auto unused = MakeNumeric(s);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MakeNumeric(s));
   }
 }
 BENCHMARK(BM_NumericFromString);
@@ -65,8 +63,7 @@ BENCHMARK(BM_NumericFromString);
 void BM_NumericFromDouble(benchmark::State& state) {
   double d = 9.999999999999999e+28;
   for (auto _ : state) {
-    auto unused = MakeNumeric(d);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MakeNumeric(d));
   }
 }
 BENCHMARK(BM_NumericFromDouble);
@@ -74,8 +71,7 @@ BENCHMARK(BM_NumericFromDouble);
 void BM_NumericFromUnsigned(benchmark::State& state) {
   auto u = std::numeric_limits<std::uint64_t>::max();
   for (auto _ : state) {
-    auto unused = MakeNumeric(u);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MakeNumeric(u));
   }
 }
 BENCHMARK(BM_NumericFromUnsigned);
@@ -83,8 +79,7 @@ BENCHMARK(BM_NumericFromUnsigned);
 void BM_NumericFromInteger(benchmark::State& state) {
   auto i = std::numeric_limits<std::int64_t>::min();
   for (auto _ : state) {
-    auto unused = MakeNumeric(i);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(MakeNumeric(i));
   }
 }
 BENCHMARK(BM_NumericFromInteger);
@@ -103,8 +98,7 @@ void BM_NumericToDouble(benchmark::State& state) {
   double d = 9.999999999999999e+28;
   Numeric n = MakeNumeric(d).value();
   for (auto _ : state) {
-    auto unused = ToDouble(n);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(ToDouble(n));
   }
 }
 BENCHMARK(BM_NumericToDouble);
@@ -113,8 +107,7 @@ void BM_NumericToUnsigned(benchmark::State& state) {
   auto u = std::numeric_limits<std::uint64_t>::max();
   Numeric n = MakeNumeric(u).value();
   for (auto _ : state) {
-    auto unused = ToInteger<std::uint64_t>(n);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(ToInteger<std::uint64_t>(n));
   }
 }
 BENCHMARK(BM_NumericToUnsigned);
@@ -123,8 +116,7 @@ void BM_NumericToInteger(benchmark::State& state) {
   auto i = std::numeric_limits<std::int64_t>::min();
   Numeric n = MakeNumeric(i).value();
   for (auto _ : state) {
-    auto unused = ToInteger<std::int64_t>(n);
-    benchmark::DoNotOptimize(std::move(unused));
+    benchmark::DoNotOptimize(ToInteger<std::int64_t>(n));
   }
 }
 BENCHMARK(BM_NumericToInteger);

--- a/google/cloud/spanner/row_benchmark.cc
+++ b/google/cloud/spanner/row_benchmark.cc
@@ -38,12 +38,9 @@ namespace {
 void BM_RowGetByPosition(benchmark::State& state) {
   Row row = spanner_mocks::MakeRow(1, "blah", true);
   for (auto _ : state) {
-    auto unused_0 = row.get(0);
-    benchmark::DoNotOptimize(std::move(unused_0));
-    auto unused_1 = row.get(1);
-    benchmark::DoNotOptimize(std::move(unused_1));
-    auto unused_2 = row.get(2);
-    benchmark::DoNotOptimize(std::move(unused_2));
+    benchmark::DoNotOptimize(row.get(0));
+    benchmark::DoNotOptimize(row.get(1));
+    benchmark::DoNotOptimize(row.get(2));
   }
 }
 BENCHMARK(BM_RowGetByPosition);
@@ -55,12 +52,9 @@ void BM_RowGetByColumnName(benchmark::State& state) {
       {"c", Value(true)}     //
   });
   for (auto _ : state) {
-    auto unused_a = row.get("a");
-    benchmark::DoNotOptimize(std::move(unused_a));
-    auto unused_b = row.get("b");
-    benchmark::DoNotOptimize(std::move(unused_b));
-    auto unused_c = row.get("c");
-    benchmark::DoNotOptimize(std::move(unused_c));
+    benchmark::DoNotOptimize(row.get("a"));
+    benchmark::DoNotOptimize(row.get("b"));
+    benchmark::DoNotOptimize(row.get("c"));
   }
 }
 BENCHMARK(BM_RowGetByColumnName);

--- a/google/cloud/storage/internal/crc32c_benchmark.cc
+++ b/google/cloud/storage/internal/crc32c_benchmark.cc
@@ -47,8 +47,7 @@ void BM_Crc32cDuplicateNonAbseil(benchmark::State& state) {
     for (std::size_t offset = 0; offset < kUploadSize; offset += kWriteSize) {
       for (std::size_t m = 0; m < kWriteSize; m += kMessage) {
         auto w = absl::string_view{buffer}.substr(m, kMessage);
-        auto c = crc32c::Crc32c(w.data(), w.size());
-        benchmark::DoNotOptimize(std::move(c));
+        benchmark::DoNotOptimize(crc32c::Crc32c(w.data(), w.size()));
       }
       crc = crc32c::Extend(crc,
                            reinterpret_cast<std::uint8_t const*>(buffer.data()),
@@ -66,8 +65,7 @@ void BM_Crc32cDuplicate(benchmark::State& state) {
     for (std::size_t offset = 0; offset < kUploadSize; offset += kWriteSize) {
       for (std::size_t m = 0; m < kWriteSize; m += kMessage) {
         auto w = absl::string_view{buffer}.substr(m, kMessage);
-        auto c = Crc32c(w);
-        benchmark::DoNotOptimize(std::move(c));
+        benchmark::DoNotOptimize(Crc32c(w));
       }
       crc = ExtendCrc32c(crc, buffer);
     }


### PR DESCRIPTION
A followup to #12015 where we can simplify some calls to `benchmark::DoNotOptimize()` because we already have an r-value handy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12026)
<!-- Reviewable:end -->
