### PR TITLE
impl(bigquery): Dataset api response field name changes

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/dataset.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset.cc
@@ -43,76 +43,70 @@ TargetType TargetType::Views() { return TargetType{"VIEWS"}; }
 TargetType TargetType::Routines() { return TargetType{"ROUTINES"}; }
 
 void to_json(nlohmann::json& j, Dataset const& d) {
-  j = nlohmann::json{
-      {"kind", d.kind},
-      {"etag", d.etag},
-      {"id", d.id},
-      {"self_link", d.self_link},
-      {"friendly_name", d.friendly_name},
-      {"description", d.description},
-      {"type", d.type},
-      {"location", d.location},
-      {"default_collation", d.default_collation},
-      {"published", d.published},
-      {"is_case_insensitive", d.is_case_insensitive},
-      {"labels", d.labels},
-      {"access", d.access},
-      {"tags", d.tags},
-      {"dataset_reference", d.dataset_reference},
+  j = nlohmann::json{{"kind", d.kind},
+                     {"etag", d.etag},
+                     {"id", d.id},
+                     {"selfLink", d.self_link},
+                     {"friendlyName", d.friendly_name},
+                     {"description", d.description},
+                     {"type", d.type},
+                     {"location", d.location},
+                     {"defaultCollation", d.default_collation},
+                     {"published", d.published},
+                     {"isCaseInsensitive", d.is_case_insensitive},
+                     {"labels", d.labels},
+                     {"access", d.access},
+                     {"tags", d.tags},
+                     {"datasetReference", d.dataset_reference},
+                     {"linkedDatasetSource", d.linked_dataset_source},
+                     {"defaultRoundingMode", d.default_rounding_mode},
+                     {"storageBillingModel", d.storage_billing_model}};
 
-      {"linked_dataset_source", d.linked_dataset_source},
-      {"external_dataset_reference", d.external_dataset_reference},
-      {"default_rounding_mode", d.default_rounding_mode},
-      {"storage_billing_model", d.storage_billing_model}};
-
-  ToJson(d.default_table_expiration, j, "default_table_expiration");
-  ToJson(d.default_partition_expiration, j, "default_partition_expiration");
-  ToJson(d.creation_time, j, "creation_time");
-  ToJson(d.last_modified_time, j, "last_modified_time");
-  ToJson(d.max_time_travel, j, "max_time_travel");
+  ToJson(d.default_table_expiration, j, "defaultTableExpirationMs");
+  ToJson(d.default_partition_expiration, j, "defaultPartitionExpirationMs");
+  ToJson(d.creation_time, j, "creationTime");
+  ToJson(d.last_modified_time, j, "lastModifiedTime");
+  ToJson(d.max_time_travel, j, "maxTimeTravelHours");
 }
 
 void from_json(nlohmann::json const& j, Dataset& d) {
   if (j.contains("kind")) j.at("kind").get_to(d.kind);
   if (j.contains("etag")) j.at("etag").get_to(d.etag);
   if (j.contains("id")) j.at("id").get_to(d.id);
-  if (j.contains("self_link")) j.at("self_link").get_to(d.self_link);
-  if (j.contains("friendly_name"))
-    j.at("friendly_name").get_to(d.friendly_name);
+  if (j.contains("selfLink")) j.at("selfLink").get_to(d.self_link);
+  if (j.contains("friendlyName")) j.at("friendlyName").get_to(d.friendly_name);
   if (j.contains("description")) j.at("description").get_to(d.description);
   if (j.contains("type")) j.at("type").get_to(d.type);
   if (j.contains("location")) j.at("location").get_to(d.location);
-  if (j.contains("default_collation"))
-    j.at("default_collation").get_to(d.default_collation);
+  if (j.contains("defaultCollation"))
+    j.at("defaultCollation").get_to(d.default_collation);
   if (j.contains("published")) j.at("published").get_to(d.published);
-  if (j.contains("is_case_insensitive"))
-    j.at("is_case_insensitive").get_to(d.is_case_insensitive);
+  if (j.contains("isCaseInsensitive"))
+    j.at("isCaseInsensitive").get_to(d.is_case_insensitive);
   if (j.contains("labels")) j.at("labels").get_to(d.labels);
   if (j.contains("access")) j.at("access").get_to(d.access);
   if (j.contains("tags")) j.at("tags").get_to(d.tags);
-  if (j.contains("dataset_reference"))
-    j.at("dataset_reference").get_to(d.dataset_reference);
-  if (j.contains("linked_dataset_source"))
-    j.at("linked_dataset_source").get_to(d.linked_dataset_source);
-  if (j.contains("external_dataset_reference"))
-    j.at("external_dataset_reference").get_to(d.external_dataset_reference);
-  if (j.contains("default_rounding_mode"))
-    j.at("default_rounding_mode").get_to(d.default_rounding_mode);
-  if (j.contains("storage_billing_model"))
-    j.at("storage_billing_model").get_to(d.storage_billing_model);
+  if (j.contains("datasetReference"))
+    j.at("datasetReference").get_to(d.dataset_reference);
+  if (j.contains("linkedDatasetSource"))
+    j.at("linkedDatasetSource").get_to(d.linked_dataset_source);
+  if (j.contains("defaultRoundingMode"))
+    j.at("defaultRoundingMode").get_to(d.default_rounding_mode);
+  if (j.contains("storageBillingModel"))
+    j.at("storageBillingModel").get_to(d.storage_billing_model);
 
-  FromJson(d.default_table_expiration, j, "default_table_expiration");
-  FromJson(d.default_partition_expiration, j, "default_partition_expiration");
-  FromJson(d.creation_time, j, "creation_time");
-  FromJson(d.last_modified_time, j, "last_modified_time");
-  FromJson(d.max_time_travel, j, "max_time_travel");
+  FromJson(d.default_table_expiration, j, "defaultTableExpirationMs");
+  FromJson(d.default_partition_expiration, j, "defaultPartitionExpirationMs");
+  FromJson(d.creation_time, j, "creationTime");
+  FromJson(d.last_modified_time, j, "lastModifiedTime");
+  FromJson(d.max_time_travel, j, "maxTimeTravelHours");
 }
 
 std::string LinkedDatasetSource::DebugString(absl::string_view name,
                                              TracingOptions const& options,
                                              int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .SubMessage("source_dataset", source_dataset)
+      .SubMessage("source_dataset", sourceDataset)
       .Build();
 }
 
@@ -137,7 +131,7 @@ std::string DatasetAccessEntry::DebugString(absl::string_view name,
                                             int indent) const {
   return internal::DebugFormatter(name, options, indent)
       .SubMessage("dataset", dataset)
-      .Field("target_types", target_types)
+      .Field("target_types", targetTypes)
       .Build();
 }
 
