### PR TITLE
ci(gha): checkout correct version on PRs

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -25,7 +25,7 @@ jobs:
     name: Require Approval for External PRs
     runs-on: ubuntu-latest
     outputs:
-      checkout-sha: ${{ steps.safe-checkout.outputs.sha }}
+      checkout-sha: ${{ steps.save-pull-request.outputs.sha }}
     steps:
       - name: Save Pull Request
         id: save-pull-request


### PR DESCRIPTION
Using the wrong step id results in an empty string (not an error), and then you checkout the target branch instead of the PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12134)
<!-- Reviewable:end -->
