### PR TITLE
ci(gha): create configuration for Windows builds

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -51,3 +51,10 @@ jobs:
     with:
       checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
     secrets: inherit
+  windows:
+    name: Windows
+    needs: [pre-flight]
+    uses: ./.github/workflows/windows.yml
+    with:
+      checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
+    secrets: inherit

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,7 +118,7 @@ jobs:
           shard: Compute
         include:
         - msvc: windows-2022
-          os: windows-latest
+          os: windows-2022
         - msvc: windows-2019
           os: windows-2019
         - shard: Core

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,204 @@
+name: Windows-Builds
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        required: true
+        description: "The ref we want to compile"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  bazel:
+    name: bazel + ${{ matrix.msvc }} + ${{ matrix.compilation_mode }} + ${{ matrix.shard }}
+    runs-on:
+      group: cpp-runners
+      labels:  ${{ matrix.os }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    strategy:
+      # Continue other builds even if one fails
+      fail-fast: false
+      matrix:
+        msvc: [ msvc-2019 ]
+        # - dbg creates very large debugging files and GHA has limited storage.
+        # - fastbuild also takes too much storage.
+        compilation_mode: [ opt ]
+        shard: [ Core, Compute, Other ]
+        include:
+        - msvc: msvc-2019
+          os: windows-2019
+        - shard: Core
+          targets:
+          - //google/cloud:all
+          # - //generator/...  # Does not build on Windows
+          # - //docfx/...      # Does not build on Windows
+          - +//google/cloud/bigtable/...
+          - +//google/cloud/pubsub/...
+          - +//google/cloud/pubsublite/...
+          - +//google/cloud/spanner/...
+          - +//google/cloud/storage/...
+        - shard: Compute
+          targets:
+          - //google/cloud/compute/...
+        - shard: Other
+          targets:
+          - //...
+          # From Core
+          - -//google/cloud:all
+          - -//generator/...
+          - -//docfx/...
+          - -//google/cloud/bigtable/...
+          - -//google/cloud/pubsub/...
+          - -//google/cloud/pubsublite/...
+          - -//google/cloud/spanner/...
+          - -//google/cloud/storage/...
+          # From Compute
+          - -//google/cloud/compute/...
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.checkout-ref }}
+    - uses: google-github-actions/auth@v1
+      with:
+        create_credentials_file: true
+        credentials_json: ${{ secrets.BUILD_CACHE_KEY }}
+    # go/github-actions#gha-bestpractices explains why we use a SHA instead of
+    # a named version for this runner. We could avoid using this runner with the
+    # ideas from:
+    #   https://github.com/microsoft/vswhere/wiki/Find-VC
+    # Note that in other runners the publisher is GitHub. If we trust GitHub
+    # to run the VM, we should trust their runners.
+    - uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 # @v1.21.1
+    - name: Build google-cloud-cpp
+      shell: bash
+      run: |
+        # Having `/usr/bin/link` in the path will conflict with the MSVC linker.
+        rm -f /usr/bin/link >/dev/null 2>&1
+        # Bazel creates really long paths, sometimes exceeding the MSVC limits.
+        # Using a short name like this avoids the problem in most cases.
+        mkdir -p 'c:\b' || true
+        export BAZEL_ROOT='c:\b'
+        ci/gha/builds/windows-bazel.sh ${{ matrix.compilation_mode }} ${{ join(matrix.targets, ' ') }}
+    env:
+      USE_BAZEL_VERSION: 6.2.1
+      BAZEL_REMOTE_CACHE: https://storage.googleapis.com/cloud-cpp-gha-cache/bazel-cache/${{ matrix.msvc }}/${{ matrix.compliation_mode }}
+
+  cmake:
+    name: cmake + ${{ matrix.msvc }} + ${{ matrix.build_type }} + ${{ matrix.shard }}
+    runs-on:
+      group: cpp-runners
+      labels: ${{ matrix.os }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    strategy:
+      # Continue other builds even if one fails
+      fail-fast: false
+      matrix:
+        msvc: [ windows-2022, windows-2019 ]
+        build_type: [ Debug, Release ]
+        vcpkg_triplet: [ x64-windows ]
+        shard:
+        - Core
+        - Compute
+        - Other
+        exclude:
+        # Compute is (currently) a single `.lib` file. This file is too large in
+        # Debug mode. MSVC uses COFF:
+        #     https://en.wikipedia.org/wiki/COFF
+        # and COFF offsets are 32-bits. No library or program can exceed this
+        # limit:
+        #     https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk1248
+        - build_type: Debug
+          shard: Compute
+        include:
+        - msvc: windows-2022
+          os: windows-latest
+        - msvc: windows-2019
+          os: windows-2019
+        - shard: Core
+          features:
+          - bigtable
+          - pubsub
+          - pubsublite
+          - spanner
+          - storage
+        - shard: Compute
+          features:
+          - compute
+        - shard: Other
+          features:
+          - __ga_libraries__
+          - __experimental_libraries__
+          - -bigtable
+          - -pubsub
+          - -pubsublite
+          - -spanner
+          - -storage
+          - -compute
+          # We use vcpkg in this build, which ships with Protobuf v21.x.
+          # These require Protobuf >= 23.x to compile on Windows.
+          - -asset
+          - -channel
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.checkout-ref }}
+    - uses: google-github-actions/auth@v1
+      with:
+        create_credentials_file: true
+        credentials_json: ${{ secrets.BUILD_CACHE_KEY }}
+    - uses: actions/setup-python@v4
+      id: py311
+      with:
+        python-version: '3.11'
+    - uses: google-github-actions/setup-gcloud@v1
+    - name: Get vcpkg Version
+      id: vcpkg-version
+      shell: bash
+      run: |
+        echo "version=$(cat ci/etc/vcpkg-version.txt)" >> "${GITHUB_OUTPUT}"
+    - name: Download and Install sccache
+      working-directory: "${{runner.temp}}"
+      shell: bash
+      run: |
+        curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-pc-windows-msvc.tar.gz | \
+          tar -zxf - --strip-components=1
+        chmod +x sccache.exe
+        mv sccache.exe /c/Users/runneradmin/.cargo/bin
+    - name: Download and Install vcpkg
+      shell: bash
+      run: |
+        cd "${TEMP}"
+        mkdir -p .build/vcpkg
+        curl -fsSL "https://github.com/microsoft/vcpkg/archive/${{ steps.vcpkg-version.outputs.version }}.tar.gz" |
+            tar -C .build/vcpkg --strip-components=1 -zxf -
+        .build/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+    # go/github-actions#gha-bestpractices explains why we use a SHA instead of
+    # a named version for this runner. We could avoid using this runner with the
+    # ideas from:
+    #   https://github.com/microsoft/vswhere/wiki/Find-VC
+    # Note that in other runners the publisher is GitHub. If we trust GitHub
+    # to run the VM, we should trust their runners.
+    - uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 # @v1.21.1
+    - name: Build google-cloud-cpp
+      shell: bash
+      run: |
+        export VCPKG_ROOT="${TEMP}/.build/vcpkg"
+        export CLOUDSDK_PYTHON="${{ steps.py311.outputs.python-path }}"
+        # Put the CMake output in a directory with more space and keep it short
+        # to avoid running into the MSVC limits.
+        export CMAKE_OUT='c:\b'
+        ci/gha/builds/windows-cmake.sh ${{ matrix.build_type }} ${{ join(matrix.features, ',') }}
+    env:
+      SCCACHE_GCS_BUCKET: cloud-cpp-gha-cache
+      SCCACHE_GCS_KEY_PREFIX: sccache/${{ matrix.msvc }}/${{ matrix.build_type }}
+      SCCACHE_GCS_RW_MODE: READ_WRITE
+      SCCACHE_IGNORE_SERVER_IO_ERROR: 1
+      VCPKG_BINARY_SOURCES: x-gcs,gs://cloud-cpp-gha-cache/vcpkg-cache/${{ matrix.msvc }},readwrite
+      VCPKG_TRIPLET: ${{ matrix.vcpkg_triplet }}

