### PR TITLE
impl(bigquery): Modified SafeGetTo() to be a template function

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
@@ -67,12 +67,6 @@ void ToJson(std::chrono::system_clock::time_point const& field,
           .count());
 }
 
-void SafeGetTo(std::string& value, nlohmann::json const& j,
-               std::string const& key) {
-  auto i = j.find(key);
-  if (i != j.end()) i->get_to(value);
-}
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.h
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.h
@@ -42,8 +42,12 @@ void FromJson(std::chrono::hours& field, nlohmann::json const& j,
 void ToJson(std::chrono::hours const& field, nlohmann::json& j,
             char const* name);
 
-void SafeGetTo(std::string& value, nlohmann::json const& j,
-               std::string const& key);
+template <typename ResponseType>
+void SafeGetTo(ResponseType& value, nlohmann::json const& j,
+               std::string const& key) {
+  auto i = j.find(key);
+  if (i != j.end()) i->get_to(value);
+}
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/internal/json_utils.h"
+#include "google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -124,6 +125,27 @@ TEST(JsonUtilsTest, SafeGetToKeyAbsent) {
   EXPECT_THAT(val, IsEmpty());
 }
 
+TEST(JsonUtilsTest, SafeGetToCustomType) {
+  auto const* const key = "error_result";
+  auto const* json_text =
+      R"({"error_result":{
+    "reason":"testing",
+    "location":"us-east",
+    "message":"testing"
+  }})";
+  auto json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  ErrorProto actual;
+  SafeGetTo(actual, json, key);
+
+  ErrorProto expected;
+  expected.reason = "testing";
+  expected.location = "us-east";
+  expected.message = "testing";
+
+  EXPECT_EQ(expected, actual);
+}
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud


### PR DESCRIPTION
This PR modifies the `SafeGetTo` function, that was added in https://github.com/googleapis/google-cloud-cpp/pull/12192  to be a template function. This is done so that the function can be applied to all json field types and not just strings.

My apologies, I should have thought of the above when I sent the initial PR but completely slipped my mind, till I started applying the function to the json fields.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12199)
<!-- Reviewable:end -->
