### PR TITLE
ci: use sccache for public-docs build

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -31,10 +31,15 @@ doc_args=(
   "-DGOOGLE_CLOUD_CPP_INTERNAL_DOCFX=ON"
   "-DGOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV=ON"
   "-DGOOGLE_CLOUD_CPP_ENABLE=${ENABLED_FEATURES}"
-  "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON"
+  "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF"
   "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
   "-DGOOGLE_CLOUD_CPP_DOXYGEN_CLANG_OPTIONS=-resource-dir=$(clang -print-resource-dir)"
 )
+if command -v /usr/local/bin/sccache >/dev/null 2>&1; then
+  doc_args+=(
+    -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/sccache
+  )
+fi
 
 # Extract the version number if we're on a release branch.
 if grep -qP 'v\d+\.\d+\..*' <<<"${BRANCH_NAME}"; then


### PR DESCRIPTION
This saves about 5 minutes in the common case.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12200)
<!-- Reviewable:end -->
