### PR TITLE
cleanup: simplify some benchmark::DoNotOptimize() calls

### DIFF
--- a/google/cloud/storage/internal/crc32c_benchmark.cc
+++ b/google/cloud/storage/internal/crc32c_benchmark.cc
@@ -54,7 +54,7 @@ void BM_Crc32cDuplicateNonAbseil(benchmark::State& state) {
                            buffer.size());
     }
   }
-  benchmark::DoNotOptimize(std::move(crc));
+  benchmark::DoNotOptimize(crc);
 }
 BENCHMARK(BM_Crc32cDuplicateNonAbseil);
 
@@ -70,7 +70,7 @@ void BM_Crc32cDuplicate(benchmark::State& state) {
       crc = ExtendCrc32c(crc, buffer);
     }
   }
-  benchmark::DoNotOptimize(std::move(crc));
+  benchmark::DoNotOptimize(crc);
 }
 BENCHMARK(BM_Crc32cDuplicate);
 
@@ -86,7 +86,7 @@ void BM_Crc32cConcat(benchmark::State& state) {
       }
     }
   }
-  benchmark::DoNotOptimize(std::move(crc));
+  benchmark::DoNotOptimize(crc);
 }
 BENCHMARK(BM_Crc32cConcat);
 


### PR DESCRIPTION
A few of the moves of trivially-copyable types introduced in #12015 are no longer needed with benchmark v1.8.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12042)
<!-- Reviewable:end -->
