### PR TITLE
ci: increase timeout to accommodate clang-tidy-full

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -45,7 +45,7 @@ substitutions:
   _LOGS_BUCKET: 'cloud-cpp-community-publiclogs'
   _TAG1: 'team-only'
 
-timeout: 12600s
+timeout: 36000s
 tags: [
   '${_TRIGGER_TYPE}',
   '${_BUILD_NAME}',


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12070)
<!-- Reviewable:end -->
