### PR TITLE
refactor(otel): rename attribute matcher

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
@@ -36,7 +36,7 @@ using ::testing::Return;
 using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -89,7 +89,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, GenerateAccessToken) {
               "golden_v1::GoldenKitchenSinkConnection::GenerateAccessToken"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, GenerateIdToken) {
@@ -114,7 +114,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, GenerateIdToken) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::GenerateIdToken"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, WriteLogEntries) {
@@ -139,7 +139,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, WriteLogEntries) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::WriteLogEntries"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, ListLogs) {
@@ -168,7 +168,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, ListLogs) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::ListLogs"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, ListServiceAccountKeys) {
@@ -194,7 +194,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, ListServiceAccountKeys) {
               "golden_v1::GoldenKitchenSinkConnection::ListServiceAccountKeys"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, DoNothing) {
@@ -219,7 +219,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, DoNothing) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::DoNothing"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, Deprecated2) {
@@ -244,7 +244,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, Deprecated2) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::Deprecated2"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, StreamingRead) {
@@ -271,7 +271,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, StreamingRead) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::StreamingRead"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, AsyncStreamingReadWrite) {
@@ -313,7 +313,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, ExplicitRouting1) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::ExplicitRouting1"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, ExplicitRouting2) {
@@ -338,7 +338,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, ExplicitRouting2) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::ExplicitRouting2"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(MakeGoldenKitchenSinkTracingConnection, TracingEnabled) {

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -36,7 +36,7 @@ using ::testing::Return;
 
 using ::google::cloud::testing_util::InstallMockPropagator;
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -78,8 +78,8 @@ TEST(GoldenKitchenSinkTracingStubTest, GenerateAccessToken) {
                     "GenerateAccessToken"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, GenerateIdToken) {
@@ -108,8 +108,8 @@ TEST(GoldenKitchenSinkTracingStubTest, GenerateIdToken) {
                     "GenerateIdToken"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, WriteLogEntries) {
@@ -138,8 +138,8 @@ TEST(GoldenKitchenSinkTracingStubTest, WriteLogEntries) {
                     "WriteLogEntries"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, ListLogs) {
@@ -167,8 +167,8 @@ TEST(GoldenKitchenSinkTracingStubTest, ListLogs) {
           SpanNamed("google.test.admin.database.v1.GoldenKitchenSink/ListLogs"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, StreamingRead) {
@@ -199,8 +199,8 @@ TEST(GoldenKitchenSinkTracingStubTest, StreamingRead) {
               "google.test.admin.database.v1.GoldenKitchenSink/StreamingRead"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, ListServiceAccountKeys) {
@@ -229,8 +229,8 @@ TEST(GoldenKitchenSinkTracingStubTest, ListServiceAccountKeys) {
                     "ListServiceAccountKeys"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, DoNothing) {
@@ -259,8 +259,8 @@ TEST(GoldenKitchenSinkTracingStubTest, DoNothing) {
               "google.test.admin.database.v1.GoldenKitchenSink/DoNothing"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, StreamingWrite) {
@@ -294,8 +294,8 @@ TEST(GoldenKitchenSinkTracingStubTest, StreamingWrite) {
               "google.test.admin.database.v1.GoldenKitchenSink/StreamingWrite"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingRead) {
@@ -329,8 +329,8 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingRead) {
               "google.test.admin.database.v1.GoldenKitchenSink/StreamingRead"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingWrite) {
@@ -365,8 +365,8 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingWrite) {
               "google.test.admin.database.v1.GoldenKitchenSink/StreamingWrite"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingReadWrite) {
@@ -401,8 +401,8 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingReadWrite) {
                     "StreamingReadWrite"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, ExplicitRouting1) {
@@ -431,8 +431,8 @@ TEST(GoldenKitchenSinkTracingStubTest, ExplicitRouting1) {
                     "ExplicitRouting1"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, ExplicitRouting2) {
@@ -461,8 +461,8 @@ TEST(GoldenKitchenSinkTracingStubTest, ExplicitRouting2) {
                     "ExplicitRouting2"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(MakeGoldenKitchenSinkTracingStub, OpenTelemetry) {

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_connection_test.cc
@@ -36,7 +36,7 @@ using ::testing::Return;
 using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -89,7 +89,7 @@ TEST(GoldenThingAdminTracingConnectionTest, ListDatabases) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::ListDatabases"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, CreateDatabase) {
@@ -115,7 +115,7 @@ TEST(GoldenThingAdminTracingConnectionTest, CreateDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::CreateDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, GetDatabase) {
@@ -140,7 +140,7 @@ TEST(GoldenThingAdminTracingConnectionTest, GetDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::GetDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, UpdateDatabaseDdl) {
@@ -167,7 +167,7 @@ TEST(GoldenThingAdminTracingConnectionTest, UpdateDatabaseDdl) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::UpdateDatabaseDdl"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, DropDatabase) {
@@ -192,7 +192,7 @@ TEST(GoldenThingAdminTracingConnectionTest, DropDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::DropDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, GetDatabaseDdl) {
@@ -217,7 +217,7 @@ TEST(GoldenThingAdminTracingConnectionTest, GetDatabaseDdl) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::GetDatabaseDdl"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, SetIamPolicy) {
@@ -242,7 +242,7 @@ TEST(GoldenThingAdminTracingConnectionTest, SetIamPolicy) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::SetIamPolicy"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, GetIamPolicy) {
@@ -267,7 +267,7 @@ TEST(GoldenThingAdminTracingConnectionTest, GetIamPolicy) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::GetIamPolicy"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, TestIamPermissions) {
@@ -293,7 +293,7 @@ TEST(GoldenThingAdminTracingConnectionTest, TestIamPermissions) {
               "golden_v1::GoldenThingAdminConnection::TestIamPermissions"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, CreateBackup) {
@@ -318,7 +318,7 @@ TEST(GoldenThingAdminTracingConnectionTest, CreateBackup) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::CreateBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, GetBackup) {
@@ -343,7 +343,7 @@ TEST(GoldenThingAdminTracingConnectionTest, GetBackup) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::GetBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, UpdateBackup) {
@@ -368,7 +368,7 @@ TEST(GoldenThingAdminTracingConnectionTest, UpdateBackup) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::UpdateBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, DeleteBackup) {
@@ -393,7 +393,7 @@ TEST(GoldenThingAdminTracingConnectionTest, DeleteBackup) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::DeleteBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, ListBackups) {
@@ -420,7 +420,7 @@ TEST(GoldenThingAdminTracingConnectionTest, ListBackups) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::ListBackups"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, RestoreDatabase) {
@@ -446,7 +446,7 @@ TEST(GoldenThingAdminTracingConnectionTest, RestoreDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::RestoreDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, ListDatabaseOperations) {
@@ -475,7 +475,7 @@ TEST(GoldenThingAdminTracingConnectionTest, ListDatabaseOperations) {
               "golden_v1::GoldenThingAdminConnection::ListDatabaseOperations"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, ListBackupOperations) {
@@ -504,7 +504,7 @@ TEST(GoldenThingAdminTracingConnectionTest, ListBackupOperations) {
               "golden_v1::GoldenThingAdminConnection::ListBackupOperations"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, LongRunningWithoutRouting) {
@@ -531,7 +531,7 @@ TEST(GoldenThingAdminTracingConnectionTest, LongRunningWithoutRouting) {
                     "LongRunningWithoutRouting"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, AsyncGetDatabase) {
@@ -557,7 +557,7 @@ TEST(GoldenThingAdminTracingConnectionTest, AsyncGetDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::AsyncGetDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, AsyncDropDatabase) {
@@ -582,7 +582,7 @@ TEST(GoldenThingAdminTracingConnectionTest, AsyncDropDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::AsyncDropDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(MakeGoldenThingAdminTracingConnection, TracingEnabled) {

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
@@ -32,7 +32,7 @@ using ::testing::Return;
 
 using ::google::cloud::testing_util::InstallMockPropagator;
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -80,8 +80,8 @@ TEST(GoldenThingAdminTracingStubTest, ListDatabases) {
               "google.test.admin.database.v1.GoldenThingAdmin/ListDatabases"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncCreateDatabase) {
@@ -108,8 +108,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCreateDatabase) {
               "google.test.admin.database.v1.GoldenThingAdmin/CreateDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, GetDatabase) {
@@ -138,8 +138,8 @@ TEST(GoldenThingAdminTracingStubTest, GetDatabase) {
               "google.test.admin.database.v1.GoldenThingAdmin/GetDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncUpdateDatabaseDdl) {
@@ -166,8 +166,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncUpdateDatabaseDdl) {
                     "UpdateDatabaseDdl"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, DropDatabase) {
@@ -196,8 +196,8 @@ TEST(GoldenThingAdminTracingStubTest, DropDatabase) {
               "google.test.admin.database.v1.GoldenThingAdmin/DropDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, GetDatabaseDdl) {
@@ -226,8 +226,8 @@ TEST(GoldenThingAdminTracingStubTest, GetDatabaseDdl) {
               "google.test.admin.database.v1.GoldenThingAdmin/GetDatabaseDdl"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, SetIamPolicy) {
@@ -256,8 +256,8 @@ TEST(GoldenThingAdminTracingStubTest, SetIamPolicy) {
               "google.test.admin.database.v1.GoldenThingAdmin/SetIamPolicy"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, GetIamPolicy) {
@@ -286,8 +286,8 @@ TEST(GoldenThingAdminTracingStubTest, GetIamPolicy) {
               "google.test.admin.database.v1.GoldenThingAdmin/GetIamPolicy"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, TestIamPermissions) {
@@ -316,8 +316,8 @@ TEST(GoldenThingAdminTracingStubTest, TestIamPermissions) {
                     "TestIamPermissions"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncCreateBackup) {
@@ -344,8 +344,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCreateBackup) {
               "google.test.admin.database.v1.GoldenThingAdmin/CreateBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, GetBackup) {
@@ -373,8 +373,8 @@ TEST(GoldenThingAdminTracingStubTest, GetBackup) {
           SpanNamed("google.test.admin.database.v1.GoldenThingAdmin/GetBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, UpdateBackup) {
@@ -403,8 +403,8 @@ TEST(GoldenThingAdminTracingStubTest, UpdateBackup) {
               "google.test.admin.database.v1.GoldenThingAdmin/UpdateBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, DeleteBackup) {
@@ -433,8 +433,8 @@ TEST(GoldenThingAdminTracingStubTest, DeleteBackup) {
               "google.test.admin.database.v1.GoldenThingAdmin/DeleteBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, ListBackups) {
@@ -463,8 +463,8 @@ TEST(GoldenThingAdminTracingStubTest, ListBackups) {
               "google.test.admin.database.v1.GoldenThingAdmin/ListBackups"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncRestoreDatabase) {
@@ -491,8 +491,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncRestoreDatabase) {
               "google.test.admin.database.v1.GoldenThingAdmin/RestoreDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, ListDatabaseOperations) {
@@ -521,8 +521,8 @@ TEST(GoldenThingAdminTracingStubTest, ListDatabaseOperations) {
                     "ListDatabaseOperations"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, ListBackupOperations) {
@@ -551,8 +551,8 @@ TEST(GoldenThingAdminTracingStubTest, ListBackupOperations) {
                     "ListBackupOperations"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncGetDatabase) {
@@ -582,8 +582,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncGetDatabase) {
               "google.test.admin.database.v1.GoldenThingAdmin/GetDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncDropDatabase) {
@@ -612,8 +612,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncDropDatabase) {
               "google.test.admin.database.v1.GoldenThingAdmin/DropDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncGetOperation) {
@@ -639,8 +639,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncGetOperation) {
           SpanNamed("google.longrunning.Operations/GetOperation"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncCancelOperation) {
@@ -668,8 +668,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCancelOperation) {
           SpanNamed("google.longrunning.Operations/CancelOperation"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(MakeGoldenThingAdminTracingStub, OpenTelemetry) {

--- a/google/cloud/bigtable/internal/data_tracing_connection_test.cc
+++ b/google/cloud/bigtable/internal/data_tracing_connection_test.cc
@@ -30,7 +30,7 @@ namespace {
 using ::google::cloud::bigtable_mocks::MockDataConnection;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::IsOkAndHolds;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -89,7 +89,7 @@ TEST(DataTracingConnection, Apply) {
           SpanNamed("bigtable::Table::Apply"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncApply) {
@@ -112,7 +112,7 @@ TEST(DataTracingConnection, AsyncApply) {
           SpanNamed("bigtable::Table::AsyncApply"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, BulkApplySuccess) {
@@ -134,9 +134,9 @@ TEST(DataTracingConnection, BulkApplySuccess) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("bigtable::Table::BulkApply"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(SpanAttribute<std::uint32_t>(
+          SpanHasAttributes(OTelAttribute<std::uint32_t>(
                                 "gcloud.bigtable.failed_mutations", 0),
-                            SpanAttribute<std::uint32_t>(
+                            OTelAttribute<std::uint32_t>(
                                 "gcloud.bigtable.successful_mutations", 1)))));
 }
 
@@ -163,9 +163,9 @@ TEST(DataTracingConnection, BulkApplyFailure) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("bigtable::Table::BulkApply"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError),
-          SpanHasAttributes(SpanAttribute<std::uint32_t>(
+          SpanHasAttributes(OTelAttribute<std::uint32_t>(
                                 "gcloud.bigtable.failed_mutations", 2),
-                            SpanAttribute<std::uint32_t>(
+                            OTelAttribute<std::uint32_t>(
                                 "gcloud.bigtable.successful_mutations", 8)))));
 }
 
@@ -188,9 +188,9 @@ TEST(DataTracingConnection, AsyncBulkApplySuccess) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("bigtable::Table::AsyncBulkApply"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(SpanAttribute<std::uint32_t>(
+          SpanHasAttributes(OTelAttribute<std::uint32_t>(
                                 "gcloud.bigtable.failed_mutations", 0),
-                            SpanAttribute<std::uint32_t>(
+                            OTelAttribute<std::uint32_t>(
                                 "gcloud.bigtable.successful_mutations", 1)))));
 }
 
@@ -217,9 +217,9 @@ TEST(DataTracingConnection, AsyncBulkApplyFailure) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("bigtable::Table::AsyncBulkApply"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError),
-          SpanHasAttributes(SpanAttribute<std::uint32_t>(
+          SpanHasAttributes(OTelAttribute<std::uint32_t>(
                                 "gcloud.bigtable.failed_mutations", 2),
-                            SpanAttribute<std::uint32_t>(
+                            OTelAttribute<std::uint32_t>(
                                 "gcloud.bigtable.successful_mutations", 8)))));
 }
 
@@ -246,7 +246,7 @@ TEST(DataTracingConnection, ReadRows) {
           SpanNamed("bigtable::Table::ReadRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, ReadRowsFull) {
@@ -273,7 +273,7 @@ TEST(DataTracingConnection, ReadRowsFull) {
           SpanNamed("bigtable::Table::ReadRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, ReadRowFound) {
@@ -295,8 +295,8 @@ TEST(DataTracingConnection, ReadRowFound) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("bigtable::Table::ReadRow"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(SpanAttribute<int>("gcloud.status_code", 0),
-                                    SpanAttribute<bool>(
+                  SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0),
+                                    OTelAttribute<bool>(
                                         "gcloud.bigtable.row_found", true)))));
 }
 
@@ -319,8 +319,8 @@ TEST(DataTracingConnection, ReadRowNotFound) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("bigtable::Table::ReadRow"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(SpanAttribute<int>("gcloud.status_code", 0),
-                                    SpanAttribute<bool>(
+                  SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0),
+                                    OTelAttribute<bool>(
                                         "gcloud.bigtable.row_found", false)))));
 }
 
@@ -345,9 +345,9 @@ TEST(DataTracingConnection, ReadRowFailure) {
           SpanNamed("bigtable::Table::ReadRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)),
           Not(SpanHasAttributes(
-              SpanAttribute<bool>("gcloud.bigtable.row_found", _))))));
+              OTelAttribute<bool>("gcloud.bigtable.row_found", _))))));
 }
 
 TEST(DataTracingConnection, CheckAndMutateRow) {
@@ -371,7 +371,7 @@ TEST(DataTracingConnection, CheckAndMutateRow) {
           SpanNamed("bigtable::Table::CheckAndMutateRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncCheckAndMutateRow) {
@@ -396,7 +396,7 @@ TEST(DataTracingConnection, AsyncCheckAndMutateRow) {
           SpanNamed("bigtable::Table::AsyncCheckAndMutateRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, SampleRows) {
@@ -419,7 +419,7 @@ TEST(DataTracingConnection, SampleRows) {
           SpanNamed("bigtable::Table::SampleRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncSampleRows) {
@@ -443,7 +443,7 @@ TEST(DataTracingConnection, AsyncSampleRows) {
           SpanNamed("bigtable::Table::AsyncSampleRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, ReadModifyWriteRow) {
@@ -466,7 +466,7 @@ TEST(DataTracingConnection, ReadModifyWriteRow) {
           SpanNamed("bigtable::Table::ReadModifyWriteRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncReadModifyWriteRow) {
@@ -490,7 +490,7 @@ TEST(DataTracingConnection, AsyncReadModifyWriteRow) {
           SpanNamed("bigtable::Table::AsyncReadModifyWriteRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncReadRows) {
@@ -538,7 +538,7 @@ TEST(DataTracingConnection, AsyncReadRows) {
           SpanNamed("bigtable::Table::AsyncReadRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncReadRowFound) {
@@ -561,8 +561,8 @@ TEST(DataTracingConnection, AsyncReadRowFound) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("bigtable::Table::AsyncReadRow"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(SpanAttribute<int>("gcloud.status_code", 0),
-                                    SpanAttribute<bool>(
+                  SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0),
+                                    OTelAttribute<bool>(
                                         "gcloud.bigtable.row_found", true)))));
 }
 
@@ -586,8 +586,8 @@ TEST(DataTracingConnection, AsyncReadRowNotFound) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("bigtable::Table::AsyncReadRow"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(SpanAttribute<int>("gcloud.status_code", 0),
-                                    SpanAttribute<bool>(
+                  SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0),
+                                    OTelAttribute<bool>(
                                         "gcloud.bigtable.row_found", false)))));
 }
 
@@ -613,9 +613,9 @@ TEST(DataTracingConnection, AsyncReadRowFailure) {
           SpanNamed("bigtable::Table::AsyncReadRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)),
           Not(SpanHasAttributes(
-              SpanAttribute<bool>("gcloud.bigtable.row_found", _))))));
+              OTelAttribute<bool>("gcloud.bigtable.row_found", _))))));
 }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 

--- a/google/cloud/internal/async_polling_loop_test.cc
+++ b/google/cloud/internal/async_polling_loop_test.cc
@@ -624,7 +624,7 @@ TEST(AsyncPollingLoopTest, ConfigurePollContext) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::IsActive;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanNamed;
 using ::testing::AllOf;
@@ -756,7 +756,7 @@ TEST(AsyncPollingLoopTest, TraceCapturesOperationName) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
               ElementsAre(AllOf(SpanNamed("span"),
-                                SpanHasAttributes(SpanAttribute<std::string>(
+                                SpanHasAttributes(OTelAttribute<std::string>(
                                     "gcloud.LRO_name", "test-op-name")))));
 }
 

--- a/google/cloud/internal/async_read_write_stream_tracing_test.cc
+++ b/google/cloud/internal/async_read_write_stream_tracing_test.cc
@@ -27,7 +27,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::EventNamed;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanEventAttributesAre;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanNamed;
@@ -102,7 +102,7 @@ TEST(AsyncStreamingReadWriteRpcTracing, Start) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(SpanNamed("span"),
-                                       SpanHasAttributes(SpanAttribute<bool>(
+                                       SpanHasAttributes(OTelAttribute<bool>(
                                            "gcloud.stream_started", true)))));
 }
 
@@ -136,16 +136,16 @@ TEST(AsyncStreamingReadWriteRpcTracing, Read) {
           SpanEventsAre(
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 1))),
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 1))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 2))),
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 2))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 3)))))));
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 3)))))));
 }
 
 TEST(AsyncStreamingReadWriteRpcTracing, Write) {
@@ -175,22 +175,22 @@ TEST(AsyncStreamingReadWriteRpcTracing, Write) {
           SpanEventsAre(
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 1),
-                        SpanAttribute<bool>("message.is_last", false),
-                        SpanAttribute<bool>("message.success", true))),
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 1),
+                        OTelAttribute<bool>("message.is_last", false),
+                        OTelAttribute<bool>("message.success", true))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 2),
-                        SpanAttribute<bool>("message.is_last", false),
-                        SpanAttribute<bool>("message.success", false))),
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 2),
+                        OTelAttribute<bool>("message.is_last", false),
+                        OTelAttribute<bool>("message.success", false))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 3),
-                        SpanAttribute<bool>("message.is_last", true),
-                        SpanAttribute<bool>("message.success", true)))))));
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 3),
+                        OTelAttribute<bool>("message.is_last", true),
+                        OTelAttribute<bool>("message.success", true)))))));
 }
 
 TEST(AsyncStreamingReadWriteRpcTracing, SeparateCountersForReadAndWrite) {
@@ -219,14 +219,14 @@ TEST(AsyncStreamingReadWriteRpcTracing, SeparateCountersForReadAndWrite) {
           SpanEventsAre(
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 1),
-                        SpanAttribute<bool>("message.is_last", false),
-                        SpanAttribute<bool>("message.success", true))),
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 1),
+                        OTelAttribute<bool>("message.is_last", false),
+                        OTelAttribute<bool>("message.success", true))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 1)))))));
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 1)))))));
 }
 
 TEST(AsyncStreamingReadWriteRpcTracing, WritesDone) {
@@ -266,7 +266,7 @@ TEST(AsyncStreamingReadWriteRpcTracing, Finish) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)),
+          SpanHasAttributes(OTelAttribute<std::string>("grpc.peer", _)),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"))));
 }
 

