### PR TITLE
cleanup: IWYU after #12058

### DIFF
--- a/google/cloud/internal/base64_transforms.h
+++ b/google/cloud/internal/base64_transforms.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>

--- a/google/cloud/internal/make_jwt_assertion.cc
+++ b/google/cloud/internal/make_jwt_assertion.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/make_jwt_assertion.h"
+#include "google/cloud/internal/base64_transforms.h"
 #include "google/cloud/internal/openssl_util.h"
 
 namespace google {

--- a/google/cloud/internal/openssl_util.cc
+++ b/google/cloud/internal/openssl_util.cc
@@ -21,7 +21,6 @@
 #include <openssl/md5.h>
 #include <openssl/opensslv.h>
 #include <openssl/pem.h>
-#include <algorithm>
 #include <array>
 #include <memory>
 #include <type_traits>

--- a/google/cloud/internal/openssl_util.h
+++ b/google/cloud/internal/openssl_util.h
@@ -15,10 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OPENSSL_UTIL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OPENSSL_UTIL_H
 
-#include "google/cloud/internal/base64_transforms.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/constants.h"
 #include "google/cloud/storage/testing/mock_http_request.h"
 #include "google/cloud/storage/testing/write_base64.h"
+#include "google/cloud/internal/base64_transforms.h"
 #include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/openssl_util.h"
 #include "google/cloud/internal/random.h"


### PR DESCRIPTION
@devbww points out that we no longer `#include <algorithm>` while using `std::replace()` after #12508, which has google3 consequences.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12078)
<!-- Reviewable:end -->
