### PR TITLE
cleanup(otel): tests use scoped span catcher

### DIFF
--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -155,7 +155,7 @@ SpanCatcher::SpanCatcher()
   std::shared_ptr<opentelemetry::trace::TracerProvider> provider =
       opentelemetry::sdk::trace::TracerProviderFactory::Create(
           std::move(processor));
-  opentelemetry::trace::Provider::SetTracerProvider(provider);
+  opentelemetry::trace::Provider::SetTracerProvider(std::move(provider));
 }
 
 SpanCatcher::~SpanCatcher() {

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -204,7 +204,7 @@ class SpanCatcher {
  * Calling this method will install an in-memory trace exporter. It returns a
  * type that provides access to captured spans.
  *
- * To extract the spans, call `InMemorySpanData::GetSpans()`. Note that each
+ * To extract the spans, call `SpanCatcher::GetSpans()`. Note that each
  * call to `GetSpans()` will clear the previously collected spans.
  *
  * Also note that this sets the global trace exporter. Thus it is important that

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -26,6 +26,7 @@
 #include <opentelemetry/trace/span.h>
 #include <opentelemetry/trace/span_metadata.h>
 #include <opentelemetry/trace/tracer.h>
+#include <opentelemetry/trace/tracer_provider.h>
 #include <iosfwd>
 #include <memory>
 #include <string>
@@ -184,6 +185,19 @@ template <typename... Args>
   return SpanEventsAreImpl(::testing::ElementsAre(matchers...));
 }
 
+class SpanCatcher {
+ public:
+  SpanCatcher();
+  ~SpanCatcher();
+
+  std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>> GetSpans();
+
+ private:
+  std::shared_ptr<opentelemetry::exporter::memory::InMemorySpanData> span_data_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>
+      previous_;
+};
+
 /**
  * Provides access to created spans.
  *
@@ -198,8 +212,7 @@ template <typename... Args>
  * 1. a new exporter is installed for each test
  * 2. the tests within a fixture do not execute in parallel
  */
-std::shared_ptr<opentelemetry::exporter::memory::InMemorySpanData>
-InstallSpanCatcher();
+std::shared_ptr<SpanCatcher> InstallSpanCatcher();
 
 class MockTextMapPropagator
     : public opentelemetry::context::propagation::TextMapPropagator {

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -207,10 +207,8 @@ class SpanCatcher {
  * To extract the spans, call `InMemorySpanData::GetSpans()`. Note that each
  * call to `GetSpans()` will clear the previously collected spans.
  *
- * Also note that this sets the global trace exporter, which will persist from
- * one test in a test fixture to the next. Thus it is important that:
- * 1. a new exporter is installed for each test
- * 2. the tests within a fixture do not execute in parallel
+ * Also note that this sets the global trace exporter. Thus it is important that
+ * the tests within a fixture do not execute in parallel.
  */
 std::shared_ptr<SpanCatcher> InstallSpanCatcher();
 


### PR DESCRIPTION
Use a scoped span catcher object, that restores the `NoopTracerProvider` after a test runs.

If we forget to `InstallSpanCatcher()` in a test that creates spans, we can see a different valid test fail, because it picks up the extra spans. I don't quite understand why that behavior happens, but I think this PR will eliminate it.

Keep the interface the same so I don't have to update N tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12097)
<!-- Reviewable:end -->