--- a/google/cloud/internal/async_rest_polling_loop_test.cc
+++ b/google/cloud/internal/async_rest_polling_loop_test.cc
@@ -681,7 +681,7 @@ TEST(AsyncRestPollingLoopTest, PollThenSuccessWithBespokeOperationTypes) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::IsActive;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanNamed;
 using ::testing::AllOf;
@@ -813,7 +813,7 @@ TEST(AsyncRestPollingLoopTest, TraceCapturesOperationName) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
               ElementsAre(AllOf(SpanNamed("span"),
-                                SpanHasAttributes(SpanAttribute<std::string>(
+                                SpanHasAttributes(OTelAttribute<std::string>(
                                     "gcloud.LRO_name", "test-op-name")))));
 }
 

--- a/google/cloud/internal/async_streaming_read_rpc_tracing_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_tracing_test.cc
@@ -27,7 +27,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::EventNamed;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanEventAttributesAre;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanNamed;
@@ -100,7 +100,7 @@ TEST(AsyncStreamingReadRpcTracing, Start) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(SpanNamed("span"),
-                                       SpanHasAttributes(SpanAttribute<bool>(
+                                       SpanHasAttributes(OTelAttribute<bool>(
                                            "gcloud.stream_started", true)))));
 }
 
@@ -134,16 +134,16 @@ TEST(AsyncStreamingReadRpcTracing, Read) {
           SpanEventsAre(
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 1))),
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 1))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 2))),
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 2))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 3)))))));
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 3)))))));
 }
 
 TEST(AsyncStreamingReadRpcTracing, Finish) {
@@ -163,7 +163,7 @@ TEST(AsyncStreamingReadRpcTracing, Finish) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)),
+          SpanHasAttributes(OTelAttribute<std::string>("grpc.peer", _)),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"))));
 }
 