--- a/ci/gha/builds/cmake/windows-sccache.cmake
+++ b/ci/gha/builds/cmake/windows-sccache.cmake
@@ -1,0 +1,30 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# To use sccache with MSVC one must replace the default debug flags in CMake.
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
+    string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELEASE
+                   "${CMAKE_CXX_FLAGS_RELEASE}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO
+                   "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO
+                   "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+endif ()

--- a/ci/gha/builds/lib/bazel.sh
+++ b/ci/gha/builds/lib/bazel.sh
@@ -54,13 +54,21 @@ function bazel::test_args() {
 function bazel::msvc_args() {
   local args=(
     # "--keep_going",
+    # We want to enable all warnings and treat warnings as errors in our code
     "--per_file_copt=^//google/cloud@-W3"
     "--per_file_copt=^//google/cloud@-WX"
+    # Unfortunately this would break our build if any header from a different
+    # project generated warnings with MSVC (and they do). This is the motivation
+    # to include external headers with angle brackets: we can turn off warnings
+    # for them.
     "--per_file_copt=^//google/cloud@-experimental:external"
     "--per_file_copt=^//google/cloud@-external:W0"
     "--per_file_copt=^//google/cloud@-external:anglebrackets"
     # Disable warnings on generated proto files.
     "--per_file_copt=.*\.pb\.cc@/wd4244"
+    # Disable warnings on generated upb files.
+    "--per_file_copt=.*\.upb\.c@/wd4090"
+    "--per_file_copt=.*\.upbdefs\.c@/wd4090"
   )
   printf "%s\n" "${args[@]}"
 }

--- a/ci/gha/builds/lib/cmake.sh
+++ b/ci/gha/builds/lib/cmake.sh
@@ -55,6 +55,9 @@ function cmake::common_args() {
       -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
     )
   fi
+  if [[ -n "${VCPKG_TRIPLET:-}" ]]; then
+    args+=("-DVCPKG_TARGET_TRIPLET=${VCPKG_TRIPLET}")
+  fi
   printf "%s\n" "${args[@]}"
 }
 