@@ -146,42 +140,14 @@ std::string Access::DebugString(absl::string_view name,
                                 int indent) const {
   return internal::DebugFormatter(name, options, indent)
       .StringField("role", role)
-      .StringField("user_by_email", user_by_email)
-      .StringField("group_by_email", group_by_email)
+      .StringField("user_by_email", userByEmail)
+      .StringField("group_by_email", groupByEmail)
       .StringField("domain", domain)
-      .StringField("special_group", special_group)
-      .StringField("iam_member", iam_member)
+      .StringField("special_group", specialGroup)
+      .StringField("iam_member", iamMember)
       .SubMessage("view", view)
       .SubMessage("routine", routine)
       .SubMessage("dataset", dataset)
-      .Build();
-}
-
-std::string HiveMetastoreConnectivity::DebugString(
-    absl::string_view name, TracingOptions const& options, int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("access_uri_type", access_uri_type)
-      .StringField("access_uri", access_uri)
-      .StringField("metadata_connection", metadata_connection)
-      .StringField("storage_connection", storage_connection)
-      .Build();
-}
-
-std::string HiveDatabaseReference::DebugString(absl::string_view name,
-                                               TracingOptions const& options,
-                                               int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("catalog_id", catalog_id)
-      .StringField("database", database)
-      .SubMessage("metadata_connectivity", metadata_connectivity)
-      .Build();
-}
-
-std::string ExternalDatasetReference::DebugString(absl::string_view name,
-                                                  TracingOptions const& options,
-                                                  int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .SubMessage("hive_database", hive_database)
       .Build();
 }
 
@@ -189,8 +155,8 @@ std::string GcpTag::DebugString(absl::string_view name,
                                 TracingOptions const& options,
                                 int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .StringField("tag_key", tag_key)
-      .StringField("tag_value", tag_value)
+      .StringField("tag_key", tagKey)
+      .StringField("tag_value", tagValue)
       .Build();
 }
 