--- a/google/cloud/internal/async_streaming_write_rpc_tracing_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_tracing_test.cc
@@ -27,7 +27,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::EventNamed;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanEventAttributesAre;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanNamed;
@@ -103,7 +103,7 @@ TEST(AsyncStreamingWriteRpcTracing, Start) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(SpanNamed("span"),
-                                       SpanHasAttributes(SpanAttribute<bool>(
+                                       SpanHasAttributes(OTelAttribute<bool>(
                                            "gcloud.stream_started", true)))));
 }
 
@@ -135,22 +135,22 @@ TEST(AsyncStreamingWriteRpcTracing, Write) {
           SpanEventsAre(
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 1),
-                        SpanAttribute<bool>("message.is_last", false),
-                        SpanAttribute<bool>("message.success", true))),
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 1),
+                        OTelAttribute<bool>("message.is_last", false),
+                        OTelAttribute<bool>("message.success", true))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 2),
-                        SpanAttribute<bool>("message.is_last", false),
-                        SpanAttribute<bool>("message.success", false))),
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 2),
+                        OTelAttribute<bool>("message.is_last", false),
+                        OTelAttribute<bool>("message.success", false))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 3),
-                        SpanAttribute<bool>("message.is_last", true),
-                        SpanAttribute<bool>("message.success", true)))))));
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 3),
+                        OTelAttribute<bool>("message.is_last", true),
+                        OTelAttribute<bool>("message.success", true)))))));
 }
 
 TEST(AsyncStreamingWriteRpcTracing, WritesDone) {
@@ -192,7 +192,7 @@ TEST(AsyncStreamingWriteRpcTracing, Finish) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)),
+          SpanHasAttributes(OTelAttribute<std::string>("grpc.peer", _)),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"))));
 }
 

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -38,7 +38,7 @@ using ::testing::Return;
 using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -65,14 +65,14 @@ TEST(OpenTelemetry, MakeSpanGrpc) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("google.cloud.foo.v1.Foo/GetBar"),
           SpanHasAttributes(
-              SpanAttribute<std::string>(sc::kRpcSystem,
+              OTelAttribute<std::string>(sc::kRpcSystem,
                                          sc::RpcSystemValues::kGrpc),
-              SpanAttribute<std::string>(sc::kRpcService,
+              OTelAttribute<std::string>(sc::kRpcService,
                                          "google.cloud.foo.v1.Foo"),
-              SpanAttribute<std::string>(sc::kRpcMethod, "GetBar"),
-              SpanAttribute<std::string>(sc::kNetTransport,
+              OTelAttribute<std::string>(sc::kRpcMethod, "GetBar"),
+              OTelAttribute<std::string>(sc::kNetTransport,
                                          sc::NetTransportValues::kIpTcp),
-              SpanAttribute<std::string>("grpc.version", grpc::Version())))));
+              OTelAttribute<std::string>("grpc.version", grpc::Version())))));
 }
 
 TEST(OpenTelemetry, MakeSpanGrpcHandlesNonNullTerminatedStringView) {
@@ -118,7 +118,7 @@ TEST(OpenTelemetry, EndSpan) {
       spans,
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)))));
+          SpanHasAttributes(OTelAttribute<std::string>("grpc.peer", _)))));
 }
 
 TEST(OpenTelemetry, EndSpanFuture) {
@@ -140,7 +140,7 @@ TEST(OpenTelemetry, EndSpanFuture) {
       spans,
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)))));
+          SpanHasAttributes(OTelAttribute<std::string>("grpc.peer", _)))));
 }
 
 TEST(OpenTelemetry, TracedAsyncBackoffEnabled) {

--- a/google/cloud/internal/minimal_iam_credentials_stub_test.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub_test.cc
@@ -190,7 +190,7 @@ TEST_F(MinimalIamCredentialsStubTest,
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -256,8 +256,8 @@ TEST_F(MinimalIamCredentialsStubTest, AsyncGenerateAccessTokenTracing) {
               "google.iam.credentials.v1.IAMCredentials/GenerateAccessToken"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 
 TEST_F(MinimalIamCredentialsStubTest, SignBlobNoTracing) {
@@ -307,8 +307,8 @@ TEST_F(MinimalIamCredentialsStubTest, SignBlobTracing) {
           SpanNamed("google.iam.credentials.v1.IAMCredentials/SignBlob"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              SpanAttribute<std::string>("grpc.peer", _),
-              SpanAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<std::string>("grpc.peer", _),
+              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
 }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -37,7 +37,7 @@ using ::testing::MockFunction;
 using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -123,7 +123,7 @@ TEST(OpenTelemetry, EndSpanImplSuccess) {
       spans,
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(SpanAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
 }
 
 TEST(OpenTelemetry, EndSpanImplFail) {
@@ -138,7 +138,7 @@ TEST(OpenTelemetry, EndSpanImplFail) {
       spans,
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
-          SpanHasAttributes(SpanAttribute<int>("gcloud.status_code", code)))));
+          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", code)))));
 }
 
 TEST(OpenTelemetry, EndSpanImplErrorInfo) {
@@ -154,8 +154,8 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", code),
-              SpanAttribute<std::string>("gcloud.error.reason", "reason")))));
+              OTelAttribute<int>("gcloud.status_code", code),
+              OTelAttribute<std::string>("gcloud.error.reason", "reason")))));
 
   span = MakeSpan("domain");
   EndSpanImpl(*span, Status(StatusCode::kAborted, "not good",
@@ -166,8 +166,8 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", code),
-              SpanAttribute<std::string>("gcloud.error.domain", "domain")))));
+              OTelAttribute<int>("gcloud.status_code", code),
+              OTelAttribute<std::string>("gcloud.error.domain", "domain")))));
 
   span = MakeSpan("metadata");
   EndSpanImpl(*span, Status(StatusCode::kAborted, "not good",
@@ -178,9 +178,9 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
-              SpanAttribute<int>("gcloud.status_code", code),
-              SpanAttribute<std::string>("gcloud.error.metadata.k1", "v1"),
-              SpanAttribute<std::string>("gcloud.error.metadata.k2", "v2")))));
+              OTelAttribute<int>("gcloud.status_code", code),
+              OTelAttribute<std::string>("gcloud.error.metadata.k1", "v1"),
+              OTelAttribute<std::string>("gcloud.error.metadata.k2", "v2")))));
 }
 
 TEST(OpenTelemetry, EndSpanStatus) {
@@ -330,7 +330,7 @@ TEST(OpenTelemetry, AddSpanAttributeEnabled) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
               ElementsAre(AllOf(SpanNamed("span"),
-                                SpanHasAttributes(SpanAttribute<std::string>(
+                                SpanHasAttributes(OTelAttribute<std::string>(
                                     "key", "value")))));
 }
 
@@ -348,7 +348,7 @@ TEST(OpenTelemetry, AddSpanAttributeDisabled) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          Not(SpanHasAttributes(SpanAttribute<std::string>("key", "value"))))));
+          Not(SpanHasAttributes(OTelAttribute<std::string>("key", "value"))))));
 }
 
 #else

