### PR TITLE
ci(gha): do not trigger on `labeled`

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -19,9 +19,6 @@ on:
     - opened
     - synchronize
     - reopened
-    # We also need to restart the builds when a label is assigned. This can
-    # be used to trigger a full build.
-    - labeled
 
 # Cancel in-progress runs of the workflow if somebody adds a new commit to the
 # PR or branch. That reduces billing, but it creates more noise about cancelled


### PR DESCRIPTION
This did not work as I expected when unrelated labels get added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12195)
<!-- Reviewable:end -->
