### PR TITLE
cleanup: const-correctness for unified credentials

### DIFF
--- a/google/cloud/credentials.h
+++ b/google/cloud/credentials.h
@@ -57,7 +57,7 @@ class Credentials {
 
  private:
   friend class internal::CredentialsVisitor;
-  virtual void dispatch(internal::CredentialsVisitor& visitor) = 0;
+  virtual void dispatch(internal::CredentialsVisitor& visitor) const = 0;
 };
 
 /**

--- a/google/cloud/internal/credentials_impl.cc
+++ b/google/cloud/internal/credentials_impl.cc
@@ -41,7 +41,7 @@ Options PopulateAuthOptions(Options options) {
       std::move(options));
 }
 
-void CredentialsVisitor::dispatch(Credentials& credentials,
+void CredentialsVisitor::dispatch(Credentials const& credentials,
                                   CredentialsVisitor& visitor) {
   credentials.dispatch(visitor);
 }

--- a/google/cloud/internal/credentials_impl.h
+++ b/google/cloud/internal/credentials_impl.h
@@ -42,14 +42,15 @@ class ExternalAccountConfig;
 class CredentialsVisitor {
  public:
   virtual ~CredentialsVisitor() = default;
-  virtual void visit(InsecureCredentialsConfig&) = 0;
-  virtual void visit(GoogleDefaultCredentialsConfig&) = 0;
-  virtual void visit(AccessTokenConfig&) = 0;
-  virtual void visit(ImpersonateServiceAccountConfig&) = 0;
-  virtual void visit(ServiceAccountConfig&) = 0;
-  virtual void visit(ExternalAccountConfig&) = 0;
+  virtual void visit(InsecureCredentialsConfig const&) = 0;
+  virtual void visit(GoogleDefaultCredentialsConfig const&) = 0;
+  virtual void visit(AccessTokenConfig const&) = 0;
+  virtual void visit(ImpersonateServiceAccountConfig const&) = 0;
+  virtual void visit(ServiceAccountConfig const&) = 0;
+  virtual void visit(ExternalAccountConfig const&) = 0;
 
-  static void dispatch(Credentials& credentials, CredentialsVisitor& visitor);
+  static void dispatch(Credentials const& credentials,
+                       CredentialsVisitor& visitor);
 };
 
 class InsecureCredentialsConfig : public Credentials {
@@ -60,7 +61,7 @@ class InsecureCredentialsConfig : public Credentials {
   Options const& options() const { return options_; }
 
  private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+  void dispatch(CredentialsVisitor& v) const override { v.visit(*this); }
 
   Options options_;
 };
@@ -73,7 +74,7 @@ class GoogleDefaultCredentialsConfig : public Credentials {
   Options const& options() const { return options_; }
 
  private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+  void dispatch(CredentialsVisitor& v) const override { v.visit(*this); }
 
   Options options_;
 };
@@ -89,7 +90,7 @@ class AccessTokenConfig : public Credentials {
   Options const& options() const { return options_; }
 
  private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+  void dispatch(CredentialsVisitor& v) const override { v.visit(*this); }
 
   AccessToken access_token_;
   Options options_;
@@ -113,7 +114,7 @@ class ImpersonateServiceAccountConfig : public Credentials {
   Options const& options() const { return options_; }
 
  private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+  void dispatch(CredentialsVisitor& v) const override { v.visit(*this); }
 
   std::shared_ptr<Credentials> base_credentials_;
   std::string target_service_account_;
@@ -128,7 +129,7 @@ class ServiceAccountConfig : public Credentials {
   Options const& options() const { return options_; }
 
  private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+  void dispatch(CredentialsVisitor& v) const override { v.visit(*this); }
 
   std::string json_object_;
   Options options_;
@@ -142,7 +143,7 @@ class ExternalAccountConfig : public Credentials {
   Options const& options() const { return options_; }
 
  private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+  void dispatch(CredentialsVisitor& v) const override { v.visit(*this); }
 
   std::string json_object_;
   Options options_;

--- a/google/cloud/internal/credentials_impl_test.cc
+++ b/google/cloud/internal/credentials_impl_test.cc
@@ -28,29 +28,29 @@ using ::testing::IsNull;
 struct Visitor : public CredentialsVisitor {
   std::string name;
   AccessToken access_token;
-  ImpersonateServiceAccountConfig* impersonate = nullptr;
+  ImpersonateServiceAccountConfig const* impersonate = nullptr;
   std::string json_object;
   Options options;
 
-  void visit(InsecureCredentialsConfig&) override {
+  void visit(InsecureCredentialsConfig const&) override {
     name = "InsecureCredentialsConfig";
   }
-  void visit(GoogleDefaultCredentialsConfig&) override {
+  void visit(GoogleDefaultCredentialsConfig const&) override {
     name = "GoogleDefaultCredentialsConfig";
   }
-  void visit(AccessTokenConfig& cfg) override {
+  void visit(AccessTokenConfig const& cfg) override {
     name = "AccessTokenConfig";
     access_token = cfg.access_token();
   }
-  void visit(ImpersonateServiceAccountConfig& cfg) override {
+  void visit(ImpersonateServiceAccountConfig const& cfg) override {
     name = "ImpersonateServiceAccountConfig";
     impersonate = &cfg;
   }
-  void visit(ServiceAccountConfig& cfg) override {
+  void visit(ServiceAccountConfig const& cfg) override {
     name = "ServiceAccountConfig";
     json_object = cfg.json_object();
   }
-  void visit(ExternalAccountConfig& cfg) override {
+  void visit(ExternalAccountConfig const& cfg) override {
     name = "ExternalAccountConfig";
     json_object = cfg.json_object();
     options = cfg.options();

--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -103,7 +103,7 @@ CurlRestClient::CurlRestClient(std::string endpoint_address,
                                 google::cloud::internal::ApiClientHeader()),
       options_(std::move(options)) {
   if (options_.has<UnifiedCredentialsOption>()) {
-    credentials_ = MapCredentials(options_.get<UnifiedCredentialsOption>());
+    credentials_ = MapCredentials(*options_.get<UnifiedCredentialsOption>());
   }
 }
 

--- a/google/cloud/internal/grpc_impersonate_service_account.cc
+++ b/google/cloud/internal/grpc_impersonate_service_account.cc
@@ -29,7 +29,7 @@ using ::google::iam::credentials::v1::GenerateAccessTokenResponse;
 AsyncAccessTokenSource MakeSource(ImpersonateServiceAccountConfig const& config,
                                   CompletionQueue cq, Options const& options) {
   auto stub = MakeMinimalIamCredentialsStub(
-      CreateAuthenticationStrategy(config.base_credentials(), std::move(cq),
+      CreateAuthenticationStrategy(*config.base_credentials(), std::move(cq),
                                    options),
       MakeMinimalIamCredentialsOptions(options));
 

--- a/google/cloud/internal/oauth2_impersonate_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_impersonate_service_account_credentials.cc
@@ -39,7 +39,7 @@ ImpersonateServiceAccountCredentials::ImpersonateServiceAccountCredentials(
     HttpClientFactory client_factory)
     : ImpersonateServiceAccountCredentials(
           config, MakeMinimalIamCredentialsRestStub(
-                      rest_internal::MapCredentials(config.base_credentials()),
+                      rest_internal::MapCredentials(*config.base_credentials()),
                       config.options(), std::move(client_factory))) {}
 
 ImpersonateServiceAccountCredentials::ImpersonateServiceAccountCredentials(

--- a/google/cloud/internal/unified_grpc_credentials.h
+++ b/google/cloud/internal/unified_grpc_credentials.h
@@ -45,8 +45,7 @@ std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
     google::cloud::CompletionQueue cq, Options const& options);
 
 std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
-    std::shared_ptr<Credentials> const& credentials, CompletionQueue cq,
-    Options options = {});
+    Credentials const& credentials, CompletionQueue cq, Options options = {});
 
 std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
     std::shared_ptr<grpc::ChannelCredentials> const& credentials);

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -67,7 +67,7 @@ TEST(UnifiedGrpcCredentialsTest, WithGrpcCredentials) {
 
 TEST(UnifiedGrpcCredentialsTest, WithInsecureCredentials) {
   CompletionQueue cq;
-  auto result = CreateAuthenticationStrategy(MakeInsecureCredentials(), cq);
+  auto result = CreateAuthenticationStrategy(*MakeInsecureCredentials(), cq);
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
   auto status = result->ConfigureContext(context);
@@ -83,7 +83,7 @@ TEST(UnifiedGrpcCredentialsTest, WithDefaultCredentials) {
 
   CompletionQueue cq;
   auto result =
-      CreateAuthenticationStrategy(MakeGoogleDefaultCredentials(), cq);
+      CreateAuthenticationStrategy(*MakeGoogleDefaultCredentials(), cq);
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
   auto status = result->ConfigureContext(context);
@@ -96,7 +96,7 @@ TEST(UnifiedGrpcCredentialsTest, WithAccessTokenCredentials) {
       std::chrono::system_clock::now() + std::chrono::hours(1);
   CompletionQueue cq;
   auto result = CreateAuthenticationStrategy(
-      MakeAccessTokenCredentials("test-token", expiration), cq);
+      *MakeAccessTokenCredentials("test-token", expiration), cq);
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
   auto status = result->ConfigureContext(context);

--- a/google/cloud/internal/unified_rest_credentials.h
+++ b/google/cloud/internal/unified_rest_credentials.h
@@ -31,7 +31,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * `google::cloud::oauth2_internal::Credentials` type.
  */
 std::shared_ptr<oauth2_internal::Credentials> MapCredentials(
-    std::shared_ptr<google::cloud::Credentials> const& credentials);
+    google::cloud::Credentials const& credentials);
 
 /**
  * @copydoc MapCredentials(std::shared_ptr<google::cloud::Credentials> const&)
@@ -39,7 +39,7 @@ std::shared_ptr<oauth2_internal::Credentials> MapCredentials(
  * This is used in tests, where the HTTP client needs to be mocked.
  */
 std::shared_ptr<oauth2_internal::Credentials> MapCredentials(
-    std::shared_ptr<google::cloud::Credentials> const& credentials,
+    google::cloud::Credentials const& credentials,
     oauth2_internal::HttpClientFactory client_factory);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -282,16 +282,16 @@ Options DefaultOptionsWithCredentials(Options opts) {
   }
   if (opts.has<UnifiedCredentialsOption>()) {
     auto credentials =
-        internal::MapCredentials(opts.get<UnifiedCredentialsOption>());
+        internal::MapCredentials(*opts.get<UnifiedCredentialsOption>());
     return internal::DefaultOptions(std::move(credentials), std::move(opts));
   }
   if (GetEmulator().has_value()) {
     return internal::DefaultOptions(
-        internal::MapCredentials(google::cloud::MakeInsecureCredentials()),
+        internal::MapCredentials(*google::cloud::MakeInsecureCredentials()),
         std::move(opts));
   }
   return internal::DefaultOptions(
-      internal::MapCredentials(google::cloud::MakeGoogleDefaultCredentials()),
+      internal::MapCredentials(*google::cloud::MakeGoogleDefaultCredentials()),
       std::move(opts));
 }
 

