### PR TITLE
cleanup(otel): fix includes for v1.10.0

### DIFF
--- a/google/cloud/opentelemetry/configure_basic_tracing.cc
+++ b/google/cloud/opentelemetry/configure_basic_tracing.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/opentelemetry/configure_basic_tracing.h"
 #include "google/cloud/opentelemetry/trace_exporter.h"
 #include <opentelemetry/sdk/trace/batch_span_processor.h>
+#include <opentelemetry/sdk/trace/batch_span_processor_options.h>
 #include <opentelemetry/sdk/trace/samplers/trace_id_ratio_factory.h>
 #include <opentelemetry/sdk/trace/tracer_provider.h>
 #include <opentelemetry/trace/provider.h>

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -18,6 +18,7 @@
 #include "absl/time/clock.h"
 #include <google/rpc/code.pb.h>
 #include <gmock/gmock.h>
+#include <opentelemetry/sdk/resource/resource.h>
 #include <opentelemetry/sdk/resource/semantic_conventions.h>
 
 namespace google {

--- a/google/cloud/opentelemetry/samples/samples.cc
+++ b/google/cloud/opentelemetry/samples/samples.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/example_driver.h"
 #include <opentelemetry/sdk/trace/batch_span_processor_factory.h>
+#include <opentelemetry/sdk/trace/batch_span_processor_options.h>
+#include <opentelemetry/sdk/trace/processor.h>
 #include <opentelemetry/sdk/trace/tracer_provider_factory.h>
 #include <opentelemetry/trace/provider.h>
 #include <string>


### PR DESCRIPTION
Prepare for `opentelemetry-cpp` v1.10.0. (See the `renovate-bot` PR: #12072)

Tested (using `cxx14`): https://pantheon.corp.google.com/cloud-build/builds;region=us-east1/a813048e-5eca-49d7-b316-182ac714efe9?project=cloud-cpp-testing-resources&jsmode=o&mods=logs_tg_prod

Note that the `cxx20` build fails for a different (external) reason. I sent https://github.com/open-telemetry/opentelemetry-cpp/pull/2230 upstream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12075)
<!-- Reviewable:end -->