--- a/ci/gha/builds/lib/windows.sh
+++ b/ci/gha/builds/lib/windows.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # Make our include guard clean against set -o nounset.
-test -n "${CI_CLOUDBUILD_BUILDS_LIB_LINUX_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_LINUX_SH__=0
-if ((CI_CLOUDBUILD_BUILDS_LIB_LINUX_SH__++ != 0)); then
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_WINDOWS_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_WINDOWS_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_WINDOWS_SH__++ != 0)); then
   return 0
 fi # include guard
 
@@ -26,25 +26,38 @@ function google_time() {
   curl -sI google.com | tr -d '\r' | sed -n 's/Date: \(.*\)/\1/p'
 }
 
+mapfile -t CI_CLOUDBUILD_BUILDS_LIB_WINDOWS_SH_SYSTEM_INFO < <(systeminfo | tr '\t' ' ')
+
+function os::name() {
+  printf "%s\n" "${CI_CLOUDBUILD_BUILDS_LIB_WINDOWS_SH_SYSTEM_INFO[@]}" | sed -n 's/^OS Name: \(.*\)/\1/p'
+}
+
+function os::version() {
+  printf "%s\n" "${CI_CLOUDBUILD_BUILDS_LIB_WINDOWS_SH_SYSTEM_INFO[@]}" | sed -n 's/^OS Version: \(.*\)/\1/p'
+}
+
+function os::mem() {
+  printf "%s\n" "${CI_CLOUDBUILD_BUILDS_LIB_WINDOWS_SH_SYSTEM_INFO[@]}" | sed -n 's/Virtual Memory: Available: \(.*\)/\1/p'
+}
+
 function os::cpus() {
   nproc
 }
 
 function os::prefetch() {
-  echo "@remotejdk11_linux//:jdk"
+  echo "@remotejdk11_win//:jdk"
 }
 
 io::log_h1 "Machine Info"
 printf "%10s %s\n" "host:" "$(date -u --rfc-3339=seconds)"
 printf "%10s %s\n" "google:" "$(date -ud "$(google_time)" --rfc-3339=seconds)"
 printf "%10s %s\n" "kernel:" "$(uname -v)"
-printf "%10s %s\n" "os:" "$(grep PRETTY_NAME /etc/os-release)"
+printf "%10s %s\n" "os name:" "$(os::name)"
+printf "%10s %s\n" "os version:" "$(os::version)"
 printf "%10s %s\n" "nproc:" "$(os::cpus)"
-printf "%10s %s\n" "mem:" "$(mem_total)"
+printf "%10s %s\n" "mem:" "$(os::mem)"
 printf "%10s %s\n" "term:" "${TERM-}"
 printf "%10s %s\n" "bash:" "$(bash --version 2>&1 | head -1)"
 printf "%10s %s\n" "bash:" "${BASH_VERSION:-}"
-printf "%10s %s\n" "gcc:" "$(gcc --version 2>&1 | head -1)"
-printf "%10s %s\n" "clang:" "$(clang --version 2>&1 | head -1)"
-printf "%10s %s\n" "cc:" "$(cc --version 2>&1 | head -1)"
+printf "%10s %s\n" "cl:" "$(cl.exe --version 2>&1 | head -1)"
 echo >&2

