### PR TITLE
cleanup(bigtable): websafe encoding of feature flags

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -49,10 +49,7 @@ std::string FeaturesMetadata() {
   static auto const* const kFeatures = new auto([] {
     google::bigtable::v2::FeatureFlags proto;
     proto.set_reverse_scans(true);
-    auto bytes = proto.SerializeAsString();
-    internal::Base64Encoder enc;
-    for (auto c : bytes) enc.PushBack(c);
-    return std::move(enc).FlushAndPad();
+    return internal::UrlsafeBase64Encode(proto.SerializeAsString());
   }());
   return *kFeatures;
 }

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -256,14 +256,14 @@ TEST_F(BigtableStubFactory, AsyncMutateRow) {
 }
 
 TEST_F(BigtableStubFactory, FeaturesFlags) {
+  auto constexpr kWebSafeBase64Regex = "[A-Z0-9_-]+";
   MockFactory factory;
   EXPECT_CALL(factory, Call)
-      .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
+      .WillOnce([=](std::shared_ptr<grpc::Channel> const&) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, MutateRow)
-            .WillOnce([](grpc::ClientContext& context,
-                         google::bigtable::v2::MutateRowRequest const&) {
-              auto constexpr kWebSafeBase64Regex = "[A-Z0-9_-]+";
+            .WillOnce([=](grpc::ClientContext& context,
+                          google::bigtable::v2::MutateRowRequest const&) {
               ValidateMetadataFixture fixture;
               auto headers = fixture.GetMetadata(context);
               EXPECT_THAT(headers,

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -41,8 +41,7 @@ using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::Contains;
 using ::testing::HasSubstr;
-using ::testing::IsEmpty;
-using ::testing::Not;
+using ::testing::MatchesRegex;
 using ::testing::NotNull;
 using ::testing::Return;
 
@@ -264,10 +263,12 @@ TEST_F(BigtableStubFactory, FeaturesFlags) {
         EXPECT_CALL(*mock, MutateRow)
             .WillOnce([](grpc::ClientContext& context,
                          google::bigtable::v2::MutateRowRequest const&) {
+              auto constexpr kWebSafeBase64Regex = "[A-Z0-9_-]+";
               ValidateMetadataFixture fixture;
               auto headers = fixture.GetMetadata(context);
               EXPECT_THAT(headers,
-                          Contains(Pair("bigtable-features", Not(IsEmpty()))));
+                          Contains(Pair("bigtable-features",
+                                        MatchesRegex(kWebSafeBase64Regex))));
               return internal::AbortedError("fail");
             });
         return mock;

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -42,12 +42,14 @@ using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::Contains;
 using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+using ::testing::Not;
 using ::testing::NotNull;
 using ::testing::Pair;
 using ::testing::Return;
 
 MATCHER(IsWebSafeBase64, "") {
-  std::regex regex(R"re([A-Z0-9_-]+)re");
+  std::regex regex(R"re([A-Z0-9_-]*)re");
   return std::regex_match(arg, regex);
 }
 
@@ -271,8 +273,10 @@ TEST_F(BigtableStubFactory, FeaturesFlags) {
                          google::bigtable::v2::MutateRowRequest const&) {
               ValidateMetadataFixture fixture;
               auto headers = fixture.GetMetadata(context);
-              EXPECT_THAT(headers, Contains(Pair("bigtable-features",
-                                                 IsWebSafeBase64())));
+              EXPECT_THAT(
+                  headers,
+                  Contains(Pair("bigtable-features",
+                                AllOf(Not(IsEmpty()), IsWebSafeBase64()))));
               return internal::AbortedError("fail");
             });
         return mock;

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -264,11 +264,11 @@ TEST_F(BigtableStubFactory, AsyncMutateRow) {
 TEST_F(BigtableStubFactory, FeaturesFlags) {
   MockFactory factory;
   EXPECT_CALL(factory, Call)
-      .WillOnce([=](std::shared_ptr<grpc::Channel> const&) {
+      .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, MutateRow)
-            .WillOnce([=](grpc::ClientContext& context,
-                          google::bigtable::v2::MutateRowRequest const&) {
+            .WillOnce([](grpc::ClientContext& context,
+                         google::bigtable::v2::MutateRowRequest const&) {
               ValidateMetadataFixture fixture;
               auto headers = fixture.GetMetadata(context);
               EXPECT_THAT(headers, Contains(Pair("bigtable-features",


### PR DESCRIPTION
cc: @igorbernstein2 who pointed out that the feature flags metadata should be web safe escaped.

Aside: there are probably several uses of `internal::Base64Encoder` that could be replaced with the abseil implementation. I do not plan to refactor them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12057)
<!-- Reviewable:end -->