--- a/google/cloud/internal/rest_opentelemetry_test.cc
+++ b/google/cloud/internal/rest_opentelemetry_test.cc
@@ -28,7 +28,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -66,16 +66,16 @@ TEST(RestOpentelemetry, MakeSpanHttp) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("HTTP/GET"),
           SpanHasAttributes(
-              SpanAttribute<std::string>(sc::kNetTransport,
+              OTelAttribute<std::string>(sc::kNetTransport,
                                          sc::NetTransportValues::kIpTcp),
-              SpanAttribute<std::string>(sc::kHttpMethod, "GET"),
-              SpanAttribute<std::string>(sc::kHttpUrl, kUrl),
-              SpanAttribute<std::string>("http.request.header.empty", ""),
-              SpanAttribute<std::string>("http.request.header.x-goog-foo",
+              OTelAttribute<std::string>(sc::kHttpMethod, "GET"),
+              OTelAttribute<std::string>(sc::kHttpUrl, kUrl),
+              OTelAttribute<std::string>("http.request.header.empty", ""),
+              OTelAttribute<std::string>("http.request.header.x-goog-foo",
                                          "bar"),
-              SpanAttribute<std::string>("http.request.header.x-goog-bar",
+              OTelAttribute<std::string>("http.request.header.x-goog-bar",
                                          kLongValue),
-              SpanAttribute<std::string>("http.request.header.authorization",
+              OTelAttribute<std::string>("http.request.header.authorization",
                                          secret.substr(0, 32))))));
 }
 