--- a/ci/gha/builds/windows-bazel.sh
+++ b/ci/gha/builds/windows-bazel.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/gha/builds/lib/windows.sh
+source module ci/gha/builds/lib/bazel.sh
+
+# Usage: windows-bazel.sh <compilation-mode> [bazel query expression]
+#
+# The compilation mode is passed to Bazel via `--compilation_mode`.
+#
+# The build compiles the targets found via `bazel query`. Recall that:
+#    bazel query //a/...
+# returns the targets matching the pattern `//a/...`.` Furthermore, the
+# expressions can be combined using `+` and `-`, so:
+#    bazel query //a/... +//b/... -//a/c/...
+# Returns the targets that match `//a/...` or `//b/...`, but not `//a/c/...`.
+#
+
+test_args+=("${msvc_args[@]}")
+mapfile -t args < <(bazel::common_args)
+mapfile -t test_args < <(bazel::test_args)
+mapfile -t msvc_args < <(bazel::msvc_args)
+test_args+=("${msvc_args[@]}")
+# Do not run the integration tests
+test_args+=(--test_tag_filters=-integration-test)
+if [[ $# -gt 1 ]]; then
+  test_args+=("--compilation_mode=${1}")
+  shift
+fi
+
+if [[ -z "${VCINSTALLDIR}" ]]; then
+  echo "ERROR: Missing VCINSTALLDIR, this is needed to configure Bazel+MSVC"
+  exit 1
+fi
+export BAZEL_VC="${VCINSTALLDIR}"
+
+io::log_h1 "Get target list for: " "$@"
+# The output from `bazelisk query` includes \r\n lines as this is running
+# on Windows. We need to clean things up before feeding them through bash.
+#
+# I (coryan@) do not understand why: `//examples` gets converted to `/examples`
+# somewhere in the `printf ... | xargs -n 64 bazelisk ...` call. Using `///`
+# seems to work.
+mapfile -t targets < <(bazelisk "${args[@]}" query -- "$@" | tr -d '\r' | sed 's;//examples;///examples;g' | sort)
+
+io::log_h1 "Starting Build"
+TIMEFORMAT="==> 🕑 bazel test done in %R seconds"
+time {
+  # Always run //google/cloud:status_test in case the list of targets has
+  # no unit tests.
+  io::log_bold bazelisk "${args[@]}" test "${test_args[@]}" -- //google/cloud:status_test "${targets[@]}"
+  printf "%s\n" "${targets[@]}" | xargs -n 64 bazelisk "${args[@]}" test "${test_args[@]}" -- //google/cloud:status_test
+}

--- a/ci/gha/builds/windows-cmake.sh
+++ b/ci/gha/builds/windows-cmake.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/gha/builds/lib/windows.sh
+source module ci/gha/builds/lib/cmake.sh
+
+# Usage: macos-cmake.sh <build-type> <value for GOOGLE_CLOUD_CPP_ENABLE>
+#
+# The build-type sets `-DCMAKE_BUILD_TYPE`, typically Release or Debug.
+#
+# The GOOGLE_CLOUD_CPP_ENABLE CMake configuration option controls what
+# subdirectories of google/cloud/ get built. For more details see
+#     /doc/compile-time-configuration.md
+
+if [[ -z "${CMAKE_OUT:-}" ]]; then
+  CMAKE_OUT=cmake-out
+fi
+mapfile -t args < <(cmake::common_args "${CMAKE_OUT}")
+mapfile -t vcpkg_args < <(cmake::vcpkg_args)
+mapfile -t ctest_args < <(ctest::common_args)
+if [[ $# -gt 1 ]]; then
+  args+=("-DCMAKE_BUILD_TYPE=${1}")
+  shift
+fi
+if command -v sccache >/dev/null 2>&1; then
+  args+=(
+    # sccache requires specific workarounds with MSVC.
+    -DCMAKE_PROJECT_google-cloud-cpp_INCLUDE="$(dirname "$0")/cmake/windows-sccache.cmake"
+  )
+fi
+
+io::log_h1 "Starting Build"
+TIMEFORMAT="==> 🕑 CMake configuration done in %R seconds"
+time {
+  # Always run //google/cloud:status_test in case the list of targets has
+  # no unit tests.
+  io::run cmake "${args[@]}" "${vcpkg_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE="$*"
+}
+
+TIMEFORMAT="==> 🕑 CMake build done in %R seconds"
+time {
+  # Always run //google/cloud:status_test in case the list of targets has
+  # no unit tests.
+  io::run cmake --build "${CMAKE_OUT}"
+}
+
+TIMEFORMAT="==> 🕑 CMake test done in %R seconds"
+time {
+  io::run ctest "${ctest_args[@]}" --test-dir "${CMAKE_OUT}" -LE integration-test
+}


### PR DESCRIPTION
As usual, we want to test the builds with Bazel and CMake. We also support MSVC 2019 and MSVC 2022, so we want to test with both compilers. And with MSVC there is a big difference between the C++ library in Debug vs. Release mode, so we need to test both. There is no need to test all these things with Bazel and CMake. So Bazel gets one build and CMake gets 4.  We also need to shard the builds.

This replaces the flakes caused by Kokoro with flakes caused by GHA (hopefully fewer). It also improves the caching strategy for Windows builds using sccache as proposed in #11944

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12128)
<!-- Reviewable:end -->
