### PR TITLE
impl(bigquery): Idempotency policy Query api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
@@ -47,6 +47,18 @@ Idempotency BigQueryJobIdempotencyPolicy::CancelJob(CancelJobRequest const&) {
   return Idempotency::kNonIdempotent;
 }
 
+Idempotency BigQueryJobIdempotencyPolicy::Query(
+    PostQueryRequest const& request) {
+  // Query requests containing request_id maybe considered idempotent.
+  // Please see the rules here:
+  // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#queryrequest
+  if (!request.query_request().request_id().empty()) {
+    return Idempotency::kIdempotent;
+  }
+
+  return Idempotency::kNonIdempotent;
+}
+
 std::unique_ptr<BigQueryJobIdempotencyPolicy>
 MakeDefaultBigQueryJobIdempotencyPolicy() {
   return std::make_unique<BigQueryJobIdempotencyPolicy>();

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
@@ -40,6 +40,8 @@ class BigQueryJobIdempotencyPolicy {
   virtual google::cloud::Idempotency InsertJob(InsertJobRequest const& request);
 
   virtual google::cloud::Idempotency CancelJob(CancelJobRequest const& request);
+
+  virtual google::cloud::Idempotency Query(PostQueryRequest const& request);
 };
 
 std::unique_ptr<BigQueryJobIdempotencyPolicy>

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy_test.cc
@@ -54,6 +54,27 @@ TEST(JobIdempotencyPolicytTest, CancelJob) {
   EXPECT_EQ(actual->CancelJob(request), expected);
 }
 
+TEST(JobIdempotencyPolicytTest, QueryNonIdempotent) {
+  auto actual = MakeDefaultBigQueryJobIdempotencyPolicy();
+  auto expected = Idempotency::kNonIdempotent;
+
+  PostQueryRequest request;
+  EXPECT_EQ(actual->Query(request), expected);
+}
+
+TEST(JobIdempotencyPolicytTest, QueryIdempotent) {
+  auto actual = MakeDefaultBigQueryJobIdempotencyPolicy();
+  auto expected = Idempotency::kIdempotent;
+
+  QueryRequest query_request;
+  query_request.set_request_id("123");
+
+  PostQueryRequest request;
+  request.set_query_request(query_request);
+
+  EXPECT_EQ(actual->Query(request), expected);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud


### PR DESCRIPTION
Implements the `Idempotency` policy for query api, with tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12051)
<!-- Reviewable:end -->
