### PR TITLE
cleanup(rest): treat 1xx as UNAVAILABLE

### DIFF
--- a/google/cloud/internal/rest_response.cc
+++ b/google/cloud/internal/rest_response.cc
@@ -26,9 +26,11 @@ StatusCode MapHttpCodeToStatus0xx(std::int32_t) {
 }
 
 StatusCode MapHttpCodeToStatus1xx(std::int32_t) {
-  // We treat the 100s (e.g. 100 Continue) as OK results. They normally are
-  // ignored by libcurl, so we do not really expect to see them.
-  return StatusCode::kOk;
+  // Even though the 100s (e.g. 100 Continue) are an indication that the client
+  // request is continuing, we treat them as UNAVAILABLE, because the response
+  // is incomplete. In practice, they are ignored by libcurl, so we do not
+  // expect to see them.
+  return StatusCode::kUnavailable;
 }
 
 StatusCode MapHttpCodeToStatus2xx(std::int32_t) {

--- a/google/cloud/internal/rest_response_test.cc
+++ b/google/cloud/internal/rest_response_test.cc
@@ -43,8 +43,9 @@ TEST_P(MapHttpCodeToStatusTest, CorrectMapping) {
 INSTANTIATE_TEST_SUITE_P(
     MappingPairs, MapHttpCodeToStatusTest,
     testing::Values(
-        std::make_pair(HttpStatusCode::kContinue, StatusCode::kOk),
-        std::make_pair(static_cast<HttpStatusCode>(102), StatusCode::kOk),
+        std::make_pair(HttpStatusCode::kContinue, StatusCode::kUnavailable),
+        std::make_pair(static_cast<HttpStatusCode>(102),
+                       StatusCode::kUnavailable),
         std::make_pair(HttpStatusCode::kOk, StatusCode::kOk),
         std::make_pair(HttpStatusCode::kCreated, StatusCode::kOk),
         std::make_pair(static_cast<HttpStatusCode>(202), StatusCode::kOk),


### PR DESCRIPTION
Fixes #12060 

No, I am not 100% sure this is the right fix. See the issue statement for alternatives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12061)
<!-- Reviewable:end -->
