### PR TITLE
ci(gha): restructure external accounts build

### DIFF
--- a/.github/workflows/external-account-integration.yml
+++ b/.github/workflows/external-account-integration.yml
@@ -1,11 +1,15 @@
 name: "External Account Integration"
 
-# Build on pull requests and pushes to `main`. The PR builds will be
-# non-blocking for now, but that is configured elsewhere.
 on:
-  pull_request:
-  push:
-    branches: [ 'main' ]
+  workflow_call:
+    inputs:
+      checkout-ref:
+        required: true
+        description: "The ref we want to compile"
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
   # A minimal build to validate external account (aka Workload/Workforce
@@ -15,74 +19,61 @@ jobs:
   # usable in this case.
   identity-federation-integration-test:
     name: external-account-integration-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Add "id-token" with the intended permissions.
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: read
+      id-token: write
 
     steps:
-      - name: install ninja
-        run: sudo apt install ninja-build
-      - uses: 'actions/checkout@v3'
-      - name: vcpkg-version
-        id: vcpkg-version
-        run: |
-          echo "version=$(cat ci/etc/vcpkg-version.txt)" >> "${GITHUB_OUTPUT}"
-        shell: bash
-      - name: clone-vcpkg
-        working-directory: "${{runner.temp}}"
-        run: |
-          mkdir -p vcpkg
-          curl -fsSL "https://github.com/microsoft/vcpkg/archive/${{ steps.vcpkg-version.outputs.version }}.tar.gz" |
-              tar -C vcpkg --strip-components=1 -zxf -
-          vcpkg/bootstrap-vcpkg.sh -disableMetrics
-      - name: cache-vcpkg
-        id: cache-vcpkg
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/vcpkg
-          key: |
-            vcpkg-${{ steps.vcpkg-version.outputs.version }}-${{ hashFiles('vcpkg.json', '/usr/bin/g++', '/usr/bin/gcc') }}
-          restore-keys: |
-            vcpkg-${{ steps.vcpkg-version.outputs.version }}-
-
-      # Configuring CMake installs the dependencies from the vcpkg cache, or
-      # warms up said cache.
-      - name: configure
-        run: |
-          cmake -G Ninja -S . -B "${{runner.temp}}/build" \
-              -DGOOGLE_CLOUD_CPP_ENABLE=storage,iam \
-              -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-
-      - uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: |
-            ~/.cache/vcpkg
-          key: vcpkg-${{ steps.vcpkg-version.outputs.version }}-${{ hashFiles('vcpkg.json', '/usr/bin/g++', '/usr/bin/gcc') }}
-
-      - name: build
-        run: |
-          cmake --build "${{runner.temp}}/build" -j 2 \
-            --target common_internal_external_account_integration_test
-
-      # Configure Workload Identity Federation and generate an access token.
-      - id: 'auth'
-        if: '!github.event.pull_request.head.repo.fork'
-        name: 'Authenticate to GCP'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          create_credentials_file: 'true'
-          workload_identity_provider: 'projects/49427430084/locations/global/workloadIdentityPools/github-wif-pool/providers/github-wif-provider'
-          service_account: 'github-actions@cloud-cpp-identity-federation.iam.gserviceaccount.com'
-      - id: 'test'
-        if: '!github.event.pull_request.head.repo.fork'
-        name: 'Run Integration Test'
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
-          GOOGLE_CLOUD_CPP_TEST_WIF_BUCKET: "cloud-cpp-wif-test-bucket"
-          GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG: "lastN,1024,WARNING"
-        run: |
-          ctest --test-dir "${{runner.temp}}/build" --output-on-failure -R common_internal_external_account_integration_test
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.checkout-ref }}
+    - id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        create_credentials_file: true
+        credentials_json: ${{ secrets.BUILD_CACHE_KEY }}
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+    - name: vcpkg-version
+      id: vcpkg-version
+      run: |
+        echo "version=$(cat ci/etc/vcpkg-version.txt)" >> "${GITHUB_OUTPUT}"
+      shell: bash
+    - name: install ninja
+      run: sudo apt install ninja-build
+    - name: download-sccache
+      working-directory: "${{runner.temp}}"
+      run: |
+        curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | \
+          tar -zxf - --strip-components=1 && \
+        sudo mv sccache /usr/bin/sccache && \
+        sudo chmod +x /usr/bin/sccache
+    - name: download-vcpkg
+      working-directory: "${{runner.temp}}"
+      run: |
+        mkdir -p vcpkg
+        curl -fsSL "https://github.com/microsoft/vcpkg/archive/${{ steps.vcpkg-version.outputs.version }}.tar.gz" |
+            tar -C vcpkg --strip-components=1 -zxf -
+        vcpkg/bootstrap-vcpkg.sh -disableMetrics
+    # First compile the code using the identity with access to the build cache
+    - run: |
+        env VCPKG_ROOT="${{ runner.temp }}/vcpkg" ci/gha/builds/external-account.sh
+    # Then switch to the BYOID identity and run the integration test
+    - id: byoid-auth
+      if: '!github.event.pull_request.head.repo.fork'
+      name: 'Authenticate to GCP'
+      uses: 'google-github-actions/auth@v1'
+      with:
+        create_credentials_file: true
+        workload_identity_provider: 'projects/49427430084/locations/global/workloadIdentityPools/github-wif-pool/providers/github-wif-provider'
+        service_account: 'github-actions@cloud-cpp-identity-federation.iam.gserviceaccount.com'
+    - run: |
+        ctest --test-dir cmake-out --output-on-failure -R common_internal_external_account_integration_test
+    env:
+      SCCACHE_GCS_BUCKET: cloud-cpp-gha-cache
+      SCCACHE_GCS_KEY_PREFIX: sccache/ubuntu-22.04/${{ github.job }}
+      SCCACHE_GCS_RW_MODE: READ_WRITE
+      SCCACHE_IGNORE_SERVER_IO_ERROR: 1
+      VCPKG_BINARY_SOURCES: x-gcs,gs://cloud-cpp-gha-cache/vcpkg-cache/ubuntu-22.04/${{ github.job }},readwrite

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -37,14 +37,6 @@ jobs:
   # in separate files to keep the size of this file under control. Note how
   # the additional jobs inherit any secrets needed to use the remote caches and
   # receive what version to checkout as an input.
