### PR TITLE
test(bigtable): verify reverse scan row order

### DIFF
--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -33,6 +33,7 @@ using ::std::chrono::duration_cast;
 using ::std::chrono::microseconds;
 using ::std::chrono::milliseconds;
 using ::testing::Contains;
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 
 class DataIntegrationTest : public TableIntegrationTest,
@@ -198,12 +199,6 @@ TEST_P(DataIntegrationTest, TableReadRowsAllRows) {
 
   auto read4 = table.ReadRows(RowSet(), Filter::PassAllFilter());
   CheckEqualUnordered(created, MoveCellsFromReader(read4));
-
-  if (GetParam() == "with-data-connection" && !UsingCloudBigtableEmulator()) {
-    auto read5 = table.ReadRows(RowSet(), Filter::PassAllFilter(),
-                                Options{}.set<ReverseScanOption>(true));
-    CheckEqualUnordered(created, MoveCellsFromReader(read5));
-  }
 }
 
 TEST_P(DataIntegrationTest, TableReadRowsPartialRows) {
@@ -246,6 +241,30 @@ TEST_P(DataIntegrationTest, TableReadRowsPartialRows) {
     auto reader = table.ReadRows(std::move(rows), Filter::PassAllFilter());
     CheckEqualUnordered(expected, MoveCellsFromReader(reader));
   }
+}
+
+TEST_P(DataIntegrationTest, TableReadRowsReverseScan) {
+  if (GetParam() == "with-data-client") GTEST_SKIP();
+  // The emulator does not yet support reverse scans.
+  if (UsingCloudBigtableEmulator()) GTEST_SKIP();
+  auto table = GetTable(GetParam());
+
+  std::vector<Cell> created{{"row-key-1", kFamily4, "c1", 1000, "a"},
+                            {"row-key-1", kFamily4, "c2", 2000, "b"},
+                            {"row-key-2", kFamily4, "c1", 3000, "c"},
+                            {"row-key-3", kFamily4, "c1", 4000, "d"}};
+
+  CreateCells(table, created);
+
+  auto reader = table.ReadRows(RowSet(), Filter::PassAllFilter(),
+                               Options{}.set<ReverseScanOption>(true));
+  auto cells = MoveCellsFromReader(reader);
+  CheckEqualUnordered(created, cells);
+  std::vector<RowKeyType> rows(cells.size());
+  std::transform(cells.begin(), cells.end(), rows.begin(),
+                 [](Cell const& cell) { return cell.row_key(); });
+  EXPECT_THAT(rows,
+              ElementsAre("row-key-3", "row-key-2", "row-key-1", "row-key-1"));
 }
 
 TEST_P(DataIntegrationTest, TableReadRowsNoRows) {


### PR DESCRIPTION
Related to #12010 

Bigtable does not make guarantees on how it stores column families, which is why we use `CheckEqualUnordered(...)` for a list of cells.

Bigtable does make guarantees on the order of row keys returned. So we should verify that a reverse scan receives rows in reverse order.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12054)
<!-- Reviewable:end -->