--- a/google/cloud/internal/streaming_read_rpc_tracing_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_tracing_test.cc
@@ -26,7 +26,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::EventNamed;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanEventAttributesAre;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanNamed;
@@ -108,20 +108,20 @@ TEST(StreamingReadRpcTracingTest, Read) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          SpanHasAttributes(SpanAttribute<std::string>("grpc.peer", _)),
+          SpanHasAttributes(OTelAttribute<std::string>("grpc.peer", _)),
           SpanEventsAre(
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 1))),
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 1))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 2))),
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 2))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "RECEIVED"),
-                        SpanAttribute<int>("message.id", 3)))))));
+                        OTelAttribute<std::string>("message.type", "RECEIVED"),
+                        OTelAttribute<int>("message.id", 3)))))));
 }
 
 TEST(StreamingReadRpcTracingTest, GetRequestMetadata) {

--- a/google/cloud/internal/streaming_write_rpc_tracing_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_tracing_test.cc
@@ -26,7 +26,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::EventNamed;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanEventAttributesAre;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanNamed;
@@ -105,22 +105,22 @@ TEST(StreamingWriteRpcTracingTest, Write) {
           SpanEventsAre(
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 1),
-                        SpanAttribute<bool>("message.is_last", false),
-                        SpanAttribute<bool>("message.success", true))),
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 1),
+                        OTelAttribute<bool>("message.is_last", false),
+                        OTelAttribute<bool>("message.success", true))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 2),
-                        SpanAttribute<bool>("message.is_last", false),
-                        SpanAttribute<bool>("message.success", false))),
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 2),
+                        OTelAttribute<bool>("message.is_last", false),
+                        OTelAttribute<bool>("message.success", false))),
               AllOf(EventNamed("message"),
                     SpanEventAttributesAre(
-                        SpanAttribute<std::string>("message.type", "SENT"),
-                        SpanAttribute<int>("message.id", 3),
-                        SpanAttribute<bool>("message.is_last", true),
-                        SpanAttribute<bool>("message.success", true))),
+                        OTelAttribute<std::string>("message.type", "SENT"),
+                        OTelAttribute<int>("message.id", 3),
+                        OTelAttribute<bool>("message.is_last", true),
+                        OTelAttribute<bool>("message.success", true))),
               EventNamed("close")))));
 }
 
@@ -138,7 +138,7 @@ TEST(StreamingWriteRpcTracingTest, Close) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
               ElementsAre(AllOf(SpanNamed("span"),
-                                SpanHasAttributes(SpanAttribute<std::string>(
+                                SpanHasAttributes(OTelAttribute<std::string>(
                                     "grpc.peer", _)))));
 }
 

