### PR TITLE
cleanup: reduce tarball size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ci/abi-dumps export-ignore


### PR DESCRIPTION
Exclude the ci/abi-dumps directory from the tarball, saving about 78MiB from the tarball, or about 30% of the size.