### PR TITLE
ci: more robust vcpkg cache for GHA build

### DIFF
--- a/.github/workflows/external-account-integration.yml
+++ b/.github/workflows/external-account-integration.yml
@@ -44,7 +44,7 @@ jobs:
           path: |
             ~/.cache/vcpkg
           key: |
-            vcpkg-${{ steps.vcpkg-version.outputs.version }}-${{ hashFiles('vcpkg.json') }}
+            vcpkg-${{ steps.vcpkg-version.outputs.version }}-${{ hashFiles('vcpkg.json', '/usr/bin/g++', '/usr/bin/gcc') }}
           restore-keys: |
             vcpkg-${{ steps.vcpkg-version.outputs.version }}-
 
@@ -55,6 +55,13 @@ jobs:
           cmake -G Ninja -S . -B "${{runner.temp}}/build" \
               -DGOOGLE_CLOUD_CPP_ENABLE=storage,iam \
               -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.cache/vcpkg
+          key: vcpkg-${{ steps.vcpkg-version.outputs.version }}-${{ hashFiles('vcpkg.json', '/usr/bin/g++', '/usr/bin/gcc') }}
 
       - name: build
         run: |


### PR DESCRIPTION
The vcpkg binary cache uses the compiler executable SHA as part of its hash. We need to include these files in the GHA hash or the GHA is treated as "valid" even though it is no longer usable.

Save the vcpkg cache as soon as it builds correctly. This preserves the vcpkg cache when our build fails but building the deps succeeded.

Part of the work for #11211

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12077)
<!-- Reviewable:end -->