--- a/google/cloud/internal/tracing_http_payload_test.cc
+++ b/google/cloud/internal/tracing_http_payload_test.cc
@@ -31,7 +31,7 @@ namespace {
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
 using ::google::cloud::testing_util::MockHttpPayload;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -63,15 +63,15 @@ TEST(TracingHttpPayload, Success) {
     return AllOf(SpanNamed("Read"), SpanHasInstrumentationScope(),
                  SpanKindIsClient(),
                  SpanHasAttributes(
-                     SpanAttribute<std::int32_t>("gcloud.status_code", 0),
-                     SpanAttribute<std::int64_t>("read.buffer.size", bs),
-                     SpanAttribute<std::int64_t>("read.returned.size", rs)));
+                     OTelAttribute<std::int32_t>("gcloud.status_code", 0),
+                     OTelAttribute<std::int64_t>("read.buffer.size", bs),
+                     OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };
   EXPECT_THAT(
       spans, UnorderedElementsAre(
                  AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
                        SpanKindIsClient(),
-                       SpanHasAttributes(SpanAttribute<std::string>(
+                       SpanHasAttributes(OTelAttribute<std::string>(
                            sc::kNetTransport, sc::NetTransportValues::kIpTcp))),
                  make_read_matcher(16, 16), make_read_matcher(16, 16),
                  make_read_matcher(16, 11), make_read_matcher(16, 0)));
@@ -102,17 +102,17 @@ TEST(TracingHttpPayload, Failure) {
     return AllOf(SpanNamed("Read"), SpanHasInstrumentationScope(),
                  SpanKindIsClient(),
                  SpanHasAttributes(
-                     SpanAttribute<std::int32_t>("gcloud.status_code", 0),
-                     SpanAttribute<std::int64_t>("read.buffer.size", bs),
-                     SpanAttribute<std::int64_t>("read.returned.size", rs)));
+                     OTelAttribute<std::int32_t>("gcloud.status_code", 0),
+                     OTelAttribute<std::int64_t>("read.buffer.size", bs),
+                     OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };
   auto make_read_error_matcher = [](auto bs, StatusCode code) {
     return AllOf(SpanNamed("Read"), SpanHasInstrumentationScope(),
                  SpanKindIsClient(),
                  SpanHasAttributes(
-                     SpanAttribute<std::int32_t>(
+                     OTelAttribute<std::int32_t>(
                          "gcloud.status_code", static_cast<std::int32_t>(code)),
-                     SpanAttribute<std::int64_t>("read.buffer.size", bs)));
+                     OTelAttribute<std::int64_t>("read.buffer.size", bs)));
   };
   EXPECT_THAT(
       spans,
@@ -120,9 +120,9 @@ TEST(TracingHttpPayload, Failure) {
           AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
                 SpanKindIsClient(),
                 SpanHasAttributes(
-                    SpanAttribute<std::string>(sc::kNetTransport,
+                    OTelAttribute<std::string>(sc::kNetTransport,
                                                sc::NetTransportValues::kIpTcp),
-                    SpanAttribute<int>(
+                    OTelAttribute<int>(
                         "gcloud.status_code",
                         static_cast<int>(StatusCode::kUnavailable)))),
           make_read_success_matcher(16, 16),

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -36,7 +36,7 @@ using ::google::cloud::testing_util::IsOkAndHolds;
 using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
 using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasEvents;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
@@ -101,15 +101,15 @@ TEST(TracingRestClient, Delete) {
           AllOf(SpanNamed("HTTP/DELETE"), SpanHasInstrumentationScope(),
                 SpanKindIsClient(),
                 SpanHasAttributes(
-                    SpanAttribute<std::string>(sc::kNetTransport,
+                    OTelAttribute<std::string>(sc::kNetTransport,
                                                sc::NetTransportValues::kIpTcp),
-                    SpanAttribute<std::string>(sc::kHttpMethod, "DELETE"),
-                    SpanAttribute<std::string>(sc::kHttpUrl, kUrl),
-                    SpanAttribute<std::string>(
+                    OTelAttribute<std::string>(sc::kHttpMethod, "DELETE"),
+                    OTelAttribute<std::string>(sc::kHttpUrl, kUrl),
+                    OTelAttribute<std::string>(
                         "http.request.header.x-test-header-3", "value3"),
-                    SpanAttribute<std::string>(
+                    OTelAttribute<std::string>(
                         "http.response.header.x-test-header-1", "value1"),
-                    SpanAttribute<std::string>(
+                    OTelAttribute<std::string>(
                         "http.response.header.x-test-header-2", "value2"))),
           SpanNamed("SendRequest"), SpanNamed("Read"), SpanNamed("Read")));
 }
@@ -152,7 +152,7 @@ TEST(TracingRestClient, HasScope) {
       UnorderedElementsAre(
           AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
                 SpanKindIsClient(),
-                SpanHasAttributes(SpanAttribute<std::string>("test.attribute",
+                SpanHasAttributes(OTelAttribute<std::string>("test.attribute",
                                                              "test.value"))),
           SpanNamed("SendRequest"), SpanNamed("Read"), SpanNamed("Read")));
 }
@@ -296,17 +296,17 @@ TEST(TracingRestClient, WithRestContextDetails) {
       UnorderedElementsAre(
           AllOf(SpanNamed("HTTP/POST"),
                 SpanHasAttributes(
-                    SpanAttribute<std::string>(sc::kNetTransport,
+                    OTelAttribute<std::string>(sc::kNetTransport,
                                                sc::NetTransportValues::kIpTcp),
-                    SpanAttribute<std::string>(sc::kHttpMethod, "POST"),
-                    SpanAttribute<std::string>(sc::kHttpUrl, kUrl),
-                    SpanAttribute<std::string>(sc::kNetPeerName, "192.168.1.1"),
-                    SpanAttribute<std::int32_t>(sc::kNetPeerPort, 443),
-                    SpanAttribute<std::string>(sc::kNetHostName, "127.0.0.1"),
-                    SpanAttribute<std::int32_t>(sc::kNetHostPort, 32000))),
+                    OTelAttribute<std::string>(sc::kHttpMethod, "POST"),
+                    OTelAttribute<std::string>(sc::kHttpUrl, kUrl),
+                    OTelAttribute<std::string>(sc::kNetPeerName, "192.168.1.1"),
+                    OTelAttribute<std::int32_t>(sc::kNetPeerPort, 443),
+                    OTelAttribute<std::string>(sc::kNetHostName, "127.0.0.1"),
+                    OTelAttribute<std::int32_t>(sc::kNetHostPort, 32000))),
           AllOf(SpanNamed("SendRequest"),
                 SpanHasAttributes(
-                    SpanAttribute<bool>("gcloud-cpp.cached_connection", false)),
+                    OTelAttribute<bool>("gcloud-cpp.cached_connection", false)),
                 SpanHasEvents(EventNamed("curl.namelookup"),
                               EventNamed("curl.connected"),
                               EventNamed("curl.ssl.handshake"))),
@@ -347,7 +347,7 @@ TEST(TracingRestClient, CachedConnection) {
   EXPECT_THAT(spans, UnorderedElementsAre(
                          SpanNamed("HTTP/PUT"),
                          AllOf(SpanNamed("SendRequest"),
-                               SpanHasAttributes(SpanAttribute<bool>(
+                               SpanHasAttributes(OTelAttribute<bool>(
                                    "gcloud-cpp.cached_connection", true)),
                                SpanHasEvents(EventNamed("curl.connected"))),
                          SpanNamed("Read"), SpanNamed("Read")));

--- a/google/cloud/internal/tracing_rest_response_test.cc
+++ b/google/cloud/internal/tracing_rest_response_test.cc
@@ -32,7 +32,7 @@ namespace {
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
 using ::google::cloud::testing_util::MockRestResponse;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -75,16 +75,16 @@ TEST(TracingRestResponseTest, Success) {
     return AllOf(SpanNamed("Read"), SpanHasInstrumentationScope(),
                  SpanKindIsClient(),
                  SpanHasAttributes(
-                     SpanAttribute<std::int32_t>("gcloud.status_code", 0),
-                     SpanAttribute<std::int64_t>("read.buffer.size", bs),
-                     SpanAttribute<std::int64_t>("read.returned.size", rs)));
+                     OTelAttribute<std::int32_t>("gcloud.status_code", 0),
+                     OTelAttribute<std::int64_t>("read.buffer.size", bs),
+                     OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };
   auto const content_size = static_cast<std::int64_t>(MockContents().size());
   EXPECT_THAT(
       spans, UnorderedElementsAre(
                  AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
                        SpanKindIsClient(),
-                       SpanHasAttributes(SpanAttribute<std::string>(
+                       SpanHasAttributes(OTelAttribute<std::string>(
                            sc::kNetTransport, sc::NetTransportValues::kIpTcp))),
                  make_read_event_matcher(kBufferSize, content_size),
                  make_read_event_matcher(kBufferSize, 0)));

--- a/google/cloud/opentelemetry/internal/resource_detector_impl_test.cc
+++ b/google/cloud/opentelemetry/internal/resource_detector_impl_test.cc
@@ -38,7 +38,7 @@ using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
 using ::google::cloud::testing_util::MockHttpPayload;
 using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::testing::_;
 using ::testing::ByMove;
 using ::testing::Contains;
@@ -120,7 +120,7 @@ TEST(ResourceDetector, RetriesTransientConnectionError) {
 
   EXPECT_THAT(
       attributes,
-      Not(Contains(SpanAttribute<std::string>(sc::kCloudProvider, "gcp"))));
+      Not(Contains(OTelAttribute<std::string>(sc::kCloudProvider, "gcp"))));
 
   EXPECT_THAT(
       log.ExtractLines(),
@@ -144,7 +144,7 @@ TEST(ResourceDetector, PermanentConnectionError) {
 
   EXPECT_THAT(
       attributes,
-      Not(Contains(SpanAttribute<std::string>(sc::kCloudProvider, "gcp"))));
+      Not(Contains(OTelAttribute<std::string>(sc::kCloudProvider, "gcp"))));
 
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr("Could not query the metadata server"),
@@ -174,7 +174,7 @@ TEST(ResourceDetector, HttpError) {
 
   EXPECT_THAT(
       attributes,
-      Not(Contains(SpanAttribute<std::string>(sc::kCloudProvider, "gcp"))));
+      Not(Contains(OTelAttribute<std::string>(sc::kCloudProvider, "gcp"))));
 
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr("Could not query the metadata server"),
@@ -211,7 +211,7 @@ TEST(ResourceDetector, ValidatesHeaders) {
 
     EXPECT_THAT(
         attributes,
-        Not(Contains(SpanAttribute<std::string>(sc::kCloudProvider, "gcp"))));
+        Not(Contains(OTelAttribute<std::string>(sc::kCloudProvider, "gcp"))));
 
     EXPECT_THAT(
         log.ExtractLines(),
@@ -248,7 +248,7 @@ TEST(ResourceDetector, PayloadReadError) {
 
   EXPECT_THAT(
       attributes,
-      Not(Contains(SpanAttribute<std::string>(sc::kCloudProvider, "gcp"))));
+      Not(Contains(OTelAttribute<std::string>(sc::kCloudProvider, "gcp"))));
 
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr("Could not query the metadata server"),
@@ -304,13 +304,13 @@ TEST(ResourceDetector, GkeRegion) {
   EXPECT_THAT(
       attributes,
       IsSupersetOf({
-          SpanAttribute<std::string>(sc::kCloudProvider, "gcp"),
-          SpanAttribute<std::string>(sc::kCloudAccountId, "test-project"),
-          SpanAttribute<std::string>(sc::kCloudPlatform,
+          OTelAttribute<std::string>(sc::kCloudProvider, "gcp"),
+          OTelAttribute<std::string>(sc::kCloudAccountId, "test-project"),
+          OTelAttribute<std::string>(sc::kCloudPlatform,
                                      "gcp_kubernetes_engine"),
-          SpanAttribute<std::string>(sc::kK8sClusterName, "test-cluster"),
-          SpanAttribute<std::string>(sc::kHostId, "1020304050607080900"),
-          SpanAttribute<std::string>(sc::kCloudRegion, "us-central1"),
+          OTelAttribute<std::string>(sc::kK8sClusterName, "test-cluster"),
+          OTelAttribute<std::string>(sc::kHostId, "1020304050607080900"),
+          OTelAttribute<std::string>(sc::kCloudRegion, "us-central1"),
       }));
 }
 
@@ -336,13 +336,13 @@ TEST(ResourceDetector, GkeZone) {
   EXPECT_THAT(
       attributes,
       IsSupersetOf({
-          SpanAttribute<std::string>(sc::kCloudProvider, "gcp"),
-          SpanAttribute<std::string>(sc::kCloudAccountId, "test-project"),
-          SpanAttribute<std::string>(sc::kCloudPlatform,
+          OTelAttribute<std::string>(sc::kCloudProvider, "gcp"),
+          OTelAttribute<std::string>(sc::kCloudAccountId, "test-project"),
+          OTelAttribute<std::string>(sc::kCloudPlatform,
                                      "gcp_kubernetes_engine"),
-          SpanAttribute<std::string>(sc::kK8sClusterName, "test-cluster"),
-          SpanAttribute<std::string>(sc::kHostId, "1020304050607080900"),
-          SpanAttribute<std::string>(sc::kCloudAvailabilityZone,
+          OTelAttribute<std::string>(sc::kK8sClusterName, "test-cluster"),
+          OTelAttribute<std::string>(sc::kHostId, "1020304050607080900"),
+          OTelAttribute<std::string>(sc::kCloudAvailabilityZone,
                                      "us-central1-a"),
       }));
 }
@@ -368,12 +368,12 @@ TEST(ResourceDetector, CloudFunctions) {
   EXPECT_THAT(
       attributes,
       IsSupersetOf({
-          SpanAttribute<std::string>(sc::kCloudProvider, "gcp"),
-          SpanAttribute<std::string>(sc::kCloudAccountId, "test-project"),
-          SpanAttribute<std::string>(sc::kCloudPlatform, "gcp_cloud_functions"),
-          SpanAttribute<std::string>(sc::kFaasName, "test-service"),
-          SpanAttribute<std::string>(sc::kFaasVersion, "test-version"),
-          SpanAttribute<std::string>(sc::kFaasInstance, "1020304050607080900"),
+          OTelAttribute<std::string>(sc::kCloudProvider, "gcp"),
+          OTelAttribute<std::string>(sc::kCloudAccountId, "test-project"),
+          OTelAttribute<std::string>(sc::kCloudPlatform, "gcp_cloud_functions"),
+          OTelAttribute<std::string>(sc::kFaasName, "test-service"),
+          OTelAttribute<std::string>(sc::kFaasVersion, "test-version"),
+          OTelAttribute<std::string>(sc::kFaasInstance, "1020304050607080900"),
       }));
 }
 
@@ -399,12 +399,12 @@ TEST(ResourceDetector, CloudRun) {
   EXPECT_THAT(
       attributes,
       IsSupersetOf({
-          SpanAttribute<std::string>(sc::kCloudProvider, "gcp"),
-          SpanAttribute<std::string>(sc::kCloudAccountId, "test-project"),
-          SpanAttribute<std::string>(sc::kCloudPlatform, "gcp_cloud_run"),
-          SpanAttribute<std::string>(sc::kFaasName, "test-service"),
-          SpanAttribute<std::string>(sc::kFaasVersion, "test-version"),
-          SpanAttribute<std::string>(sc::kFaasInstance, "1020304050607080900"),
+          OTelAttribute<std::string>(sc::kCloudProvider, "gcp"),
+          OTelAttribute<std::string>(sc::kCloudAccountId, "test-project"),
+          OTelAttribute<std::string>(sc::kCloudPlatform, "gcp_cloud_run"),
+          OTelAttribute<std::string>(sc::kFaasName, "test-service"),
+          OTelAttribute<std::string>(sc::kFaasVersion, "test-version"),
+          OTelAttribute<std::string>(sc::kFaasInstance, "1020304050607080900"),
       }));
 }
 
@@ -431,15 +431,15 @@ TEST(ResourceDetector, Gae) {
   EXPECT_THAT(
       attributes,
       IsSupersetOf({
-          SpanAttribute<std::string>(sc::kCloudProvider, "gcp"),
-          SpanAttribute<std::string>(sc::kCloudAccountId, "test-project"),
-          SpanAttribute<std::string>(sc::kCloudPlatform, "gcp_app_engine"),
-          SpanAttribute<std::string>(sc::kFaasName, "test-service"),
-          SpanAttribute<std::string>(sc::kFaasVersion, "test-version"),
-          SpanAttribute<std::string>(sc::kFaasInstance, "test-instance"),
-          SpanAttribute<std::string>(sc::kCloudAvailabilityZone,
+          OTelAttribute<std::string>(sc::kCloudProvider, "gcp"),
+          OTelAttribute<std::string>(sc::kCloudAccountId, "test-project"),
+          OTelAttribute<std::string>(sc::kCloudPlatform, "gcp_app_engine"),
+          OTelAttribute<std::string>(sc::kFaasName, "test-service"),
+          OTelAttribute<std::string>(sc::kFaasVersion, "test-version"),
+          OTelAttribute<std::string>(sc::kFaasInstance, "test-instance"),
+          OTelAttribute<std::string>(sc::kCloudAvailabilityZone,
                                      "us-central1-a"),
-          SpanAttribute<std::string>(sc::kCloudRegion, "us-central1"),
+          OTelAttribute<std::string>(sc::kCloudRegion, "us-central1"),
       }));
 }
 
@@ -467,15 +467,15 @@ TEST(ResourceDetector, Gce) {
   EXPECT_THAT(
       attributes,
       IsSupersetOf({
-          SpanAttribute<std::string>(sc::kCloudProvider, "gcp"),
-          SpanAttribute<std::string>(sc::kCloudAccountId, "test-project"),
-          SpanAttribute<std::string>(sc::kCloudPlatform, "gcp_compute_engine"),
-          SpanAttribute<std::string>(sc::kHostType, "c2d-standard-16"),
-          SpanAttribute<std::string>(sc::kHostId, "1020304050607080900"),
-          SpanAttribute<std::string>(sc::kHostName, "test-instance"),
-          SpanAttribute<std::string>(sc::kCloudAvailabilityZone,
+          OTelAttribute<std::string>(sc::kCloudProvider, "gcp"),
+          OTelAttribute<std::string>(sc::kCloudAccountId, "test-project"),
+          OTelAttribute<std::string>(sc::kCloudPlatform, "gcp_compute_engine"),
+          OTelAttribute<std::string>(sc::kHostType, "c2d-standard-16"),
+          OTelAttribute<std::string>(sc::kHostId, "1020304050607080900"),
+          OTelAttribute<std::string>(sc::kHostName, "test-instance"),
+          OTelAttribute<std::string>(sc::kCloudAvailabilityZone,
                                      "us-central1-a"),
-          SpanAttribute<std::string>(sc::kCloudRegion, "us-central1"),
+          OTelAttribute<std::string>(sc::kCloudRegion, "us-central1"),
       }));
 }
 

--- a/google/cloud/storage/internal/tracing_client_test.cc
+++ b/google/cloud/storage/internal/tracing_client_test.cc
@@ -31,7 +31,7 @@ namespace {
 using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::SpanAttribute;
+using ::google::cloud::testing_util::OTelAttribute;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -72,7 +72,7 @@ TEST(TracingClientTest, ListBuckets) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("storage::Client::ListBuckets"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -94,7 +94,7 @@ TEST(TracingClientTest, CreateBucket) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("storage::Client::CreateBucket"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -116,7 +116,7 @@ TEST(TracingClientTest, GetBucketMetadata) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("storage::Client::GetBucketMetadata"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -138,7 +138,7 @@ TEST(TracingClientTest, DeleteBucket) {
                   SpanNamed("storage::Client::DeleteBucket"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -160,7 +160,7 @@ TEST(TracingClientTest, UpdateBucket) {
                   SpanNamed("storage::Client::UpdateBucket"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -181,7 +181,7 @@ TEST(TracingClientTest, PatchBucket) {
                   SpanNamed("storage::Client::PatchBucket"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -203,7 +203,7 @@ TEST(TracingClientTest, GetNativeBucketIamPolicy) {
                   SpanNamed("storage::Client::GetNativeBucketIamPolicy"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -227,7 +227,7 @@ TEST(TracingClientTest, SetNativeBucketIamPolicy) {
                   SpanNamed("storage::Client::SetNativeBucketIamPolicy"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -249,7 +249,7 @@ TEST(TracingClientTest, TestBucketIamPermissions) {
                   SpanNamed("storage::Client::TestBucketIamPermissions"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -271,7 +271,7 @@ TEST(TracingClientTest, LockBucketRetentionPolicy) {
                   SpanNamed("storage::Client::LockBucketRetentionPolicy"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -293,7 +293,7 @@ TEST(TracingClientTest, InsertObjectMedia) {
                   SpanNamed("storage::Client::InsertObjectMedia"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -314,7 +314,7 @@ TEST(TracingClientTest, CopyObject) {
                   SpanNamed("storage::Client::CopyObject"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -336,7 +336,7 @@ TEST(TracingClientTest, GetObjectMetadata) {
                   SpanNamed("storage::Client::GetObjectMetadata"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -358,7 +358,7 @@ TEST(TracingClientTest, ReadObject) {
                   SpanNamed("storage::Client::ReadObject"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -379,7 +379,7 @@ TEST(TracingClientTest, ListObjects) {
                   SpanNamed("storage::Client::ListObjects"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -401,7 +401,7 @@ TEST(TracingClientTest, DeleteObject) {
                   SpanNamed("storage::Client::DeleteObject"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -423,7 +423,7 @@ TEST(TracingClientTest, UpdateObject) {
                   SpanNamed("storage::Client::UpdateObject"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -444,7 +444,7 @@ TEST(TracingClientTest, PatchObject) {
                   SpanNamed("storage::Client::PatchObject"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -466,7 +466,7 @@ TEST(TracingClientTest, ComposeObject) {
                   SpanNamed("storage::Client::ComposeObject"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -488,7 +488,7 @@ TEST(TracingClientTest, RewriteObject) {
                   SpanNamed("storage::Client::RewriteObject"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -511,7 +511,7 @@ TEST(TracingClientTest, CreateResumableUpload) {
           AllOf(SpanNamed("storage::Client::WriteObject/CreateResumableUpload"),
                 SpanHasInstrumentationScope(), SpanKindIsClient(),
                 SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                SpanHasAttributes(SpanAttribute<int>(
+                SpanHasAttributes(OTelAttribute<int>(
                     "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -534,7 +534,7 @@ TEST(TracingClientTest, QueryResumableUpload) {
           AllOf(SpanNamed("storage::Client::WriteObject/QueryResumableUpload"),
                 SpanHasInstrumentationScope(), SpanKindIsClient(),
                 SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                SpanHasAttributes(SpanAttribute<int>(
+                SpanHasAttributes(OTelAttribute<int>(
                     "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -556,7 +556,7 @@ TEST(TracingClientTest, DeleteResumableUpload) {
                   SpanNamed("storage::Client::DeleteResumableUpload"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -577,7 +577,7 @@ TEST(TracingClientTest, UploadChunk) {
                   SpanNamed("storage::Client::WriteObject/UploadChunk"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -599,7 +599,7 @@ TEST(TracingClientTest, ListBucketAcl) {
                   SpanNamed("storage::Client::ListBucketAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -621,7 +621,7 @@ TEST(TracingClientTest, CreateBucketAcl) {
                   SpanNamed("storage::Client::CreateBucketAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -643,7 +643,7 @@ TEST(TracingClientTest, DeleteBucketAcl) {
                   SpanNamed("storage::Client::DeleteBucketAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -665,7 +665,7 @@ TEST(TracingClientTest, GetBucketAcl) {
                   SpanNamed("storage::Client::GetBucketAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -687,7 +687,7 @@ TEST(TracingClientTest, UpdateBucketAcl) {
                   SpanNamed("storage::Client::UpdateBucketAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -711,7 +711,7 @@ TEST(TracingClientTest, PatchBucketAcl) {
                   SpanNamed("storage::Client::PatchBucketAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -733,7 +733,7 @@ TEST(TracingClientTest, ListObjectAcl) {
                   SpanNamed("storage::Client::ListObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -755,7 +755,7 @@ TEST(TracingClientTest, CreateObjectAcl) {
                   SpanNamed("storage::Client::CreateObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -777,7 +777,7 @@ TEST(TracingClientTest, DeleteObjectAcl) {
                   SpanNamed("storage::Client::DeleteObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -799,7 +799,7 @@ TEST(TracingClientTest, GetObjectAcl) {
                   SpanNamed("storage::Client::GetObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -821,7 +821,7 @@ TEST(TracingClientTest, UpdateObjectAcl) {
                   SpanNamed("storage::Client::UpdateObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -845,7 +845,7 @@ TEST(TracingClientTest, PatchObjectAcl) {
                   SpanNamed("storage::Client::PatchObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -867,7 +867,7 @@ TEST(TracingClientTest, ListDefaultObjectAcl) {
                   SpanNamed("storage::Client::ListDefaultObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -889,7 +889,7 @@ TEST(TracingClientTest, CreateDefaultObjectAcl) {
                   SpanNamed("storage::Client::CreateDefaultObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -911,7 +911,7 @@ TEST(TracingClientTest, DeleteDefaultObjectAcl) {
                   SpanNamed("storage::Client::DeleteDefaultObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -933,7 +933,7 @@ TEST(TracingClientTest, GetDefaultObjectAcl) {
                   SpanNamed("storage::Client::GetDefaultObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -955,7 +955,7 @@ TEST(TracingClientTest, UpdateDefaultObjectAcl) {
                   SpanNamed("storage::Client::UpdateDefaultObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -979,7 +979,7 @@ TEST(TracingClientTest, PatchDefaultObjectAcl) {
                   SpanNamed("storage::Client::PatchDefaultObjectAcl"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1001,7 +1001,7 @@ TEST(TracingClientTest, GetServiceAccount) {
                   SpanNamed("storage::Client::GetServiceAccount"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1023,7 +1023,7 @@ TEST(TracingClientTest, ListHmacKeys) {
                   SpanNamed("storage::Client::ListHmacKeys"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1045,7 +1045,7 @@ TEST(TracingClientTest, CreateHmacKey) {
                   SpanNamed("storage::Client::CreateHmacKey"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1068,7 +1068,7 @@ TEST(TracingClientTest, DeleteHmacKey) {
                   SpanNamed("storage::Client::DeleteHmacKey"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1090,7 +1090,7 @@ TEST(TracingClientTest, GetHmacKey) {
                   SpanNamed("storage::Client::GetHmacKey"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1113,7 +1113,7 @@ TEST(TracingClientTest, UpdateHmacKey) {
                   SpanNamed("storage::Client::UpdateHmacKey"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1135,7 +1135,7 @@ TEST(TracingClientTest, SignBlob) {
                   SpanNamed("storage::Client::SignBlob"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1157,7 +1157,7 @@ TEST(TracingClientTest, ListNotifications) {
                   SpanNamed("storage::Client::ListNotifications"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1179,7 +1179,7 @@ TEST(TracingClientTest, CreateNotification) {
                   SpanNamed("storage::Client::CreateNotification"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1201,7 +1201,7 @@ TEST(TracingClientTest, GetNotification) {
                   SpanNamed("storage::Client::GetNotification"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 
@@ -1223,7 +1223,7 @@ TEST(TracingClientTest, DeleteNotification) {
                   SpanNamed("storage::Client::DeleteNotification"),
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
-                  SpanHasAttributes(SpanAttribute<int>(
+                  SpanHasAttributes(OTelAttribute<int>(
                       "gcloud.status_code", static_cast<int>(code))))));
 }
 

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -53,17 +53,18 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace testing_util_internal {
 
-using SpanAttributeMap =
+using OTelAttributeMap =
     std::unordered_map<std::string,
                        opentelemetry::sdk::common::OwnedAttributeValue>;
+
 MATCHER_P(SpanAttributesImpl, matcher,
-          ::testing::DescribeMatcher<SpanAttributeMap>(matcher)) {
+          ::testing::DescribeMatcher<OTelAttributeMap>(matcher)) {
   return ::testing::ExplainMatchResult(matcher, arg->GetAttributes(),
                                        result_listener);
 }
 
 MATCHER_P(EventAttributesImpl, matcher,
-          ::testing::DescribeMatcher<SpanAttributeMap>(matcher)) {
+          ::testing::DescribeMatcher<OTelAttributeMap>(matcher)) {
   return ::testing::ExplainMatchResult(matcher, arg.GetAttributes(),
                                        result_listener);
 }
@@ -151,7 +152,7 @@ template <typename... Args>
 template <typename T>
 ::testing::Matcher<
     std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>>
-SpanAttribute(std::string const& key, ::testing::Matcher<T const&> matcher) {
+OTelAttribute(std::string const& key, ::testing::Matcher<T const&> matcher) {
   return ::testing::Pair(key, ::testing::VariantWith<T>(matcher));
 }
 


### PR DESCRIPTION
Fixes #11082 

This is purely a rename. It eliminates strange code like: `EventAttributesAre(SpanAttribute<>(...))`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12154)
<!-- Reviewable:end -->