-  macos:
-    name: macOS
-    needs: [pre-flight]
-    uses: ./.github/workflows/macos.yml
-    with:
-      checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
-    secrets: inherit
-
   external-account-integration:
     name: External Account Integration
     needs: [pre-flight]

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -6,7 +6,7 @@ on:
   # Start these builds on pushes (think "after the merge") too. Normally there
   # are no `ci-gha**` branches in our repository. The contributors to the repo
   # can create such branches when testing or troubleshooting builds. In such
-  # branch we can disable builds (to speed up the testing) or add new ones,
+  # branches we can disable builds (to speed up the testing) or add new ones,
   # without impacting the rest of the team.
   push:
     branches: [ 'main', 'v[2-9]**', 'ci-gha**' ]

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -1,0 +1,54 @@
+name: "Test"
+
+# Build on pull requests and pushes to `main`. The PR builds will be
+# non-blocking for now, but that is configured elsewhere.
+on:
+  # Start these builds on pushes (think "after the merge") too. Normally there
+  # are no `ci-gha**` branches in our repository. The contributors to the repo
+  # can create such branches when testing or troubleshooting builds. In such
+  # branch we can disable builds (to speed up the testing) or add new ones,
+  # without impacting the rest of the team.
+  push:
+    branches: [ 'main', 'v[2-9]**', 'ci-gha**' ]
+  # Start the build in the context of the target branch. This is considered
+  # "safe", as the workflow files are already committed. These types of builds
+  # have access to the secrets in the build, which we need to use the remote
+  # caches (Bazel and sccache).
+  pull_request_target:
+
+jobs:
+  pre-flight:
+    # For external contributors, run the build in the `external` environment.
+    # This requires manual approval from a contributor. It also saves the
+    # `ref` of the pull request, so downstream jobs know what to checkout.
+    environment: ${{ (github.event_name != 'pull_request_target' && 'internal') || (github.event.pull_request.head.repo.full_name == github.repository && 'internal') || (contains(fromJSON(vars.TRUSTED_FORKS), github.actor) && 'internal') || 'external' }}
+    name: Require Approval for External PRs
+    runs-on: ubuntu-latest
+    outputs:
+      checkout-sha: ${{ steps.safe-checkout.outputs.sha }}
+    steps:
+      - name: Save Pull Request
+        id: save-pull-request
+        run: >
+          echo "sha=${{ github.event.pull_request.head.sha || github.ref }}" >> $GITHUB_OUTPUT
+
+  # Run other jobs once the `pre-flight` job passes. When the `pre-flight`
+  # job requires approval, these blocks all the other jobs. The jobs are defined
+  # in separate files to keep the size of this file under control. Note how
+  # the additional jobs inherit any secrets needed to use the remote caches and
+  # receive what version to checkout as an input.
+  macos:
+    name: macOS
+    needs: [pre-flight]
+    uses: ./.github/workflows/macos.yml
+    with:
+      checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
+    secrets: inherit
+
+  external-account-integration:
+    name: External Account Integration
+    needs: [pre-flight]
+    uses: ./.github/workflows/external-account-integration.yml
+    with:
+      checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
+    secrets: inherit

