### PR TITLE
fix(compute): enable `rest_internal` if needed

### DIFF
--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -230,6 +230,7 @@ function (google_cloud_cpp_enable_cleanup)
 
     set(GOOGLE_CLOUD_CPP_ENABLE_REST OFF)
     if ((storage IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+        OR (compute IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
         OR (experimental-bigquery_rest IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
         OR (experimental-opentelemetry IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
         OR (sql IN_LIST GOOGLE_CLOUD_CPP_ENABLE)


### PR DESCRIPTION
If only the `compute` feature is enabled we need to manually enable `rest_internal`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12096)
<!-- Reviewable:end -->