--- a/google/cloud/storage/internal/impersonate_service_account_credentials.cc
+++ b/google/cloud/storage/internal/impersonate_service_account_credentials.cc
@@ -40,7 +40,7 @@ ImpersonateServiceAccountCredentials::ImpersonateServiceAccountCredentials(
     google::cloud::internal::ImpersonateServiceAccountConfig const& config)
     : ImpersonateServiceAccountCredentials(
           config, MakeMinimalIamCredentialsRestStub(
-                      MapCredentials(config.base_credentials()))) {}
+                      MapCredentials(*config.base_credentials()))) {}
 
 ImpersonateServiceAccountCredentials::ImpersonateServiceAccountCredentials(
     google::cloud::internal::ImpersonateServiceAccountConfig const& config,

--- a/google/cloud/storage/internal/unified_rest_credentials.h
+++ b/google/cloud/storage/internal/unified_rest_credentials.h
@@ -27,7 +27,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 std::shared_ptr<oauth2::Credentials> MapCredentials(
-    std::shared_ptr<google::cloud::Credentials> const& credentials);
+    google::cloud::Credentials const& credentials);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/unified_rest_credentials_test.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials_test.cc
@@ -55,7 +55,7 @@ class UnifiedRestCredentialsTest : public ::testing::Test {
 };
 
 TEST_F(UnifiedRestCredentialsTest, Insecure) {
-  auto credentials = MapCredentials(MakeInsecureCredentials());
+  auto credentials = MapCredentials(*MakeInsecureCredentials());
   auto header = credentials->AuthorizationHeader();
   ASSERT_THAT(header, IsOk());
   EXPECT_THAT(*header, IsEmpty());
@@ -63,7 +63,7 @@ TEST_F(UnifiedRestCredentialsTest, Insecure) {
 
 TEST_F(UnifiedRestCredentialsTest, AccessToken) {
   auto credentials = MapCredentials(
-      MakeAccessTokenCredentials("token1", std::chrono::system_clock::now()));
+      *MakeAccessTokenCredentials("token1", std::chrono::system_clock::now()));
   for (std::string expected : {"token1", "token1", "token1"}) {
     auto header = credentials->AuthorizationHeader();
     ASSERT_THAT(header, IsOk());
@@ -77,7 +77,7 @@ TEST_F(UnifiedRestCredentialsTest, LoadError) {
   auto const filename = TempKeyFileName();
   ScopedEnvironment env("GOOGLE_APPLICATION_CREDENTIALS", filename);
 
-  auto credentials = MapCredentials(MakeGoogleDefaultCredentials());
+  auto credentials = MapCredentials(*MakeGoogleDefaultCredentials());
   EXPECT_THAT(credentials->AuthorizationHeader(), Not(IsOk()));
 }
 
@@ -107,7 +107,7 @@ TEST_F(UnifiedRestCredentialsTest, LoadSuccess) {
 
   ScopedEnvironment env("GOOGLE_APPLICATION_CREDENTIALS", filename);
 
-  auto credentials = MapCredentials(MakeGoogleDefaultCredentials());
+  auto credentials = MapCredentials(*MakeGoogleDefaultCredentials());
   // Calling AuthorizationHeader() makes RPCs which would turn this into an
   // integration test, fortunately there are easier ways to verify the file was
   // loaded correctly:


### PR DESCRIPTION
When mapping `google::cloud::Credentials` to the implementation (gRPC or REST) we don't need a `std::shared_ptr<>` or (shudder) `std::shared_ptr<> const&`.  The visitor can work with a `const&`.

Motivated by https://github.com/googleapis/google-cloud-cpp/pull/12064#discussion_r1260032585

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12073)
<!-- Reviewable:end -->
