### PR TITLE
impl(bigquery): Adds SafeGetTo method for potential perf improvement

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
@@ -67,6 +67,12 @@ void ToJson(std::chrono::system_clock::time_point const& field,
           .count());
 }
 
+void SafeGetTo(std::string& value, nlohmann::json const& j,
+               std::string const& key) {
+  auto i = j.find(key);
+  if (i != j.end()) i->get_to(value);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.h
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.h
@@ -42,6 +42,9 @@ void FromJson(std::chrono::hours& field, nlohmann::json const& j,
 void ToJson(std::chrono::hours const& field, nlohmann::json& j,
             char const* name);
 
+void SafeGetTo(std::string& value, nlohmann::json const& j,
+               std::string const& key);
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -21,6 +21,8 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+using ::testing::IsEmpty;
+
 TEST(JsonUtilsTest, FromJsonMilliseconds) {
   auto const* const name = "start_time";
   auto const* json_text = R"({"start_time":10})";
@@ -96,6 +98,30 @@ TEST(JsonUtilsTest, ToJsonTimepoint) {
   ToJson(field, actual_json, name);
 
   EXPECT_EQ(expected_json, actual_json);
+}
+
+TEST(JsonUtilsTest, SafeGetToKeyPresent) {
+  auto const* const key = "project_id";
+  auto const* json_text = R"({"project_id":"123"})";
+  auto json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  SafeGetTo(val, json, key);
+
+  EXPECT_EQ(val, "123");
+}
+
+TEST(JsonUtilsTest, SafeGetToKeyAbsent) {
+  auto const* const key = "job_id";
+  auto const* json_text = R"({"project_id":"123"})";
+  auto json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  SafeGetTo(val, json, key);
+
+  EXPECT_THAT(val, IsEmpty());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
This PR adds a SafeGetTo() json utility method for parsing fields from the json body, as a potential performance improvement.
Please see https://github.com/googleapis/google-cloud-cpp/issues/12188 for more details.

Application of this function will be in separate PRs based on the resource type. 

Please note that this function will only be applied to manual `to_json` and `from_json` methods.  It cannot be applied to `to_json` and `from_json` methods generated from NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT macros.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12192)
<!-- Reviewable:end -->