@@ -219,7 +185,6 @@ std::string Dataset::DebugString(absl::string_view name,
       .Field("tags", tags)
       .SubMessage("dataset_reference", dataset_reference)
       .SubMessage("linked_dataset_source", linked_dataset_source)
-      .SubMessage("external_dataset_reference", external_dataset_reference)
       .SubMessage("default_rounding_mode", default_rounding_mode)
       .SubMessage("storage_billing_model", storage_billing_model)
       .Build();
@@ -231,10 +196,10 @@ std::string ListFormatDataset::DebugString(absl::string_view name,
   return internal::DebugFormatter(name, options, indent)
       .StringField("kind", kind)
       .StringField("id", id)
-      .StringField("friendly_name", friendly_name)
+      .StringField("friendly_name", friendlyName)
       .StringField("location", location)
       .StringField("type", type)
-      .SubMessage("dataset_reference", dataset_reference)
+      .SubMessage("dataset_reference", datasetReference)
       .Field("labels", labels)
       .Build();
 }

--- a/google/cloud/bigquery/v2/minimal/internal/dataset.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset.cc
@@ -106,7 +106,7 @@ std::string LinkedDatasetSource::DebugString(absl::string_view name,
                                              TracingOptions const& options,
                                              int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .SubMessage("source_dataset", sourceDataset)
+      .SubMessage("source_dataset", source_dataset)
       .Build();
 }
 
@@ -131,7 +131,7 @@ std::string DatasetAccessEntry::DebugString(absl::string_view name,
                                             int indent) const {
   return internal::DebugFormatter(name, options, indent)
       .SubMessage("dataset", dataset)
-      .Field("target_types", targetTypes)
+      .Field("target_types", target_types)
       .Build();
 }
 
@@ -140,11 +140,11 @@ std::string Access::DebugString(absl::string_view name,
                                 int indent) const {
   return internal::DebugFormatter(name, options, indent)
       .StringField("role", role)
-      .StringField("user_by_email", userByEmail)
-      .StringField("group_by_email", groupByEmail)
+      .StringField("user_by_email", user_by_email)
+      .StringField("group_by_email", group_by_email)
       .StringField("domain", domain)
-      .StringField("special_group", specialGroup)
-      .StringField("iam_member", iamMember)
+      .StringField("special_group", special_group)
+      .StringField("iam_member", iam_member)
       .SubMessage("view", view)
       .SubMessage("routine", routine)
       .SubMessage("dataset", dataset)
@@ -155,8 +155,8 @@ std::string GcpTag::DebugString(absl::string_view name,
                                 TracingOptions const& options,
                                 int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .StringField("tag_key", tagKey)
-      .StringField("tag_value", tagValue)
+      .StringField("tag_key", tag_key)
+      .StringField("tag_value", tag_value)
       .Build();
 }
 
@@ -196,12 +196,86 @@ std::string ListFormatDataset::DebugString(absl::string_view name,
   return internal::DebugFormatter(name, options, indent)
       .StringField("kind", kind)
       .StringField("id", id)
-      .StringField("friendly_name", friendlyName)
+      .StringField("friendly_name", friendly_name)
       .StringField("location", location)
       .StringField("type", type)
-      .SubMessage("dataset_reference", datasetReference)
+      .SubMessage("dataset_reference", dataset_reference)
       .Field("labels", labels)
       .Build();
+}
+
+void to_json(nlohmann::json& j, ListFormatDataset const& d) {
+  j = nlohmann::json{{"kind", d.kind},
+                     {"id", d.id},
+                     {"friendlyName", d.friendly_name},
+                     {"location", d.location},
+                     {"type", d.type},
+                     {"datasetReference", d.dataset_reference},
+                     {"labels", d.labels}};
+}
+void from_json(nlohmann::json const& j, ListFormatDataset& d) {
+  // TODO(#12188): Implement SafeGetTo(...) for potentially better performance.
+  if (j.contains("kind")) j.at("kind").get_to(d.kind);
+  if (j.contains("id")) j.at("id").get_to(d.id);
+  if (j.contains("friendlyName")) j.at("friendlyName").get_to(d.friendly_name);
+  if (j.contains("location")) j.at("location").get_to(d.location);
+  if (j.contains("type")) j.at("type").get_to(d.type);
+  if (j.contains("datasetReference")) {
+    j.at("datasetReference").get_to(d.dataset_reference);
+  }
+  if (j.contains("labels")) j.at("labels").get_to(d.labels);
+}
+
+void to_json(nlohmann::json& j, GcpTag const& t) {
+  j = nlohmann::json{{"tagKey", t.tag_key}, {"tagValue", t.tag_value}};
+}
+void from_json(nlohmann::json const& j, GcpTag& t) {
+  // TODO(#12188): Implement SafeGetTo(...) for potentially better performance.
+  if (j.contains("tagKey")) j.at("tagKey").get_to(t.tag_key);
+  if (j.contains("tagValue")) j.at("tagValue").get_to(t.tag_value);
+}
+
+void to_json(nlohmann::json& j, Access const& a) {
+  j = nlohmann::json{{"role", a.role},
+                     {"userByEmail", a.user_by_email},
+                     {"groupByEmail", a.group_by_email},
+                     {"domain", a.domain},
+                     {"specialGroup", a.special_group},
+                     {"iamMember", a.iam_member},
+                     {"view", a.view},
+                     {"routine", a.routine},
+                     {"dataset", a.dataset}};
+}
+void from_json(nlohmann::json const& j, Access& a) {
+  // TODO(#12188): Implement SafeGetTo(...) for potentially better performance.
+  if (j.contains("role")) j.at("role").get_to(a.role);
+  if (j.contains("userByEmail")) j.at("userByEmail").get_to(a.user_by_email);
+  if (j.contains("groupByEmail")) j.at("groupByEmail").get_to(a.group_by_email);
+  if (j.contains("domain")) j.at("domain").get_to(a.domain);
+  if (j.contains("specialGroup")) j.at("specialGroup").get_to(a.special_group);
+  if (j.contains("iamMember")) j.at("iamMember").get_to(a.iam_member);
+  if (j.contains("view")) j.at("view").get_to(a.view);
+  if (j.contains("routine")) j.at("routine").get_to(a.routine);
+  if (j.contains("dataset")) j.at("dataset").get_to(a.dataset);
+}
+
+void to_json(nlohmann::json& j, DatasetAccessEntry const& d) {
+  j = nlohmann::json{{"dataset", d.dataset}, {"targetTypes", d.target_types}};
+}
+void from_json(nlohmann::json const& j, DatasetAccessEntry& d) {
+  // TODO(#12188): Implement SafeGetTo(...) for potentially better performance.
+  if (j.contains("dataset")) j.at("dataset").get_to(d.dataset);
+  if (j.contains("targetTypes")) j.at("targetTypes").get_to(d.target_types);
+}
+
+void to_json(nlohmann::json& j, LinkedDatasetSource const& d) {
+  j = nlohmann::json{{"sourceDataset", d.source_dataset}};
+}
+void from_json(nlohmann::json const& j, LinkedDatasetSource& d) {
+  // TODO(#12188): Implement SafeGetTo(...) for potentially better performance.
+  if (j.contains("sourceDataset")) {
+    j.at("sourceDataset").get_to(d.source_dataset);
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/dataset.h
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset.h
@@ -61,33 +61,33 @@ struct TargetType {
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(TargetType, value);
 
 struct LinkedDatasetSource {
-  DatasetReference source_dataset;
+  DatasetReference sourceDataset;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(LinkedDatasetSource,
-                                                source_dataset);
+                                                sourceDataset);
 
 struct DatasetAccessEntry {
   DatasetReference dataset;
-  std::vector<TargetType> target_types;
+  std::vector<TargetType> targetTypes;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(DatasetAccessEntry, dataset,
-                                                target_types);
+                                                targetTypes);
 
 struct Access {
   std::string role;
-  std::string user_by_email;
-  std::string group_by_email;
+  std::string userByEmail;
+  std::string groupByEmail;
   std::string domain;
-  std::string special_group;
-  std::string iam_member;
+  std::string specialGroup;
+  std::string iamMember;
 
   TableReference view;
   RoutineReference routine;
@@ -97,59 +97,20 @@ struct Access {
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Access, role, user_by_email,
-                                                group_by_email, domain,
-                                                special_group, iam_member, view,
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Access, role, userByEmail,
+                                                groupByEmail, domain,
+                                                specialGroup, iamMember, view,
                                                 routine, dataset);
 
-struct HiveMetastoreConnectivity {
-  std::string access_uri_type;
-  std::string access_uri;
-  std::string metadata_connection;
-  std::string storage_connection;
-
-  std::string DebugString(absl::string_view name,
-                          TracingOptions const& options = {},
-                          int indent = 0) const;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(HiveMetastoreConnectivity,
-                                                access_uri_type, access_uri,
-                                                metadata_connection,
-                                                storage_connection);
-
-struct HiveDatabaseReference {
-  std::string catalog_id;
-  std::string database;
-
-  HiveMetastoreConnectivity metadata_connectivity;
-
-  std::string DebugString(absl::string_view name,
-                          TracingOptions const& options = {},
-                          int indent = 0) const;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(HiveDatabaseReference,
-                                                catalog_id, database,
-                                                metadata_connectivity);
-
-struct ExternalDatasetReference {
-  HiveDatabaseReference hive_database;
-
-  std::string DebugString(absl::string_view name,
-                          TracingOptions const& options = {},
-                          int indent = 0) const;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ExternalDatasetReference,
-                                                hive_database);
-
 struct GcpTag {
-  std::string tag_key;
-  std::string tag_value;
+  std::string tagKey;
+  std::string tagValue;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(GcpTag, tag_key, tag_value);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(GcpTag, tagKey, tagValue);
 
 struct Dataset {
   std::string kind;
@@ -179,7 +140,6 @@ struct Dataset {
 
   DatasetReference dataset_reference;
   LinkedDatasetSource linked_dataset_source;
-  ExternalDatasetReference external_dataset_reference;
   RoundingMode default_rounding_mode;
 
   StorageBillingModel storage_billing_model;
@@ -192,11 +152,11 @@ struct Dataset {
 struct ListFormatDataset {
   std::string kind;
   std::string id;
-  std::string friendly_name;
+  std::string friendlyName;
   std::string location;
   std::string type;
 
-  DatasetReference dataset_reference;
+  DatasetReference datasetReference;
   std::map<std::string, std::string> labels;
 
   std::string DebugString(absl::string_view name,
@@ -204,8 +164,8 @@ struct ListFormatDataset {
                           int indent = 0) const;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ListFormatDataset, kind, id,
-                                                friendly_name, location, type,
-                                                dataset_reference, labels);
+                                                friendlyName, location, type,
+                                                datasetReference, labels);
 
 void to_json(nlohmann::json& j, Dataset const& d);
 void from_json(nlohmann::json const& j, Dataset& d);

--- a/google/cloud/bigquery/v2/minimal/internal/dataset.h
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset.h
@@ -61,33 +61,33 @@ struct TargetType {
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(TargetType, value);
 
 struct LinkedDatasetSource {
-  DatasetReference sourceDataset;
+  DatasetReference source_dataset;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(LinkedDatasetSource,
-                                                sourceDataset);
+void to_json(nlohmann::json& j, LinkedDatasetSource const& d);
+void from_json(nlohmann::json const& j, LinkedDatasetSource& d);
 
 struct DatasetAccessEntry {
   DatasetReference dataset;
-  std::vector<TargetType> targetTypes;
+  std::vector<TargetType> target_types;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(DatasetAccessEntry, dataset,
-                                                targetTypes);
+void to_json(nlohmann::json& j, DatasetAccessEntry const& d);
+void from_json(nlohmann::json const& j, DatasetAccessEntry& d);
 
 struct Access {
   std::string role;
-  std::string userByEmail;
-  std::string groupByEmail;
+  std::string user_by_email;
+  std::string group_by_email;
   std::string domain;
-  std::string specialGroup;
-  std::string iamMember;
+  std::string special_group;
+  std::string iam_member;
 
   TableReference view;
   RoutineReference routine;
@@ -97,20 +97,19 @@ struct Access {
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Access, role, userByEmail,
-                                                groupByEmail, domain,
-                                                specialGroup, iamMember, view,
-                                                routine, dataset);
+void to_json(nlohmann::json& j, Access const& a);
+void from_json(nlohmann::json const& j, Access& a);
 
 struct GcpTag {
-  std::string tagKey;
-  std::string tagValue;
+  std::string tag_key;
+  std::string tag_value;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(GcpTag, tagKey, tagValue);
+void to_json(nlohmann::json& j, GcpTag const& t);
+void from_json(nlohmann::json const& j, GcpTag& t);
 
 struct Dataset {
   std::string kind;
@@ -148,27 +147,25 @@ struct Dataset {
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
+void to_json(nlohmann::json& j, Dataset const& d);
+void from_json(nlohmann::json const& j, Dataset& d);
 
 struct ListFormatDataset {
   std::string kind;
   std::string id;
-  std::string friendlyName;
+  std::string friendly_name;
   std::string location;
   std::string type;
 
-  DatasetReference datasetReference;
+  DatasetReference dataset_reference;
   std::map<std::string, std::string> labels;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ListFormatDataset, kind, id,
-                                                friendlyName, location, type,
-                                                datasetReference, labels);
-
-void to_json(nlohmann::json& j, Dataset const& d);
-void from_json(nlohmann::json const& j, Dataset& d);
+void to_json(nlohmann::json& j, ListFormatDataset const& d);
+void from_json(nlohmann::json const& j, ListFormatDataset& d);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_connection_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_connection_test.cc
@@ -61,7 +61,7 @@ TEST(DatasetConnectionTest, GetDatasetSuccess) {
           "id": "d-id",
           "selfLink": "d-selfLink",
           "friendlyName": "d-friendly-name",
-          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
+          "datasetReference": {"projectId": "p-id", "datasetId": "d-id"}
     })";
 
   EXPECT_CALL(*mock, GetDataset)

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_connection_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_connection_test.cc
@@ -59,9 +59,9 @@ TEST(DatasetConnectionTest, GetDatasetSuccess) {
       R"({"kind": "d-kind",
           "etag": "d-tag",
           "id": "d-id",
-          "self_link": "d-selfLink",
-          "friendly_name": "d-friendly-name",
-          "dataset_reference": {"projectId": "p-id", "datasetId": "d-id"}
+          "selfLink": "d-selfLink",
+          "friendlyName": "d-friendly-name",
+          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
     })";
 
   EXPECT_CALL(*mock, GetDataset)

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_logging_test.cc
@@ -49,7 +49,7 @@ TEST(DatasetLoggingClientTest, GetDataset) {
           "id": "d-id",
           "selfLink": "d-selfLink",
           "friendlyName": "d-friendly-name",
-          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
+          "datasetReference": {"projectId": "p-id", "datasetId": "d-id"}
     })";
 
   EXPECT_CALL(*mock_stub, GetDataset)
@@ -102,7 +102,7 @@ TEST(DatasetLoggingClientTest, ListDatasets) {
               {
                 "id": "1",
                 "kind": "kind-1",
-                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
+                "datasetReference": {"projectId": "p123", "datasetId": "d123"},
                 "friendlyName": "friendly-name",
                 "location": "location",
                 "type": "DEFAULT"

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_logging_test.cc
@@ -47,9 +47,9 @@ TEST(DatasetLoggingClientTest, GetDataset) {
       R"({"kind": "d-kind",
           "etag": "d-tag",
           "id": "d-id",
-          "self_link": "d-selfLink",
-          "friendly_name": "d-friendly-name",
-          "dataset_reference": {"projectId": "p-id", "datasetId": "d-id"}
+          "selfLink": "d-selfLink",
+          "friendlyName": "d-friendly-name",
+          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
     })";
 
   EXPECT_CALL(*mock_stub, GetDataset)
@@ -97,13 +97,13 @@ TEST(DatasetLoggingClientTest, ListDatasets) {
   auto constexpr kExpectedPayload =
       R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
+          "nextPageToken": "npt-123",
           "datasets": [
               {
                 "id": "1",
                 "kind": "kind-1",
-                "dataset_reference": {"projectId": "p123", "datasetId": "d123"},
-                "friendly_name": "friendly-name",
+                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
+                "friendlyName": "friendly-name",
                 "location": "location",
                 "type": "DEFAULT"
               }

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_metadata_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_metadata_test.cc
@@ -42,9 +42,9 @@ TEST(DatasetMetadataTest, GetDataset) {
       R"({"kind": "d-kind",
           "etag": "d-tag",
           "id": "d-id",
-          "self_link": "d-selfLink",
-          "friendly_name": "d-friendly-name",
-          "dataset_reference": {"project_id": "p-id", "dataset_id": "d-id"}
+          "selfLink": "d-selfLink",
+          "friendlyName": "d-friendly-name",
+          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
     })";
 
   EXPECT_CALL(*mock_stub, GetDataset)
@@ -77,14 +77,14 @@ TEST(DatasetMetadataTest, ListDatasets) {
   auto constexpr kExpectedPayload =
       R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
+          "nextPageToken": "npt-123",
           "datasets": [
               {
                 "id": "1",
                 "kind": "kind-2",
-                "dataset_reference": {"project_id": "p123", "dataset_id": "d123"},
+                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
 
-                "friendly_name": "friendly-name",
+                "friendlyName": "friendly-name",
                 "location": "location",
                 "type": "DEFAULT"
               }

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_metadata_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_metadata_test.cc
@@ -44,7 +44,7 @@ TEST(DatasetMetadataTest, GetDataset) {
           "id": "d-id",
           "selfLink": "d-selfLink",
           "friendlyName": "d-friendly-name",
-          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
+          "datasetReference": {"projectId": "p-id", "datasetId": "d-id"}
     })";
 
   EXPECT_CALL(*mock_stub, GetDataset)
@@ -82,7 +82,7 @@ TEST(DatasetMetadataTest, ListDatasets) {
               {
                 "id": "1",
                 "kind": "kind-2",
-                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
+                "datasetReference": {"projectId": "p123", "datasetId": "d123"},
 
                 "friendlyName": "friendly-name",
                 "location": "location",

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_response.cc
@@ -26,17 +26,17 @@ namespace {
 
 bool valid_dataset(nlohmann::json const& j) {
   return (j.contains("kind") && j.contains("etag") && j.contains("id") &&
-          j.contains("dataset_reference"));
+          j.contains("datasetReference"));
 }
 
 bool valid_list_format_dataset(nlohmann::json const& j) {
   return (j.contains("kind") && j.contains("id") &&
-          j.contains("dataset_reference"));
+          j.contains("datasetReference"));
 }
 
 bool valid_datasets_list(nlohmann::json const& j) {
   return (j.contains("kind") && j.contains("etag") &&
-          j.contains("next_page_token") && j.contains("datasets"));
+          j.contains("nextPageToken") && j.contains("datasets"));
 }
 
 StatusOr<nlohmann::json> parse_json(std::string const& payload) {
@@ -84,7 +84,7 @@ StatusOr<ListDatasetsResponse> ListDatasetsResponse::BuildFromHttpResponse(
 
   result.kind = json->value("kind", "");
   result.etag = json->value("etag", "");
-  result.next_page_token = json->value("next_page_token", "");
+  result.next_page_token = json->value("nextPageToken", "");
 
   for (auto const& kv : json->at("datasets").items()) {
     auto const& json_list_format_dataset_obj = kv.value();

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
@@ -32,9 +32,9 @@ TEST(GetDatasetResponseTest, Success) {
       R"({"kind": "d-kind",
           "etag": "d-tag",
           "id": "d-id",
-          "self_link": "d-selfLink",
-          "friendly_name": "d-friendly-name",
-          "dataset_reference": {"projectId": "p-id", "datasetId": "d-id"}
+          "selfLink": "d-selfLink",
+          "friendlyName": "d-friendly-name",
+          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
     })";
   auto const response =
       GetDatasetResponse::BuildFromHttpResponse(http_response);
@@ -74,7 +74,7 @@ TEST(GetDatasetResponseTest, InvalidDataset) {
       R"({"kind": "dkind",
           "etag": "dtag",
           "id": "jd123",
-          "self_link": "dselfLink"})";
+          "selfLink": "dselfLink"})";
   auto const response =
       GetDatasetResponse::BuildFromHttpResponse(http_response);
   EXPECT_THAT(response, StatusIs(StatusCode::kInternal,
@@ -86,14 +86,13 @@ TEST(ListDatasetsResponseTest, Success) {
   http_response.payload =
       R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
+          "nextPageToken": "npt-123",
           "datasets": [
               {
                 "id": "1",
                 "kind": "kind-2",
-                "dataset_reference": {"projectId": "p123", "datasetId": "d123"},
-
-                "friendly_name": "friendly-name",
+                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
+                "friendlyName": "friendly-name",
                 "location": "location",
                 "type": "DEFAULT"
               }
@@ -110,9 +109,9 @@ TEST(ListDatasetsResponseTest, Success) {
   ASSERT_EQ(datasets.size(), 1);
   EXPECT_EQ(datasets[0].id, "1");
   EXPECT_EQ(datasets[0].kind, "kind-2");
-  EXPECT_EQ(datasets[0].friendly_name, "friendly-name");
-  EXPECT_EQ(datasets[0].dataset_reference.project_id, "p123");
-  EXPECT_EQ(datasets[0].dataset_reference.dataset_id, "d123");
+  EXPECT_EQ(datasets[0].friendlyName, "friendly-name");
+  EXPECT_EQ(datasets[0].datasetReference.project_id, "p123");
+  EXPECT_EQ(datasets[0].datasetReference.dataset_id, "d123");
   EXPECT_EQ(datasets[0].location, "location");
   EXPECT_EQ(datasets[0].type, "DEFAULT");
 }
@@ -153,7 +152,7 @@ TEST(ListDatasetsResponseTest, InvalidListFormatDataset) {
   http_response.payload =
       R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
+          "nextPageToken": "npt-123",
           "datasets": [
               {
                 "id": "1",
@@ -175,9 +174,9 @@ TEST(GetDatasetResponseTest, DebugString) {
       R"({"kind": "d-kind",
           "etag": "d-tag",
           "id": "d-id",
-          "self_link": "d-selfLink",
-          "friendly_name": "d-friendly-name",
-          "dataset_reference": {"projectId": "p-id", "datasetId": "d-id"}
+          "selfLink": "d-selfLink",
+          "friendlyName": "d-friendly-name",
+          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
     })";
   auto response = GetDatasetResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
@@ -209,18 +208,6 @@ TEST(GetDatasetResponseTest, DebugString) {
             R"( source_dataset {)"
             R"( project_id: "")"
             R"( dataset_id: "")"
-            R"( })"
-            R"( })"
-            R"( external_dataset_reference {)"
-            R"( hive_database {)"
-            R"( catalog_id: "")"
-            R"( database: "")"
-            R"( metadata_connectivity {)"
-            R"( access_uri_type: "")"
-            R"( access_uri: "")"
-            R"( metadata_connection: "")"
-            R"( storage_connection: "")"
-            R"( })"
             R"( })"
             R"( })"
             R"( default_rounding_mode {)"
@@ -268,18 +255,6 @@ TEST(GetDatasetResponseTest, DebugString) {
             R"( source_dataset {)"
             R"( project_id: "")"
             R"( dataset_id: "")"
-            R"( })"
-            R"( })"
-            R"( external_dataset_reference {)"
-            R"( hive_database {)"
-            R"( catalog_id: "")"
-            R"( database: "")"
-            R"( metadata_connectivity {)"
-            R"( access_uri_type: "")"
-            R"( access_uri: "")"
-            R"( metadata_connection: "")"
-            R"( storage_connection: "")"
-            R"( })"
             R"( })"
             R"( })"
             R"( default_rounding_mode {)"
@@ -339,18 +314,6 @@ TEST(GetDatasetResponseTest, DebugString) {
         dataset_id: ""
       }
     }
-    external_dataset_reference {
-      hive_database {
-        catalog_id: ""
-        database: ""
-        metadata_connectivity {
-          access_uri_type: ""
-          access_uri: ""
-          metadata_connection: ""
-          storage_connection: ""
-        }
-      }
-    }
     default_rounding_mode {
       value: ""
     }
@@ -376,14 +339,14 @@ TEST(ListDatasetsResponseTest, DebugString) {
   http_response.payload =
       R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
+          "nextPageToken": "npt-123",
           "datasets": [
               {
                 "id": "1",
                 "kind": "kind-2",
-                "dataset_reference": {"projectId": "p123", "datasetId": "d123"},
+                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
 
-                "friendly_name": "friendly-name",
+                "friendlyName": "friendly-name",
                 "location": "loc",
                 "type": "DEFAULT"
               }

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
@@ -34,7 +34,7 @@ TEST(GetDatasetResponseTest, Success) {
           "id": "d-id",
           "selfLink": "d-selfLink",
           "friendlyName": "d-friendly-name",
-          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
+          "datasetReference": {"projectId": "p-id", "datasetId": "d-id"}
     })";
   auto const response =
       GetDatasetResponse::BuildFromHttpResponse(http_response);
@@ -91,7 +91,7 @@ TEST(ListDatasetsResponseTest, Success) {
               {
                 "id": "1",
                 "kind": "kind-2",
-                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
+                "datasetReference": {"projectId": "p123", "datasetId": "d123"},
                 "friendlyName": "friendly-name",
                 "location": "location",
                 "type": "DEFAULT"
@@ -109,9 +109,9 @@ TEST(ListDatasetsResponseTest, Success) {
   ASSERT_EQ(datasets.size(), 1);
   EXPECT_EQ(datasets[0].id, "1");
   EXPECT_EQ(datasets[0].kind, "kind-2");
-  EXPECT_EQ(datasets[0].friendlyName, "friendly-name");
-  EXPECT_EQ(datasets[0].datasetReference.project_id, "p123");
-  EXPECT_EQ(datasets[0].datasetReference.dataset_id, "d123");
+  EXPECT_EQ(datasets[0].friendly_name, "friendly-name");
+  EXPECT_EQ(datasets[0].dataset_reference.project_id, "p123");
+  EXPECT_EQ(datasets[0].dataset_reference.dataset_id, "d123");
   EXPECT_EQ(datasets[0].location, "location");
   EXPECT_EQ(datasets[0].type, "DEFAULT");
 }
@@ -176,7 +176,7 @@ TEST(GetDatasetResponseTest, DebugString) {
           "id": "d-id",
           "selfLink": "d-selfLink",
           "friendlyName": "d-friendly-name",
-          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
+          "datasetReference": {"projectId": "p-id", "datasetId": "d-id"}
     })";
   auto response = GetDatasetResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
@@ -344,7 +344,7 @@ TEST(ListDatasetsResponseTest, DebugString) {
               {
                 "id": "1",
                 "kind": "kind-2",
-                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
+                "datasetReference": {"projectId": "p123", "datasetId": "d123"},
 
                 "friendlyName": "friendly-name",
                 "location": "loc",

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_rest_stub_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_rest_stub_test.cc
@@ -56,7 +56,7 @@ TEST(DatasetStubTest, GetDatasetSuccess) {
           "id": "d-id",
           "selfLink": "d-selfLink",
           "friendlyName": "d-friendly-name",
-          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
+          "datasetReference": {"projectId": "p-id", "datasetId": "d-id"}
     })";
   auto mock_response = std::make_unique<MockRestResponse>();
 
@@ -133,7 +133,7 @@ TEST(DatasetStubTest, ListDatasetsSuccess) {
               {
                 "id": "1",
                 "kind": "kind-2",
-                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
+                "datasetReference": {"projectId": "p123", "datasetId": "d123"},
                 "friendlyName": "friendly-name",
                 "location": "location",
                 "type": "DEFAULT"

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_rest_stub_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_rest_stub_test.cc
@@ -54,9 +54,9 @@ TEST(DatasetStubTest, GetDatasetSuccess) {
       R"({"kind": "d-kind",
           "etag": "d-tag",
           "id": "d-id",
-          "self_link": "d-selfLink",
-          "friendly_name": "d-friendly-name",
-          "dataset_reference": {"project_id": "p-id", "dataset_id": "d-id"}
+          "selfLink": "d-selfLink",
+          "friendlyName": "d-friendly-name",
+          "datasetReference": {"project_id": "p-id", "dataset_id": "d-id"}
     })";
   auto mock_response = std::make_unique<MockRestResponse>();
 
@@ -128,14 +128,13 @@ TEST(DatasetStubTest, ListDatasetsSuccess) {
   std::string payload =
       R"({"etag": "tag-1",
           "kind": "kind-1",
-          "next_page_token": "npt-123",
+          "nextPageToken": "npt-123",
           "datasets": [
               {
                 "id": "1",
                 "kind": "kind-2",
-                "dataset_reference": {"project_id": "p123", "dataset_id": "d123"},
-
-                "friendly_name": "friendly-name",
+                "datasetReference": {"project_id": "p123", "dataset_id": "d123"},
+                "friendlyName": "friendly-name",
                 "location": "location",
                 "type": "DEFAULT"
               }

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_test.cc
@@ -48,14 +48,14 @@ Access MakeAccess(std::string role, std::string project_id,
   access.routine.routine_id = std::move(routine_id);
   access.dataset.dataset =
       MakeDatasetReference(std::move(project_id), std::move(dataset_id));
-  access.dataset.target_types.push_back(std::move(type));
+  access.dataset.targetTypes.push_back(std::move(type));
   return access;
 }
 
 GcpTag MakeGcpTag(std::string key, std::string value) {
   GcpTag tag;
-  tag.tag_key = std::move(key);
-  tag.tag_value = std::move(value);
+  tag.tagKey = std::move(key);
+  tag.tagValue = std::move(value);
   return tag;
 }
 
@@ -89,9 +89,7 @@ Dataset MakeDataset() {
   expected.access = access;
   expected.tags = tags;
   expected.dataset_reference = dataset_ref;
-  expected.linked_dataset_source.source_dataset = dataset_ref;
-  expected.external_dataset_reference.hive_database.catalog_id = "c1";
-  expected.external_dataset_reference.hive_database.database = "d1";
+  expected.linked_dataset_source.sourceDataset = dataset_ref;
   expected.default_rounding_mode = RoundingMode::RoundHalfEven();
   expected.storage_billing_model = StorageBillingModel::Logical();
 
@@ -122,10 +120,10 @@ void AssertEquals(Dataset const& lhs, Dataset const& rhs) {
   EXPECT_EQ(lhs.access.size(), rhs.access.size());
   EXPECT_EQ(lhs.access[0].role, rhs.access[0].role);
   EXPECT_EQ(lhs.access[0].domain, rhs.access[0].domain);
-  EXPECT_EQ(lhs.access[0].group_by_email, rhs.access[0].group_by_email);
-  EXPECT_EQ(lhs.access[0].iam_member, rhs.access[0].iam_member);
-  EXPECT_EQ(lhs.access[0].special_group, rhs.access[0].special_group);
-  EXPECT_EQ(lhs.access[0].user_by_email, rhs.access[0].user_by_email);
+  EXPECT_EQ(lhs.access[0].groupByEmail, rhs.access[0].groupByEmail);
+  EXPECT_EQ(lhs.access[0].iamMember, rhs.access[0].iamMember);
+  EXPECT_EQ(lhs.access[0].specialGroup, rhs.access[0].specialGroup);
+  EXPECT_EQ(lhs.access[0].userByEmail, rhs.access[0].userByEmail);
 
   EXPECT_EQ(lhs.access[0].view.dataset_id, rhs.access[0].view.dataset_id);
   EXPECT_EQ(lhs.access[0].view.project_id, rhs.access[0].view.project_id);
@@ -138,22 +136,16 @@ void AssertEquals(Dataset const& lhs, Dataset const& rhs) {
   ASSERT_THAT(lhs.tags, Not(IsEmpty()));
   ASSERT_THAT(rhs.tags, Not(IsEmpty()));
   EXPECT_EQ(lhs.tags.size(), rhs.tags.size());
-  EXPECT_EQ(lhs.tags[0].tag_key, rhs.tags[0].tag_key);
-  EXPECT_EQ(lhs.tags[0].tag_value, rhs.tags[0].tag_value);
+  EXPECT_EQ(lhs.tags[0].tagKey, rhs.tags[0].tagKey);
+  EXPECT_EQ(lhs.tags[0].tagValue, rhs.tags[0].tagValue);
 
   EXPECT_EQ(lhs.dataset_reference.dataset_id, rhs.dataset_reference.dataset_id);
   EXPECT_EQ(lhs.dataset_reference.project_id, rhs.dataset_reference.project_id);
 
-  EXPECT_EQ(lhs.linked_dataset_source.source_dataset.dataset_id,
-            rhs.linked_dataset_source.source_dataset.dataset_id);
-  EXPECT_EQ(lhs.linked_dataset_source.source_dataset.project_id,
-            rhs.linked_dataset_source.source_dataset.project_id);
-
-  EXPECT_EQ(lhs.external_dataset_reference.hive_database.catalog_id,
-            rhs.external_dataset_reference.hive_database.catalog_id);
-
-  EXPECT_EQ(lhs.external_dataset_reference.hive_database.database,
-            rhs.external_dataset_reference.hive_database.database);
+  EXPECT_EQ(lhs.linked_dataset_source.sourceDataset.dataset_id,
+            rhs.linked_dataset_source.sourceDataset.dataset_id);
+  EXPECT_EQ(lhs.linked_dataset_source.sourceDataset.project_id,
+            rhs.linked_dataset_source.sourceDataset.project_id);
 
   EXPECT_EQ(lhs.default_rounding_mode.value, rhs.default_rounding_mode.value);
   EXPECT_EQ(lhs.storage_billing_model.value, rhs.storage_billing_model.value);
@@ -162,59 +154,48 @@ void AssertEquals(Dataset const& lhs, Dataset const& rhs) {
 std::string MakeDatasetJsonText() {
   return R"({"access":[
     {"dataset":{
-         "dataset":{"datasetId":"d123","projectId":"p123"},
-         "target_types":[{"value":"VIEWS"}]},
-         "domain":"","group_by_email":"",
-         "iam_member":"",
+         "dataset":{"dataset_id":"d123","project_id":"p123"},
+         "targetTypes":[{"value":"VIEWS"}]},
+         "domain":"",
+         "groupByEmail":"",
+         "iamMember":"",
          "role":"accessrole",
-         "routine":{"datasetId":"d123","projectId":"p123","routineId":"r123"},
-         "special_group":"",
-         "user_by_email":"",
-         "view":{"datasetId":"d123","projectId":"p123","tableId":"t123"}
+         "routine":{"dataset_id":"d123","project_id":"p123","routine_id":"r123"},
+         "specialGroup":"",
+         "userByEmail":"",
+         "view":{"dataset_id":"d123","project_id":"p123","table_id":"t123"}
     }],
-    "creation_time":0,
-    "dataset_reference":{"datasetId":"d123","projectId":"p123"},
-    "default_collation":"ddefaultcollation",
-    "default_partition_expiration":0,
-    "default_rounding_mode":{"value":"ROUND_HALF_EVEN"},
-    "default_table_expiration":0,
+    "creationTime":0,
+    "datasetReference":{"dataset_id":"d123","project_id":"p123"},
+    "defaultCollation":"ddefaultcollation",
+    "defaultPartitionExpirationMs":0,
+    "defaultRoundingMode":{"value":"ROUND_HALF_EVEN"},
+    "defaultTableExpirationMs":0,
     "description":"ddescription",
     "etag":"detag",
-    "external_dataset_reference":{
-        "hive_database":{
-            "catalog_id":"c1",
-            "database":"d1",
-            "metadata_connectivity":{
-                "access_uri":"",
-                "access_uri_type":"",
-                "metadata_connection":"",
-                "storage_connection":""
-            }
-       }
-    },
-    "friendly_name":"dfriendlyname",
+    "friendlyName":"dfriendlyname",
     "id":"did",
-    "is_case_insensitive":true,
+    "isCaseInsensitive":true,
     "kind":"dkind",
     "labels":{"l1":"v1","l2":"v2"},
-    "last_modified_time":0,
-    "linked_dataset_source":{"source_dataset":{
-        "datasetId":"d123",
-        "projectId":"p123"
+    "lastModifiedTime":0,
+    "linkedDatasetSource":{"sourceDataset":{
+        "dataset_id":"d123",
+        "project_id":"p123"
     }},
     "location":"dlocation",
-    "max_time_travel":0,
+    "maxTimeTravelHours":0,
     "published":false,
-    "self_link":"dselflink",
-    "storage_billing_model":{"value":"LOGICAL"},
-    "tags":[{"tag_key":"t1","tag_value":"t2"}],
+    "selfLink":"dselflink",
+    "storageBillingModel":{"value":"LOGICAL"},
+    "tags":[{"tagKey":"t1","tagValue":"t2"}],
     "type":"dtype"})";
 }
 
 void AssertEquals(ListFormatDataset const& lhs, ListFormatDataset const& rhs) {
   EXPECT_EQ(lhs.kind, rhs.kind);
   EXPECT_EQ(lhs.id, rhs.id);
-  EXPECT_EQ(lhs.friendly_name, rhs.friendly_name);
+  EXPECT_EQ(lhs.friendlyName, rhs.friendlyName);
   EXPECT_EQ(lhs.type, rhs.type);
   EXPECT_EQ(lhs.location, rhs.location);
 
@@ -224,18 +205,18 @@ void AssertEquals(ListFormatDataset const& lhs, ListFormatDataset const& rhs) {
   EXPECT_EQ(lhs.labels.find("l1")->second, rhs.labels.find("l1")->second);
   EXPECT_EQ(lhs.labels.find("l2")->second, rhs.labels.find("l2")->second);
 
-  EXPECT_EQ(lhs.dataset_reference.dataset_id, rhs.dataset_reference.dataset_id);
-  EXPECT_EQ(lhs.dataset_reference.project_id, rhs.dataset_reference.project_id);
+  EXPECT_EQ(lhs.datasetReference.dataset_id, rhs.datasetReference.dataset_id);
+  EXPECT_EQ(lhs.datasetReference.project_id, rhs.datasetReference.project_id);
 }
 
 std::string MakeListFormatDatasetJsonText() {
   return R"({
     "kind":"dkind",
     "id":"did",
-    "friendly_name":"dfriendlyname",
+    "friendlyName":"dfriendlyname",
     "location":"dlocation",
     "type":"DEFAULT",
-    "dataset_reference": {"projectId":"p123", "datasetId":"d123"},
+    "datasetReference": {"project_id":"p123", "dataset_id":"d123"},
     "labels":{"l1":"v1","l2":"v2"}
 })";
 }
@@ -250,12 +231,12 @@ ListFormatDataset MakeListFormatDataset() {
   ListFormatDataset expected;
   expected.kind = "dkind";
   expected.id = "did";
-  expected.friendly_name = "dfriendlyname";
+  expected.friendlyName = "dfriendlyname";
   expected.location = "dlocation";
   expected.type = "DEFAULT";
   expected.location = "dlocation";
   expected.labels = labels;
-  expected.dataset_reference = dataset_ref;
+  expected.datasetReference = dataset_ref;
 
   return expected;
 }
@@ -356,18 +337,6 @@ TEST(DatasetTest, DatasetDebugString) {
       R"( linked_dataset_source {)"
       R"( source_dataset { project_id: "p123" dataset_id: "d123" })"
       R"( })"
-      R"( external_dataset_reference {)"
-      R"( hive_database {)"
-      R"( catalog_id: "c1")"
-      R"( database: "d1")"
-      R"( metadata_connectivity {)"
-      R"( access_uri_type: "")"
-      R"( access_uri: "")"
-      R"( metadata_connection: "")"
-      R"( storage_connection: "")"
-      R"( })"
-      R"( })"
-      R"( })"
       R"( default_rounding_mode {)"
       R"( value: "ROUND_HALF_EVEN")"
       R"( })"
@@ -414,18 +383,6 @@ TEST(DatasetTest, DatasetDebugString) {
       R"( dataset_reference { project_id: "p123" dataset_id: "d123" })"
       R"( linked_dataset_source {)"
       R"( source_dataset { project_id: "p123" dataset_id: "d123" })"
-      R"( })"
-      R"( external_dataset_reference {)"
-      R"( hive_database {)"
-      R"( catalog_id: "c1")"
-      R"( database: "d1")"
-      R"( metadata_connectivity {)"
-      R"( access_uri_type: "")"
-      R"( access_uri: "")"
-      R"( metadata_connection: "")"
-      R"( storage_connection: "")"
-      R"( })"
-      R"( })"
       R"( })"
       R"( default_rounding_mode {)"
       R"( value: "ROUND_H...<truncated>...")"
@@ -509,18 +466,6 @@ TEST(DatasetTest, DatasetDebugString) {
     source_dataset {
       project_id: "p123"
       dataset_id: "d123"
-    }
-  }
-  external_dataset_reference {
-    hive_database {
-      catalog_id: "c1"
-      database: "d1"
-      metadata_connectivity {
-        access_uri_type: ""
-        access_uri: ""
-        metadata_connection: ""
-        storage_connection: ""
-      }
     }
   }
   default_rounding_mode {

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_test.cc
@@ -48,14 +48,14 @@ Access MakeAccess(std::string role, std::string project_id,
   access.routine.routine_id = std::move(routine_id);
   access.dataset.dataset =
       MakeDatasetReference(std::move(project_id), std::move(dataset_id));
-  access.dataset.targetTypes.push_back(std::move(type));
+  access.dataset.target_types.push_back(std::move(type));
   return access;
 }
 
 GcpTag MakeGcpTag(std::string key, std::string value) {
   GcpTag tag;
-  tag.tagKey = std::move(key);
-  tag.tagValue = std::move(value);
+  tag.tag_key = std::move(key);
+  tag.tag_value = std::move(value);
   return tag;
 }
 
@@ -89,7 +89,7 @@ Dataset MakeDataset() {
   expected.access = access;
   expected.tags = tags;
   expected.dataset_reference = dataset_ref;
-  expected.linked_dataset_source.sourceDataset = dataset_ref;
+  expected.linked_dataset_source.source_dataset = dataset_ref;
   expected.default_rounding_mode = RoundingMode::RoundHalfEven();
   expected.storage_billing_model = StorageBillingModel::Logical();
 
@@ -120,10 +120,10 @@ void AssertEquals(Dataset const& lhs, Dataset const& rhs) {
   EXPECT_EQ(lhs.access.size(), rhs.access.size());
   EXPECT_EQ(lhs.access[0].role, rhs.access[0].role);
   EXPECT_EQ(lhs.access[0].domain, rhs.access[0].domain);
-  EXPECT_EQ(lhs.access[0].groupByEmail, rhs.access[0].groupByEmail);
-  EXPECT_EQ(lhs.access[0].iamMember, rhs.access[0].iamMember);
-  EXPECT_EQ(lhs.access[0].specialGroup, rhs.access[0].specialGroup);
-  EXPECT_EQ(lhs.access[0].userByEmail, rhs.access[0].userByEmail);
+  EXPECT_EQ(lhs.access[0].group_by_email, rhs.access[0].group_by_email);
+  EXPECT_EQ(lhs.access[0].iam_member, rhs.access[0].iam_member);
+  EXPECT_EQ(lhs.access[0].special_group, rhs.access[0].special_group);
+  EXPECT_EQ(lhs.access[0].user_by_email, rhs.access[0].user_by_email);
 
   EXPECT_EQ(lhs.access[0].view.dataset_id, rhs.access[0].view.dataset_id);
   EXPECT_EQ(lhs.access[0].view.project_id, rhs.access[0].view.project_id);
@@ -136,16 +136,16 @@ void AssertEquals(Dataset const& lhs, Dataset const& rhs) {
   ASSERT_THAT(lhs.tags, Not(IsEmpty()));
   ASSERT_THAT(rhs.tags, Not(IsEmpty()));
   EXPECT_EQ(lhs.tags.size(), rhs.tags.size());
-  EXPECT_EQ(lhs.tags[0].tagKey, rhs.tags[0].tagKey);
-  EXPECT_EQ(lhs.tags[0].tagValue, rhs.tags[0].tagValue);
+  EXPECT_EQ(lhs.tags[0].tag_key, rhs.tags[0].tag_key);
+  EXPECT_EQ(lhs.tags[0].tag_value, rhs.tags[0].tag_value);
 
   EXPECT_EQ(lhs.dataset_reference.dataset_id, rhs.dataset_reference.dataset_id);
   EXPECT_EQ(lhs.dataset_reference.project_id, rhs.dataset_reference.project_id);
 
-  EXPECT_EQ(lhs.linked_dataset_source.sourceDataset.dataset_id,
-            rhs.linked_dataset_source.sourceDataset.dataset_id);
-  EXPECT_EQ(lhs.linked_dataset_source.sourceDataset.project_id,
-            rhs.linked_dataset_source.sourceDataset.project_id);
+  EXPECT_EQ(lhs.linked_dataset_source.source_dataset.dataset_id,
+            rhs.linked_dataset_source.source_dataset.dataset_id);
+  EXPECT_EQ(lhs.linked_dataset_source.source_dataset.project_id,
+            rhs.linked_dataset_source.source_dataset.project_id);
 
   EXPECT_EQ(lhs.default_rounding_mode.value, rhs.default_rounding_mode.value);
   EXPECT_EQ(lhs.storage_billing_model.value, rhs.storage_billing_model.value);
@@ -154,19 +154,19 @@ void AssertEquals(Dataset const& lhs, Dataset const& rhs) {
 std::string MakeDatasetJsonText() {
   return R"({"access":[
     {"dataset":{
-         "dataset":{"dataset_id":"d123","project_id":"p123"},
+         "dataset":{"datasetId":"d123","projectId":"p123"},
          "targetTypes":[{"value":"VIEWS"}]},
          "domain":"",
          "groupByEmail":"",
          "iamMember":"",
          "role":"accessrole",
-         "routine":{"dataset_id":"d123","project_id":"p123","routine_id":"r123"},
+         "routine":{"datasetId":"d123","projectId":"p123","routineId":"r123"},
          "specialGroup":"",
          "userByEmail":"",
-         "view":{"dataset_id":"d123","project_id":"p123","table_id":"t123"}
+         "view":{"datasetId":"d123","projectId":"p123","tableId":"t123"}
     }],
     "creationTime":0,
-    "datasetReference":{"dataset_id":"d123","project_id":"p123"},
+    "datasetReference":{"datasetId":"d123","projectId":"p123"},
     "defaultCollation":"ddefaultcollation",
     "defaultPartitionExpirationMs":0,
     "defaultRoundingMode":{"value":"ROUND_HALF_EVEN"},
@@ -180,8 +180,8 @@ std::string MakeDatasetJsonText() {
     "labels":{"l1":"v1","l2":"v2"},
     "lastModifiedTime":0,
     "linkedDatasetSource":{"sourceDataset":{
-        "dataset_id":"d123",
-        "project_id":"p123"
+        "datasetId":"d123",
+        "projectId":"p123"
     }},
     "location":"dlocation",
     "maxTimeTravelHours":0,
@@ -195,7 +195,7 @@ std::string MakeDatasetJsonText() {
 void AssertEquals(ListFormatDataset const& lhs, ListFormatDataset const& rhs) {
   EXPECT_EQ(lhs.kind, rhs.kind);
   EXPECT_EQ(lhs.id, rhs.id);
-  EXPECT_EQ(lhs.friendlyName, rhs.friendlyName);
+  EXPECT_EQ(lhs.friendly_name, rhs.friendly_name);
   EXPECT_EQ(lhs.type, rhs.type);
   EXPECT_EQ(lhs.location, rhs.location);
 
@@ -205,8 +205,8 @@ void AssertEquals(ListFormatDataset const& lhs, ListFormatDataset const& rhs) {
   EXPECT_EQ(lhs.labels.find("l1")->second, rhs.labels.find("l1")->second);
   EXPECT_EQ(lhs.labels.find("l2")->second, rhs.labels.find("l2")->second);
 
-  EXPECT_EQ(lhs.datasetReference.dataset_id, rhs.datasetReference.dataset_id);
-  EXPECT_EQ(lhs.datasetReference.project_id, rhs.datasetReference.project_id);
+  EXPECT_EQ(lhs.dataset_reference.dataset_id, rhs.dataset_reference.dataset_id);
+  EXPECT_EQ(lhs.dataset_reference.project_id, rhs.dataset_reference.project_id);
 }
 
 std::string MakeListFormatDatasetJsonText() {
@@ -216,7 +216,7 @@ std::string MakeListFormatDatasetJsonText() {
     "friendlyName":"dfriendlyname",
     "location":"dlocation",
     "type":"DEFAULT",
-    "datasetReference": {"project_id":"p123", "dataset_id":"d123"},
+    "datasetReference": {"projectId":"p123", "datasetId":"d123"},
     "labels":{"l1":"v1","l2":"v2"}
 })";
 }
@@ -231,12 +231,12 @@ ListFormatDataset MakeListFormatDataset() {
   ListFormatDataset expected;
   expected.kind = "dkind";
   expected.id = "did";
-  expected.friendlyName = "dfriendlyname";
+  expected.friendly_name = "dfriendlyname";
   expected.location = "dlocation";
   expected.type = "DEFAULT";
   expected.location = "dlocation";
   expected.labels = labels;
-  expected.datasetReference = dataset_ref;
+  expected.dataset_reference = dataset_ref;
 
   return expected;
 }


### PR DESCRIPTION
This PR fixes the json field names in the response for the Dataset apis. Ensure  that the json field names parsed from the response body for the Get and list Dataset apis are in accordance with the API docs mentioned below:

https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/get
https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list

The request object is already in compliance with the api docs.

No processing logic has been changes. Just the json field names that are being parsed from the response and corresponding unit tests.

This fixes the github issue https://github.com/googleapis/google-cloud-cpp/issues/12110

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12155)
<!-- Reviewable:end -->
