### PR TITLE
ci(gha): stop concurrent builds for same PR

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -16,6 +16,13 @@ on:
   # caches (Bazel and sccache).
   pull_request_target:
 
+# Cancel in-progress runs of the workflow if somebody adds a new commit to the
+# PR or branch. That reduces billing, but it creates more noise about cancelled
+# jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-flight:
     # For external contributors, run the build in the `external` environment.


### PR DESCRIPTION
Tested on https://github.com/googleapis/google-cloud-cpp/actions/runs/5591585074

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12144)
<!-- Reviewable:end -->