--- a/ci/gha/builds/external-account.sh
+++ b/ci/gha/builds/external-account.sh
@@ -24,9 +24,9 @@ mapfile -t args < <(cmake::common_args)
 mapfile -t vcpkg_args < <(cmake::vcpkg_args)
 mapfile -t ctest_args < <(ctest::common_args)
 
-# This is a build to test External Accounts, this is a feature to use accounts
+# This is a build to test External Accounts. This is a feature to use accounts
 # from providers other than Google to access Google services. In this case we
-# using "GitHub Actions" as the provider.
+# are using "GitHub Actions" as the provider.
 # The External Accounts feature is sometimes known as Workload Identity
 # Federation, and sometimes BYOID (Bring Your Own ID).
 features=(
@@ -41,14 +41,11 @@ enable=${enable:1}
 io::log_h1 "Starting Build"
 TIMEFORMAT="==> 🕑 CMake configuration done in %R seconds"
 time {
-  # Always run //google/cloud:status_test in case the list of targets has
-  # no unit tests.
   io::run cmake "${args[@]}" "${vcpkg_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE="${enable}"
 }
 
 TIMEFORMAT="==> 🕑 CMake build done in %R seconds"
 time {
-  # Always run //google/cloud:status_test in case the list of targets has
-  # no unit tests.
+  # Compile only the integration test we need for this build
   io::run cmake --build cmake-out --target common_internal_external_account_integration_test
 }

--- a/ci/gha/builds/external-account.sh
+++ b/ci/gha/builds/external-account.sh
@@ -30,10 +30,10 @@ mapfile -t ctest_args < <(ctest::common_args)
 # The External Accounts feature is sometimes known as Workload Identity
 # Federation, and sometimes BYOID (Bring Your Own ID).
 features=(
-    # Enable the smallest set of libraries libraries that will compile gRPC and
-    # REST-based authentication components
-    storage
-    iam
+  # Enable the smallest set of libraries libraries that will compile gRPC and
+  # REST-based authentication components
+  storage
+  iam
 )
 enable=$(printf ";%s" "${features[@]}")
 enable=${enable:1}
@@ -41,14 +41,14 @@ enable=${enable:1}
 io::log_h1 "Starting Build"
 TIMEFORMAT="==> 🕑 CMake configuration done in %R seconds"
 time {
-    # Always run //google/cloud:status_test in case the list of targets has
-    # no unit tests.
-    io::run cmake "${args[@]}" "${vcpkg_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE="${enable}"
+  # Always run //google/cloud:status_test in case the list of targets has
+  # no unit tests.
+  io::run cmake "${args[@]}" "${vcpkg_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE="${enable}"
 }
 
 TIMEFORMAT="==> 🕑 CMake build done in %R seconds"
 time {
-    # Always run //google/cloud:status_test in case the list of targets has
-    # no unit tests.
-    io::run cmake --build cmake-out --target common_internal_external_account_integration_test
+  # Always run //google/cloud:status_test in case the list of targets has
+  # no unit tests.
+  io::run cmake --build cmake-out --target common_internal_external_account_integration_test
 }

--- a/ci/gha/builds/external-account.sh
+++ b/ci/gha/builds/external-account.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/gha/builds/lib/linux.sh
+source module ci/gha/builds/lib/cmake.sh
+
+mapfile -t args < <(cmake::common_args)
+mapfile -t vcpkg_args < <(cmake::vcpkg_args)
+mapfile -t ctest_args < <(ctest::common_args)
+
+# This is a build to test External Accounts, this is a feature to use accounts
+# from providers other than Google to access Google services. In this case we
+# using "GitHub Actions" as the provider.
+# The External Accounts feature is sometimes known as Workload Identity
+# Federation, and sometimes BYOID (Bring Your Own ID).
+features=(
+    # Enable the smallest set of libraries libraries that will compile gRPC and
+    # REST-based authentication components
+    storage
+    iam
+)
+enable=$(printf ";%s" "${features[@]}")
+enable=${enable:1}
+
+io::log_h1 "Starting Build"
+TIMEFORMAT="==> 🕑 CMake configuration done in %R seconds"
+time {
+    # Always run //google/cloud:status_test in case the list of targets has
+    # no unit tests.
+    io::run cmake "${args[@]}" "${vcpkg_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE="${enable}"
+}
+
+TIMEFORMAT="==> 🕑 CMake build done in %R seconds"
+time {
+    # Always run //google/cloud:status_test in case the list of targets has
+    # no unit tests.
+    io::run cmake --build cmake-out --target common_internal_external_account_integration_test
+}

--- a/ci/gha/builds/lib/cmake.sh
+++ b/ci/gha/builds/lib/cmake.sh
@@ -61,7 +61,9 @@ function cmake::common_args() {
 function cmake::vcpkg_args() {
   local args
   args=(
-    -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+    -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    # The version of vcpkg we are using ships with Protobuf v21.x, the
+    # workarounds are required until v23.x.
     -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON
   )
   printf "%s\n" "${args[@]}"

--- a/ci/gha/builds/lib/cmake.sh
+++ b/ci/gha/builds/lib/cmake.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_CMAKE_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_CMAKE_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_CMAKE_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+source module ci/lib/io.sh
+
+io::log_h1 "CMake Info"
+printf "%10s %s\n" "cmake:" "$(cmake --version || echo not available)"
+printf "%10s %s\n" "ninja:" "$(ninja --version || echo not available)"
+printf "%10s %s\n" "sccache:" "$(sccache --version || echo not available)"
+
+if command -v sccache >/dev/null 2>&1; then
+  io::log "Clearing sccache stats"
+  sccache --zero-stats
+  function show_stats_handler() {
+    io::log "Final sccache stats"
+    sccache --show-stats
+  }
+  trap show_stats_handler EXIT
+fi
+
+function cmake::common_args() {
+  local binary="cmake-out"
+  if [[ $# -ge 1 ]]; then
+    binary="$1"
+  fi
+  local args
+  args=(
+    -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON
+    -GNinja
+    -S .
+    -B "${binary}"
+  )
+  if command -v sccache >/dev/null 2>&1; then
+    args+=(
+      -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+    )
+  fi
+  printf "%s\n" "${args[@]}"
+}
+
+function cmake::vcpkg_args() {
+  local args
+  args=(
+    -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+    -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON
+  )
+  printf "%s\n" "${args[@]}"
+}
+
+function ctest::common_args() {
+  local args
+  args=(
+    # Print the full output on failures
+    --output-on-failure
+    # Run many tests in parallel, use -j for compatibility with old versions
+    -j "$(os::cpus)"
+    # Make the output shorter on interactive tests
+    --progress
+  )
+  printf "%s\n" "${args[@]}"
+}

--- a/ci/gha/builds/lib/linux.sh
+++ b/ci/gha/builds/lib/linux.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_LINUX_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_LINUX_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_LINUX_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+source module ci/lib/io.sh
+
+function google_time() {
+  curl -sI google.com | tr -d '\r' | sed -n 's/Date: \(.*\)/\1/p'
+}
+
+function os::cpus() {
+  nproc
+}
+
+io::log_h1 "Machine Info"
+printf "%10s %s\n" "host:" "$(date -u --rfc-3339=seconds)"
+printf "%10s %s\n" "google:" "$(date -ud "$(google_time)" --rfc-3339=seconds)"
+printf "%10s %s\n" "kernel:" "$(uname -v)"
+printf "%10s %s\n" "os:" "$(grep PRETTY_NAME /etc/os-release)"
+printf "%10s %s\n" "nproc:" "$(os::cpus)"
+printf "%10s %s\n" "mem:" "$(mem_total)"
+printf "%10s %s\n" "term:" "${TERM-}"
+printf "%10s %s\n" "bash:" "$(bash --version 2>&1 | head -1)"
+printf "%10s %s\n" "bash:" "${BASH_VERSION:-}"
+printf "%10s %s\n" "gcc:" "$(gcc --version 2>&1 | head -1)"
+printf "%10s %s\n" "clang:" "$(clang --version 2>&1 | head -1)"
+printf "%10s %s\n" "cc:" "$(cc --version 2>&1 | head -1)"


### PR DESCRIPTION
Restructure the external-accounts build to support additional builds in the near future. All the steps to prepare the VM running the build are in the workflow file. The steps to compile the code are in a shell script, which follows the structure of analogous scripts for the GCB-based builds.

This build is still "special" in that it runs one integration test from the workflow file. We may want to refactor that in the future.

This helps with #11944. It also prepares us to move the macOS builds to GHA, which I hope will avoid problems such as #10272 and #9975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12095)
<!-- Reviewable:end -->
