### PR TITLE
impl(bigquery): Response field changes for Projects api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/project.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project.cc
@@ -25,7 +25,7 @@ std::string ProjectReference::DebugString(absl::string_view name,
                                           TracingOptions const& options,
                                           int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .StringField("project_id", projectId)
+      .StringField("project_id", project_id)
       .Build();
 }
 
@@ -35,10 +35,33 @@ std::string Project::DebugString(absl::string_view name,
   return internal::DebugFormatter(name, options, indent)
       .StringField("kind", kind)
       .StringField("id", id)
-      .StringField("friendly_name", friendlyName)
-      .SubMessage("project_reference", projectReference)
-      .Field("numeric_id", numericId)
+      .StringField("friendly_name", friendly_name)
+      .SubMessage("project_reference", project_reference)
+      .Field("numeric_id", numeric_id)
       .Build();
+}
+
+void to_json(nlohmann::json& j, ProjectReference const& p) {
+  j = nlohmann::json{{"projectId", p.project_id}};
+}
+void from_json(nlohmann::json const& j, ProjectReference& p) {
+  if (j.contains("projectId")) j.at("projectId").get_to(p.project_id);
+}
+
+void to_json(nlohmann::json& j, Project const& p) {
+  j = nlohmann::json{{"kind", p.kind},
+                     {"id", p.id},
+                     {"friendlyName", p.friendly_name},
+                     {"numericId", p.numeric_id},
+                     {"projectReference", p.project_reference}};
+}
+void from_json(nlohmann::json const& j, Project& p) {
+  if (j.contains("kind")) j.at("kind").get_to(p.kind);
+  if (j.contains("id")) j.at("id").get_to(p.id);
+  if (j.contains("friendlyName")) j.at("friendlyName").get_to(p.friendly_name);
+  if (j.contains("numericId")) j.at("numericId").get_to(p.numeric_id);
+  if (j.contains("projectReference"))
+    j.at("projectReference").get_to(p.project_reference);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/project.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project.cc
@@ -45,6 +45,7 @@ void to_json(nlohmann::json& j, ProjectReference const& p) {
   j = nlohmann::json{{"projectId", p.project_id}};
 }
 void from_json(nlohmann::json const& j, ProjectReference& p) {
+  // TODO(#12188): Implement SafeGetTo(...)
   if (j.contains("projectId")) j.at("projectId").get_to(p.project_id);
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/project.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project.cc
@@ -25,7 +25,7 @@ std::string ProjectReference::DebugString(absl::string_view name,
                                           TracingOptions const& options,
                                           int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .StringField("project_id", project_id)
+      .StringField("project_id", projectId)
       .Build();
 }
 
@@ -35,9 +35,9 @@ std::string Project::DebugString(absl::string_view name,
   return internal::DebugFormatter(name, options, indent)
       .StringField("kind", kind)
       .StringField("id", id)
-      .StringField("friendly_name", friendly_name)
-      .SubMessage("project_reference", project_reference)
-      .Field("numeric_id", numeric_id)
+      .StringField("friendly_name", friendlyName)
+      .SubMessage("project_reference", projectReference)
+      .Field("numeric_id", numericId)
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/project.h
+++ b/google/cloud/bigquery/v2/minimal/internal/project.h
@@ -32,30 +32,29 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 using namespace nlohmann::literals;  // NOLINT
 
 struct ProjectReference {
-  std::string project_id;
+  std::string projectId;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ProjectReference, project_id);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ProjectReference, projectId);
 
 struct Project {
   std::string kind;
   std::string id;
-  std::string friendly_name;
+  std::string friendlyName;
 
-  std::int64_t numeric_id;
+  std::int64_t numericId;
 
-  ProjectReference project_reference;
+  ProjectReference projectReference;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Project, kind, id,
-                                                friendly_name, numeric_id,
-                                                project_reference);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Project, kind, id, friendlyName,
+                                                numericId, projectReference);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/project.h
+++ b/google/cloud/bigquery/v2/minimal/internal/project.h
@@ -27,34 +27,31 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-// Disabling clang-tidy here as the namespace is needed for using the
-// NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT.
-using namespace nlohmann::literals;  // NOLINT
-
 struct ProjectReference {
-  std::string projectId;
+  std::string project_id;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ProjectReference, projectId);
+void to_json(nlohmann::json& j, ProjectReference const& p);
+void from_json(nlohmann::json const& j, ProjectReference& p);
 
 struct Project {
   std::string kind;
   std::string id;
-  std::string friendlyName;
+  std::string friendly_name;
 
-  std::int64_t numericId;
+  std::int64_t numeric_id;
 
-  ProjectReference projectReference;
+  ProjectReference project_reference;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Project, kind, id, friendlyName,
-                                                numericId, projectReference);
+void to_json(nlohmann::json& j, Project const& p);
+void from_json(nlohmann::json const& j, Project& p);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/project_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_response.cc
@@ -27,12 +27,12 @@ namespace {
 
 bool valid_project(nlohmann::json const& j) {
   return (j.contains("kind") && j.contains("id") &&
-          j.contains("project_reference"));
+          j.contains("projectReference"));
 }
 
 bool valid_projects_list(nlohmann::json const& j) {
   return (j.contains("kind") && j.contains("etag") &&
-          j.contains("next_page_token") && j.contains("projects"));
+          j.contains("nextPageToken") && j.contains("projects"));
 }
 
 StatusOr<nlohmann::json> parse_json(std::string const& payload) {
@@ -63,9 +63,9 @@ StatusOr<ListProjectsResponse> ListProjectsResponse::BuildFromHttpResponse(
 
   result.kind = json->value("kind", "");
   result.etag = json->value("etag", "");
-  result.next_page_token = json->value("next_page_token", "");
-  if (!absl::SimpleAtoi(json->value("total_items", "0"), &result.total_items)) {
-    return internal::InternalError("Invalid value for total_items",
+  result.next_page_token = json->value("nextPageToken", "");
+  if (!absl::SimpleAtoi(json->value("totalItems", "0"), &result.total_items)) {
+    return internal::InternalError("Invalid value for totalItems",
                                    GCP_ERROR_INFO());
   }
 

--- a/google/cloud/bigquery/v2/minimal/internal/project_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_response_test.cc
@@ -87,8 +87,8 @@ TEST(ListProjectsResponseTest, InvalidProject) {
   http_response.payload =
       R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
-          "total_items": "1",
+          "nextPageToken": "npt-123",
+          "totalItems": "1",
           "projects": [
               {
                 "id": "1",
@@ -106,13 +106,13 @@ TEST(ListProjectsResponseTest, InvalidTotalItems) {
   http_response.payload =
       R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
-          "total_items": "invalid",
+          "nextPageToken": "npt-123",
+          "totalItems": "invalid",
           "projects": []})";
   auto const response =
       ListProjectsResponse::BuildFromHttpResponse(http_response);
   EXPECT_THAT(response, StatusIs(StatusCode::kInternal,
-                                 HasSubstr("Invalid value for total_items")));
+                                 HasSubstr("Invalid value for totalItems")));
 }
 
 TEST(ListProjectsResponseTest, DebugString) {

--- a/google/cloud/bigquery/v2/minimal/testing/project_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/project_test_utils.cc
@@ -25,9 +25,9 @@ bigquery_v2_minimal_internal::Project MakeProject() {
   bigquery_v2_minimal_internal::Project expected;
   expected.kind = "p-kind";
   expected.id = "p-id";
-  expected.friendlyName = "p-friendly-name";
-  expected.numericId = 123;
-  expected.projectReference.projectId = "p-project-id";
+  expected.friendly_name = "p-friendly-name";
+  expected.numeric_id = 123;
+  expected.project_reference.project_id = "p-project-id";
 
   return expected;
 }
@@ -36,9 +36,9 @@ void AssertEquals(bigquery_v2_minimal_internal::Project const& lhs,
                   bigquery_v2_minimal_internal::Project const& rhs) {
   EXPECT_EQ(lhs.kind, rhs.kind);
   EXPECT_EQ(lhs.id, rhs.id);
-  EXPECT_EQ(lhs.friendlyName, rhs.friendlyName);
-  EXPECT_EQ(lhs.numericId, rhs.numericId);
-  EXPECT_EQ(lhs.projectReference.projectId, rhs.projectReference.projectId);
+  EXPECT_EQ(lhs.friendly_name, rhs.friendly_name);
+  EXPECT_EQ(lhs.numeric_id, rhs.numeric_id);
+  EXPECT_EQ(lhs.project_reference.project_id, rhs.project_reference.project_id);
 }
 
 std::string MakeProjectJsonText() {

--- a/google/cloud/bigquery/v2/minimal/testing/project_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/project_test_utils.cc
@@ -25,9 +25,9 @@ bigquery_v2_minimal_internal::Project MakeProject() {
   bigquery_v2_minimal_internal::Project expected;
   expected.kind = "p-kind";
   expected.id = "p-id";
-  expected.friendly_name = "p-friendly-name";
-  expected.numeric_id = 123;
-  expected.project_reference.project_id = "p-project-id";
+  expected.friendlyName = "p-friendly-name";
+  expected.numericId = 123;
+  expected.projectReference.projectId = "p-project-id";
 
   return expected;
 }
@@ -36,18 +36,18 @@ void AssertEquals(bigquery_v2_minimal_internal::Project const& lhs,
                   bigquery_v2_minimal_internal::Project const& rhs) {
   EXPECT_EQ(lhs.kind, rhs.kind);
   EXPECT_EQ(lhs.id, rhs.id);
-  EXPECT_EQ(lhs.friendly_name, rhs.friendly_name);
-  EXPECT_EQ(lhs.numeric_id, rhs.numeric_id);
-  EXPECT_EQ(lhs.project_reference.project_id, rhs.project_reference.project_id);
+  EXPECT_EQ(lhs.friendlyName, rhs.friendlyName);
+  EXPECT_EQ(lhs.numericId, rhs.numericId);
+  EXPECT_EQ(lhs.projectReference.projectId, rhs.projectReference.projectId);
 }
 
 std::string MakeProjectJsonText() {
   return R"({"kind":"p-kind")"
          R"(,"id":"p-id")"
-         R"(,"friendly_name":"p-friendly-name")"
-         R"(,"numeric_id":123)"
-         R"(,"project_reference":{)"
-         R"("project_id":"p-project-id")"
+         R"(,"friendlyName":"p-friendly-name")"
+         R"(,"numericId":123)"
+         R"(,"projectReference":{)"
+         R"("projectId":"p-project-id")"
          R"(})"
          R"(})";
 }
@@ -56,8 +56,8 @@ std::string MakeListProjectsResponseJsonText() {
   auto projects_json_txt = MakeProjectJsonText();
   return R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
-          "total_items": "1",
+          "nextPageToken": "npt-123",
+          "totalItems": "1",
           "projects": [)" +
          projects_json_txt + R"(]})";
 }


### PR DESCRIPTION
This PR implements the json field name changes for Project response object. It ensures the field names in the response are in accordance with the[ response body](https://cloud.google.com/bigquery/docs/reference/rest/v2/projects/list#response-body) mentioned in the api docs.

No logic has been changes. Just the field names and corresponding unit tests.

This fixes the github issue https://github.com/googleapis/google-cloud-cpp/issues/12109

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12150)
<!-- Reviewable:end -->
