### PR TITLE
impl(generator): emit implicit api http paths for compute

### DIFF
--- a/generator/internal/discovery_file_test.cc
+++ b/generator/internal/discovery_file_test.cc
@@ -169,7 +169,7 @@ service MyResources {
 
   rpc DoFoo(DoFooRequest) returns (other.package.Operation) {
     option (google.api.http) = {
-      post: "my/service/projects/{project=project}/zones/{zone=zone}/myResources/{foo_id=foo_id}/doFoo"
+      post: "my/service/projects/{project}/zones/{zone}/myResources/{foo_id}/doFoo"
       body: "my_foo_resource"
     };
     option (google.api.method_signature) = "project,zone,foo_id,my_foo_resource";
@@ -179,7 +179,7 @@ service MyResources {
   // Description for the get method.
   rpc GetMyResources(GetMyResourcesRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      get: "my/service/projects/{project=project}/regions/{region=region}/myResources/{foo=foo}"
+      get: "my/service/projects/{project}/regions/{region}/myResources/{foo}"
     };
     option (google.api.method_signature) = "project,region,foo";
   }
@@ -281,7 +281,7 @@ service MyResources {
 
   rpc DoFoo(DoFooRequest) returns (other.package.Operation) {
     option (google.api.http) = {
-      post: "my/service/projects/{project=project}/zones/{zone=zone}/myResources/{foo_id=foo_id}/doFoo"
+      post: "my/service/projects/{project}/zones/{zone}/myResources/{foo_id}/doFoo"
       body: "my_foo_resource"
     };
     option (google.api.method_signature) = "project,zone,foo_id,my_foo_resource";
@@ -291,7 +291,7 @@ service MyResources {
   // Description for the get method.
   rpc GetMyResources(GetMyResourcesRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      get: "my/service/projects/{project=project}/regions/{region=region}/myResources/{foo=foo}"
+      get: "my/service/projects/{project}/regions/{region}/myResources/{foo}"
     };
     option (google.api.method_signature) = "project,region,foo";
   }

--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -101,8 +101,7 @@ std::string DiscoveryResource::FormatUrlPath(std::string const& path) {
     current = open + 1;
     auto close = path.find('}', current);
     absl::StrAppend(
-        &output, CamelCaseToSnakeCase(path.substr(current, close - current)),
-        "=", CamelCaseToSnakeCase(path.substr(current, close - current)));
+        &output, CamelCaseToSnakeCase(path.substr(current, close - current)));
     current = close;
   }
   absl::StrAppend(&output, path.substr(current));

--- a/generator/internal/discovery_resource_test.cc
+++ b/generator/internal/discovery_resource_test.cc
@@ -59,17 +59,17 @@ TEST(DiscoveryResourceTest, FormatUrlPath) {
               Eq("base/path/test"));
   EXPECT_THAT(DiscoveryResource::FormatUrlPath(
                   "projects/{project}/zones/{zone}/myTests/{foo}/method1"),
-              Eq("projects/{project=project}/zones/{zone=zone}/myTests/"
-                 "{foo=foo}/method1"));
+              Eq("projects/{project}/zones/{zone}/myTests/"
+                 "{foo}/method1"));
   EXPECT_THAT(DiscoveryResource::FormatUrlPath(
                   "projects/{project}/zones/{zone}/myTests/{fooId}/method1"),
-              Eq("projects/{project=project}/zones/{zone=zone}/myTests/"
-                 "{foo_id=foo_id}/method1"));
+              Eq("projects/{project}/zones/{zone}/myTests/"
+                 "{foo_id}/method1"));
   EXPECT_THAT(
       DiscoveryResource::FormatUrlPath(
           "projects/{project}/zones/{zoneName}/myTests/{fooId}:method1"),
-      Eq("projects/{project=project}/zones/{zone_name=zone_name}/myTests/"
-         "{foo_id=foo_id}:method1"));
+      Eq("projects/{project}/zones/{zone_name}/myTests/"
+         "{foo_id}:method1"));
 }
 
 TEST(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
@@ -85,7 +85,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      get: "base/path/projects/{project=project}/regions/{region=region}/myTests/{foo=foo}"
+      get: "base/path/projects/{project}/regions/{region}/myTests/{foo}"
     };
     option (google.api.method_signature) = "project,region,foo";)""";
   auto method_json = nlohmann::json::parse(kMethodJson, nullptr, false);
@@ -117,7 +117,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPatchZone) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      patch: "base/path/projects/{project=project}/zones/{zone=zone}/myTests/{foo_id=foo_id}/method1"
+      patch: "base/path/projects/{project}/zones/{zone}/myTests/{foo_id}/method1"
       body: "my_request_resource"
     };
     option (google.api.method_signature) = "project,zone,foo_id,my_request_resource";
@@ -151,7 +151,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegion) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      put: "base/path/projects/{project=project}/regions/{region=region}/myTests/{foo_id=foo_id}/method1"
+      put: "base/path/projects/{project}/regions/{region}/myTests/{foo_id}/method1"
       body: "my_request_resource"
     };
     option (google.api.method_signature) = "project,region,foo_id,my_request_resource";
@@ -179,7 +179,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobal) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      post: "base/path/projects/{project=project}/global/myTests/{foo=foo}:cancel"
+      post: "base/path/projects/{project}/global/myTests/{foo}:cancel"
       body: "*"
     };
     option (google.api.method_signature) = "project,foo";)""";
@@ -209,7 +209,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationResponse) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      post: "base/path/projects/{project=project}/global/myTests/{foo=foo}:cancel"
+      post: "base/path/projects/{project}/global/myTests/{foo}:cancel"
       body: "*"
     };
     option (google.api.method_signature) = "project,foo";
@@ -326,7 +326,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegionOperationService) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      put: "base/path/projects/{project=project}/regions/{region=region}/myTests/{foo_id=foo_id}/method1"
+      put: "base/path/projects/{project}/regions/{region}/myTests/{foo_id}/method1"
       body: "my_request_resource"
     };
     option (google.api.method_signature) = "project,region,foo_id,my_request_resource";)""";
@@ -357,7 +357,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationService) {
 })""";
   auto constexpr kExpectedProto =
       R"""(    option (google.api.http) = {
-      post: "base/path/projects/{project=project}/global/myTests/{foo=foo}:cancel"
+      post: "base/path/projects/{project}/global/myTests/{foo}:cancel"
       body: "*"
     };
     option (google.api.method_signature) = "project,foo";)""";
@@ -520,7 +520,7 @@ service MyResources {
 
   rpc DoFoo(DoFooRequest) returns (other.package.Operation) {
     option (google.api.http) = {
-      post: "base/path/projects/{project=project}/zones/{zone=zone}/myResources/{foo_id=foo_id}/doFoo"
+      post: "base/path/projects/{project}/zones/{zone}/myResources/{foo_id}/doFoo"
       body: "my_foo_resource"
     };
     option (google.api.method_signature) = "project,zone,foo_id,my_foo_resource";
@@ -530,7 +530,7 @@ service MyResources {
   // Description for the get method.
   rpc GetMyResources(GetMyResourcesRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      get: "base/path/projects/{project=project}/regions/{region=region}/myResources/{foo=foo}"
+      get: "base/path/projects/{project}/regions/{region}/myResources/{foo}"
     };
     option (google.api.method_signature) = "project,region,foo";
   }

--- a/google/cloud/compute/accelerator_types/v1/accelerator_types.proto
+++ b/google/cloud/compute/accelerator_types/v1/accelerator_types.proto
@@ -39,7 +39,7 @@ service AcceleratorTypes {
   rpc AggregatedListAcceleratorTypes(AggregatedListAcceleratorTypesRequest)
       returns (google.cloud.cpp.compute.v1.AcceleratorTypeAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/acceleratorTypes"
+      get: "/compute/v1/projects/{project}/aggregated/acceleratorTypes"
     };
     option (google.api.method_signature) = "project";
   }
@@ -48,7 +48,7 @@ service AcceleratorTypes {
   rpc GetAcceleratorTypes(GetAcceleratorTypesRequest)
       returns (google.cloud.cpp.compute.v1.AcceleratorType) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/acceleratorTypes/{accelerator_type=accelerator_type}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/acceleratorTypes/{accelerator_type}"
     };
     option (google.api.method_signature) = "project,zone,accelerator_type";
   }
@@ -58,7 +58,7 @@ service AcceleratorTypes {
   rpc ListAcceleratorTypes(ListAcceleratorTypesRequest)
       returns (google.cloud.cpp.compute.v1.AcceleratorTypeList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/acceleratorTypes"
+      get: "/compute/v1/projects/{project}/zones/{zone}/acceleratorTypes"
     };
     option (google.api.method_signature) = "project,zone";
   }

--- a/google/cloud/compute/addresses/v1/addresses.proto
+++ b/google/cloud/compute/addresses/v1/addresses.proto
@@ -40,7 +40,7 @@ service Addresses {
   rpc AggregatedListAddresses(AggregatedListAddressesRequest)
       returns (google.cloud.cpp.compute.v1.AddressAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/addresses"
+      get: "/compute/v1/projects/{project}/aggregated/addresses"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service Addresses {
   rpc DeleteAddresses(DeleteAddressesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/addresses/{address=address}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/addresses/{address}"
     };
     option (google.api.method_signature) = "project,region,address";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service Addresses {
   rpc GetAddresses(GetAddressesRequest)
       returns (google.cloud.cpp.compute.v1.Address) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/addresses/{address=address}"
+      get: "/compute/v1/projects/{project}/regions/{region}/addresses/{address}"
     };
     option (google.api.method_signature) = "project,region,address";
   }
@@ -69,7 +69,7 @@ service Addresses {
   rpc InsertAddresses(InsertAddressesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/addresses"
+      post: "/compute/v1/projects/{project}/regions/{region}/addresses"
       body: "address_resource"
     };
     option (google.api.method_signature) = "project,region,address_resource";
@@ -80,7 +80,7 @@ service Addresses {
   rpc ListAddresses(ListAddressesRequest)
       returns (google.cloud.cpp.compute.v1.AddressList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/addresses"
+      get: "/compute/v1/projects/{project}/regions/{region}/addresses"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -90,7 +90,7 @@ service Addresses {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/addresses/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/regions/{region}/addresses/{resource}/setLabels"
       body: "region_set_labels_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/autoscalers/v1/autoscalers.proto
+++ b/google/cloud/compute/autoscalers/v1/autoscalers.proto
@@ -40,7 +40,7 @@ service Autoscalers {
   rpc AggregatedListAutoscalers(AggregatedListAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.AutoscalerAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/autoscalers"
+      get: "/compute/v1/projects/{project}/aggregated/autoscalers"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service Autoscalers {
   rpc DeleteAutoscalers(DeleteAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/autoscalers/{autoscaler=autoscaler}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/autoscalers/{autoscaler}"
     };
     option (google.api.method_signature) = "project,zone,autoscaler";
     option (google.cloud.operation_service) = "ZoneOperations";
@@ -59,7 +59,7 @@ service Autoscalers {
   rpc GetAutoscalers(GetAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Autoscaler) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/autoscalers/{autoscaler=autoscaler}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/autoscalers/{autoscaler}"
     };
     option (google.api.method_signature) = "project,zone,autoscaler";
   }
@@ -69,7 +69,7 @@ service Autoscalers {
   rpc InsertAutoscalers(InsertAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/autoscalers"
+      post: "/compute/v1/projects/{project}/zones/{zone}/autoscalers"
       body: "autoscaler_resource"
     };
     option (google.api.method_signature) = "project,zone,autoscaler_resource";
@@ -80,7 +80,7 @@ service Autoscalers {
   rpc ListAutoscalers(ListAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.AutoscalerList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/autoscalers"
+      get: "/compute/v1/projects/{project}/zones/{zone}/autoscalers"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -91,7 +91,7 @@ service Autoscalers {
   rpc PatchAutoscalers(PatchAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/autoscalers"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/autoscalers"
       body: "autoscaler_resource"
     };
     option (google.api.method_signature) = "project,zone,autoscaler_resource";
@@ -103,7 +103,7 @@ service Autoscalers {
   rpc UpdateAutoscalers(UpdateAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/zones/{zone=zone}/autoscalers"
+      put: "/compute/v1/projects/{project}/zones/{zone}/autoscalers"
       body: "autoscaler_resource"
     };
     option (google.api.method_signature) = "project,zone,autoscaler_resource";

--- a/google/cloud/compute/backend_buckets/v1/backend_buckets.proto
+++ b/google/cloud/compute/backend_buckets/v1/backend_buckets.proto
@@ -41,7 +41,7 @@ service BackendBuckets {
   rpc AddSignedUrlKey(AddSignedUrlKeyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendBuckets/{backend_bucket=backend_bucket}/addSignedUrlKey"
+      post: "/compute/v1/projects/{project}/global/backendBuckets/{backend_bucket}/addSignedUrlKey"
       body: "signed_url_key_resource"
     };
     option (google.api.method_signature) =
@@ -53,7 +53,7 @@ service BackendBuckets {
   rpc DeleteBackendBuckets(DeleteBackendBucketsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/backendBuckets/{backend_bucket=backend_bucket}"
+      delete: "/compute/v1/projects/{project}/global/backendBuckets/{backend_bucket}"
     };
     option (google.api.method_signature) = "project,backend_bucket";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -64,7 +64,7 @@ service BackendBuckets {
   rpc DeleteSignedUrlKey(DeleteSignedUrlKeyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendBuckets/{backend_bucket=backend_bucket}/deleteSignedUrlKey"
+      post: "/compute/v1/projects/{project}/global/backendBuckets/{backend_bucket}/deleteSignedUrlKey"
       body: "*"
     };
     option (google.api.method_signature) = "project,backend_bucket,key_name";
@@ -75,7 +75,7 @@ service BackendBuckets {
   rpc GetBackendBuckets(GetBackendBucketsRequest)
       returns (google.cloud.cpp.compute.v1.BackendBucket) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/backendBuckets/{backend_bucket=backend_bucket}"
+      get: "/compute/v1/projects/{project}/global/backendBuckets/{backend_bucket}"
     };
     option (google.api.method_signature) = "project,backend_bucket";
   }
@@ -85,7 +85,7 @@ service BackendBuckets {
   rpc InsertBackendBuckets(InsertBackendBucketsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendBuckets"
+      post: "/compute/v1/projects/{project}/global/backendBuckets"
       body: "backend_bucket_resource"
     };
     option (google.api.method_signature) = "project,backend_bucket_resource";
@@ -97,7 +97,7 @@ service BackendBuckets {
   rpc ListBackendBuckets(ListBackendBucketsRequest)
       returns (google.cloud.cpp.compute.v1.BackendBucketList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/backendBuckets"
+      get: "/compute/v1/projects/{project}/global/backendBuckets"
     };
     option (google.api.method_signature) = "project";
   }
@@ -108,7 +108,7 @@ service BackendBuckets {
   rpc PatchBackendBuckets(PatchBackendBucketsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/backendBuckets/{backend_bucket=backend_bucket}"
+      patch: "/compute/v1/projects/{project}/global/backendBuckets/{backend_bucket}"
       body: "backend_bucket_resource"
     };
     option (google.api.method_signature) =
@@ -120,7 +120,7 @@ service BackendBuckets {
   rpc SetEdgeSecurityPolicy(SetEdgeSecurityPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendBuckets/{backend_bucket=backend_bucket}/setEdgeSecurityPolicy"
+      post: "/compute/v1/projects/{project}/global/backendBuckets/{backend_bucket}/setEdgeSecurityPolicy"
       body: "security_policy_reference_resource"
     };
     option (google.api.method_signature) =
@@ -133,7 +133,7 @@ service BackendBuckets {
   rpc UpdateBackendBuckets(UpdateBackendBucketsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/global/backendBuckets/{backend_bucket=backend_bucket}"
+      put: "/compute/v1/projects/{project}/global/backendBuckets/{backend_bucket}"
       body: "backend_bucket_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/backend_services/v1/backend_services.proto
+++ b/google/cloud/compute/backend_services/v1/backend_services.proto
@@ -41,7 +41,7 @@ service BackendServices {
   rpc AddSignedUrlKey(AddSignedUrlKeyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}/addSignedUrlKey"
+      post: "/compute/v1/projects/{project}/global/backendServices/{backend_service}/addSignedUrlKey"
       body: "signed_url_key_resource"
     };
     option (google.api.method_signature) =
@@ -54,7 +54,7 @@ service BackendServices {
   rpc AggregatedListBackendServices(AggregatedListBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.BackendServiceAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/backendServices"
+      get: "/compute/v1/projects/{project}/aggregated/backendServices"
     };
     option (google.api.method_signature) = "project";
   }
@@ -63,7 +63,7 @@ service BackendServices {
   rpc DeleteBackendServices(DeleteBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}"
+      delete: "/compute/v1/projects/{project}/global/backendServices/{backend_service}"
     };
     option (google.api.method_signature) = "project,backend_service";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -74,7 +74,7 @@ service BackendServices {
   rpc DeleteSignedUrlKey(DeleteSignedUrlKeyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}/deleteSignedUrlKey"
+      post: "/compute/v1/projects/{project}/global/backendServices/{backend_service}/deleteSignedUrlKey"
       body: "*"
     };
     option (google.api.method_signature) = "project,backend_service,key_name";
@@ -85,7 +85,7 @@ service BackendServices {
   rpc GetBackendServices(GetBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.BackendService) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}"
+      get: "/compute/v1/projects/{project}/global/backendServices/{backend_service}"
     };
     option (google.api.method_signature) = "project,backend_service";
   }
@@ -96,7 +96,7 @@ service BackendServices {
   rpc GetHealth(GetHealthRequest)
       returns (google.cloud.cpp.compute.v1.BackendServiceGroupHealth) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}/getHealth"
+      post: "/compute/v1/projects/{project}/global/backendServices/{backend_service}/getHealth"
       body: "resource_group_reference_resource"
     };
     option (google.api.method_signature) =
@@ -108,7 +108,7 @@ service BackendServices {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/backendServices/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/global/backendServices/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,resource";
   }
@@ -119,7 +119,7 @@ service BackendServices {
   rpc InsertBackendServices(InsertBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendServices"
+      post: "/compute/v1/projects/{project}/global/backendServices"
       body: "backend_service_resource"
     };
     option (google.api.method_signature) = "project,backend_service_resource";
@@ -131,7 +131,7 @@ service BackendServices {
   rpc ListBackendServices(ListBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.BackendServiceList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/backendServices"
+      get: "/compute/v1/projects/{project}/global/backendServices"
     };
     option (google.api.method_signature) = "project";
   }
@@ -143,7 +143,7 @@ service BackendServices {
   rpc PatchBackendServices(PatchBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}"
+      patch: "/compute/v1/projects/{project}/global/backendServices/{backend_service}"
       body: "backend_service_resource"
     };
     option (google.api.method_signature) =
@@ -155,7 +155,7 @@ service BackendServices {
   rpc SetEdgeSecurityPolicy(SetEdgeSecurityPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}/setEdgeSecurityPolicy"
+      post: "/compute/v1/projects/{project}/global/backendServices/{backend_service}/setEdgeSecurityPolicy"
       body: "security_policy_reference_resource"
     };
     option (google.api.method_signature) =
@@ -168,7 +168,7 @@ service BackendServices {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendServices/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/global/backendServices/{resource}/setIamPolicy"
       body: "global_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -180,7 +180,7 @@ service BackendServices {
   rpc SetSecurityPolicy(SetSecurityPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}/setSecurityPolicy"
+      post: "/compute/v1/projects/{project}/global/backendServices/{backend_service}/setSecurityPolicy"
       body: "security_policy_reference_resource"
     };
     option (google.api.method_signature) =
@@ -193,7 +193,7 @@ service BackendServices {
   rpc UpdateBackendServices(UpdateBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/global/backendServices/{backend_service=backend_service}"
+      put: "/compute/v1/projects/{project}/global/backendServices/{backend_service}"
       body: "backend_service_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/disk_types/v1/disk_types.proto
+++ b/google/cloud/compute/disk_types/v1/disk_types.proto
@@ -39,7 +39,7 @@ service DiskTypes {
   rpc AggregatedListDiskTypes(AggregatedListDiskTypesRequest)
       returns (google.cloud.cpp.compute.v1.DiskTypeAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/diskTypes"
+      get: "/compute/v1/projects/{project}/aggregated/diskTypes"
     };
     option (google.api.method_signature) = "project";
   }
@@ -48,7 +48,7 @@ service DiskTypes {
   rpc GetDiskTypes(GetDiskTypesRequest)
       returns (google.cloud.cpp.compute.v1.DiskType) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/diskTypes/{disk_type=disk_type}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/diskTypes/{disk_type}"
     };
     option (google.api.method_signature) = "project,zone,disk_type";
   }
@@ -57,7 +57,7 @@ service DiskTypes {
   rpc ListDiskTypes(ListDiskTypesRequest)
       returns (google.cloud.cpp.compute.v1.DiskTypeList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/diskTypes"
+      get: "/compute/v1/projects/{project}/zones/{zone}/diskTypes"
     };
     option (google.api.method_signature) = "project,zone";
   }

--- a/google/cloud/compute/disks/v1/disks.proto
+++ b/google/cloud/compute/disks/v1/disks.proto
@@ -41,7 +41,7 @@ service Disks {
   rpc AddResourcePolicies(AddResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{disk=disk}/addResourcePolicies"
+      post: "/compute/v1/projects/{project}/zones/{zone}/disks/{disk}/addResourcePolicies"
       body: "disks_add_resource_policies_request_resource"
     };
     option (google.api.method_signature) =
@@ -53,7 +53,7 @@ service Disks {
   rpc AggregatedListDisks(AggregatedListDisksRequest)
       returns (google.cloud.cpp.compute.v1.DiskAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/disks"
+      get: "/compute/v1/projects/{project}/aggregated/disks"
     };
     option (google.api.method_signature) = "project";
   }
@@ -65,7 +65,7 @@ service Disks {
   rpc CreateSnapshot(CreateSnapshotRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{disk=disk}/createSnapshot"
+      post: "/compute/v1/projects/{project}/zones/{zone}/disks/{disk}/createSnapshot"
       body: "snapshot_resource"
     };
     option (google.api.method_signature) =
@@ -80,7 +80,7 @@ service Disks {
   rpc DeleteDisks(DeleteDisksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{disk=disk}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/disks/{disk}"
     };
     option (google.api.method_signature) = "project,zone,disk";
     option (google.cloud.operation_service) = "ZoneOperations";
@@ -89,7 +89,7 @@ service Disks {
   // Returns the specified persistent disk.
   rpc GetDisks(GetDisksRequest) returns (google.cloud.cpp.compute.v1.Disk) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{disk=disk}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/disks/{disk}"
     };
     option (google.api.method_signature) = "project,zone,disk";
   }
@@ -99,7 +99,7 @@ service Disks {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/zones/{zone}/disks/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,zone,resource";
   }
@@ -112,7 +112,7 @@ service Disks {
   rpc InsertDisks(InsertDisksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks"
+      post: "/compute/v1/projects/{project}/zones/{zone}/disks"
       body: "disk_resource"
     };
     option (google.api.method_signature) = "project,zone,disk_resource";
@@ -123,7 +123,7 @@ service Disks {
   rpc ListDisks(ListDisksRequest)
       returns (google.cloud.cpp.compute.v1.DiskList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks"
+      get: "/compute/v1/projects/{project}/zones/{zone}/disks"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -132,7 +132,7 @@ service Disks {
   rpc RemoveResourcePolicies(RemoveResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{disk=disk}/removeResourcePolicies"
+      post: "/compute/v1/projects/{project}/zones/{zone}/disks/{disk}/removeResourcePolicies"
       body: "disks_remove_resource_policies_request_resource"
     };
     option (google.api.method_signature) =
@@ -144,7 +144,7 @@ service Disks {
   // the disk.
   rpc Resize(ResizeRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{disk=disk}/resize"
+      post: "/compute/v1/projects/{project}/zones/{zone}/disks/{disk}/resize"
       body: "disks_resize_request_resource"
     };
     option (google.api.method_signature) =
@@ -157,7 +157,7 @@ service Disks {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/zones/{zone}/disks/{resource}/setIamPolicy"
       body: "zone_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -169,7 +169,7 @@ service Disks {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/zones/{zone}/disks/{resource}/setLabels"
       body: "zone_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -181,7 +181,7 @@ service Disks {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/zones/{zone}/disks/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =
@@ -194,7 +194,7 @@ service Disks {
   rpc UpdateDisks(UpdateDisksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/disks/{disk=disk}"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/disks/{disk}"
       body: "disk_resource"
     };
     option (google.api.method_signature) = "project,zone,disk,disk_resource";

--- a/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways.proto
+++ b/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways.proto
@@ -40,7 +40,7 @@ service ExternalVpnGateways {
   rpc DeleteExternalVpnGateways(DeleteExternalVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/externalVpnGateways/{external_vpn_gateway=external_vpn_gateway}"
+      delete: "/compute/v1/projects/{project}/global/externalVpnGateways/{external_vpn_gateway}"
     };
     option (google.api.method_signature) = "project,external_vpn_gateway";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -51,7 +51,7 @@ service ExternalVpnGateways {
   rpc GetExternalVpnGateways(GetExternalVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.ExternalVpnGateway) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/externalVpnGateways/{external_vpn_gateway=external_vpn_gateway}"
+      get: "/compute/v1/projects/{project}/global/externalVpnGateways/{external_vpn_gateway}"
     };
     option (google.api.method_signature) = "project,external_vpn_gateway";
   }
@@ -61,7 +61,7 @@ service ExternalVpnGateways {
   rpc InsertExternalVpnGateways(InsertExternalVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/externalVpnGateways"
+      post: "/compute/v1/projects/{project}/global/externalVpnGateways"
       body: "external_vpn_gateway_resource"
     };
     option (google.api.method_signature) =
@@ -74,7 +74,7 @@ service ExternalVpnGateways {
   rpc ListExternalVpnGateways(ListExternalVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.ExternalVpnGatewayList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/externalVpnGateways"
+      get: "/compute/v1/projects/{project}/global/externalVpnGateways"
     };
     option (google.api.method_signature) = "project";
   }
@@ -84,7 +84,7 @@ service ExternalVpnGateways {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/externalVpnGateways/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/global/externalVpnGateways/{resource}/setLabels"
       body: "global_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -96,7 +96,7 @@ service ExternalVpnGateways {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/externalVpnGateways/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/global/externalVpnGateways/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/firewall_policies/v1/firewall_policies.proto
+++ b/google/cloud/compute/firewall_policies/v1/firewall_policies.proto
@@ -40,7 +40,7 @@ service FirewallPolicies {
   rpc AddAssociation(AddAssociationRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/addAssociation"
+      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/addAssociation"
       body: "firewall_policy_association_resource"
     };
     option (google.api.method_signature) =
@@ -51,7 +51,7 @@ service FirewallPolicies {
   // Inserts a rule into a firewall policy.
   rpc AddRule(AddRuleRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/addRule"
+      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/addRule"
       body: "firewall_policy_rule_resource"
     };
     option (google.api.method_signature) =
@@ -63,7 +63,7 @@ service FirewallPolicies {
   rpc CloneRules(CloneRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/cloneRules"
+      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/cloneRules"
       body: "*"
     };
     option (google.api.method_signature) = "firewall_policy";
@@ -74,7 +74,7 @@ service FirewallPolicies {
   rpc DeleteFirewallPolicies(DeleteFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}"
+      delete: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}"
     };
     option (google.api.method_signature) = "firewall_policy";
     option (google.cloud.operation_service) = "GlobalOrganizationOperations";
@@ -84,7 +84,7 @@ service FirewallPolicies {
   rpc GetFirewallPolicies(GetFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicy) {
     option (google.api.http) = {
-      get: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}"
+      get: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}"
     };
     option (google.api.method_signature) = "firewall_policy";
   }
@@ -93,7 +93,7 @@ service FirewallPolicies {
   rpc GetAssociation(GetAssociationRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicyAssociation) {
     option (google.api.http) = {
-      get: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/getAssociation"
+      get: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/getAssociation"
     };
     option (google.api.method_signature) = "firewall_policy";
   }
@@ -103,7 +103,7 @@ service FirewallPolicies {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/locations/global/firewallPolicies/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/locations/global/firewallPolicies/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "resource";
   }
@@ -112,7 +112,7 @@ service FirewallPolicies {
   rpc GetRule(GetRuleRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicyRule) {
     option (google.api.http) = {
-      get: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/getRule"
+      get: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/getRule"
     };
     option (google.api.method_signature) = "firewall_policy";
   }
@@ -148,7 +148,7 @@ service FirewallPolicies {
   // Moves the specified firewall policy.
   rpc Move(MoveRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/move"
+      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/move"
       body: "*"
     };
     option (google.api.method_signature) = "firewall_policy";
@@ -159,7 +159,7 @@ service FirewallPolicies {
   rpc PatchFirewallPolicies(PatchFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}"
+      patch: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}"
       body: "firewall_policy_resource"
     };
     option (google.api.method_signature) =
@@ -171,7 +171,7 @@ service FirewallPolicies {
   rpc PatchRule(PatchRuleRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/patchRule"
+      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/patchRule"
       body: "firewall_policy_rule_resource"
     };
     option (google.api.method_signature) =
@@ -183,7 +183,7 @@ service FirewallPolicies {
   rpc RemoveAssociation(RemoveAssociationRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/removeAssociation"
+      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/removeAssociation"
       body: "*"
     };
     option (google.api.method_signature) = "firewall_policy";
@@ -194,7 +194,7 @@ service FirewallPolicies {
   rpc RemoveRule(RemoveRuleRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy=firewall_policy}/removeRule"
+      post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/removeRule"
       body: "*"
     };
     option (google.api.method_signature) = "firewall_policy";
@@ -206,7 +206,7 @@ service FirewallPolicies {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/locations/global/firewallPolicies/{resource}/setIamPolicy"
       body: "global_organization_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -217,7 +217,7 @@ service FirewallPolicies {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/locations/global/firewallPolicies/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/locations/global/firewallPolicies/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/firewalls/v1/firewalls.proto
+++ b/google/cloud/compute/firewalls/v1/firewalls.proto
@@ -40,7 +40,7 @@ service Firewalls {
   rpc DeleteFirewalls(DeleteFirewallsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/firewalls/{firewall=firewall}"
+      delete: "/compute/v1/projects/{project}/global/firewalls/{firewall}"
     };
     option (google.api.method_signature) = "project,firewall";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -50,7 +50,7 @@ service Firewalls {
   rpc GetFirewalls(GetFirewallsRequest)
       returns (google.cloud.cpp.compute.v1.Firewall) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/firewalls/{firewall=firewall}"
+      get: "/compute/v1/projects/{project}/global/firewalls/{firewall}"
     };
     option (google.api.method_signature) = "project,firewall";
   }
@@ -60,7 +60,7 @@ service Firewalls {
   rpc InsertFirewalls(InsertFirewallsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewalls"
+      post: "/compute/v1/projects/{project}/global/firewalls"
       body: "firewall_resource"
     };
     option (google.api.method_signature) = "project,firewall_resource";
@@ -71,7 +71,7 @@ service Firewalls {
   rpc ListFirewalls(ListFirewallsRequest)
       returns (google.cloud.cpp.compute.v1.FirewallList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/firewalls"
+      get: "/compute/v1/projects/{project}/global/firewalls"
     };
     option (google.api.method_signature) = "project";
   }
@@ -82,7 +82,7 @@ service Firewalls {
   rpc PatchFirewalls(PatchFirewallsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/firewalls/{firewall=firewall}"
+      patch: "/compute/v1/projects/{project}/global/firewalls/{firewall}"
       body: "firewall_resource"
     };
     option (google.api.method_signature) = "project,firewall,firewall_resource";
@@ -95,7 +95,7 @@ service Firewalls {
   rpc UpdateFirewalls(UpdateFirewallsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/global/firewalls/{firewall=firewall}"
+      put: "/compute/v1/projects/{project}/global/firewalls/{firewall}"
       body: "firewall_resource"
     };
     option (google.api.method_signature) = "project,firewall,firewall_resource";

--- a/google/cloud/compute/forwarding_rules/v1/forwarding_rules.proto
+++ b/google/cloud/compute/forwarding_rules/v1/forwarding_rules.proto
@@ -40,7 +40,7 @@ service ForwardingRules {
   rpc AggregatedListForwardingRules(AggregatedListForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.ForwardingRuleAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/forwardingRules"
+      get: "/compute/v1/projects/{project}/aggregated/forwardingRules"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service ForwardingRules {
   rpc DeleteForwardingRules(DeleteForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/forwardingRules/{forwarding_rule=forwarding_rule}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/forwardingRules/{forwarding_rule}"
     };
     option (google.api.method_signature) = "project,region,forwarding_rule";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service ForwardingRules {
   rpc GetForwardingRules(GetForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.ForwardingRule) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/forwardingRules/{forwarding_rule=forwarding_rule}"
+      get: "/compute/v1/projects/{project}/regions/{region}/forwardingRules/{forwarding_rule}"
     };
     option (google.api.method_signature) = "project,region,forwarding_rule";
   }
@@ -69,7 +69,7 @@ service ForwardingRules {
   rpc InsertForwardingRules(InsertForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/forwardingRules"
+      post: "/compute/v1/projects/{project}/regions/{region}/forwardingRules"
       body: "forwarding_rule_resource"
     };
     option (google.api.method_signature) =
@@ -82,7 +82,7 @@ service ForwardingRules {
   rpc ListForwardingRules(ListForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.ForwardingRuleList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/forwardingRules"
+      get: "/compute/v1/projects/{project}/regions/{region}/forwardingRules"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -94,7 +94,7 @@ service ForwardingRules {
   rpc PatchForwardingRules(PatchForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/forwardingRules/{forwarding_rule=forwarding_rule}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/forwardingRules/{forwarding_rule}"
       body: "forwarding_rule_resource"
     };
     option (google.api.method_signature) =
@@ -107,7 +107,7 @@ service ForwardingRules {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/forwardingRules/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/regions/{region}/forwardingRules/{resource}/setLabels"
       body: "region_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -120,7 +120,7 @@ service ForwardingRules {
   rpc SetTarget(SetTargetRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/forwardingRules/{forwarding_rule=forwarding_rule}/setTarget"
+      post: "/compute/v1/projects/{project}/regions/{region}/forwardingRules/{forwarding_rule}/setTarget"
       body: "target_reference_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/global_addresses/v1/global_addresses.proto
+++ b/google/cloud/compute/global_addresses/v1/global_addresses.proto
@@ -40,7 +40,7 @@ service GlobalAddresses {
   rpc DeleteGlobalAddresses(DeleteGlobalAddressesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/addresses/{address=address}"
+      delete: "/compute/v1/projects/{project}/global/addresses/{address}"
     };
     option (google.api.method_signature) = "project,address";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -50,7 +50,7 @@ service GlobalAddresses {
   rpc GetGlobalAddresses(GetGlobalAddressesRequest)
       returns (google.cloud.cpp.compute.v1.Address) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/addresses/{address=address}"
+      get: "/compute/v1/projects/{project}/global/addresses/{address}"
     };
     option (google.api.method_signature) = "project,address";
   }
@@ -60,7 +60,7 @@ service GlobalAddresses {
   rpc InsertGlobalAddresses(InsertGlobalAddressesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/addresses"
+      post: "/compute/v1/projects/{project}/global/addresses"
       body: "address_resource"
     };
     option (google.api.method_signature) = "project,address_resource";
@@ -71,7 +71,7 @@ service GlobalAddresses {
   rpc ListGlobalAddresses(ListGlobalAddressesRequest)
       returns (google.cloud.cpp.compute.v1.AddressList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/addresses"
+      get: "/compute/v1/projects/{project}/global/addresses"
     };
     option (google.api.method_signature) = "project";
   }
@@ -81,7 +81,7 @@ service GlobalAddresses {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/addresses/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/global/addresses/{resource}/setLabels"
       body: "global_set_labels_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules.proto
+++ b/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules.proto
@@ -40,7 +40,7 @@ service GlobalForwardingRules {
   rpc DeleteGlobalForwardingRules(DeleteGlobalForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/forwardingRules/{forwarding_rule=forwarding_rule}"
+      delete: "/compute/v1/projects/{project}/global/forwardingRules/{forwarding_rule}"
     };
     option (google.api.method_signature) = "project,forwarding_rule";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -51,7 +51,7 @@ service GlobalForwardingRules {
   rpc GetGlobalForwardingRules(GetGlobalForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.ForwardingRule) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/forwardingRules/{forwarding_rule=forwarding_rule}"
+      get: "/compute/v1/projects/{project}/global/forwardingRules/{forwarding_rule}"
     };
     option (google.api.method_signature) = "project,forwarding_rule";
   }
@@ -61,7 +61,7 @@ service GlobalForwardingRules {
   rpc InsertGlobalForwardingRules(InsertGlobalForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/forwardingRules"
+      post: "/compute/v1/projects/{project}/global/forwardingRules"
       body: "forwarding_rule_resource"
     };
     option (google.api.method_signature) = "project,forwarding_rule_resource";
@@ -73,7 +73,7 @@ service GlobalForwardingRules {
   rpc ListGlobalForwardingRules(ListGlobalForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.ForwardingRuleList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/forwardingRules"
+      get: "/compute/v1/projects/{project}/global/forwardingRules"
     };
     option (google.api.method_signature) = "project";
   }
@@ -85,7 +85,7 @@ service GlobalForwardingRules {
   rpc PatchGlobalForwardingRules(PatchGlobalForwardingRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/forwardingRules/{forwarding_rule=forwarding_rule}"
+      patch: "/compute/v1/projects/{project}/global/forwardingRules/{forwarding_rule}"
       body: "forwarding_rule_resource"
     };
     option (google.api.method_signature) =
@@ -98,7 +98,7 @@ service GlobalForwardingRules {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/forwardingRules/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/global/forwardingRules/{resource}/setLabels"
       body: "global_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -111,7 +111,7 @@ service GlobalForwardingRules {
   rpc SetTarget(SetTargetRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/forwardingRules/{forwarding_rule=forwarding_rule}/setTarget"
+      post: "/compute/v1/projects/{project}/global/forwardingRules/{forwarding_rule}/setTarget"
       body: "target_reference_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups.proto
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups.proto
@@ -40,7 +40,7 @@ service GlobalNetworkEndpointGroups {
   rpc AttachNetworkEndpoints(AttachNetworkEndpointsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}/attachNetworkEndpoints"
+      post: "/compute/v1/projects/{project}/global/networkEndpointGroups/{network_endpoint_group}/attachNetworkEndpoints"
       body: "global_network_endpoint_groups_attach_endpoints_request_resource"
     };
     option (google.api.method_signature) =
@@ -54,7 +54,7 @@ service GlobalNetworkEndpointGroups {
       DeleteGlobalNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}"
+      delete: "/compute/v1/projects/{project}/global/networkEndpointGroups/{network_endpoint_group}"
     };
     option (google.api.method_signature) = "project,network_endpoint_group";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -64,7 +64,7 @@ service GlobalNetworkEndpointGroups {
   rpc DetachNetworkEndpoints(DetachNetworkEndpointsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}/detachNetworkEndpoints"
+      post: "/compute/v1/projects/{project}/global/networkEndpointGroups/{network_endpoint_group}/detachNetworkEndpoints"
       body: "global_network_endpoint_groups_detach_endpoints_request_resource"
     };
     option (google.api.method_signature) =
@@ -76,7 +76,7 @@ service GlobalNetworkEndpointGroups {
   rpc GetGlobalNetworkEndpointGroups(GetGlobalNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkEndpointGroup) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}"
+      get: "/compute/v1/projects/{project}/global/networkEndpointGroups/{network_endpoint_group}"
     };
     option (google.api.method_signature) = "project,network_endpoint_group";
   }
@@ -87,7 +87,7 @@ service GlobalNetworkEndpointGroups {
       InsertGlobalNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/networkEndpointGroups"
+      post: "/compute/v1/projects/{project}/global/networkEndpointGroups"
       body: "network_endpoint_group_resource"
     };
     option (google.api.method_signature) =
@@ -100,7 +100,7 @@ service GlobalNetworkEndpointGroups {
   rpc ListGlobalNetworkEndpointGroups(ListGlobalNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkEndpointGroupList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/networkEndpointGroups"
+      get: "/compute/v1/projects/{project}/global/networkEndpointGroups"
     };
     option (google.api.method_signature) = "project";
   }
@@ -109,7 +109,7 @@ service GlobalNetworkEndpointGroups {
   rpc ListNetworkEndpoints(ListNetworkEndpointsRequest) returns (
       google.cloud.cpp.compute.v1.NetworkEndpointGroupsListNetworkEndpoints) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}/listNetworkEndpoints"
+      post: "/compute/v1/projects/{project}/global/networkEndpointGroups/{network_endpoint_group}/listNetworkEndpoints"
       body: "*"
     };
     option (google.api.method_signature) = "project,network_endpoint_group";

--- a/google/cloud/compute/global_operations/v1/global_operations.proto
+++ b/google/cloud/compute/global_operations/v1/global_operations.proto
@@ -41,7 +41,7 @@ service GlobalOperations {
   rpc AggregatedListGlobalOperations(AggregatedListGlobalOperationsRequest)
       returns (google.cloud.cpp.compute.v1.OperationAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/operations"
+      get: "/compute/v1/projects/{project}/aggregated/operations"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service GlobalOperations {
   rpc DeleteGlobalOperations(DeleteGlobalOperationsRequest)
       returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/operations/{operation=operation}"
+      delete: "/compute/v1/projects/{project}/global/operations/{operation}"
     };
     option (google.api.method_signature) = "project,operation";
   }
@@ -59,7 +59,7 @@ service GlobalOperations {
   rpc GetGlobalOperations(GetGlobalOperationsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/operations/{operation=operation}"
+      get: "/compute/v1/projects/{project}/global/operations/{operation}"
     };
     option (google.api.method_signature) = "project,operation";
   }
@@ -69,7 +69,7 @@ service GlobalOperations {
   rpc ListGlobalOperations(ListGlobalOperationsRequest)
       returns (google.cloud.cpp.compute.v1.OperationList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/operations"
+      get: "/compute/v1/projects/{project}/global/operations"
     };
     option (google.api.method_signature) = "project";
   }
@@ -87,7 +87,7 @@ service GlobalOperations {
   // the operation is not `DONE`.
   rpc Wait(WaitRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/operations/{operation=operation}/wait"
+      post: "/compute/v1/projects/{project}/global/operations/{operation}/wait"
       body: "*"
     };
     option (google.api.method_signature) = "project,operation";

--- a/google/cloud/compute/global_organization_operations/v1/global_organization_operations.proto
+++ b/google/cloud/compute/global_organization_operations/v1/global_organization_operations.proto
@@ -42,7 +42,7 @@ service GlobalOrganizationOperations {
       DeleteGlobalOrganizationOperationsRequest)
       returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      delete: "/compute/v1/locations/global/operations/{operation=operation}"
+      delete: "/compute/v1/locations/global/operations/{operation}"
     };
     option (google.api.method_signature) = "operation";
   }
@@ -52,7 +52,7 @@ service GlobalOrganizationOperations {
   rpc GetGlobalOrganizationOperations(GetGlobalOrganizationOperationsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      get: "/compute/v1/locations/global/operations/{operation=operation}"
+      get: "/compute/v1/locations/global/operations/{operation}"
     };
     option (google.api.method_signature) = "operation";
   }

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes.proto
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes.proto
@@ -41,7 +41,7 @@ service GlobalPublicDelegatedPrefixes {
       DeleteGlobalPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/publicDelegatedPrefixes/{public_delegated_prefix=public_delegated_prefix}"
+      delete: "/compute/v1/projects/{project}/global/publicDelegatedPrefixes/{public_delegated_prefix}"
     };
     option (google.api.method_signature) = "project,public_delegated_prefix";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -51,7 +51,7 @@ service GlobalPublicDelegatedPrefixes {
   rpc GetGlobalPublicDelegatedPrefixes(GetGlobalPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.PublicDelegatedPrefix) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/publicDelegatedPrefixes/{public_delegated_prefix=public_delegated_prefix}"
+      get: "/compute/v1/projects/{project}/global/publicDelegatedPrefixes/{public_delegated_prefix}"
     };
     option (google.api.method_signature) = "project,public_delegated_prefix";
   }
@@ -62,7 +62,7 @@ service GlobalPublicDelegatedPrefixes {
       InsertGlobalPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/publicDelegatedPrefixes"
+      post: "/compute/v1/projects/{project}/global/publicDelegatedPrefixes"
       body: "public_delegated_prefix_resource"
     };
     option (google.api.method_signature) =
@@ -75,7 +75,7 @@ service GlobalPublicDelegatedPrefixes {
       ListGlobalPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.PublicDelegatedPrefixList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/publicDelegatedPrefixes"
+      get: "/compute/v1/projects/{project}/global/publicDelegatedPrefixes"
     };
     option (google.api.method_signature) = "project";
   }
@@ -87,7 +87,7 @@ service GlobalPublicDelegatedPrefixes {
       PatchGlobalPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/publicDelegatedPrefixes/{public_delegated_prefix=public_delegated_prefix}"
+      patch: "/compute/v1/projects/{project}/global/publicDelegatedPrefixes/{public_delegated_prefix}"
       body: "public_delegated_prefix_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/health_checks/v1/health_checks.proto
+++ b/google/cloud/compute/health_checks/v1/health_checks.proto
@@ -41,7 +41,7 @@ service HealthChecks {
   rpc AggregatedListHealthChecks(AggregatedListHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HealthChecksAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/healthChecks"
+      get: "/compute/v1/projects/{project}/aggregated/healthChecks"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service HealthChecks {
   rpc DeleteHealthChecks(DeleteHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/healthChecks/{health_check=health_check}"
+      delete: "/compute/v1/projects/{project}/global/healthChecks/{health_check}"
     };
     option (google.api.method_signature) = "project,health_check";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -60,7 +60,7 @@ service HealthChecks {
   rpc GetHealthChecks(GetHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HealthCheck) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/healthChecks/{health_check=health_check}"
+      get: "/compute/v1/projects/{project}/global/healthChecks/{health_check}"
     };
     option (google.api.method_signature) = "project,health_check";
   }
@@ -70,7 +70,7 @@ service HealthChecks {
   rpc InsertHealthChecks(InsertHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/healthChecks"
+      post: "/compute/v1/projects/{project}/global/healthChecks"
       body: "health_check_resource"
     };
     option (google.api.method_signature) = "project,health_check_resource";
@@ -82,7 +82,7 @@ service HealthChecks {
   rpc ListHealthChecks(ListHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HealthCheckList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/healthChecks"
+      get: "/compute/v1/projects/{project}/global/healthChecks"
     };
     option (google.api.method_signature) = "project";
   }
@@ -93,7 +93,7 @@ service HealthChecks {
   rpc PatchHealthChecks(PatchHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/healthChecks/{health_check=health_check}"
+      patch: "/compute/v1/projects/{project}/global/healthChecks/{health_check}"
       body: "health_check_resource"
     };
     option (google.api.method_signature) =
@@ -106,7 +106,7 @@ service HealthChecks {
   rpc UpdateHealthChecks(UpdateHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/global/healthChecks/{health_check=health_check}"
+      put: "/compute/v1/projects/{project}/global/healthChecks/{health_check}"
       body: "health_check_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/http_health_checks/v1/http_health_checks.proto
+++ b/google/cloud/compute/http_health_checks/v1/http_health_checks.proto
@@ -40,7 +40,7 @@ service HttpHealthChecks {
   rpc DeleteHttpHealthChecks(DeleteHttpHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/httpHealthChecks/{http_health_check=http_health_check}"
+      delete: "/compute/v1/projects/{project}/global/httpHealthChecks/{http_health_check}"
     };
     option (google.api.method_signature) = "project,http_health_check";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -50,7 +50,7 @@ service HttpHealthChecks {
   rpc GetHttpHealthChecks(GetHttpHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HttpHealthCheck) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/httpHealthChecks/{http_health_check=http_health_check}"
+      get: "/compute/v1/projects/{project}/global/httpHealthChecks/{http_health_check}"
     };
     option (google.api.method_signature) = "project,http_health_check";
   }
@@ -60,7 +60,7 @@ service HttpHealthChecks {
   rpc InsertHttpHealthChecks(InsertHttpHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/httpHealthChecks"
+      post: "/compute/v1/projects/{project}/global/httpHealthChecks"
       body: "http_health_check_resource"
     };
     option (google.api.method_signature) = "project,http_health_check_resource";
@@ -72,7 +72,7 @@ service HttpHealthChecks {
   rpc ListHttpHealthChecks(ListHttpHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HttpHealthCheckList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/httpHealthChecks"
+      get: "/compute/v1/projects/{project}/global/httpHealthChecks"
     };
     option (google.api.method_signature) = "project";
   }
@@ -83,7 +83,7 @@ service HttpHealthChecks {
   rpc PatchHttpHealthChecks(PatchHttpHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/httpHealthChecks/{http_health_check=http_health_check}"
+      patch: "/compute/v1/projects/{project}/global/httpHealthChecks/{http_health_check}"
       body: "http_health_check_resource"
     };
     option (google.api.method_signature) =
@@ -96,7 +96,7 @@ service HttpHealthChecks {
   rpc UpdateHttpHealthChecks(UpdateHttpHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/global/httpHealthChecks/{http_health_check=http_health_check}"
+      put: "/compute/v1/projects/{project}/global/httpHealthChecks/{http_health_check}"
       body: "http_health_check_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/https_health_checks/v1/https_health_checks.proto
+++ b/google/cloud/compute/https_health_checks/v1/https_health_checks.proto
@@ -40,7 +40,7 @@ service HttpsHealthChecks {
   rpc DeleteHttpsHealthChecks(DeleteHttpsHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/httpsHealthChecks/{https_health_check=https_health_check}"
+      delete: "/compute/v1/projects/{project}/global/httpsHealthChecks/{https_health_check}"
     };
     option (google.api.method_signature) = "project,https_health_check";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -50,7 +50,7 @@ service HttpsHealthChecks {
   rpc GetHttpsHealthChecks(GetHttpsHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HttpsHealthCheck) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/httpsHealthChecks/{https_health_check=https_health_check}"
+      get: "/compute/v1/projects/{project}/global/httpsHealthChecks/{https_health_check}"
     };
     option (google.api.method_signature) = "project,https_health_check";
   }
@@ -60,7 +60,7 @@ service HttpsHealthChecks {
   rpc InsertHttpsHealthChecks(InsertHttpsHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/httpsHealthChecks"
+      post: "/compute/v1/projects/{project}/global/httpsHealthChecks"
       body: "https_health_check_resource"
     };
     option (google.api.method_signature) =
@@ -73,7 +73,7 @@ service HttpsHealthChecks {
   rpc ListHttpsHealthChecks(ListHttpsHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HttpsHealthCheckList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/httpsHealthChecks"
+      get: "/compute/v1/projects/{project}/global/httpsHealthChecks"
     };
     option (google.api.method_signature) = "project";
   }
@@ -84,7 +84,7 @@ service HttpsHealthChecks {
   rpc PatchHttpsHealthChecks(PatchHttpsHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/httpsHealthChecks/{https_health_check=https_health_check}"
+      patch: "/compute/v1/projects/{project}/global/httpsHealthChecks/{https_health_check}"
       body: "https_health_check_resource"
     };
     option (google.api.method_signature) =
@@ -97,7 +97,7 @@ service HttpsHealthChecks {
   rpc UpdateHttpsHealthChecks(UpdateHttpsHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/global/httpsHealthChecks/{https_health_check=https_health_check}"
+      put: "/compute/v1/projects/{project}/global/httpsHealthChecks/{https_health_check}"
       body: "https_health_check_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/image_family_views/v1/image_family_views.proto
+++ b/google/cloud/compute/image_family_views/v1/image_family_views.proto
@@ -40,7 +40,7 @@ service ImageFamilyViews {
   rpc GetImageFamilyViews(GetImageFamilyViewsRequest)
       returns (google.cloud.cpp.compute.v1.ImageFamilyView) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/imageFamilyViews/{family=family}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/imageFamilyViews/{family}"
     };
     option (google.api.method_signature) = "project,zone,family";
   }

--- a/google/cloud/compute/images/v1/images.proto
+++ b/google/cloud/compute/images/v1/images.proto
@@ -43,7 +43,7 @@ service Images {
   rpc DeleteImages(DeleteImagesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/images/{image=image}"
+      delete: "/compute/v1/projects/{project}/global/images/{image}"
     };
     option (google.api.method_signature) = "project,image";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -54,7 +54,7 @@ service Images {
   rpc Deprecate(DeprecateRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/images/{image=image}/deprecate"
+      post: "/compute/v1/projects/{project}/global/images/{image}/deprecate"
       body: "deprecation_status_resource"
     };
     option (google.api.method_signature) =
@@ -65,7 +65,7 @@ service Images {
   // Returns the specified image.
   rpc GetImages(GetImagesRequest) returns (google.cloud.cpp.compute.v1.Image) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/images/{image=image}"
+      get: "/compute/v1/projects/{project}/global/images/{image}"
     };
     option (google.api.method_signature) = "project,image";
   }
@@ -76,7 +76,7 @@ service Images {
   rpc GetFromFamily(GetFromFamilyRequest)
       returns (google.cloud.cpp.compute.v1.Image) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/images/family/{family=family}"
+      get: "/compute/v1/projects/{project}/global/images/family/{family}"
     };
     option (google.api.method_signature) = "project,family";
   }
@@ -86,7 +86,7 @@ service Images {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/images/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/global/images/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,resource";
   }
@@ -96,7 +96,7 @@ service Images {
   rpc InsertImages(InsertImagesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/images"
+      post: "/compute/v1/projects/{project}/global/images"
       body: "image_resource"
     };
     option (google.api.method_signature) = "project,image_resource";
@@ -112,7 +112,7 @@ service Images {
   rpc ListImages(ListImagesRequest)
       returns (google.cloud.cpp.compute.v1.ImageList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/images"
+      get: "/compute/v1/projects/{project}/global/images"
     };
     option (google.api.method_signature) = "project";
   }
@@ -122,7 +122,7 @@ service Images {
   rpc PatchImages(PatchImagesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/images/{image=image}"
+      patch: "/compute/v1/projects/{project}/global/images/{image}"
       body: "image_resource"
     };
     option (google.api.method_signature) = "project,image,image_resource";
@@ -134,7 +134,7 @@ service Images {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/images/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/global/images/{resource}/setIamPolicy"
       body: "global_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -146,7 +146,7 @@ service Images {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/images/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/global/images/{resource}/setLabels"
       body: "global_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -158,7 +158,7 @@ service Images {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/images/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/global/images/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/instance_group_managers/v1/instance_group_managers.proto
+++ b/google/cloud/compute/instance_group_managers/v1/instance_group_managers.proto
@@ -51,7 +51,7 @@ service InstanceGroupManagers {
   rpc AbandonInstances(AbandonInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/abandonInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/abandonInstances"
       body: "instance_group_managers_abandon_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -64,7 +64,7 @@ service InstanceGroupManagers {
       AggregatedListInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroupManagerAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/instanceGroupManagers"
+      get: "/compute/v1/projects/{project}/aggregated/instanceGroupManagers"
     };
     option (google.api.method_signature) = "project";
   }
@@ -74,7 +74,7 @@ service InstanceGroupManagers {
   rpc ApplyUpdatesToInstances(ApplyUpdatesToInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/applyUpdatesToInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/applyUpdatesToInstances"
       body: "instance_group_managers_apply_updates_request_resource"
     };
     option (google.api.method_signature) =
@@ -91,7 +91,7 @@ service InstanceGroupManagers {
   rpc CreateInstances(CreateInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/createInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/createInstances"
       body: "instance_group_managers_create_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -105,7 +105,7 @@ service InstanceGroupManagers {
   rpc DeleteInstanceGroupManagers(DeleteInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}"
     };
     option (google.api.method_signature) =
         "project,zone,instance_group_manager";
@@ -126,7 +126,7 @@ service InstanceGroupManagers {
   rpc DeleteInstances(DeleteInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/deleteInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/deleteInstances"
       body: "instance_group_managers_delete_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -139,7 +139,7 @@ service InstanceGroupManagers {
   rpc DeletePerInstanceConfigs(DeletePerInstanceConfigsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/deletePerInstanceConfigs"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/deletePerInstanceConfigs"
       body: "instance_group_managers_delete_per_instance_configs_req_resource"
     };
     option (google.api.method_signature) =
@@ -151,7 +151,7 @@ service InstanceGroupManagers {
   rpc GetInstanceGroupManagers(GetInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroupManager) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}"
     };
     option (google.api.method_signature) =
         "project,zone,instance_group_manager";
@@ -168,7 +168,7 @@ service InstanceGroupManagers {
   rpc InsertInstanceGroupManagers(InsertInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers"
       body: "instance_group_manager_resource"
     };
     option (google.api.method_signature) =
@@ -181,7 +181,7 @@ service InstanceGroupManagers {
   rpc ListInstanceGroupManagers(ListInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroupManagerList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -191,7 +191,7 @@ service InstanceGroupManagers {
   rpc ListErrors(ListErrorsRequest) returns (
       google.cloud.cpp.compute.v1.InstanceGroupManagersListErrorsResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/listErrors"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/listErrors"
     };
     option (google.api.method_signature) =
         "project,zone,instance_group_manager";
@@ -209,7 +209,7 @@ service InstanceGroupManagers {
       returns (google.cloud.cpp.compute.v1
                    .InstanceGroupManagersListManagedInstancesResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/listManagedInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/listManagedInstances"
       body: "*"
     };
     option (google.api.method_signature) =
@@ -222,7 +222,7 @@ service InstanceGroupManagers {
       returns (google.cloud.cpp.compute.v1
                    .InstanceGroupManagersListPerInstanceConfigsResp) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/listPerInstanceConfigs"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/listPerInstanceConfigs"
       body: "*"
     };
     option (google.api.method_signature) =
@@ -242,7 +242,7 @@ service InstanceGroupManagers {
   rpc PatchInstanceGroupManagers(PatchInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}"
       body: "instance_group_manager_resource"
     };
     option (google.api.method_signature) =
@@ -256,7 +256,7 @@ service InstanceGroupManagers {
   rpc PatchPerInstanceConfigs(PatchPerInstanceConfigsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/patchPerInstanceConfigs"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/patchPerInstanceConfigs"
       body: "instance_group_managers_patch_per_instance_configs_req_resource"
     };
     option (google.api.method_signature) =
@@ -277,7 +277,7 @@ service InstanceGroupManagers {
   rpc RecreateInstances(RecreateInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/recreateInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/recreateInstances"
       body: "instance_group_managers_recreate_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -302,7 +302,7 @@ service InstanceGroupManagers {
   // is removed or deleted.
   rpc Resize(ResizeRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/resize"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/resize"
       body: "*"
     };
     option (google.api.method_signature) =
@@ -317,7 +317,7 @@ service InstanceGroupManagers {
   rpc SetInstanceTemplate(SetInstanceTemplateRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/setInstanceTemplate"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/setInstanceTemplate"
       body: "instance_group_managers_set_instance_template_request_resource"
     };
     option (google.api.method_signature) =
@@ -334,7 +334,7 @@ service InstanceGroupManagers {
   rpc SetTargetPools(SetTargetPoolsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/setTargetPools"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/setTargetPools"
       body: "instance_group_managers_set_target_pools_request_resource"
     };
     option (google.api.method_signature) =
@@ -348,7 +348,7 @@ service InstanceGroupManagers {
   rpc UpdatePerInstanceConfigs(UpdatePerInstanceConfigsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/updatePerInstanceConfigs"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instance_group_manager}/updatePerInstanceConfigs"
       body: "instance_group_managers_update_per_instance_configs_req_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/instance_groups/v1/instance_groups.proto
+++ b/google/cloud/compute/instance_groups/v1/instance_groups.proto
@@ -42,7 +42,7 @@ service InstanceGroups {
   rpc AddInstances(AddInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroups/{instance_group=instance_group}/addInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instance_group}/addInstances"
       body: "instance_groups_add_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -54,7 +54,7 @@ service InstanceGroups {
   rpc AggregatedListInstanceGroups(AggregatedListInstanceGroupsRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroupAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/instanceGroups"
+      get: "/compute/v1/projects/{project}/aggregated/instanceGroups"
     };
     option (google.api.method_signature) = "project";
   }
@@ -65,7 +65,7 @@ service InstanceGroups {
   rpc DeleteInstanceGroups(DeleteInstanceGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroups/{instance_group=instance_group}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instance_group}"
     };
     option (google.api.method_signature) = "project,zone,instance_group";
     option (google.cloud.operation_service) = "ZoneOperations";
@@ -78,7 +78,7 @@ service InstanceGroups {
   rpc GetInstanceGroups(GetInstanceGroupsRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroup) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroups/{instance_group=instance_group}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instance_group}"
     };
     option (google.api.method_signature) = "project,zone,instance_group";
   }
@@ -88,7 +88,7 @@ service InstanceGroups {
   rpc InsertInstanceGroups(InsertInstanceGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroups"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroups"
       body: "instance_group_resource"
     };
     option (google.api.method_signature) =
@@ -102,7 +102,7 @@ service InstanceGroups {
   rpc ListInstanceGroups(ListInstanceGroupsRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroupList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroups"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instanceGroups"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -113,7 +113,7 @@ service InstanceGroups {
   rpc ListInstances(ListInstancesRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroupsListInstances) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroups/{instance_group=instance_group}/listInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instance_group}/listInstances"
       body: "instance_groups_list_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -127,7 +127,7 @@ service InstanceGroups {
   rpc RemoveInstances(RemoveInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroups/{instance_group=instance_group}/removeInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instance_group}/removeInstances"
       body: "instance_groups_remove_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -139,7 +139,7 @@ service InstanceGroups {
   rpc SetNamedPorts(SetNamedPortsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instanceGroups/{instance_group=instance_group}/setNamedPorts"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instance_group}/setNamedPorts"
       body: "instance_groups_set_named_ports_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/instance_templates/v1/instance_templates.proto
+++ b/google/cloud/compute/instance_templates/v1/instance_templates.proto
@@ -41,7 +41,7 @@ service InstanceTemplates {
   rpc AggregatedListInstanceTemplates(AggregatedListInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.InstanceTemplateAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/instanceTemplates"
+      get: "/compute/v1/projects/{project}/aggregated/instanceTemplates"
     };
     option (google.api.method_signature) = "project";
   }
@@ -52,7 +52,7 @@ service InstanceTemplates {
   rpc DeleteInstanceTemplates(DeleteInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/instanceTemplates/{instance_template=instance_template}"
+      delete: "/compute/v1/projects/{project}/global/instanceTemplates/{instance_template}"
     };
     option (google.api.method_signature) = "project,instance_template";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -62,7 +62,7 @@ service InstanceTemplates {
   rpc GetInstanceTemplates(GetInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.InstanceTemplate) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/instanceTemplates/{instance_template=instance_template}"
+      get: "/compute/v1/projects/{project}/global/instanceTemplates/{instance_template}"
     };
     option (google.api.method_signature) = "project,instance_template";
   }
@@ -72,7 +72,7 @@ service InstanceTemplates {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/instanceTemplates/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/global/instanceTemplates/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,resource";
   }
@@ -84,7 +84,7 @@ service InstanceTemplates {
   rpc InsertInstanceTemplates(InsertInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/instanceTemplates"
+      post: "/compute/v1/projects/{project}/global/instanceTemplates"
       body: "instance_template_resource"
     };
     option (google.api.method_signature) = "project,instance_template_resource";
@@ -96,7 +96,7 @@ service InstanceTemplates {
   rpc ListInstanceTemplates(ListInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.InstanceTemplateList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/instanceTemplates"
+      get: "/compute/v1/projects/{project}/global/instanceTemplates"
     };
     option (google.api.method_signature) = "project";
   }
@@ -106,7 +106,7 @@ service InstanceTemplates {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/instanceTemplates/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/global/instanceTemplates/{resource}/setIamPolicy"
       body: "global_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -117,7 +117,7 @@ service InstanceTemplates {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/instanceTemplates/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/global/instanceTemplates/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/instances/v1/instances.proto
+++ b/google/cloud/compute/instances/v1/instances.proto
@@ -41,7 +41,7 @@ service Instances {
   rpc AddAccessConfig(AddAccessConfigRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/addAccessConfig"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/addAccessConfig"
       body: "access_config_resource"
     };
     option (google.api.method_signature) =
@@ -55,7 +55,7 @@ service Instances {
   rpc AddResourcePolicies(AddResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/addResourcePolicies"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/addResourcePolicies"
       body: "instances_add_resource_policies_request_resource"
     };
     option (google.api.method_signature) =
@@ -69,7 +69,7 @@ service Instances {
   rpc AggregatedListInstances(AggregatedListInstancesRequest)
       returns (google.cloud.cpp.compute.v1.InstanceAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/instances"
+      get: "/compute/v1/projects/{project}/aggregated/instances"
     };
     option (google.api.method_signature) = "project";
   }
@@ -81,7 +81,7 @@ service Instances {
   rpc AttachDisk(AttachDiskRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/attachDisk"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/attachDisk"
       body: "attached_disk_resource"
     };
     option (google.api.method_signature) =
@@ -94,7 +94,7 @@ service Instances {
   rpc BulkInsert(BulkInsertRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/bulkInsert"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/bulkInsert"
       body: "bulk_insert_instance_resource"
     };
     option (google.api.method_signature) =
@@ -107,7 +107,7 @@ service Instances {
   rpc DeleteInstances(DeleteInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}"
     };
     option (google.api.method_signature) = "project,zone,instance";
     option (google.cloud.operation_service) = "ZoneOperations";
@@ -117,7 +117,7 @@ service Instances {
   rpc DeleteAccessConfig(DeleteAccessConfigRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/deleteAccessConfig"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/deleteAccessConfig"
       body: "*"
     };
     option (google.api.method_signature) =
@@ -129,7 +129,7 @@ service Instances {
   rpc DetachDisk(DetachDiskRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/detachDisk"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/detachDisk"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,instance,device_name";
@@ -140,7 +140,7 @@ service Instances {
   rpc GetInstances(GetInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Instance) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}"
     };
     option (google.api.method_signature) = "project,zone,instance";
   }
@@ -149,7 +149,7 @@ service Instances {
   rpc GetEffectiveFirewalls(GetEffectiveFirewallsRequest) returns (
       google.cloud.cpp.compute.v1.InstancesGetEffectiveFirewallsResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/getEffectiveFirewalls"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/getEffectiveFirewalls"
     };
     option (google.api.method_signature) =
         "project,zone,instance,network_interface";
@@ -159,7 +159,7 @@ service Instances {
   rpc GetGuestAttributes(GetGuestAttributesRequest)
       returns (google.cloud.cpp.compute.v1.GuestAttributes) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/getGuestAttributes"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/getGuestAttributes"
     };
     option (google.api.method_signature) = "project,zone,instance";
   }
@@ -169,7 +169,7 @@ service Instances {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,zone,resource";
   }
@@ -178,7 +178,7 @@ service Instances {
   rpc GetScreenshot(GetScreenshotRequest)
       returns (google.cloud.cpp.compute.v1.Screenshot) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/screenshot"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/screenshot"
     };
     option (google.api.method_signature) = "project,zone,instance";
   }
@@ -187,7 +187,7 @@ service Instances {
   rpc GetSerialPortOutput(GetSerialPortOutputRequest)
       returns (google.cloud.cpp.compute.v1.SerialPortOutput) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/serialPort"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/serialPort"
     };
     option (google.api.method_signature) = "project,zone,instance";
   }
@@ -196,7 +196,7 @@ service Instances {
   rpc GetShieldedInstanceIdentity(GetShieldedInstanceIdentityRequest)
       returns (google.cloud.cpp.compute.v1.ShieldedInstanceIdentity) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/getShieldedInstanceIdentity"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/getShieldedInstanceIdentity"
     };
     option (google.api.method_signature) = "project,zone,instance";
   }
@@ -206,7 +206,7 @@ service Instances {
   rpc InsertInstances(InsertInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances"
       body: "instance_resource"
     };
     option (google.api.method_signature) = "project,zone,instance_resource";
@@ -217,7 +217,7 @@ service Instances {
   rpc ListInstances(ListInstancesRequest)
       returns (google.cloud.cpp.compute.v1.InstanceList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -229,7 +229,7 @@ service Instances {
   rpc ListReferrers(ListReferrersRequest)
       returns (google.cloud.cpp.compute.v1.InstanceListReferrers) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/referrers"
+      get: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/referrers"
     };
     option (google.api.method_signature) = "project,zone,instance";
   }
@@ -238,7 +238,7 @@ service Instances {
   rpc RemoveResourcePolicies(RemoveResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/removeResourcePolicies"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/removeResourcePolicies"
       body: "instances_remove_resource_policies_request_resource"
     };
     option (google.api.method_signature) =
@@ -250,7 +250,7 @@ service Instances {
   // a graceful shutdown. For more information, see Resetting an instance.
   rpc Reset(ResetRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/reset"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/reset"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,instance";
@@ -261,7 +261,7 @@ service Instances {
   // method.
   rpc Resume(ResumeRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/resume"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/resume"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,instance";
@@ -272,7 +272,7 @@ service Instances {
   rpc SendDiagnosticInterrupt(SendDiagnosticInterruptRequest)
       returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/sendDiagnosticInterrupt"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/sendDiagnosticInterrupt"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,instance";
@@ -282,7 +282,7 @@ service Instances {
   rpc SetDeletionProtection(SetDeletionProtectionRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{resource=resource}/setDeletionProtection"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{resource}/setDeletionProtection"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,resource";
@@ -293,7 +293,7 @@ service Instances {
   rpc SetDiskAutoDelete(SetDiskAutoDeleteRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setDiskAutoDelete"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setDiskAutoDelete"
       body: "*"
     };
     option (google.api.method_signature) =
@@ -306,7 +306,7 @@ service Instances {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{resource}/setIamPolicy"
       body: "zone_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -318,7 +318,7 @@ service Instances {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setLabels"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setLabels"
       body: "instances_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -331,7 +331,7 @@ service Instances {
   rpc SetMachineResources(SetMachineResourcesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setMachineResources"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setMachineResources"
       body: "instances_set_machine_resources_request_resource"
     };
     option (google.api.method_signature) =
@@ -344,7 +344,7 @@ service Instances {
   rpc SetMachineType(SetMachineTypeRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setMachineType"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setMachineType"
       body: "instances_set_machine_type_request_resource"
     };
     option (google.api.method_signature) =
@@ -357,7 +357,7 @@ service Instances {
   rpc SetMetadata(SetMetadataRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setMetadata"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setMetadata"
       body: "metadata_resource"
     };
     option (google.api.method_signature) =
@@ -371,7 +371,7 @@ service Instances {
   rpc SetMinCpuPlatform(SetMinCpuPlatformRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setMinCpuPlatform"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setMinCpuPlatform"
       body: "instances_set_min_cpu_platform_request_resource"
     };
     option (google.api.method_signature) =
@@ -382,7 +382,7 @@ service Instances {
   // Sets name of an instance.
   rpc SetName(SetNameRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setName"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setName"
       body: "instances_set_name_request_resource"
     };
     option (google.api.method_signature) =
@@ -398,7 +398,7 @@ service Instances {
   rpc SetScheduling(SetSchedulingRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setScheduling"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setScheduling"
       body: "scheduling_resource"
     };
     option (google.api.method_signature) =
@@ -411,7 +411,7 @@ service Instances {
   rpc SetServiceAccount(SetServiceAccountRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setServiceAccount"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setServiceAccount"
       body: "instances_set_service_account_request_resource"
     };
     option (google.api.method_signature) =
@@ -426,7 +426,7 @@ service Instances {
       SetShieldedInstanceIntegrityPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setShieldedInstanceIntegrityPolicy"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setShieldedInstanceIntegrityPolicy"
       body: "shielded_instance_integrity_policy_resource"
     };
     option (google.api.method_signature) =
@@ -438,7 +438,7 @@ service Instances {
   // request.
   rpc SetTags(SetTagsRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/setTags"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/setTags"
       body: "tags_resource"
     };
     option (google.api.method_signature) =
@@ -451,7 +451,7 @@ service Instances {
   rpc SimulateMaintenanceEvent(SimulateMaintenanceEventRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/simulateMaintenanceEvent"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/simulateMaintenanceEvent"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,instance";
@@ -462,7 +462,7 @@ service Instances {
   // more information, see Restart an instance.
   rpc Start(StartRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/start"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/start"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,instance";
@@ -474,7 +474,7 @@ service Instances {
   rpc StartWithEncryptionKey(StartWithEncryptionKeyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/startWithEncryptionKey"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/startWithEncryptionKey"
       body: "instances_start_with_encryption_key_request_resource"
     };
     option (google.api.method_signature) =
@@ -490,7 +490,7 @@ service Instances {
   // instance.
   rpc Stop(StopRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/stop"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/stop"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,instance";
@@ -506,7 +506,7 @@ service Instances {
   // more information, see Suspending and resuming an instance.
   rpc Suspend(SuspendRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/suspend"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/suspend"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,instance";
@@ -517,7 +517,7 @@ service Instances {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =
@@ -530,7 +530,7 @@ service Instances {
   rpc UpdateInstances(UpdateInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}"
+      put: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}"
       body: "instance_resource"
     };
     option (google.api.method_signature) =
@@ -544,7 +544,7 @@ service Instances {
   rpc UpdateAccessConfig(UpdateAccessConfigRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/updateAccessConfig"
+      post: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/updateAccessConfig"
       body: "access_config_resource"
     };
     option (google.api.method_signature) =
@@ -558,7 +558,7 @@ service Instances {
   rpc UpdateDisplayDevice(UpdateDisplayDeviceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/updateDisplayDevice"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/updateDisplayDevice"
       body: "display_device_resource"
     };
     option (google.api.method_signature) =
@@ -574,7 +574,7 @@ service Instances {
   rpc UpdateNetworkInterface(UpdateNetworkInterfaceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/updateNetworkInterface"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/updateNetworkInterface"
       body: "network_interface_resource"
     };
     option (google.api.method_signature) =
@@ -588,7 +588,7 @@ service Instances {
   rpc UpdateShieldedInstanceConfig(UpdateShieldedInstanceConfigRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/instances/{instance=instance}/updateShieldedInstanceConfig"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/updateShieldedInstanceConfig"
       body: "shielded_instance_config_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments.proto
+++ b/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments.proto
@@ -42,7 +42,7 @@ service InterconnectAttachments {
       returns (
           google.cloud.cpp.compute.v1.InterconnectAttachmentAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/interconnectAttachments"
+      get: "/compute/v1/projects/{project}/aggregated/interconnectAttachments"
     };
     option (google.api.method_signature) = "project";
   }
@@ -51,7 +51,7 @@ service InterconnectAttachments {
   rpc DeleteInterconnectAttachments(DeleteInterconnectAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/interconnectAttachments/{interconnect_attachment=interconnect_attachment}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/interconnectAttachments/{interconnect_attachment}"
     };
     option (google.api.method_signature) =
         "project,region,interconnect_attachment";
@@ -62,7 +62,7 @@ service InterconnectAttachments {
   rpc GetInterconnectAttachments(GetInterconnectAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.InterconnectAttachment) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/interconnectAttachments/{interconnect_attachment=interconnect_attachment}"
+      get: "/compute/v1/projects/{project}/regions/{region}/interconnectAttachments/{interconnect_attachment}"
     };
     option (google.api.method_signature) =
         "project,region,interconnect_attachment";
@@ -73,7 +73,7 @@ service InterconnectAttachments {
   rpc InsertInterconnectAttachments(InsertInterconnectAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/interconnectAttachments"
+      post: "/compute/v1/projects/{project}/regions/{region}/interconnectAttachments"
       body: "interconnect_attachment_resource"
     };
     option (google.api.method_signature) =
@@ -86,7 +86,7 @@ service InterconnectAttachments {
   rpc ListInterconnectAttachments(ListInterconnectAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.InterconnectAttachmentList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/interconnectAttachments"
+      get: "/compute/v1/projects/{project}/regions/{region}/interconnectAttachments"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -97,7 +97,7 @@ service InterconnectAttachments {
   rpc PatchInterconnectAttachments(PatchInterconnectAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/interconnectAttachments/{interconnect_attachment=interconnect_attachment}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/interconnectAttachments/{interconnect_attachment}"
       body: "interconnect_attachment_resource"
     };
     option (google.api.method_signature) =
@@ -110,7 +110,7 @@ service InterconnectAttachments {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/interconnectAttachments/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/regions/{region}/interconnectAttachments/{resource}/setLabels"
       body: "region_set_labels_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/interconnect_locations/v1/interconnect_locations.proto
+++ b/google/cloud/compute/interconnect_locations/v1/interconnect_locations.proto
@@ -40,7 +40,7 @@ service InterconnectLocations {
   rpc GetInterconnectLocations(GetInterconnectLocationsRequest)
       returns (google.cloud.cpp.compute.v1.InterconnectLocation) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/interconnectLocations/{interconnect_location=interconnect_location}"
+      get: "/compute/v1/projects/{project}/global/interconnectLocations/{interconnect_location}"
     };
     option (google.api.method_signature) = "project,interconnect_location";
   }
@@ -50,7 +50,7 @@ service InterconnectLocations {
   rpc ListInterconnectLocations(ListInterconnectLocationsRequest)
       returns (google.cloud.cpp.compute.v1.InterconnectLocationList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/interconnectLocations"
+      get: "/compute/v1/projects/{project}/global/interconnectLocations"
     };
     option (google.api.method_signature) = "project";
   }

--- a/google/cloud/compute/interconnects/v1/interconnects.proto
+++ b/google/cloud/compute/interconnects/v1/interconnects.proto
@@ -40,7 +40,7 @@ service Interconnects {
   rpc DeleteInterconnects(DeleteInterconnectsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/interconnects/{interconnect=interconnect}"
+      delete: "/compute/v1/projects/{project}/global/interconnects/{interconnect}"
     };
     option (google.api.method_signature) = "project,interconnect";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -51,7 +51,7 @@ service Interconnects {
   rpc GetInterconnects(GetInterconnectsRequest)
       returns (google.cloud.cpp.compute.v1.Interconnect) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/interconnects/{interconnect=interconnect}"
+      get: "/compute/v1/projects/{project}/global/interconnects/{interconnect}"
     };
     option (google.api.method_signature) = "project,interconnect";
   }
@@ -60,7 +60,7 @@ service Interconnects {
   rpc GetDiagnostics(GetDiagnosticsRequest) returns (
       google.cloud.cpp.compute.v1.InterconnectsGetDiagnosticsResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/interconnects/{interconnect=interconnect}/getDiagnostics"
+      get: "/compute/v1/projects/{project}/global/interconnects/{interconnect}/getDiagnostics"
     };
     option (google.api.method_signature) = "project,interconnect";
   }
@@ -70,7 +70,7 @@ service Interconnects {
   rpc InsertInterconnects(InsertInterconnectsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/interconnects"
+      post: "/compute/v1/projects/{project}/global/interconnects"
       body: "interconnect_resource"
     };
     option (google.api.method_signature) = "project,interconnect_resource";
@@ -81,7 +81,7 @@ service Interconnects {
   rpc ListInterconnects(ListInterconnectsRequest)
       returns (google.cloud.cpp.compute.v1.InterconnectList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/interconnects"
+      get: "/compute/v1/projects/{project}/global/interconnects"
     };
     option (google.api.method_signature) = "project";
   }
@@ -92,7 +92,7 @@ service Interconnects {
   rpc PatchInterconnects(PatchInterconnectsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/interconnects/{interconnect=interconnect}"
+      patch: "/compute/v1/projects/{project}/global/interconnects/{interconnect}"
       body: "interconnect_resource"
     };
     option (google.api.method_signature) =
@@ -105,7 +105,7 @@ service Interconnects {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/interconnects/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/global/interconnects/{resource}/setLabels"
       body: "global_set_labels_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/license_codes/v1/license_codes.proto
+++ b/google/cloud/compute/license_codes/v1/license_codes.proto
@@ -42,7 +42,7 @@ service LicenseCodes {
   rpc GetLicenseCodes(GetLicenseCodesRequest)
       returns (google.cloud.cpp.compute.v1.LicenseCode) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/licenseCodes/{license_code=license_code}"
+      get: "/compute/v1/projects/{project}/global/licenseCodes/{license_code}"
     };
     option (google.api.method_signature) = "project,license_code";
   }
@@ -53,7 +53,7 @@ service LicenseCodes {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/licenseCodes/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/global/licenseCodes/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/licenses/v1/licenses.proto
+++ b/google/cloud/compute/licenses/v1/licenses.proto
@@ -44,7 +44,7 @@ service Licenses {
   rpc DeleteLicenses(DeleteLicensesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/licenses/{license=license}"
+      delete: "/compute/v1/projects/{project}/global/licenses/{license}"
     };
     option (google.api.method_signature) = "project,license";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -56,7 +56,7 @@ service Licenses {
   rpc GetLicenses(GetLicensesRequest)
       returns (google.cloud.cpp.compute.v1.License) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/licenses/{license=license}"
+      get: "/compute/v1/projects/{project}/global/licenses/{license}"
     };
     option (google.api.method_signature) = "project,license";
   }
@@ -67,7 +67,7 @@ service Licenses {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/licenses/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/global/licenses/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,resource";
   }
@@ -78,7 +78,7 @@ service Licenses {
   rpc InsertLicenses(InsertLicensesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/licenses"
+      post: "/compute/v1/projects/{project}/global/licenses"
       body: "license_resource"
     };
     option (google.api.method_signature) = "project,license_resource";
@@ -95,7 +95,7 @@ service Licenses {
   rpc ListLicenses(ListLicensesRequest)
       returns (google.cloud.cpp.compute.v1.LicensesListResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/licenses"
+      get: "/compute/v1/projects/{project}/global/licenses"
     };
     option (google.api.method_signature) = "project";
   }
@@ -106,7 +106,7 @@ service Licenses {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/licenses/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/global/licenses/{resource}/setIamPolicy"
       body: "global_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -119,7 +119,7 @@ service Licenses {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/licenses/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/global/licenses/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/machine_images/v1/machine_images.proto
+++ b/google/cloud/compute/machine_images/v1/machine_images.proto
@@ -41,7 +41,7 @@ service MachineImages {
   rpc DeleteMachineImages(DeleteMachineImagesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/machineImages/{machine_image=machine_image}"
+      delete: "/compute/v1/projects/{project}/global/machineImages/{machine_image}"
     };
     option (google.api.method_signature) = "project,machine_image";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -51,7 +51,7 @@ service MachineImages {
   rpc GetMachineImages(GetMachineImagesRequest)
       returns (google.cloud.cpp.compute.v1.MachineImage) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/machineImages/{machine_image=machine_image}"
+      get: "/compute/v1/projects/{project}/global/machineImages/{machine_image}"
     };
     option (google.api.method_signature) = "project,machine_image";
   }
@@ -61,7 +61,7 @@ service MachineImages {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/machineImages/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/global/machineImages/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,resource";
   }
@@ -73,7 +73,7 @@ service MachineImages {
   rpc InsertMachineImages(InsertMachineImagesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/machineImages"
+      post: "/compute/v1/projects/{project}/global/machineImages"
       body: "machine_image_resource"
     };
     option (google.api.method_signature) = "project,machine_image_resource";
@@ -85,7 +85,7 @@ service MachineImages {
   rpc ListMachineImages(ListMachineImagesRequest)
       returns (google.cloud.cpp.compute.v1.MachineImageList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/machineImages"
+      get: "/compute/v1/projects/{project}/global/machineImages"
     };
     option (google.api.method_signature) = "project";
   }
@@ -95,7 +95,7 @@ service MachineImages {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/machineImages/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/global/machineImages/{resource}/setIamPolicy"
       body: "global_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -106,7 +106,7 @@ service MachineImages {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/machineImages/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/global/machineImages/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/machine_types/v1/machine_types.proto
+++ b/google/cloud/compute/machine_types/v1/machine_types.proto
@@ -39,7 +39,7 @@ service MachineTypes {
   rpc AggregatedListMachineTypes(AggregatedListMachineTypesRequest)
       returns (google.cloud.cpp.compute.v1.MachineTypeAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/machineTypes"
+      get: "/compute/v1/projects/{project}/aggregated/machineTypes"
     };
     option (google.api.method_signature) = "project";
   }
@@ -48,7 +48,7 @@ service MachineTypes {
   rpc GetMachineTypes(GetMachineTypesRequest)
       returns (google.cloud.cpp.compute.v1.MachineType) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/machineTypes/{machine_type=machine_type}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/machineTypes/{machine_type}"
     };
     option (google.api.method_signature) = "project,zone,machine_type";
   }
@@ -57,7 +57,7 @@ service MachineTypes {
   rpc ListMachineTypes(ListMachineTypesRequest)
       returns (google.cloud.cpp.compute.v1.MachineTypeList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/machineTypes"
+      get: "/compute/v1/projects/{project}/zones/{zone}/machineTypes"
     };
     option (google.api.method_signature) = "project,zone";
   }

--- a/google/cloud/compute/network_attachments/v1/network_attachments.proto
+++ b/google/cloud/compute/network_attachments/v1/network_attachments.proto
@@ -41,7 +41,7 @@ service NetworkAttachments {
   rpc AggregatedListNetworkAttachments(AggregatedListNetworkAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkAttachmentAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/networkAttachments"
+      get: "/compute/v1/projects/{project}/aggregated/networkAttachments"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service NetworkAttachments {
   rpc DeleteNetworkAttachments(DeleteNetworkAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/networkAttachments/{network_attachment=network_attachment}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/networkAttachments/{network_attachment}"
     };
     option (google.api.method_signature) = "project,region,network_attachment";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -60,7 +60,7 @@ service NetworkAttachments {
   rpc GetNetworkAttachments(GetNetworkAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkAttachment) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/networkAttachments/{network_attachment=network_attachment}"
+      get: "/compute/v1/projects/{project}/regions/{region}/networkAttachments/{network_attachment}"
     };
     option (google.api.method_signature) = "project,region,network_attachment";
   }
@@ -70,7 +70,7 @@ service NetworkAttachments {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/networkAttachments/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/regions/{region}/networkAttachments/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,region,resource";
   }
@@ -80,7 +80,7 @@ service NetworkAttachments {
   rpc InsertNetworkAttachments(InsertNetworkAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/networkAttachments"
+      post: "/compute/v1/projects/{project}/regions/{region}/networkAttachments"
       body: "network_attachment_resource"
     };
     option (google.api.method_signature) =
@@ -92,7 +92,7 @@ service NetworkAttachments {
   rpc ListNetworkAttachments(ListNetworkAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkAttachmentList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/networkAttachments"
+      get: "/compute/v1/projects/{project}/regions/{region}/networkAttachments"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -102,7 +102,7 @@ service NetworkAttachments {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/networkAttachments/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/regions/{region}/networkAttachments/{resource}/setIamPolicy"
       body: "region_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -113,7 +113,7 @@ service NetworkAttachments {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/networkAttachments/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/networkAttachments/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services.proto
+++ b/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services.proto
@@ -43,7 +43,7 @@ service NetworkEdgeSecurityServices {
       returns (google.cloud.cpp.compute.v1
                    .NetworkEdgeSecurityServiceAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/networkEdgeSecurityServices"
+      get: "/compute/v1/projects/{project}/aggregated/networkEdgeSecurityServices"
     };
     option (google.api.method_signature) = "project";
   }
@@ -53,7 +53,7 @@ service NetworkEdgeSecurityServices {
       DeleteNetworkEdgeSecurityServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/networkEdgeSecurityServices/{network_edge_security_service=network_edge_security_service}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/networkEdgeSecurityServices/{network_edge_security_service}"
     };
     option (google.api.method_signature) =
         "project,region,network_edge_security_service";
@@ -64,7 +64,7 @@ service NetworkEdgeSecurityServices {
   rpc GetNetworkEdgeSecurityServices(GetNetworkEdgeSecurityServicesRequest)
       returns (google.cloud.cpp.compute.v1.NetworkEdgeSecurityService) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/networkEdgeSecurityServices/{network_edge_security_service=network_edge_security_service}"
+      get: "/compute/v1/projects/{project}/regions/{region}/networkEdgeSecurityServices/{network_edge_security_service}"
     };
     option (google.api.method_signature) =
         "project,region,network_edge_security_service";
@@ -76,7 +76,7 @@ service NetworkEdgeSecurityServices {
       InsertNetworkEdgeSecurityServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/networkEdgeSecurityServices"
+      post: "/compute/v1/projects/{project}/regions/{region}/networkEdgeSecurityServices"
       body: "network_edge_security_service_resource"
     };
     option (google.api.method_signature) =
@@ -88,7 +88,7 @@ service NetworkEdgeSecurityServices {
   rpc PatchNetworkEdgeSecurityServices(PatchNetworkEdgeSecurityServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/networkEdgeSecurityServices/{network_edge_security_service=network_edge_security_service}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/networkEdgeSecurityServices/{network_edge_security_service}"
       body: "network_edge_security_service_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups.proto
+++ b/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups.proto
@@ -41,7 +41,7 @@ service NetworkEndpointGroups {
       AggregatedListNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkEndpointGroupAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/networkEndpointGroups"
+      get: "/compute/v1/projects/{project}/aggregated/networkEndpointGroups"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service NetworkEndpointGroups {
   rpc AttachNetworkEndpoints(AttachNetworkEndpointsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}/attachNetworkEndpoints"
+      post: "/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups/{network_endpoint_group}/attachNetworkEndpoints"
       body: "network_endpoint_groups_attach_endpoints_request_resource"
     };
     option (google.api.method_signature) =
@@ -65,7 +65,7 @@ service NetworkEndpointGroups {
   rpc DeleteNetworkEndpointGroups(DeleteNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups/{network_endpoint_group}"
     };
     option (google.api.method_signature) =
         "project,zone,network_endpoint_group";
@@ -77,7 +77,7 @@ service NetworkEndpointGroups {
   rpc DetachNetworkEndpoints(DetachNetworkEndpointsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}/detachNetworkEndpoints"
+      post: "/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups/{network_endpoint_group}/detachNetworkEndpoints"
       body: "network_endpoint_groups_detach_endpoints_request_resource"
     };
     option (google.api.method_signature) =
@@ -89,7 +89,7 @@ service NetworkEndpointGroups {
   rpc GetNetworkEndpointGroups(GetNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkEndpointGroup) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups/{network_endpoint_group}"
     };
     option (google.api.method_signature) =
         "project,zone,network_endpoint_group";
@@ -100,7 +100,7 @@ service NetworkEndpointGroups {
   rpc InsertNetworkEndpointGroups(InsertNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/networkEndpointGroups"
+      post: "/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups"
       body: "network_endpoint_group_resource"
     };
     option (google.api.method_signature) =
@@ -113,7 +113,7 @@ service NetworkEndpointGroups {
   rpc ListNetworkEndpointGroups(ListNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkEndpointGroupList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/networkEndpointGroups"
+      get: "/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -122,7 +122,7 @@ service NetworkEndpointGroups {
   rpc ListNetworkEndpoints(ListNetworkEndpointsRequest) returns (
       google.cloud.cpp.compute.v1.NetworkEndpointGroupsListNetworkEndpoints) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}/listNetworkEndpoints"
+      post: "/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups/{network_endpoint_group}/listNetworkEndpoints"
       body: "network_endpoint_groups_list_endpoints_request_resource"
     };
     option (google.api.method_signature) =
@@ -133,7 +133,7 @@ service NetworkEndpointGroups {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/networkEndpointGroups/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies.proto
+++ b/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies.proto
@@ -40,7 +40,7 @@ service NetworkFirewallPolicies {
   rpc AddAssociation(AddAssociationRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}/addAssociation"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}/addAssociation"
       body: "firewall_policy_association_resource"
     };
     option (google.api.method_signature) =
@@ -51,7 +51,7 @@ service NetworkFirewallPolicies {
   // Inserts a rule into a firewall policy.
   rpc AddRule(AddRuleRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}/addRule"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}/addRule"
       body: "firewall_policy_rule_resource"
     };
     option (google.api.method_signature) =
@@ -63,7 +63,7 @@ service NetworkFirewallPolicies {
   rpc CloneRules(CloneRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}/cloneRules"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}/cloneRules"
       body: "*"
     };
     option (google.api.method_signature) = "project,firewall_policy";
@@ -74,7 +74,7 @@ service NetworkFirewallPolicies {
   rpc DeleteNetworkFirewallPolicies(DeleteNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}"
+      delete: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}"
     };
     option (google.api.method_signature) = "project,firewall_policy";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -84,7 +84,7 @@ service NetworkFirewallPolicies {
   rpc GetNetworkFirewallPolicies(GetNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}"
+      get: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}"
     };
     option (google.api.method_signature) = "project,firewall_policy";
   }
@@ -93,7 +93,7 @@ service NetworkFirewallPolicies {
   rpc GetAssociation(GetAssociationRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicyAssociation) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}/getAssociation"
+      get: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}/getAssociation"
     };
     option (google.api.method_signature) = "project,firewall_policy";
   }
@@ -103,7 +103,7 @@ service NetworkFirewallPolicies {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/firewallPolicies/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/global/firewallPolicies/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,resource";
   }
@@ -112,7 +112,7 @@ service NetworkFirewallPolicies {
   rpc GetRule(GetRuleRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicyRule) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}/getRule"
+      get: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}/getRule"
     };
     option (google.api.method_signature) = "project,firewall_policy";
   }
@@ -122,7 +122,7 @@ service NetworkFirewallPolicies {
   rpc InsertNetworkFirewallPolicies(InsertNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies"
       body: "firewall_policy_resource"
     };
     option (google.api.method_signature) = "project,firewall_policy_resource";
@@ -133,7 +133,7 @@ service NetworkFirewallPolicies {
   rpc ListNetworkFirewallPolicies(ListNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/firewallPolicies"
+      get: "/compute/v1/projects/{project}/global/firewallPolicies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -142,7 +142,7 @@ service NetworkFirewallPolicies {
   rpc PatchNetworkFirewallPolicies(PatchNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}"
+      patch: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}"
       body: "firewall_policy_resource"
     };
     option (google.api.method_signature) =
@@ -154,7 +154,7 @@ service NetworkFirewallPolicies {
   rpc PatchRule(PatchRuleRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}/patchRule"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}/patchRule"
       body: "firewall_policy_rule_resource"
     };
     option (google.api.method_signature) =
@@ -166,7 +166,7 @@ service NetworkFirewallPolicies {
   rpc RemoveAssociation(RemoveAssociationRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}/removeAssociation"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}/removeAssociation"
       body: "*"
     };
     option (google.api.method_signature) = "project,firewall_policy";
@@ -177,7 +177,7 @@ service NetworkFirewallPolicies {
   rpc RemoveRule(RemoveRuleRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies/{firewall_policy=firewall_policy}/removeRule"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies/{firewall_policy}/removeRule"
       body: "*"
     };
     option (google.api.method_signature) = "project,firewall_policy";
@@ -189,7 +189,7 @@ service NetworkFirewallPolicies {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies/{resource}/setIamPolicy"
       body: "global_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -200,7 +200,7 @@ service NetworkFirewallPolicies {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/firewallPolicies/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/global/firewallPolicies/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/networks/v1/networks.proto
+++ b/google/cloud/compute/networks/v1/networks.proto
@@ -40,7 +40,7 @@ service Networks {
   rpc AddPeering(AddPeeringRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/networks/{network=network}/addPeering"
+      post: "/compute/v1/projects/{project}/global/networks/{network}/addPeering"
       body: "networks_add_peering_request_resource"
     };
     option (google.api.method_signature) =
@@ -52,7 +52,7 @@ service Networks {
   rpc DeleteNetworks(DeleteNetworksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/networks/{network=network}"
+      delete: "/compute/v1/projects/{project}/global/networks/{network}"
     };
     option (google.api.method_signature) = "project,network";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -62,7 +62,7 @@ service Networks {
   rpc GetNetworks(GetNetworksRequest)
       returns (google.cloud.cpp.compute.v1.Network) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/networks/{network=network}"
+      get: "/compute/v1/projects/{project}/global/networks/{network}"
     };
     option (google.api.method_signature) = "project,network";
   }
@@ -71,7 +71,7 @@ service Networks {
   rpc GetEffectiveFirewalls(GetEffectiveFirewallsRequest) returns (
       google.cloud.cpp.compute.v1.NetworksGetEffectiveFirewallsResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/networks/{network=network}/getEffectiveFirewalls"
+      get: "/compute/v1/projects/{project}/global/networks/{network}/getEffectiveFirewalls"
     };
     option (google.api.method_signature) = "project,network";
   }
@@ -81,7 +81,7 @@ service Networks {
   rpc InsertNetworks(InsertNetworksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/networks"
+      post: "/compute/v1/projects/{project}/global/networks"
       body: "network_resource"
     };
     option (google.api.method_signature) = "project,network_resource";
@@ -92,7 +92,7 @@ service Networks {
   rpc ListNetworks(ListNetworksRequest)
       returns (google.cloud.cpp.compute.v1.NetworkList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/networks"
+      get: "/compute/v1/projects/{project}/global/networks"
     };
     option (google.api.method_signature) = "project";
   }
@@ -101,7 +101,7 @@ service Networks {
   rpc ListPeeringRoutes(ListPeeringRoutesRequest)
       returns (google.cloud.cpp.compute.v1.ExchangedPeeringRoutesList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/networks/{network=network}/listPeeringRoutes"
+      get: "/compute/v1/projects/{project}/global/networks/{network}/listPeeringRoutes"
     };
     option (google.api.method_signature) = "project,network";
   }
@@ -111,7 +111,7 @@ service Networks {
   rpc PatchNetworks(PatchNetworksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/networks/{network=network}"
+      patch: "/compute/v1/projects/{project}/global/networks/{network}"
       body: "network_resource"
     };
     option (google.api.method_signature) = "project,network,network_resource";
@@ -122,7 +122,7 @@ service Networks {
   rpc RemovePeering(RemovePeeringRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/networks/{network=network}/removePeering"
+      post: "/compute/v1/projects/{project}/global/networks/{network}/removePeering"
       body: "networks_remove_peering_request_resource"
     };
     option (google.api.method_signature) =
@@ -134,7 +134,7 @@ service Networks {
   rpc SwitchToCustomMode(SwitchToCustomModeRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/networks/{network=network}/switchToCustomMode"
+      post: "/compute/v1/projects/{project}/global/networks/{network}/switchToCustomMode"
       body: "*"
     };
     option (google.api.method_signature) = "project,network";
@@ -147,7 +147,7 @@ service Networks {
   rpc UpdatePeering(UpdatePeeringRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/networks/{network=network}/updatePeering"
+      patch: "/compute/v1/projects/{project}/global/networks/{network}/updatePeering"
       body: "networks_update_peering_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/node_groups/v1/node_groups.proto
+++ b/google/cloud/compute/node_groups/v1/node_groups.proto
@@ -40,7 +40,7 @@ service NodeGroups {
   rpc AddNodes(AddNodesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{node_group=node_group}/addNodes"
+      post: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{node_group}/addNodes"
       body: "node_groups_add_nodes_request_resource"
     };
     option (google.api.method_signature) =
@@ -53,7 +53,7 @@ service NodeGroups {
   rpc AggregatedListNodeGroups(AggregatedListNodeGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NodeGroupAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/nodeGroups"
+      get: "/compute/v1/projects/{project}/aggregated/nodeGroups"
     };
     option (google.api.method_signature) = "project";
   }
@@ -62,7 +62,7 @@ service NodeGroups {
   rpc DeleteNodeGroups(DeleteNodeGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{node_group=node_group}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{node_group}"
     };
     option (google.api.method_signature) = "project,zone,node_group";
     option (google.cloud.operation_service) = "ZoneOperations";
@@ -72,7 +72,7 @@ service NodeGroups {
   rpc DeleteNodes(DeleteNodesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{node_group=node_group}/deleteNodes"
+      post: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{node_group}/deleteNodes"
       body: "node_groups_delete_nodes_request_resource"
     };
     option (google.api.method_signature) =
@@ -86,7 +86,7 @@ service NodeGroups {
   rpc GetNodeGroups(GetNodeGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NodeGroup) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{node_group=node_group}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{node_group}"
     };
     option (google.api.method_signature) = "project,zone,node_group";
   }
@@ -96,7 +96,7 @@ service NodeGroups {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,zone,resource";
   }
@@ -106,7 +106,7 @@ service NodeGroups {
   rpc InsertNodeGroups(InsertNodeGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups"
+      post: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups"
       body: "node_group_resource"
     };
     option (google.api.method_signature) =
@@ -119,7 +119,7 @@ service NodeGroups {
   rpc ListNodeGroups(ListNodeGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NodeGroupList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups"
+      get: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -128,7 +128,7 @@ service NodeGroups {
   rpc ListNodes(ListNodesRequest)
       returns (google.cloud.cpp.compute.v1.NodeGroupsListNodes) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{node_group=node_group}/listNodes"
+      post: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{node_group}/listNodes"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,node_group";
@@ -138,7 +138,7 @@ service NodeGroups {
   rpc PatchNodeGroups(PatchNodeGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{node_group=node_group}"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{node_group}"
       body: "node_group_resource"
     };
     option (google.api.method_signature) =
@@ -151,7 +151,7 @@ service NodeGroups {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{resource}/setIamPolicy"
       body: "zone_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -162,7 +162,7 @@ service NodeGroups {
   rpc SetNodeTemplate(SetNodeTemplateRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{node_group=node_group}/setNodeTemplate"
+      post: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{node_group}/setNodeTemplate"
       body: "node_groups_set_node_template_request_resource"
     };
     option (google.api.method_signature) =
@@ -174,7 +174,7 @@ service NodeGroups {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeGroups/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/node_templates/v1/node_templates.proto
+++ b/google/cloud/compute/node_templates/v1/node_templates.proto
@@ -40,7 +40,7 @@ service NodeTemplates {
   rpc AggregatedListNodeTemplates(AggregatedListNodeTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.NodeTemplateAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/nodeTemplates"
+      get: "/compute/v1/projects/{project}/aggregated/nodeTemplates"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service NodeTemplates {
   rpc DeleteNodeTemplates(DeleteNodeTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/nodeTemplates/{node_template=node_template}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/nodeTemplates/{node_template}"
     };
     option (google.api.method_signature) = "project,region,node_template";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service NodeTemplates {
   rpc GetNodeTemplates(GetNodeTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.NodeTemplate) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/nodeTemplates/{node_template=node_template}"
+      get: "/compute/v1/projects/{project}/regions/{region}/nodeTemplates/{node_template}"
     };
     option (google.api.method_signature) = "project,region,node_template";
   }
@@ -69,7 +69,7 @@ service NodeTemplates {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/nodeTemplates/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/regions/{region}/nodeTemplates/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,region,resource";
   }
@@ -79,7 +79,7 @@ service NodeTemplates {
   rpc InsertNodeTemplates(InsertNodeTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/nodeTemplates"
+      post: "/compute/v1/projects/{project}/regions/{region}/nodeTemplates"
       body: "node_template_resource"
     };
     option (google.api.method_signature) =
@@ -91,7 +91,7 @@ service NodeTemplates {
   rpc ListNodeTemplates(ListNodeTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.NodeTemplateList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/nodeTemplates"
+      get: "/compute/v1/projects/{project}/regions/{region}/nodeTemplates"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -101,7 +101,7 @@ service NodeTemplates {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/nodeTemplates/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/regions/{region}/nodeTemplates/{resource}/setIamPolicy"
       body: "region_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -112,7 +112,7 @@ service NodeTemplates {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/nodeTemplates/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/nodeTemplates/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/node_types/v1/node_types.proto
+++ b/google/cloud/compute/node_types/v1/node_types.proto
@@ -39,7 +39,7 @@ service NodeTypes {
   rpc AggregatedListNodeTypes(AggregatedListNodeTypesRequest)
       returns (google.cloud.cpp.compute.v1.NodeTypeAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/nodeTypes"
+      get: "/compute/v1/projects/{project}/aggregated/nodeTypes"
     };
     option (google.api.method_signature) = "project";
   }
@@ -48,7 +48,7 @@ service NodeTypes {
   rpc GetNodeTypes(GetNodeTypesRequest)
       returns (google.cloud.cpp.compute.v1.NodeType) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeTypes/{node_type=node_type}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/nodeTypes/{node_type}"
     };
     option (google.api.method_signature) = "project,zone,node_type";
   }
@@ -57,7 +57,7 @@ service NodeTypes {
   rpc ListNodeTypes(ListNodeTypesRequest)
       returns (google.cloud.cpp.compute.v1.NodeTypeList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/nodeTypes"
+      get: "/compute/v1/projects/{project}/zones/{zone}/nodeTypes"
     };
     option (google.api.method_signature) = "project,zone";
   }

--- a/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings.proto
+++ b/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings.proto
@@ -40,7 +40,7 @@ service PacketMirrorings {
   rpc AggregatedListPacketMirrorings(AggregatedListPacketMirroringsRequest)
       returns (google.cloud.cpp.compute.v1.PacketMirroringAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/packetMirrorings"
+      get: "/compute/v1/projects/{project}/aggregated/packetMirrorings"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service PacketMirrorings {
   rpc DeletePacketMirrorings(DeletePacketMirroringsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/packetMirrorings/{packet_mirroring=packet_mirroring}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/packetMirrorings/{packet_mirroring}"
     };
     option (google.api.method_signature) = "project,region,packet_mirroring";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service PacketMirrorings {
   rpc GetPacketMirrorings(GetPacketMirroringsRequest)
       returns (google.cloud.cpp.compute.v1.PacketMirroring) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/packetMirrorings/{packet_mirroring=packet_mirroring}"
+      get: "/compute/v1/projects/{project}/regions/{region}/packetMirrorings/{packet_mirroring}"
     };
     option (google.api.method_signature) = "project,region,packet_mirroring";
   }
@@ -69,7 +69,7 @@ service PacketMirrorings {
   rpc InsertPacketMirrorings(InsertPacketMirroringsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/packetMirrorings"
+      post: "/compute/v1/projects/{project}/regions/{region}/packetMirrorings"
       body: "packet_mirroring_resource"
     };
     option (google.api.method_signature) =
@@ -82,7 +82,7 @@ service PacketMirrorings {
   rpc ListPacketMirrorings(ListPacketMirroringsRequest)
       returns (google.cloud.cpp.compute.v1.PacketMirroringList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/packetMirrorings"
+      get: "/compute/v1/projects/{project}/regions/{region}/packetMirrorings"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -93,7 +93,7 @@ service PacketMirrorings {
   rpc PatchPacketMirrorings(PatchPacketMirroringsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/packetMirrorings/{packet_mirroring=packet_mirroring}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/packetMirrorings/{packet_mirroring}"
       body: "packet_mirroring_resource"
     };
     option (google.api.method_signature) =
@@ -105,7 +105,7 @@ service PacketMirrorings {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/packetMirrorings/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/packetMirrorings/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/projects/v1/projects.proto
+++ b/google/cloud/compute/projects/v1/projects.proto
@@ -43,7 +43,7 @@ service Projects {
   rpc DisableXpnHost(DisableXpnHostRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/disableXpnHost"
+      post: "/compute/v1/projects/{project}/disableXpnHost"
       body: "*"
     };
     option (google.api.method_signature) = "project";
@@ -55,7 +55,7 @@ service Projects {
   rpc DisableXpnResource(DisableXpnResourceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/disableXpnResource"
+      post: "/compute/v1/projects/{project}/disableXpnResource"
       body: "projects_disable_xpn_resource_request_resource"
     };
     option (google.api.method_signature) =
@@ -67,7 +67,7 @@ service Projects {
   rpc EnableXpnHost(EnableXpnHostRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/enableXpnHost"
+      post: "/compute/v1/projects/{project}/enableXpnHost"
       body: "*"
     };
     option (google.api.method_signature) = "project";
@@ -80,7 +80,7 @@ service Projects {
   rpc EnableXpnResource(EnableXpnResourceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/enableXpnResource"
+      post: "/compute/v1/projects/{project}/enableXpnResource"
       body: "projects_enable_xpn_resource_request_resource"
     };
     option (google.api.method_signature) =
@@ -98,7 +98,7 @@ service Projects {
   rpc GetProjects(GetProjectsRequest)
       returns (google.cloud.cpp.compute.v1.Project) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}"
+      get: "/compute/v1/projects/{project}"
     };
     option (google.api.method_signature) = "project";
   }
@@ -108,7 +108,7 @@ service Projects {
   rpc GetXpnHost(GetXpnHostRequest)
       returns (google.cloud.cpp.compute.v1.Project) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/getXpnHost"
+      get: "/compute/v1/projects/{project}/getXpnHost"
     };
     option (google.api.method_signature) = "project";
   }
@@ -118,7 +118,7 @@ service Projects {
   rpc GetXpnResources(GetXpnResourcesRequest)
       returns (google.cloud.cpp.compute.v1.ProjectsGetXpnResources) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/getXpnResources"
+      get: "/compute/v1/projects/{project}/getXpnResources"
     };
     option (google.api.method_signature) = "project";
   }
@@ -127,7 +127,7 @@ service Projects {
   rpc ListXpnHosts(ListXpnHostsRequest)
       returns (google.cloud.cpp.compute.v1.XpnHostList) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/listXpnHosts"
+      post: "/compute/v1/projects/{project}/listXpnHosts"
       body: "projects_list_xpn_hosts_request_resource"
     };
     option (google.api.method_signature) =
@@ -138,7 +138,7 @@ service Projects {
   rpc MoveDisk(MoveDiskRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/moveDisk"
+      post: "/compute/v1/projects/{project}/moveDisk"
       body: "disk_move_request_resource"
     };
     option (google.api.method_signature) = "project,disk_move_request_resource";
@@ -152,7 +152,7 @@ service Projects {
   rpc MoveInstance(MoveInstanceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/moveInstance"
+      post: "/compute/v1/projects/{project}/moveInstance"
       body: "instance_move_request_resource"
     };
     option (google.api.method_signature) =
@@ -165,7 +165,7 @@ service Projects {
   rpc SetCommonInstanceMetadata(SetCommonInstanceMetadataRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/setCommonInstanceMetadata"
+      post: "/compute/v1/projects/{project}/setCommonInstanceMetadata"
       body: "metadata_resource"
     };
     option (google.api.method_signature) = "project,metadata_resource";
@@ -178,7 +178,7 @@ service Projects {
   rpc SetDefaultNetworkTier(SetDefaultNetworkTierRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/setDefaultNetworkTier"
+      post: "/compute/v1/projects/{project}/setDefaultNetworkTier"
       body: "projects_set_default_network_tier_request_resource"
     };
     option (google.api.method_signature) =
@@ -192,7 +192,7 @@ service Projects {
   rpc SetUsageExportBucket(SetUsageExportBucketRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/setUsageExportBucket"
+      post: "/compute/v1/projects/{project}/setUsageExportBucket"
       body: "usage_export_location_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes.proto
+++ b/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes.proto
@@ -40,7 +40,7 @@ service PublicAdvertisedPrefixes {
   rpc DeletePublicAdvertisedPrefixes(DeletePublicAdvertisedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/publicAdvertisedPrefixes/{public_advertised_prefix=public_advertised_prefix}"
+      delete: "/compute/v1/projects/{project}/global/publicAdvertisedPrefixes/{public_advertised_prefix}"
     };
     option (google.api.method_signature) = "project,public_advertised_prefix";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -50,7 +50,7 @@ service PublicAdvertisedPrefixes {
   rpc GetPublicAdvertisedPrefixes(GetPublicAdvertisedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.PublicAdvertisedPrefix) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/publicAdvertisedPrefixes/{public_advertised_prefix=public_advertised_prefix}"
+      get: "/compute/v1/projects/{project}/global/publicAdvertisedPrefixes/{public_advertised_prefix}"
     };
     option (google.api.method_signature) = "project,public_advertised_prefix";
   }
@@ -60,7 +60,7 @@ service PublicAdvertisedPrefixes {
   rpc InsertPublicAdvertisedPrefixes(InsertPublicAdvertisedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/publicAdvertisedPrefixes"
+      post: "/compute/v1/projects/{project}/global/publicAdvertisedPrefixes"
       body: "public_advertised_prefix_resource"
     };
     option (google.api.method_signature) =
@@ -72,7 +72,7 @@ service PublicAdvertisedPrefixes {
   rpc ListPublicAdvertisedPrefixes(ListPublicAdvertisedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.PublicAdvertisedPrefixList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/publicAdvertisedPrefixes"
+      get: "/compute/v1/projects/{project}/global/publicAdvertisedPrefixes"
     };
     option (google.api.method_signature) = "project";
   }
@@ -83,7 +83,7 @@ service PublicAdvertisedPrefixes {
   rpc PatchPublicAdvertisedPrefixes(PatchPublicAdvertisedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/publicAdvertisedPrefixes/{public_advertised_prefix=public_advertised_prefix}"
+      patch: "/compute/v1/projects/{project}/global/publicAdvertisedPrefixes/{public_advertised_prefix}"
       body: "public_advertised_prefix_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes.proto
+++ b/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes.proto
@@ -43,7 +43,7 @@ service PublicDelegatedPrefixes {
       returns (
           google.cloud.cpp.compute.v1.PublicDelegatedPrefixAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/publicDelegatedPrefixes"
+      get: "/compute/v1/projects/{project}/aggregated/publicDelegatedPrefixes"
     };
     option (google.api.method_signature) = "project";
   }
@@ -52,7 +52,7 @@ service PublicDelegatedPrefixes {
   rpc DeletePublicDelegatedPrefixes(DeletePublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/publicDelegatedPrefixes/{public_delegated_prefix=public_delegated_prefix}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/publicDelegatedPrefixes/{public_delegated_prefix}"
     };
     option (google.api.method_signature) =
         "project,region,public_delegated_prefix";
@@ -63,7 +63,7 @@ service PublicDelegatedPrefixes {
   rpc GetPublicDelegatedPrefixes(GetPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.PublicDelegatedPrefix) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/publicDelegatedPrefixes/{public_delegated_prefix=public_delegated_prefix}"
+      get: "/compute/v1/projects/{project}/regions/{region}/publicDelegatedPrefixes/{public_delegated_prefix}"
     };
     option (google.api.method_signature) =
         "project,region,public_delegated_prefix";
@@ -74,7 +74,7 @@ service PublicDelegatedPrefixes {
   rpc InsertPublicDelegatedPrefixes(InsertPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/publicDelegatedPrefixes"
+      post: "/compute/v1/projects/{project}/regions/{region}/publicDelegatedPrefixes"
       body: "public_delegated_prefix_resource"
     };
     option (google.api.method_signature) =
@@ -86,7 +86,7 @@ service PublicDelegatedPrefixes {
   rpc ListPublicDelegatedPrefixes(ListPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.PublicDelegatedPrefixList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/publicDelegatedPrefixes"
+      get: "/compute/v1/projects/{project}/regions/{region}/publicDelegatedPrefixes"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -97,7 +97,7 @@ service PublicDelegatedPrefixes {
   rpc PatchPublicDelegatedPrefixes(PatchPublicDelegatedPrefixesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/publicDelegatedPrefixes/{public_delegated_prefix=public_delegated_prefix}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/publicDelegatedPrefixes/{public_delegated_prefix}"
       body: "public_delegated_prefix_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_autoscalers/v1/region_autoscalers.proto
+++ b/google/cloud/compute/region_autoscalers/v1/region_autoscalers.proto
@@ -40,7 +40,7 @@ service RegionAutoscalers {
   rpc DeleteRegionAutoscalers(DeleteRegionAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/autoscalers/{autoscaler=autoscaler}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/autoscalers/{autoscaler}"
     };
     option (google.api.method_signature) = "project,region,autoscaler";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -50,7 +50,7 @@ service RegionAutoscalers {
   rpc GetRegionAutoscalers(GetRegionAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Autoscaler) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/autoscalers/{autoscaler=autoscaler}"
+      get: "/compute/v1/projects/{project}/regions/{region}/autoscalers/{autoscaler}"
     };
     option (google.api.method_signature) = "project,region,autoscaler";
   }
@@ -60,7 +60,7 @@ service RegionAutoscalers {
   rpc InsertRegionAutoscalers(InsertRegionAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/autoscalers"
+      post: "/compute/v1/projects/{project}/regions/{region}/autoscalers"
       body: "autoscaler_resource"
     };
     option (google.api.method_signature) = "project,region,autoscaler_resource";
@@ -71,7 +71,7 @@ service RegionAutoscalers {
   rpc ListRegionAutoscalers(ListRegionAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.RegionAutoscalerList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/autoscalers"
+      get: "/compute/v1/projects/{project}/regions/{region}/autoscalers"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -82,7 +82,7 @@ service RegionAutoscalers {
   rpc PatchRegionAutoscalers(PatchRegionAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/autoscalers"
+      patch: "/compute/v1/projects/{project}/regions/{region}/autoscalers"
       body: "autoscaler_resource"
     };
     option (google.api.method_signature) = "project,region,autoscaler_resource";
@@ -94,7 +94,7 @@ service RegionAutoscalers {
   rpc UpdateRegionAutoscalers(UpdateRegionAutoscalersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/regions/{region=region}/autoscalers"
+      put: "/compute/v1/projects/{project}/regions/{region}/autoscalers"
       body: "autoscaler_resource"
     };
     option (google.api.method_signature) = "project,region,autoscaler_resource";

--- a/google/cloud/compute/region_backend_services/v1/region_backend_services.proto
+++ b/google/cloud/compute/region_backend_services/v1/region_backend_services.proto
@@ -40,7 +40,7 @@ service RegionBackendServices {
   rpc DeleteRegionBackendServices(DeleteRegionBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices/{backend_service=backend_service}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/backendServices/{backend_service}"
     };
     option (google.api.method_signature) = "project,region,backend_service";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -50,7 +50,7 @@ service RegionBackendServices {
   rpc GetRegionBackendServices(GetRegionBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.BackendService) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices/{backend_service=backend_service}"
+      get: "/compute/v1/projects/{project}/regions/{region}/backendServices/{backend_service}"
     };
     option (google.api.method_signature) = "project,region,backend_service";
   }
@@ -59,7 +59,7 @@ service RegionBackendServices {
   rpc GetHealth(GetHealthRequest)
       returns (google.cloud.cpp.compute.v1.BackendServiceGroupHealth) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices/{backend_service=backend_service}/getHealth"
+      post: "/compute/v1/projects/{project}/regions/{region}/backendServices/{backend_service}/getHealth"
       body: "resource_group_reference_resource"
     };
     option (google.api.method_signature) =
@@ -71,7 +71,7 @@ service RegionBackendServices {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/regions/{region}/backendServices/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,region,resource";
   }
@@ -82,7 +82,7 @@ service RegionBackendServices {
   rpc InsertRegionBackendServices(InsertRegionBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices"
+      post: "/compute/v1/projects/{project}/regions/{region}/backendServices"
       body: "backend_service_resource"
     };
     option (google.api.method_signature) =
@@ -95,7 +95,7 @@ service RegionBackendServices {
   rpc ListRegionBackendServices(ListRegionBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.BackendServiceList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices"
+      get: "/compute/v1/projects/{project}/regions/{region}/backendServices"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -107,7 +107,7 @@ service RegionBackendServices {
   rpc PatchRegionBackendServices(PatchRegionBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices/{backend_service=backend_service}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/backendServices/{backend_service}"
       body: "backend_service_resource"
     };
     option (google.api.method_signature) =
@@ -120,7 +120,7 @@ service RegionBackendServices {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/regions/{region}/backendServices/{resource}/setIamPolicy"
       body: "region_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -133,7 +133,7 @@ service RegionBackendServices {
   rpc UpdateRegionBackendServices(UpdateRegionBackendServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/regions/{region=region}/backendServices/{backend_service=backend_service}"
+      put: "/compute/v1/projects/{project}/regions/{region}/backendServices/{backend_service}"
       body: "backend_service_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_commitments/v1/region_commitments.proto
+++ b/google/cloud/compute/region_commitments/v1/region_commitments.proto
@@ -40,7 +40,7 @@ service RegionCommitments {
   rpc AggregatedListRegionCommitments(AggregatedListRegionCommitmentsRequest)
       returns (google.cloud.cpp.compute.v1.CommitmentAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/commitments"
+      get: "/compute/v1/projects/{project}/aggregated/commitments"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service RegionCommitments {
   rpc GetRegionCommitments(GetRegionCommitmentsRequest)
       returns (google.cloud.cpp.compute.v1.Commitment) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/commitments/{commitment=commitment}"
+      get: "/compute/v1/projects/{project}/regions/{region}/commitments/{commitment}"
     };
     option (google.api.method_signature) = "project,region,commitment";
   }
@@ -59,7 +59,7 @@ service RegionCommitments {
   rpc InsertRegionCommitments(InsertRegionCommitmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/commitments"
+      post: "/compute/v1/projects/{project}/regions/{region}/commitments"
       body: "commitment_resource"
     };
     option (google.api.method_signature) = "project,region,commitment_resource";
@@ -70,7 +70,7 @@ service RegionCommitments {
   rpc ListRegionCommitments(ListRegionCommitmentsRequest)
       returns (google.cloud.cpp.compute.v1.CommitmentList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/commitments"
+      get: "/compute/v1/projects/{project}/regions/{region}/commitments"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -81,7 +81,7 @@ service RegionCommitments {
   rpc UpdateRegionCommitments(UpdateRegionCommitmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/commitments/{commitment=commitment}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/commitments/{commitment}"
       body: "commitment_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_disk_types/v1/region_disk_types.proto
+++ b/google/cloud/compute/region_disk_types/v1/region_disk_types.proto
@@ -39,7 +39,7 @@ service RegionDiskTypes {
   rpc GetRegionDiskTypes(GetRegionDiskTypesRequest)
       returns (google.cloud.cpp.compute.v1.DiskType) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/diskTypes/{disk_type=disk_type}"
+      get: "/compute/v1/projects/{project}/regions/{region}/diskTypes/{disk_type}"
     };
     option (google.api.method_signature) = "project,region,disk_type";
   }
@@ -48,7 +48,7 @@ service RegionDiskTypes {
   rpc ListRegionDiskTypes(ListRegionDiskTypesRequest)
       returns (google.cloud.cpp.compute.v1.RegionDiskTypeList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/diskTypes"
+      get: "/compute/v1/projects/{project}/regions/{region}/diskTypes"
     };
     option (google.api.method_signature) = "project,region";
   }

--- a/google/cloud/compute/region_disks/v1/region_disks.proto
+++ b/google/cloud/compute/region_disks/v1/region_disks.proto
@@ -41,7 +41,7 @@ service RegionDisks {
   rpc AddResourcePolicies(AddResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{disk=disk}/addResourcePolicies"
+      post: "/compute/v1/projects/{project}/regions/{region}/disks/{disk}/addResourcePolicies"
       body: "region_disks_add_resource_policies_request_resource"
     };
     option (google.api.method_signature) =
@@ -56,7 +56,7 @@ service RegionDisks {
   rpc CreateSnapshot(CreateSnapshotRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{disk=disk}/createSnapshot"
+      post: "/compute/v1/projects/{project}/regions/{region}/disks/{disk}/createSnapshot"
       body: "snapshot_resource"
     };
     option (google.api.method_signature) =
@@ -71,7 +71,7 @@ service RegionDisks {
   rpc DeleteRegionDisks(DeleteRegionDisksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{disk=disk}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/disks/{disk}"
     };
     option (google.api.method_signature) = "project,region,disk";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -81,7 +81,7 @@ service RegionDisks {
   rpc GetRegionDisks(GetRegionDisksRequest)
       returns (google.cloud.cpp.compute.v1.Disk) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{disk=disk}"
+      get: "/compute/v1/projects/{project}/regions/{region}/disks/{disk}"
     };
     option (google.api.method_signature) = "project,region,disk";
   }
@@ -91,7 +91,7 @@ service RegionDisks {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/regions/{region}/disks/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,region,resource";
   }
@@ -101,7 +101,7 @@ service RegionDisks {
   rpc InsertRegionDisks(InsertRegionDisksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/disks"
+      post: "/compute/v1/projects/{project}/regions/{region}/disks"
       body: "disk_resource"
     };
     option (google.api.method_signature) = "project,region,disk_resource";
@@ -113,7 +113,7 @@ service RegionDisks {
   rpc ListRegionDisks(ListRegionDisksRequest)
       returns (google.cloud.cpp.compute.v1.DiskList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/disks"
+      get: "/compute/v1/projects/{project}/regions/{region}/disks"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -122,7 +122,7 @@ service RegionDisks {
   rpc RemoveResourcePolicies(RemoveResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{disk=disk}/removeResourcePolicies"
+      post: "/compute/v1/projects/{project}/regions/{region}/disks/{disk}/removeResourcePolicies"
       body: "region_disks_remove_resource_policies_request_resource"
     };
     option (google.api.method_signature) =
@@ -133,7 +133,7 @@ service RegionDisks {
   // Resizes the specified regional persistent disk.
   rpc Resize(ResizeRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{disk=disk}/resize"
+      post: "/compute/v1/projects/{project}/regions/{region}/disks/{disk}/resize"
       body: "region_disks_resize_request_resource"
     };
     option (google.api.method_signature) =
@@ -146,7 +146,7 @@ service RegionDisks {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/regions/{region}/disks/{resource}/setIamPolicy"
       body: "region_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -157,7 +157,7 @@ service RegionDisks {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/regions/{region}/disks/{resource}/setLabels"
       body: "region_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -169,7 +169,7 @@ service RegionDisks {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/disks/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =
@@ -182,7 +182,7 @@ service RegionDisks {
   rpc UpdateRegionDisks(UpdateRegionDisksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/disks/{disk=disk}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/disks/{disk}"
       body: "disk_resource"
     };
     option (google.api.method_signature) = "project,region,disk,disk_resource";

--- a/google/cloud/compute/region_health_check_services/v1/region_health_check_services.proto
+++ b/google/cloud/compute/region_health_check_services/v1/region_health_check_services.proto
@@ -40,7 +40,7 @@ service RegionHealthCheckServices {
   rpc DeleteRegionHealthCheckServices(DeleteRegionHealthCheckServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/healthCheckServices/{health_check_service=health_check_service}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/healthCheckServices/{health_check_service}"
     };
     option (google.api.method_signature) =
         "project,region,health_check_service";
@@ -51,7 +51,7 @@ service RegionHealthCheckServices {
   rpc GetRegionHealthCheckServices(GetRegionHealthCheckServicesRequest)
       returns (google.cloud.cpp.compute.v1.HealthCheckService) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/healthCheckServices/{health_check_service=health_check_service}"
+      get: "/compute/v1/projects/{project}/regions/{region}/healthCheckServices/{health_check_service}"
     };
     option (google.api.method_signature) =
         "project,region,health_check_service";
@@ -62,7 +62,7 @@ service RegionHealthCheckServices {
   rpc InsertRegionHealthCheckServices(InsertRegionHealthCheckServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/healthCheckServices"
+      post: "/compute/v1/projects/{project}/regions/{region}/healthCheckServices"
       body: "health_check_service_resource"
     };
     option (google.api.method_signature) =
@@ -75,7 +75,7 @@ service RegionHealthCheckServices {
   rpc ListRegionHealthCheckServices(ListRegionHealthCheckServicesRequest)
       returns (google.cloud.cpp.compute.v1.HealthCheckServicesList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/healthCheckServices"
+      get: "/compute/v1/projects/{project}/regions/{region}/healthCheckServices"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -86,7 +86,7 @@ service RegionHealthCheckServices {
   rpc PatchRegionHealthCheckServices(PatchRegionHealthCheckServicesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/healthCheckServices/{health_check_service=health_check_service}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/healthCheckServices/{health_check_service}"
       body: "health_check_service_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_health_checks/v1/region_health_checks.proto
+++ b/google/cloud/compute/region_health_checks/v1/region_health_checks.proto
@@ -40,7 +40,7 @@ service RegionHealthChecks {
   rpc DeleteRegionHealthChecks(DeleteRegionHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/healthChecks/{health_check=health_check}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/healthChecks/{health_check}"
     };
     option (google.api.method_signature) = "project,region,health_check";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -50,7 +50,7 @@ service RegionHealthChecks {
   rpc GetRegionHealthChecks(GetRegionHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HealthCheck) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/healthChecks/{health_check=health_check}"
+      get: "/compute/v1/projects/{project}/regions/{region}/healthChecks/{health_check}"
     };
     option (google.api.method_signature) = "project,region,health_check";
   }
@@ -60,7 +60,7 @@ service RegionHealthChecks {
   rpc InsertRegionHealthChecks(InsertRegionHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/healthChecks"
+      post: "/compute/v1/projects/{project}/regions/{region}/healthChecks"
       body: "health_check_resource"
     };
     option (google.api.method_signature) =
@@ -73,7 +73,7 @@ service RegionHealthChecks {
   rpc ListRegionHealthChecks(ListRegionHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.HealthCheckList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/healthChecks"
+      get: "/compute/v1/projects/{project}/regions/{region}/healthChecks"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -84,7 +84,7 @@ service RegionHealthChecks {
   rpc PatchRegionHealthChecks(PatchRegionHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/healthChecks/{health_check=health_check}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/healthChecks/{health_check}"
       body: "health_check_resource"
     };
     option (google.api.method_signature) =
@@ -97,7 +97,7 @@ service RegionHealthChecks {
   rpc UpdateRegionHealthChecks(UpdateRegionHealthChecksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/regions/{region=region}/healthChecks/{health_check=health_check}"
+      put: "/compute/v1/projects/{project}/regions/{region}/healthChecks/{health_check}"
       body: "health_check_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers.proto
+++ b/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers.proto
@@ -51,7 +51,7 @@ service RegionInstanceGroupManagers {
   rpc AbandonInstances(AbandonInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/abandonInstances"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/abandonInstances"
       body: "region_instance_group_managers_abandon_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -63,7 +63,7 @@ service RegionInstanceGroupManagers {
   rpc ApplyUpdatesToInstances(ApplyUpdatesToInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/applyUpdatesToInstances"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/applyUpdatesToInstances"
       body: "region_instance_group_managers_apply_updates_request_resource"
     };
     option (google.api.method_signature) =
@@ -80,7 +80,7 @@ service RegionInstanceGroupManagers {
   rpc CreateInstances(CreateInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/createInstances"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/createInstances"
       body: "region_instance_group_managers_create_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -94,7 +94,7 @@ service RegionInstanceGroupManagers {
       DeleteRegionInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}"
     };
     option (google.api.method_signature) =
         "project,region,instance_group_manager";
@@ -116,7 +116,7 @@ service RegionInstanceGroupManagers {
   rpc DeleteInstances(DeleteInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/deleteInstances"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/deleteInstances"
       body: "region_instance_group_managers_delete_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -129,7 +129,7 @@ service RegionInstanceGroupManagers {
   rpc DeletePerInstanceConfigs(DeletePerInstanceConfigsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/deletePerInstanceConfigs"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/deletePerInstanceConfigs"
       body: "region_instance_group_manager_delete_instance_config_req_resource"
     };
     option (google.api.method_signature) =
@@ -141,7 +141,7 @@ service RegionInstanceGroupManagers {
   rpc GetRegionInstanceGroupManagers(GetRegionInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroupManager) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}"
+      get: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}"
     };
     option (google.api.method_signature) =
         "project,region,instance_group_manager";
@@ -158,7 +158,7 @@ service RegionInstanceGroupManagers {
       InsertRegionInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers"
       body: "instance_group_manager_resource"
     };
     option (google.api.method_signature) =
@@ -171,7 +171,7 @@ service RegionInstanceGroupManagers {
   rpc ListRegionInstanceGroupManagers(ListRegionInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.RegionInstanceGroupManagerList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers"
+      get: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -183,7 +183,7 @@ service RegionInstanceGroupManagers {
       returns (google.cloud.cpp.compute.v1
                    .RegionInstanceGroupManagersListErrorsResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/listErrors"
+      get: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/listErrors"
     };
     option (google.api.method_signature) =
         "project,region,instance_group_manager";
@@ -199,7 +199,7 @@ service RegionInstanceGroupManagers {
       returns (google.cloud.cpp.compute.v1
                    .RegionInstanceGroupManagersListInstancesResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/listManagedInstances"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/listManagedInstances"
       body: "*"
     };
     option (google.api.method_signature) =
@@ -212,7 +212,7 @@ service RegionInstanceGroupManagers {
       returns (google.cloud.cpp.compute.v1
                    .RegionInstanceGroupManagersListInstanceConfigsResp) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/listPerInstanceConfigs"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/listPerInstanceConfigs"
       body: "*"
     };
     option (google.api.method_signature) =
@@ -232,7 +232,7 @@ service RegionInstanceGroupManagers {
   rpc PatchRegionInstanceGroupManagers(PatchRegionInstanceGroupManagersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}"
       body: "instance_group_manager_resource"
     };
     option (google.api.method_signature) =
@@ -246,7 +246,7 @@ service RegionInstanceGroupManagers {
   rpc PatchPerInstanceConfigs(PatchPerInstanceConfigsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/patchPerInstanceConfigs"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/patchPerInstanceConfigs"
       body: "region_instance_group_manager_patch_instance_config_req_resource"
     };
     option (google.api.method_signature) =
@@ -267,7 +267,7 @@ service RegionInstanceGroupManagers {
   rpc RecreateInstances(RecreateInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/recreateInstances"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/recreateInstances"
       body: "region_instance_group_managers_recreate_request_resource"
     };
     option (google.api.method_signature) =
@@ -287,7 +287,7 @@ service RegionInstanceGroupManagers {
   // or deleted.
   rpc Resize(ResizeRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/resize"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/resize"
       body: "*"
     };
     option (google.api.method_signature) =
@@ -300,7 +300,7 @@ service RegionInstanceGroupManagers {
   rpc SetInstanceTemplate(SetInstanceTemplateRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/setInstanceTemplate"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/setInstanceTemplate"
       body: "region_instance_group_managers_set_template_request_resource"
     };
     option (google.api.method_signature) =
@@ -313,7 +313,7 @@ service RegionInstanceGroupManagers {
   rpc SetTargetPools(SetTargetPoolsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/setTargetPools"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/setTargetPools"
       body: "region_instance_group_managers_set_target_pools_request_resource"
     };
     option (google.api.method_signature) =
@@ -327,7 +327,7 @@ service RegionInstanceGroupManagers {
   rpc UpdatePerInstanceConfigs(UpdatePerInstanceConfigsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroupManagers/{instance_group_manager=instance_group_manager}/updatePerInstanceConfigs"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{instance_group_manager}/updatePerInstanceConfigs"
       body: "region_instance_group_manager_update_instance_config_req_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_instance_groups/v1/region_instance_groups.proto
+++ b/google/cloud/compute/region_instance_groups/v1/region_instance_groups.proto
@@ -40,7 +40,7 @@ service RegionInstanceGroups {
   rpc GetRegionInstanceGroups(GetRegionInstanceGroupsRequest)
       returns (google.cloud.cpp.compute.v1.InstanceGroup) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroups/{instance_group=instance_group}"
+      get: "/compute/v1/projects/{project}/regions/{region}/instanceGroups/{instance_group}"
     };
     option (google.api.method_signature) = "project,region,instance_group";
   }
@@ -50,7 +50,7 @@ service RegionInstanceGroups {
   rpc ListRegionInstanceGroups(ListRegionInstanceGroupsRequest)
       returns (google.cloud.cpp.compute.v1.RegionInstanceGroupList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroups"
+      get: "/compute/v1/projects/{project}/regions/{region}/instanceGroups"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -62,7 +62,7 @@ service RegionInstanceGroups {
   rpc ListInstances(ListInstancesRequest)
       returns (google.cloud.cpp.compute.v1.RegionInstanceGroupsListInstances) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroups/{instance_group=instance_group}/listInstances"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroups/{instance_group}/listInstances"
       body: "region_instance_groups_list_instances_request_resource"
     };
     option (google.api.method_signature) =
@@ -73,7 +73,7 @@ service RegionInstanceGroups {
   rpc SetNamedPorts(SetNamedPortsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceGroups/{instance_group=instance_group}/setNamedPorts"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceGroups/{instance_group}/setNamedPorts"
       body: "region_instance_groups_set_named_ports_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_instance_templates/v1/region_instance_templates.proto
+++ b/google/cloud/compute/region_instance_templates/v1/region_instance_templates.proto
@@ -41,7 +41,7 @@ service RegionInstanceTemplates {
   rpc DeleteRegionInstanceTemplates(DeleteRegionInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceTemplates/{instance_template=instance_template}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/instanceTemplates/{instance_template}"
     };
     option (google.api.method_signature) = "project,region,instance_template";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -51,7 +51,7 @@ service RegionInstanceTemplates {
   rpc GetRegionInstanceTemplates(GetRegionInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.InstanceTemplate) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceTemplates/{instance_template=instance_template}"
+      get: "/compute/v1/projects/{project}/regions/{region}/instanceTemplates/{instance_template}"
     };
     option (google.api.method_signature) = "project,region,instance_template";
   }
@@ -61,7 +61,7 @@ service RegionInstanceTemplates {
   rpc InsertRegionInstanceTemplates(InsertRegionInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceTemplates"
+      post: "/compute/v1/projects/{project}/regions/{region}/instanceTemplates"
       body: "instance_template_resource"
     };
     option (google.api.method_signature) =
@@ -74,7 +74,7 @@ service RegionInstanceTemplates {
   rpc ListRegionInstanceTemplates(ListRegionInstanceTemplatesRequest)
       returns (google.cloud.cpp.compute.v1.InstanceTemplateList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/instanceTemplates"
+      get: "/compute/v1/projects/{project}/regions/{region}/instanceTemplates"
     };
     option (google.api.method_signature) = "project,region";
   }

--- a/google/cloud/compute/region_instances/v1/region_instances.proto
+++ b/google/cloud/compute/region_instances/v1/region_instances.proto
@@ -40,7 +40,7 @@ service RegionInstances {
   rpc BulkInsert(BulkInsertRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/instances/bulkInsert"
+      post: "/compute/v1/projects/{project}/regions/{region}/instances/bulkInsert"
       body: "bulk_insert_instance_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups.proto
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups.proto
@@ -42,7 +42,7 @@ service RegionNetworkEndpointGroups {
       DeleteRegionNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/networkEndpointGroups/{network_endpoint_group}"
     };
     option (google.api.method_signature) =
         "project,region,network_endpoint_group";
@@ -53,7 +53,7 @@ service RegionNetworkEndpointGroups {
   rpc GetRegionNetworkEndpointGroups(GetRegionNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkEndpointGroup) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/networkEndpointGroups/{network_endpoint_group=network_endpoint_group}"
+      get: "/compute/v1/projects/{project}/regions/{region}/networkEndpointGroups/{network_endpoint_group}"
     };
     option (google.api.method_signature) =
         "project,region,network_endpoint_group";
@@ -65,7 +65,7 @@ service RegionNetworkEndpointGroups {
       InsertRegionNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/networkEndpointGroups"
+      post: "/compute/v1/projects/{project}/regions/{region}/networkEndpointGroups"
       body: "network_endpoint_group_resource"
     };
     option (google.api.method_signature) =
@@ -78,7 +78,7 @@ service RegionNetworkEndpointGroups {
   rpc ListRegionNetworkEndpointGroups(ListRegionNetworkEndpointGroupsRequest)
       returns (google.cloud.cpp.compute.v1.NetworkEndpointGroupList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/networkEndpointGroups"
+      get: "/compute/v1/projects/{project}/regions/{region}/networkEndpointGroups"
     };
     option (google.api.method_signature) = "project,region";
   }

--- a/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies.proto
+++ b/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies.proto
@@ -40,7 +40,7 @@ service RegionNetworkFirewallPolicies {
   rpc AddAssociation(AddAssociationRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}/addAssociation"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}/addAssociation"
       body: "firewall_policy_association_resource"
     };
     option (google.api.method_signature) =
@@ -51,7 +51,7 @@ service RegionNetworkFirewallPolicies {
   // Inserts a rule into a network firewall policy.
   rpc AddRule(AddRuleRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}/addRule"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}/addRule"
       body: "firewall_policy_rule_resource"
     };
     option (google.api.method_signature) =
@@ -63,7 +63,7 @@ service RegionNetworkFirewallPolicies {
   rpc CloneRules(CloneRulesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}/cloneRules"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}/cloneRules"
       body: "*"
     };
     option (google.api.method_signature) = "project,region,firewall_policy";
@@ -75,7 +75,7 @@ service RegionNetworkFirewallPolicies {
       DeleteRegionNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}"
     };
     option (google.api.method_signature) = "project,region,firewall_policy";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -85,7 +85,7 @@ service RegionNetworkFirewallPolicies {
   rpc GetRegionNetworkFirewallPolicies(GetRegionNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}"
+      get: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}"
     };
     option (google.api.method_signature) = "project,region,firewall_policy";
   }
@@ -94,7 +94,7 @@ service RegionNetworkFirewallPolicies {
   rpc GetAssociation(GetAssociationRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicyAssociation) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}/getAssociation"
+      get: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}/getAssociation"
     };
     option (google.api.method_signature) = "project,region,firewall_policy";
   }
@@ -104,7 +104,7 @@ service RegionNetworkFirewallPolicies {
       google.cloud.cpp.compute.v1
           .RegionNetworkFirewallPoliciesGetEffectiveFirewallsResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/getEffectiveFirewalls"
+      get: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/getEffectiveFirewalls"
     };
     option (google.api.method_signature) = "project,region,network";
   }
@@ -114,7 +114,7 @@ service RegionNetworkFirewallPolicies {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,region,resource";
   }
@@ -123,7 +123,7 @@ service RegionNetworkFirewallPolicies {
   rpc GetRule(GetRuleRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicyRule) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}/getRule"
+      get: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}/getRule"
     };
     option (google.api.method_signature) = "project,region,firewall_policy";
   }
@@ -133,7 +133,7 @@ service RegionNetworkFirewallPolicies {
       InsertRegionNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies"
       body: "firewall_policy_resource"
     };
     option (google.api.method_signature) =
@@ -147,7 +147,7 @@ service RegionNetworkFirewallPolicies {
       ListRegionNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.FirewallPolicyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies"
+      get: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -157,7 +157,7 @@ service RegionNetworkFirewallPolicies {
       PatchRegionNetworkFirewallPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}"
       body: "firewall_policy_resource"
     };
     option (google.api.method_signature) =
@@ -169,7 +169,7 @@ service RegionNetworkFirewallPolicies {
   rpc PatchRule(PatchRuleRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}/patchRule"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}/patchRule"
       body: "firewall_policy_rule_resource"
     };
     option (google.api.method_signature) =
@@ -181,7 +181,7 @@ service RegionNetworkFirewallPolicies {
   rpc RemoveAssociation(RemoveAssociationRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}/removeAssociation"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}/removeAssociation"
       body: "*"
     };
     option (google.api.method_signature) = "project,region,firewall_policy";
@@ -192,7 +192,7 @@ service RegionNetworkFirewallPolicies {
   rpc RemoveRule(RemoveRuleRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{firewall_policy=firewall_policy}/removeRule"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{firewall_policy}/removeRule"
       body: "*"
     };
     option (google.api.method_signature) = "project,region,firewall_policy";
@@ -204,7 +204,7 @@ service RegionNetworkFirewallPolicies {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{resource}/setIamPolicy"
       body: "region_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -215,7 +215,7 @@ service RegionNetworkFirewallPolicies {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/firewallPolicies/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/firewallPolicies/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints.proto
+++ b/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints.proto
@@ -41,7 +41,7 @@ service RegionNotificationEndpoints {
       DeleteRegionNotificationEndpointsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/notificationEndpoints/{notification_endpoint=notification_endpoint}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/notificationEndpoints/{notification_endpoint}"
     };
     option (google.api.method_signature) =
         "project,region,notification_endpoint";
@@ -52,7 +52,7 @@ service RegionNotificationEndpoints {
   rpc GetRegionNotificationEndpoints(GetRegionNotificationEndpointsRequest)
       returns (google.cloud.cpp.compute.v1.NotificationEndpoint) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/notificationEndpoints/{notification_endpoint=notification_endpoint}"
+      get: "/compute/v1/projects/{project}/regions/{region}/notificationEndpoints/{notification_endpoint}"
     };
     option (google.api.method_signature) =
         "project,region,notification_endpoint";
@@ -64,7 +64,7 @@ service RegionNotificationEndpoints {
       InsertRegionNotificationEndpointsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/notificationEndpoints"
+      post: "/compute/v1/projects/{project}/regions/{region}/notificationEndpoints"
       body: "notification_endpoint_resource"
     };
     option (google.api.method_signature) =
@@ -76,7 +76,7 @@ service RegionNotificationEndpoints {
   rpc ListRegionNotificationEndpoints(ListRegionNotificationEndpointsRequest)
       returns (google.cloud.cpp.compute.v1.NotificationEndpointList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/notificationEndpoints"
+      get: "/compute/v1/projects/{project}/regions/{region}/notificationEndpoints"
     };
     option (google.api.method_signature) = "project,region";
   }

--- a/google/cloud/compute/region_operations/v1/region_operations.proto
+++ b/google/cloud/compute/region_operations/v1/region_operations.proto
@@ -41,7 +41,7 @@ service RegionOperations {
   rpc DeleteRegionOperations(DeleteRegionOperationsRequest)
       returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/operations/{operation=operation}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/operations/{operation}"
     };
     option (google.api.method_signature) = "project,region,operation";
   }
@@ -50,7 +50,7 @@ service RegionOperations {
   rpc GetRegionOperations(GetRegionOperationsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/operations/{operation=operation}"
+      get: "/compute/v1/projects/{project}/regions/{region}/operations/{operation}"
     };
     option (google.api.method_signature) = "project,region,operation";
   }
@@ -60,7 +60,7 @@ service RegionOperations {
   rpc ListRegionOperations(ListRegionOperationsRequest)
       returns (google.cloud.cpp.compute.v1.OperationList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/operations"
+      get: "/compute/v1/projects/{project}/regions/{region}/operations"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -78,7 +78,7 @@ service RegionOperations {
   // the operation is not `DONE`.
   rpc Wait(WaitRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/operations/{operation=operation}/wait"
+      post: "/compute/v1/projects/{project}/regions/{region}/operations/{operation}/wait"
       body: "*"
     };
     option (google.api.method_signature) = "project,region,operation";

--- a/google/cloud/compute/region_security_policies/v1/region_security_policies.proto
+++ b/google/cloud/compute/region_security_policies/v1/region_security_policies.proto
@@ -40,7 +40,7 @@ service RegionSecurityPolicies {
   rpc DeleteRegionSecurityPolicies(DeleteRegionSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/securityPolicies/{security_policy=security_policy}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/securityPolicies/{security_policy}"
     };
     option (google.api.method_signature) = "project,region,security_policy";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -50,7 +50,7 @@ service RegionSecurityPolicies {
   rpc GetRegionSecurityPolicies(GetRegionSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SecurityPolicy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/securityPolicies/{security_policy=security_policy}"
+      get: "/compute/v1/projects/{project}/regions/{region}/securityPolicies/{security_policy}"
     };
     option (google.api.method_signature) = "project,region,security_policy";
   }
@@ -60,7 +60,7 @@ service RegionSecurityPolicies {
   rpc InsertRegionSecurityPolicies(InsertRegionSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/securityPolicies"
+      post: "/compute/v1/projects/{project}/regions/{region}/securityPolicies"
       body: "security_policy_resource"
     };
     option (google.api.method_signature) =
@@ -73,7 +73,7 @@ service RegionSecurityPolicies {
   rpc ListRegionSecurityPolicies(ListRegionSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SecurityPolicyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/securityPolicies"
+      get: "/compute/v1/projects/{project}/regions/{region}/securityPolicies"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -86,7 +86,7 @@ service RegionSecurityPolicies {
   rpc PatchRegionSecurityPolicies(PatchRegionSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/securityPolicies/{security_policy=security_policy}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/securityPolicies/{security_policy}"
       body: "security_policy_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates.proto
+++ b/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates.proto
@@ -40,7 +40,7 @@ service RegionSslCertificates {
   rpc DeleteRegionSslCertificates(DeleteRegionSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/sslCertificates/{ssl_certificate=ssl_certificate}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/sslCertificates/{ssl_certificate}"
     };
     option (google.api.method_signature) = "project,region,ssl_certificate";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -51,7 +51,7 @@ service RegionSslCertificates {
   rpc GetRegionSslCertificates(GetRegionSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.SslCertificate) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/sslCertificates/{ssl_certificate=ssl_certificate}"
+      get: "/compute/v1/projects/{project}/regions/{region}/sslCertificates/{ssl_certificate}"
     };
     option (google.api.method_signature) = "project,region,ssl_certificate";
   }
@@ -61,7 +61,7 @@ service RegionSslCertificates {
   rpc InsertRegionSslCertificates(InsertRegionSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/sslCertificates"
+      post: "/compute/v1/projects/{project}/regions/{region}/sslCertificates"
       body: "ssl_certificate_resource"
     };
     option (google.api.method_signature) =
@@ -74,7 +74,7 @@ service RegionSslCertificates {
   rpc ListRegionSslCertificates(ListRegionSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.SslCertificateList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/sslCertificates"
+      get: "/compute/v1/projects/{project}/regions/{region}/sslCertificates"
     };
     option (google.api.method_signature) = "project,region";
   }

--- a/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies.proto
+++ b/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies.proto
@@ -42,7 +42,7 @@ service RegionSslPolicies {
   rpc DeleteRegionSslPolicies(DeleteRegionSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/sslPolicies/{ssl_policy=ssl_policy}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/sslPolicies/{ssl_policy}"
     };
     option (google.api.method_signature) = "project,region,ssl_policy";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -52,7 +52,7 @@ service RegionSslPolicies {
   rpc GetRegionSslPolicies(GetRegionSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SslPolicy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/sslPolicies/{ssl_policy=ssl_policy}"
+      get: "/compute/v1/projects/{project}/regions/{region}/sslPolicies/{ssl_policy}"
     };
     option (google.api.method_signature) = "project,region,ssl_policy";
   }
@@ -62,7 +62,7 @@ service RegionSslPolicies {
   rpc InsertRegionSslPolicies(InsertRegionSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/sslPolicies"
+      post: "/compute/v1/projects/{project}/regions/{region}/sslPolicies"
       body: "ssl_policy_resource"
     };
     option (google.api.method_signature) = "project,region,ssl_policy_resource";
@@ -74,7 +74,7 @@ service RegionSslPolicies {
   rpc ListRegionSslPolicies(ListRegionSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SslPoliciesList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/sslPolicies"
+      get: "/compute/v1/projects/{project}/regions/{region}/sslPolicies"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -84,7 +84,7 @@ service RegionSslPolicies {
   rpc ListAvailableFeatures(ListAvailableFeaturesRequest) returns (
       google.cloud.cpp.compute.v1.SslPoliciesListAvailableFeaturesResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/sslPolicies/listAvailableFeatures"
+      get: "/compute/v1/projects/{project}/regions/{region}/sslPolicies/listAvailableFeatures"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -93,7 +93,7 @@ service RegionSslPolicies {
   rpc PatchRegionSslPolicies(PatchRegionSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/sslPolicies/{ssl_policy=ssl_policy}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/sslPolicies/{ssl_policy}"
       body: "ssl_policy_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies.proto
+++ b/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies.proto
@@ -40,7 +40,7 @@ service RegionTargetHttpProxies {
   rpc DeleteRegionTargetHttpProxies(DeleteRegionTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpProxies/{target_http_proxy=target_http_proxy}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/targetHttpProxies/{target_http_proxy}"
     };
     option (google.api.method_signature) = "project,region,target_http_proxy";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -50,7 +50,7 @@ service RegionTargetHttpProxies {
   rpc GetRegionTargetHttpProxies(GetRegionTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpProxy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpProxies/{target_http_proxy=target_http_proxy}"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetHttpProxies/{target_http_proxy}"
     };
     option (google.api.method_signature) = "project,region,target_http_proxy";
   }
@@ -60,7 +60,7 @@ service RegionTargetHttpProxies {
   rpc InsertRegionTargetHttpProxies(InsertRegionTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpProxies"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetHttpProxies"
       body: "target_http_proxy_resource"
     };
     option (google.api.method_signature) =
@@ -73,7 +73,7 @@ service RegionTargetHttpProxies {
   rpc ListRegionTargetHttpProxies(ListRegionTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpProxyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpProxies"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetHttpProxies"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -82,7 +82,7 @@ service RegionTargetHttpProxies {
   rpc SetUrlMap(SetUrlMapRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpProxies/{target_http_proxy=target_http_proxy}/setUrlMap"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetHttpProxies/{target_http_proxy}/setUrlMap"
       body: "url_map_reference_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies.proto
+++ b/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies.proto
@@ -40,7 +40,7 @@ service RegionTargetHttpsProxies {
   rpc DeleteRegionTargetHttpsProxies(DeleteRegionTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpsProxies/{target_https_proxy=target_https_proxy}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies/{target_https_proxy}"
     };
     option (google.api.method_signature) = "project,region,target_https_proxy";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -50,7 +50,7 @@ service RegionTargetHttpsProxies {
   rpc GetRegionTargetHttpsProxies(GetRegionTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpsProxy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpsProxies/{target_https_proxy=target_https_proxy}"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies/{target_https_proxy}"
     };
     option (google.api.method_signature) = "project,region,target_https_proxy";
   }
@@ -60,7 +60,7 @@ service RegionTargetHttpsProxies {
   rpc InsertRegionTargetHttpsProxies(InsertRegionTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpsProxies"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies"
       body: "target_https_proxy_resource"
     };
     option (google.api.method_signature) =
@@ -73,7 +73,7 @@ service RegionTargetHttpsProxies {
   rpc ListRegionTargetHttpsProxies(ListRegionTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpsProxyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpsProxies"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -84,7 +84,7 @@ service RegionTargetHttpsProxies {
   rpc PatchRegionTargetHttpsProxies(PatchRegionTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpsProxies/{target_https_proxy=target_https_proxy}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies/{target_https_proxy}"
       body: "target_https_proxy_resource"
     };
     option (google.api.method_signature) =
@@ -96,7 +96,7 @@ service RegionTargetHttpsProxies {
   rpc SetSslCertificates(SetSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpsProxies/{target_https_proxy=target_https_proxy}/setSslCertificates"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies/{target_https_proxy}/setSslCertificates"
       body: "region_target_https_proxies_set_ssl_certificates_request_resource"
     };
     option (google.api.method_signature) =
@@ -108,7 +108,7 @@ service RegionTargetHttpsProxies {
   rpc SetUrlMap(SetUrlMapRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetHttpsProxies/{target_https_proxy=target_https_proxy}/setUrlMap"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies/{target_https_proxy}/setUrlMap"
       body: "url_map_reference_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies.proto
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies.proto
@@ -40,7 +40,7 @@ service RegionTargetTcpProxies {
   rpc DeleteRegionTargetTcpProxies(DeleteRegionTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/targetTcpProxies/{target_tcp_proxy=target_tcp_proxy}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/targetTcpProxies/{target_tcp_proxy}"
     };
     option (google.api.method_signature) = "project,region,target_tcp_proxy";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -50,7 +50,7 @@ service RegionTargetTcpProxies {
   rpc GetRegionTargetTcpProxies(GetRegionTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetTcpProxy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetTcpProxies/{target_tcp_proxy=target_tcp_proxy}"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetTcpProxies/{target_tcp_proxy}"
     };
     option (google.api.method_signature) = "project,region,target_tcp_proxy";
   }
@@ -60,7 +60,7 @@ service RegionTargetTcpProxies {
   rpc InsertRegionTargetTcpProxies(InsertRegionTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetTcpProxies"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetTcpProxies"
       body: "target_tcp_proxy_resource"
     };
     option (google.api.method_signature) =
@@ -73,7 +73,7 @@ service RegionTargetTcpProxies {
   rpc ListRegionTargetTcpProxies(ListRegionTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetTcpProxyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetTcpProxies"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetTcpProxies"
     };
     option (google.api.method_signature) = "project,region";
   }

--- a/google/cloud/compute/region_url_maps/v1/region_url_maps.proto
+++ b/google/cloud/compute/region_url_maps/v1/region_url_maps.proto
@@ -40,7 +40,7 @@ service RegionUrlMaps {
   rpc DeleteRegionUrlMaps(DeleteRegionUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/urlMaps/{url_map=url_map}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/urlMaps/{url_map}"
     };
     option (google.api.method_signature) = "project,region,url_map";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -50,7 +50,7 @@ service RegionUrlMaps {
   rpc GetRegionUrlMaps(GetRegionUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.UrlMap) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/urlMaps/{url_map=url_map}"
+      get: "/compute/v1/projects/{project}/regions/{region}/urlMaps/{url_map}"
     };
     option (google.api.method_signature) = "project,region,url_map";
   }
@@ -60,7 +60,7 @@ service RegionUrlMaps {
   rpc InsertRegionUrlMaps(InsertRegionUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/urlMaps"
+      post: "/compute/v1/projects/{project}/regions/{region}/urlMaps"
       body: "url_map_resource"
     };
     option (google.api.method_signature) = "project,region,url_map_resource";
@@ -72,7 +72,7 @@ service RegionUrlMaps {
   rpc ListRegionUrlMaps(ListRegionUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.UrlMapList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/urlMaps"
+      get: "/compute/v1/projects/{project}/regions/{region}/urlMaps"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -83,7 +83,7 @@ service RegionUrlMaps {
   rpc PatchRegionUrlMaps(PatchRegionUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/urlMaps/{url_map=url_map}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/urlMaps/{url_map}"
       body: "url_map_resource"
     };
     option (google.api.method_signature) =
@@ -96,7 +96,7 @@ service RegionUrlMaps {
   rpc UpdateRegionUrlMaps(UpdateRegionUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/regions/{region=region}/urlMaps/{url_map=url_map}"
+      put: "/compute/v1/projects/{project}/regions/{region}/urlMaps/{url_map}"
       body: "url_map_resource"
     };
     option (google.api.method_signature) =
@@ -110,7 +110,7 @@ service RegionUrlMaps {
   rpc Validate(ValidateRequest)
       returns (google.cloud.cpp.compute.v1.UrlMapsValidateResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/urlMaps/{url_map=url_map}/validate"
+      post: "/compute/v1/projects/{project}/regions/{region}/urlMaps/{url_map}/validate"
       body: "region_url_maps_validate_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/regions/v1/regions.proto
+++ b/google/cloud/compute/regions/v1/regions.proto
@@ -45,7 +45,7 @@ service Regions {
   rpc GetRegions(GetRegionsRequest)
       returns (google.cloud.cpp.compute.v1.Region) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}"
+      get: "/compute/v1/projects/{project}/regions/{region}"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -61,7 +61,7 @@ service Regions {
   rpc ListRegions(ListRegionsRequest)
       returns (google.cloud.cpp.compute.v1.RegionList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions"
+      get: "/compute/v1/projects/{project}/regions"
     };
     option (google.api.method_signature) = "project";
   }

--- a/google/cloud/compute/reservations/v1/reservations.proto
+++ b/google/cloud/compute/reservations/v1/reservations.proto
@@ -40,7 +40,7 @@ service Reservations {
   rpc AggregatedListReservations(AggregatedListReservationsRequest)
       returns (google.cloud.cpp.compute.v1.ReservationAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/reservations"
+      get: "/compute/v1/projects/{project}/aggregated/reservations"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service Reservations {
   rpc DeleteReservations(DeleteReservationsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations/{reservation=reservation}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/reservations/{reservation}"
     };
     option (google.api.method_signature) = "project,zone,reservation";
     option (google.cloud.operation_service) = "ZoneOperations";
@@ -59,7 +59,7 @@ service Reservations {
   rpc GetReservations(GetReservationsRequest)
       returns (google.cloud.cpp.compute.v1.Reservation) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations/{reservation=reservation}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/reservations/{reservation}"
     };
     option (google.api.method_signature) = "project,zone,reservation";
   }
@@ -69,7 +69,7 @@ service Reservations {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/zones/{zone}/reservations/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,zone,resource";
   }
@@ -79,7 +79,7 @@ service Reservations {
   rpc InsertReservations(InsertReservationsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations"
+      post: "/compute/v1/projects/{project}/zones/{zone}/reservations"
       body: "reservation_resource"
     };
     option (google.api.method_signature) = "project,zone,reservation_resource";
@@ -91,7 +91,7 @@ service Reservations {
   rpc ListReservations(ListReservationsRequest)
       returns (google.cloud.cpp.compute.v1.ReservationList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations"
+      get: "/compute/v1/projects/{project}/zones/{zone}/reservations"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -100,7 +100,7 @@ service Reservations {
   // more information, read Modifying reservations.
   rpc Resize(ResizeRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations/{reservation=reservation}/resize"
+      post: "/compute/v1/projects/{project}/zones/{zone}/reservations/{reservation}/resize"
       body: "reservations_resize_request_resource"
     };
     option (google.api.method_signature) =
@@ -113,7 +113,7 @@ service Reservations {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/zones/{zone}/reservations/{resource}/setIamPolicy"
       body: "zone_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -124,7 +124,7 @@ service Reservations {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/zones/{zone}/reservations/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =
@@ -135,7 +135,7 @@ service Reservations {
   rpc UpdateReservations(UpdateReservationsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/zones/{zone=zone}/reservations/{reservation=reservation}"
+      patch: "/compute/v1/projects/{project}/zones/{zone}/reservations/{reservation}"
       body: "reservation_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/resource_policies/v1/resource_policies.proto
+++ b/google/cloud/compute/resource_policies/v1/resource_policies.proto
@@ -40,7 +40,7 @@ service ResourcePolicies {
   rpc AggregatedListResourcePolicies(AggregatedListResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.ResourcePolicyAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/resourcePolicies"
+      get: "/compute/v1/projects/{project}/aggregated/resourcePolicies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service ResourcePolicies {
   rpc DeleteResourcePolicies(DeleteResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/resourcePolicies/{resource_policy=resource_policy}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/resourcePolicies/{resource_policy}"
     };
     option (google.api.method_signature) = "project,region,resource_policy";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service ResourcePolicies {
   rpc GetResourcePolicies(GetResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.ResourcePolicy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/resourcePolicies/{resource_policy=resource_policy}"
+      get: "/compute/v1/projects/{project}/regions/{region}/resourcePolicies/{resource_policy}"
     };
     option (google.api.method_signature) = "project,region,resource_policy";
   }
@@ -69,7 +69,7 @@ service ResourcePolicies {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/resourcePolicies/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/regions/{region}/resourcePolicies/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,region,resource";
   }
@@ -78,7 +78,7 @@ service ResourcePolicies {
   rpc InsertResourcePolicies(InsertResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/resourcePolicies"
+      post: "/compute/v1/projects/{project}/regions/{region}/resourcePolicies"
       body: "resource_policy_resource"
     };
     option (google.api.method_signature) =
@@ -91,7 +91,7 @@ service ResourcePolicies {
   rpc ListResourcePolicies(ListResourcePoliciesRequest)
       returns (google.cloud.cpp.compute.v1.ResourcePolicyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/resourcePolicies"
+      get: "/compute/v1/projects/{project}/regions/{region}/resourcePolicies"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -101,7 +101,7 @@ service ResourcePolicies {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/resourcePolicies/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/regions/{region}/resourcePolicies/{resource}/setIamPolicy"
       body: "region_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -112,7 +112,7 @@ service ResourcePolicies {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/resourcePolicies/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/resourcePolicies/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/routers/v1/routers.proto
+++ b/google/cloud/compute/routers/v1/routers.proto
@@ -40,7 +40,7 @@ service Routers {
   rpc AggregatedListRouters(AggregatedListRoutersRequest)
       returns (google.cloud.cpp.compute.v1.RouterAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/routers"
+      get: "/compute/v1/projects/{project}/aggregated/routers"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service Routers {
   rpc DeleteRouters(DeleteRoutersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/routers/{router=router}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/routers/{router}"
     };
     option (google.api.method_signature) = "project,region,router";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service Routers {
   rpc GetRouters(GetRoutersRequest)
       returns (google.cloud.cpp.compute.v1.Router) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/routers/{router=router}"
+      get: "/compute/v1/projects/{project}/regions/{region}/routers/{router}"
     };
     option (google.api.method_signature) = "project,region,router";
   }
@@ -68,7 +68,7 @@ service Routers {
   rpc GetNatMappingInfo(GetNatMappingInfoRequest)
       returns (google.cloud.cpp.compute.v1.VmEndpointNatMappingsList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/routers/{router=router}/getNatMappingInfo"
+      get: "/compute/v1/projects/{project}/regions/{region}/routers/{router}/getNatMappingInfo"
     };
     option (google.api.method_signature) = "project,region,router";
   }
@@ -77,7 +77,7 @@ service Routers {
   rpc GetRouterStatus(GetRouterStatusRequest)
       returns (google.cloud.cpp.compute.v1.RouterStatusResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/routers/{router=router}/getRouterStatus"
+      get: "/compute/v1/projects/{project}/regions/{region}/routers/{router}/getRouterStatus"
     };
     option (google.api.method_signature) = "project,region,router";
   }
@@ -87,7 +87,7 @@ service Routers {
   rpc InsertRouters(InsertRoutersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/routers"
+      post: "/compute/v1/projects/{project}/regions/{region}/routers"
       body: "router_resource"
     };
     option (google.api.method_signature) = "project,region,router_resource";
@@ -98,7 +98,7 @@ service Routers {
   rpc ListRouters(ListRoutersRequest)
       returns (google.cloud.cpp.compute.v1.RouterList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/routers"
+      get: "/compute/v1/projects/{project}/regions/{region}/routers"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -109,7 +109,7 @@ service Routers {
   rpc PatchRouters(PatchRoutersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/routers/{router=router}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/routers/{router}"
       body: "router_resource"
     };
     option (google.api.method_signature) =
@@ -122,7 +122,7 @@ service Routers {
   rpc Preview(PreviewRequest)
       returns (google.cloud.cpp.compute.v1.RoutersPreviewResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/routers/{router=router}/preview"
+      post: "/compute/v1/projects/{project}/regions/{region}/routers/{router}/preview"
       body: "router_resource"
     };
     option (google.api.method_signature) =
@@ -136,7 +136,7 @@ service Routers {
   rpc UpdateRouters(UpdateRoutersRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/regions/{region=region}/routers/{router=router}"
+      put: "/compute/v1/projects/{project}/regions/{region}/routers/{router}"
       body: "router_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/routes/v1/routes.proto
+++ b/google/cloud/compute/routes/v1/routes.proto
@@ -40,7 +40,7 @@ service Routes {
   rpc DeleteRoutes(DeleteRoutesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/routes/{route=route}"
+      delete: "/compute/v1/projects/{project}/global/routes/{route}"
     };
     option (google.api.method_signature) = "project,route";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -49,7 +49,7 @@ service Routes {
   // Returns the specified Route resource.
   rpc GetRoutes(GetRoutesRequest) returns (google.cloud.cpp.compute.v1.Route) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/routes/{route=route}"
+      get: "/compute/v1/projects/{project}/global/routes/{route}"
     };
     option (google.api.method_signature) = "project,route";
   }
@@ -59,7 +59,7 @@ service Routes {
   rpc InsertRoutes(InsertRoutesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/routes"
+      post: "/compute/v1/projects/{project}/global/routes"
       body: "route_resource"
     };
     option (google.api.method_signature) = "project,route_resource";
@@ -70,7 +70,7 @@ service Routes {
   rpc ListRoutes(ListRoutesRequest)
       returns (google.cloud.cpp.compute.v1.RouteList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/routes"
+      get: "/compute/v1/projects/{project}/global/routes"
     };
     option (google.api.method_signature) = "project";
   }

--- a/google/cloud/compute/security_policies/v1/security_policies.proto
+++ b/google/cloud/compute/security_policies/v1/security_policies.proto
@@ -39,7 +39,7 @@ service SecurityPolicies {
   // Inserts a rule into a security policy.
   rpc AddRule(AddRuleRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/securityPolicies/{security_policy=security_policy}/addRule"
+      post: "/compute/v1/projects/{project}/global/securityPolicies/{security_policy}/addRule"
       body: "security_policy_rule_resource"
     };
     option (google.api.method_signature) =
@@ -52,7 +52,7 @@ service SecurityPolicies {
   rpc AggregatedListSecurityPolicies(AggregatedListSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SecurityPoliciesAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/securityPolicies"
+      get: "/compute/v1/projects/{project}/aggregated/securityPolicies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -61,7 +61,7 @@ service SecurityPolicies {
   rpc DeleteSecurityPolicies(DeleteSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/securityPolicies/{security_policy=security_policy}"
+      delete: "/compute/v1/projects/{project}/global/securityPolicies/{security_policy}"
     };
     option (google.api.method_signature) = "project,security_policy";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -71,7 +71,7 @@ service SecurityPolicies {
   rpc GetSecurityPolicies(GetSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SecurityPolicy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/securityPolicies/{security_policy=security_policy}"
+      get: "/compute/v1/projects/{project}/global/securityPolicies/{security_policy}"
     };
     option (google.api.method_signature) = "project,security_policy";
   }
@@ -80,7 +80,7 @@ service SecurityPolicies {
   rpc GetRule(GetRuleRequest)
       returns (google.cloud.cpp.compute.v1.SecurityPolicyRule) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/securityPolicies/{security_policy=security_policy}/getRule"
+      get: "/compute/v1/projects/{project}/global/securityPolicies/{security_policy}/getRule"
     };
     option (google.api.method_signature) = "project,security_policy";
   }
@@ -90,7 +90,7 @@ service SecurityPolicies {
   rpc InsertSecurityPolicies(InsertSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/securityPolicies"
+      post: "/compute/v1/projects/{project}/global/securityPolicies"
       body: "security_policy_resource"
     };
     option (google.api.method_signature) = "project,security_policy_resource";
@@ -101,7 +101,7 @@ service SecurityPolicies {
   rpc ListSecurityPolicies(ListSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SecurityPolicyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/securityPolicies"
+      get: "/compute/v1/projects/{project}/global/securityPolicies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -112,7 +112,7 @@ service SecurityPolicies {
       returns (google.cloud.cpp.compute.v1
                    .SecurityPoliciesListPreconfiguredExpressionSetsResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/securityPolicies/listPreconfiguredExpressionSets"
+      get: "/compute/v1/projects/{project}/global/securityPolicies/listPreconfiguredExpressionSets"
     };
     option (google.api.method_signature) = "project";
   }
@@ -125,7 +125,7 @@ service SecurityPolicies {
   rpc PatchSecurityPolicies(PatchSecurityPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/securityPolicies/{security_policy=security_policy}"
+      patch: "/compute/v1/projects/{project}/global/securityPolicies/{security_policy}"
       body: "security_policy_resource"
     };
     option (google.api.method_signature) =
@@ -137,7 +137,7 @@ service SecurityPolicies {
   rpc PatchRule(PatchRuleRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/securityPolicies/{security_policy=security_policy}/patchRule"
+      post: "/compute/v1/projects/{project}/global/securityPolicies/{security_policy}/patchRule"
       body: "security_policy_rule_resource"
     };
     option (google.api.method_signature) =
@@ -149,7 +149,7 @@ service SecurityPolicies {
   rpc RemoveRule(RemoveRuleRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/securityPolicies/{security_policy=security_policy}/removeRule"
+      post: "/compute/v1/projects/{project}/global/securityPolicies/{security_policy}/removeRule"
       body: "*"
     };
     option (google.api.method_signature) = "project,security_policy";
@@ -161,7 +161,7 @@ service SecurityPolicies {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/securityPolicies/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/global/securityPolicies/{resource}/setLabels"
       body: "global_set_labels_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/service_attachments/v1/service_attachments.proto
+++ b/google/cloud/compute/service_attachments/v1/service_attachments.proto
@@ -41,7 +41,7 @@ service ServiceAttachments {
   rpc AggregatedListServiceAttachments(AggregatedListServiceAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.ServiceAttachmentAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/serviceAttachments"
+      get: "/compute/v1/projects/{project}/aggregated/serviceAttachments"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service ServiceAttachments {
   rpc DeleteServiceAttachments(DeleteServiceAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/serviceAttachments/{service_attachment=service_attachment}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/serviceAttachments/{service_attachment}"
     };
     option (google.api.method_signature) = "project,region,service_attachment";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -60,7 +60,7 @@ service ServiceAttachments {
   rpc GetServiceAttachments(GetServiceAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.ServiceAttachment) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/serviceAttachments/{service_attachment=service_attachment}"
+      get: "/compute/v1/projects/{project}/regions/{region}/serviceAttachments/{service_attachment}"
     };
     option (google.api.method_signature) = "project,region,service_attachment";
   }
@@ -70,7 +70,7 @@ service ServiceAttachments {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/serviceAttachments/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/regions/{region}/serviceAttachments/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,region,resource";
   }
@@ -80,7 +80,7 @@ service ServiceAttachments {
   rpc InsertServiceAttachments(InsertServiceAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/serviceAttachments"
+      post: "/compute/v1/projects/{project}/regions/{region}/serviceAttachments"
       body: "service_attachment_resource"
     };
     option (google.api.method_signature) =
@@ -92,7 +92,7 @@ service ServiceAttachments {
   rpc ListServiceAttachments(ListServiceAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.ServiceAttachmentList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/serviceAttachments"
+      get: "/compute/v1/projects/{project}/regions/{region}/serviceAttachments"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -103,7 +103,7 @@ service ServiceAttachments {
   rpc PatchServiceAttachments(PatchServiceAttachmentsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/serviceAttachments/{service_attachment=service_attachment}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/serviceAttachments/{service_attachment}"
       body: "service_attachment_resource"
     };
     option (google.api.method_signature) =
@@ -116,7 +116,7 @@ service ServiceAttachments {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/serviceAttachments/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/regions/{region}/serviceAttachments/{resource}/setIamPolicy"
       body: "region_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -127,7 +127,7 @@ service ServiceAttachments {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/serviceAttachments/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/serviceAttachments/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/snapshots/v1/snapshots.proto
+++ b/google/cloud/compute/snapshots/v1/snapshots.proto
@@ -44,7 +44,7 @@ service Snapshots {
   rpc DeleteSnapshots(DeleteSnapshotsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/snapshots/{snapshot=snapshot}"
+      delete: "/compute/v1/projects/{project}/global/snapshots/{snapshot}"
     };
     option (google.api.method_signature) = "project,snapshot";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -54,7 +54,7 @@ service Snapshots {
   rpc GetSnapshots(GetSnapshotsRequest)
       returns (google.cloud.cpp.compute.v1.Snapshot) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/snapshots/{snapshot=snapshot}"
+      get: "/compute/v1/projects/{project}/global/snapshots/{snapshot}"
     };
     option (google.api.method_signature) = "project,snapshot";
   }
@@ -64,7 +64,7 @@ service Snapshots {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/snapshots/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/global/snapshots/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,resource";
   }
@@ -76,7 +76,7 @@ service Snapshots {
   rpc InsertSnapshots(InsertSnapshotsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/snapshots"
+      post: "/compute/v1/projects/{project}/global/snapshots"
       body: "snapshot_resource"
     };
     option (google.api.method_signature) = "project,snapshot_resource";
@@ -88,7 +88,7 @@ service Snapshots {
   rpc ListSnapshots(ListSnapshotsRequest)
       returns (google.cloud.cpp.compute.v1.SnapshotList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/snapshots"
+      get: "/compute/v1/projects/{project}/global/snapshots"
     };
     option (google.api.method_signature) = "project";
   }
@@ -98,7 +98,7 @@ service Snapshots {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/snapshots/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/global/snapshots/{resource}/setIamPolicy"
       body: "global_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -110,7 +110,7 @@ service Snapshots {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/snapshots/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/global/snapshots/{resource}/setLabels"
       body: "global_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -122,7 +122,7 @@ service Snapshots {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/snapshots/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/global/snapshots/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/ssl_certificates/v1/ssl_certificates.proto
+++ b/google/cloud/compute/ssl_certificates/v1/ssl_certificates.proto
@@ -41,7 +41,7 @@ service SslCertificates {
   rpc AggregatedListSslCertificates(AggregatedListSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.SslCertificateAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/sslCertificates"
+      get: "/compute/v1/projects/{project}/aggregated/sslCertificates"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service SslCertificates {
   rpc DeleteSslCertificates(DeleteSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/sslCertificates/{ssl_certificate=ssl_certificate}"
+      delete: "/compute/v1/projects/{project}/global/sslCertificates/{ssl_certificate}"
     };
     option (google.api.method_signature) = "project,ssl_certificate";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -60,7 +60,7 @@ service SslCertificates {
   rpc GetSslCertificates(GetSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.SslCertificate) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/sslCertificates/{ssl_certificate=ssl_certificate}"
+      get: "/compute/v1/projects/{project}/global/sslCertificates/{ssl_certificate}"
     };
     option (google.api.method_signature) = "project,ssl_certificate";
   }
@@ -70,7 +70,7 @@ service SslCertificates {
   rpc InsertSslCertificates(InsertSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/sslCertificates"
+      post: "/compute/v1/projects/{project}/global/sslCertificates"
       body: "ssl_certificate_resource"
     };
     option (google.api.method_signature) = "project,ssl_certificate_resource";
@@ -82,7 +82,7 @@ service SslCertificates {
   rpc ListSslCertificates(ListSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.SslCertificateList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/sslCertificates"
+      get: "/compute/v1/projects/{project}/global/sslCertificates"
     };
     option (google.api.method_signature) = "project";
   }

--- a/google/cloud/compute/ssl_policies/v1/ssl_policies.proto
+++ b/google/cloud/compute/ssl_policies/v1/ssl_policies.proto
@@ -41,7 +41,7 @@ service SslPolicies {
   rpc AggregatedListSslPolicies(AggregatedListSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SslPoliciesAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/sslPolicies"
+      get: "/compute/v1/projects/{project}/aggregated/sslPolicies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -52,7 +52,7 @@ service SslPolicies {
   rpc DeleteSslPolicies(DeleteSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/sslPolicies/{ssl_policy=ssl_policy}"
+      delete: "/compute/v1/projects/{project}/global/sslPolicies/{ssl_policy}"
     };
     option (google.api.method_signature) = "project,ssl_policy";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -62,7 +62,7 @@ service SslPolicies {
   rpc GetSslPolicies(GetSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SslPolicy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/sslPolicies/{ssl_policy=ssl_policy}"
+      get: "/compute/v1/projects/{project}/global/sslPolicies/{ssl_policy}"
     };
     option (google.api.method_signature) = "project,ssl_policy";
   }
@@ -71,7 +71,7 @@ service SslPolicies {
   rpc InsertSslPolicies(InsertSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/sslPolicies"
+      post: "/compute/v1/projects/{project}/global/sslPolicies"
       body: "ssl_policy_resource"
     };
     option (google.api.method_signature) = "project,ssl_policy_resource";
@@ -83,7 +83,7 @@ service SslPolicies {
   rpc ListSslPolicies(ListSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.SslPoliciesList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/sslPolicies"
+      get: "/compute/v1/projects/{project}/global/sslPolicies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -93,7 +93,7 @@ service SslPolicies {
   rpc ListAvailableFeatures(ListAvailableFeaturesRequest) returns (
       google.cloud.cpp.compute.v1.SslPoliciesListAvailableFeaturesResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/sslPolicies/listAvailableFeatures"
+      get: "/compute/v1/projects/{project}/global/sslPolicies/listAvailableFeatures"
     };
     option (google.api.method_signature) = "project";
   }
@@ -102,7 +102,7 @@ service SslPolicies {
   rpc PatchSslPolicies(PatchSslPoliciesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/sslPolicies/{ssl_policy=ssl_policy}"
+      patch: "/compute/v1/projects/{project}/global/sslPolicies/{ssl_policy}"
       body: "ssl_policy_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/subnetworks/v1/subnetworks.proto
+++ b/google/cloud/compute/subnetworks/v1/subnetworks.proto
@@ -40,7 +40,7 @@ service Subnetworks {
   rpc AggregatedListSubnetworks(AggregatedListSubnetworksRequest)
       returns (google.cloud.cpp.compute.v1.SubnetworkAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/subnetworks"
+      get: "/compute/v1/projects/{project}/aggregated/subnetworks"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service Subnetworks {
   rpc DeleteSubnetworks(DeleteSubnetworksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks/{subnetwork=subnetwork}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/subnetworks/{subnetwork}"
     };
     option (google.api.method_signature) = "project,region,subnetwork";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service Subnetworks {
   rpc ExpandIpCidrRange(ExpandIpCidrRangeRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks/{subnetwork=subnetwork}/expandIpCidrRange"
+      post: "/compute/v1/projects/{project}/regions/{region}/subnetworks/{subnetwork}/expandIpCidrRange"
       body: "subnetworks_expand_ip_cidr_range_request_resource"
     };
     option (google.api.method_signature) =
@@ -71,7 +71,7 @@ service Subnetworks {
   rpc GetSubnetworks(GetSubnetworksRequest)
       returns (google.cloud.cpp.compute.v1.Subnetwork) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks/{subnetwork=subnetwork}"
+      get: "/compute/v1/projects/{project}/regions/{region}/subnetworks/{subnetwork}"
     };
     option (google.api.method_signature) = "project,region,subnetwork";
   }
@@ -81,7 +81,7 @@ service Subnetworks {
   rpc GetIamPolicy(GetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks/{resource=resource}/getIamPolicy"
+      get: "/compute/v1/projects/{project}/regions/{region}/subnetworks/{resource}/getIamPolicy"
     };
     option (google.api.method_signature) = "project,region,resource";
   }
@@ -91,7 +91,7 @@ service Subnetworks {
   rpc InsertSubnetworks(InsertSubnetworksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks"
+      post: "/compute/v1/projects/{project}/regions/{region}/subnetworks"
       body: "subnetwork_resource"
     };
     option (google.api.method_signature) = "project,region,subnetwork_resource";
@@ -102,7 +102,7 @@ service Subnetworks {
   rpc ListSubnetworks(ListSubnetworksRequest)
       returns (google.cloud.cpp.compute.v1.SubnetworkList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks"
+      get: "/compute/v1/projects/{project}/regions/{region}/subnetworks"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -111,7 +111,7 @@ service Subnetworks {
   rpc ListUsable(ListUsableRequest)
       returns (google.cloud.cpp.compute.v1.UsableSubnetworksAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/subnetworks/listUsable"
+      get: "/compute/v1/projects/{project}/aggregated/subnetworks/listUsable"
     };
     option (google.api.method_signature) = "project";
   }
@@ -123,7 +123,7 @@ service Subnetworks {
   rpc PatchSubnetworks(PatchSubnetworksRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks/{subnetwork=subnetwork}"
+      patch: "/compute/v1/projects/{project}/regions/{region}/subnetworks/{subnetwork}"
       body: "subnetwork_resource"
     };
     option (google.api.method_signature) =
@@ -136,7 +136,7 @@ service Subnetworks {
   rpc SetIamPolicy(SetIamPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Policy) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks/{resource=resource}/setIamPolicy"
+      post: "/compute/v1/projects/{project}/regions/{region}/subnetworks/{resource}/setIamPolicy"
       body: "region_set_policy_request_resource"
     };
     option (google.api.method_signature) =
@@ -148,7 +148,7 @@ service Subnetworks {
   rpc SetPrivateIpGoogleAccess(SetPrivateIpGoogleAccessRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks/{subnetwork=subnetwork}/setPrivateIpGoogleAccess"
+      post: "/compute/v1/projects/{project}/regions/{region}/subnetworks/{subnetwork}/setPrivateIpGoogleAccess"
       body: "subnetworks_set_private_ip_google_access_request_resource"
     };
     option (google.api.method_signature) =
@@ -160,7 +160,7 @@ service Subnetworks {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/subnetworks/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/subnetworks/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies.proto
+++ b/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies.proto
@@ -40,7 +40,7 @@ service TargetGrpcProxies {
   rpc DeleteTargetGrpcProxies(DeleteTargetGrpcProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/targetGrpcProxies/{target_grpc_proxy=target_grpc_proxy}"
+      delete: "/compute/v1/projects/{project}/global/targetGrpcProxies/{target_grpc_proxy}"
     };
     option (google.api.method_signature) = "project,target_grpc_proxy";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -50,7 +50,7 @@ service TargetGrpcProxies {
   rpc GetTargetGrpcProxies(GetTargetGrpcProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetGrpcProxy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetGrpcProxies/{target_grpc_proxy=target_grpc_proxy}"
+      get: "/compute/v1/projects/{project}/global/targetGrpcProxies/{target_grpc_proxy}"
     };
     option (google.api.method_signature) = "project,target_grpc_proxy";
   }
@@ -60,7 +60,7 @@ service TargetGrpcProxies {
   rpc InsertTargetGrpcProxies(InsertTargetGrpcProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetGrpcProxies"
+      post: "/compute/v1/projects/{project}/global/targetGrpcProxies"
       body: "target_grpc_proxy_resource"
     };
     option (google.api.method_signature) = "project,target_grpc_proxy_resource";
@@ -71,7 +71,7 @@ service TargetGrpcProxies {
   rpc ListTargetGrpcProxies(ListTargetGrpcProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetGrpcProxyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetGrpcProxies"
+      get: "/compute/v1/projects/{project}/global/targetGrpcProxies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -82,7 +82,7 @@ service TargetGrpcProxies {
   rpc PatchTargetGrpcProxies(PatchTargetGrpcProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/targetGrpcProxies/{target_grpc_proxy=target_grpc_proxy}"
+      patch: "/compute/v1/projects/{project}/global/targetGrpcProxies/{target_grpc_proxy}"
       body: "target_grpc_proxy_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/target_http_proxies/v1/target_http_proxies.proto
+++ b/google/cloud/compute/target_http_proxies/v1/target_http_proxies.proto
@@ -41,7 +41,7 @@ service TargetHttpProxies {
   rpc AggregatedListTargetHttpProxies(AggregatedListTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpProxyAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/targetHttpProxies"
+      get: "/compute/v1/projects/{project}/aggregated/targetHttpProxies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service TargetHttpProxies {
   rpc DeleteTargetHttpProxies(DeleteTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/targetHttpProxies/{target_http_proxy=target_http_proxy}"
+      delete: "/compute/v1/projects/{project}/global/targetHttpProxies/{target_http_proxy}"
     };
     option (google.api.method_signature) = "project,target_http_proxy";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -60,7 +60,7 @@ service TargetHttpProxies {
   rpc GetTargetHttpProxies(GetTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpProxy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetHttpProxies/{target_http_proxy=target_http_proxy}"
+      get: "/compute/v1/projects/{project}/global/targetHttpProxies/{target_http_proxy}"
     };
     option (google.api.method_signature) = "project,target_http_proxy";
   }
@@ -70,7 +70,7 @@ service TargetHttpProxies {
   rpc InsertTargetHttpProxies(InsertTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetHttpProxies"
+      post: "/compute/v1/projects/{project}/global/targetHttpProxies"
       body: "target_http_proxy_resource"
     };
     option (google.api.method_signature) = "project,target_http_proxy_resource";
@@ -82,7 +82,7 @@ service TargetHttpProxies {
   rpc ListTargetHttpProxies(ListTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpProxyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetHttpProxies"
+      get: "/compute/v1/projects/{project}/global/targetHttpProxies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -93,7 +93,7 @@ service TargetHttpProxies {
   rpc PatchTargetHttpProxies(PatchTargetHttpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/targetHttpProxies/{target_http_proxy=target_http_proxy}"
+      patch: "/compute/v1/projects/{project}/global/targetHttpProxies/{target_http_proxy}"
       body: "target_http_proxy_resource"
     };
     option (google.api.method_signature) =
@@ -105,7 +105,7 @@ service TargetHttpProxies {
   rpc SetUrlMap(SetUrlMapRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/targetHttpProxies/{target_http_proxy=target_http_proxy}/setUrlMap"
+      post: "/compute/v1/projects/{project}/targetHttpProxies/{target_http_proxy}/setUrlMap"
       body: "url_map_reference_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/target_https_proxies/v1/target_https_proxies.proto
+++ b/google/cloud/compute/target_https_proxies/v1/target_https_proxies.proto
@@ -41,7 +41,7 @@ service TargetHttpsProxies {
   rpc AggregatedListTargetHttpsProxies(AggregatedListTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpsProxyAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/targetHttpsProxies"
+      get: "/compute/v1/projects/{project}/aggregated/targetHttpsProxies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service TargetHttpsProxies {
   rpc DeleteTargetHttpsProxies(DeleteTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/targetHttpsProxies/{target_https_proxy=target_https_proxy}"
+      delete: "/compute/v1/projects/{project}/global/targetHttpsProxies/{target_https_proxy}"
     };
     option (google.api.method_signature) = "project,target_https_proxy";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -60,7 +60,7 @@ service TargetHttpsProxies {
   rpc GetTargetHttpsProxies(GetTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpsProxy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetHttpsProxies/{target_https_proxy=target_https_proxy}"
+      get: "/compute/v1/projects/{project}/global/targetHttpsProxies/{target_https_proxy}"
     };
     option (google.api.method_signature) = "project,target_https_proxy";
   }
@@ -70,7 +70,7 @@ service TargetHttpsProxies {
   rpc InsertTargetHttpsProxies(InsertTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetHttpsProxies"
+      post: "/compute/v1/projects/{project}/global/targetHttpsProxies"
       body: "target_https_proxy_resource"
     };
     option (google.api.method_signature) =
@@ -83,7 +83,7 @@ service TargetHttpsProxies {
   rpc ListTargetHttpsProxies(ListTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetHttpsProxyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetHttpsProxies"
+      get: "/compute/v1/projects/{project}/global/targetHttpsProxies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -94,7 +94,7 @@ service TargetHttpsProxies {
   rpc PatchTargetHttpsProxies(PatchTargetHttpsProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/targetHttpsProxies/{target_https_proxy=target_https_proxy}"
+      patch: "/compute/v1/projects/{project}/global/targetHttpsProxies/{target_https_proxy}"
       body: "target_https_proxy_resource"
     };
     option (google.api.method_signature) =
@@ -106,7 +106,7 @@ service TargetHttpsProxies {
   rpc SetCertificateMap(SetCertificateMapRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetHttpsProxies/{target_https_proxy=target_https_proxy}/setCertificateMap"
+      post: "/compute/v1/projects/{project}/global/targetHttpsProxies/{target_https_proxy}/setCertificateMap"
       body: "target_https_proxies_set_certificate_map_request_resource"
     };
     option (google.api.method_signature) =
@@ -118,7 +118,7 @@ service TargetHttpsProxies {
   rpc SetQuicOverride(SetQuicOverrideRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetHttpsProxies/{target_https_proxy=target_https_proxy}/setQuicOverride"
+      post: "/compute/v1/projects/{project}/global/targetHttpsProxies/{target_https_proxy}/setQuicOverride"
       body: "target_https_proxies_set_quic_override_request_resource"
     };
     option (google.api.method_signature) =
@@ -130,7 +130,7 @@ service TargetHttpsProxies {
   rpc SetSslCertificates(SetSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/targetHttpsProxies/{target_https_proxy=target_https_proxy}/setSslCertificates"
+      post: "/compute/v1/projects/{project}/targetHttpsProxies/{target_https_proxy}/setSslCertificates"
       body: "target_https_proxies_set_ssl_certificates_request_resource"
     };
     option (google.api.method_signature) =
@@ -145,7 +145,7 @@ service TargetHttpsProxies {
   rpc SetSslPolicy(SetSslPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetHttpsProxies/{target_https_proxy=target_https_proxy}/setSslPolicy"
+      post: "/compute/v1/projects/{project}/global/targetHttpsProxies/{target_https_proxy}/setSslPolicy"
       body: "ssl_policy_reference_resource"
     };
     option (google.api.method_signature) =
@@ -157,7 +157,7 @@ service TargetHttpsProxies {
   rpc SetUrlMap(SetUrlMapRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/targetHttpsProxies/{target_https_proxy=target_https_proxy}/setUrlMap"
+      post: "/compute/v1/projects/{project}/targetHttpsProxies/{target_https_proxy}/setUrlMap"
       body: "url_map_reference_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/target_instances/v1/target_instances.proto
+++ b/google/cloud/compute/target_instances/v1/target_instances.proto
@@ -40,7 +40,7 @@ service TargetInstances {
   rpc AggregatedListTargetInstances(AggregatedListTargetInstancesRequest)
       returns (google.cloud.cpp.compute.v1.TargetInstanceAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/targetInstances"
+      get: "/compute/v1/projects/{project}/aggregated/targetInstances"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service TargetInstances {
   rpc DeleteTargetInstances(DeleteTargetInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/targetInstances/{target_instance=target_instance}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/targetInstances/{target_instance}"
     };
     option (google.api.method_signature) = "project,zone,target_instance";
     option (google.cloud.operation_service) = "ZoneOperations";
@@ -59,7 +59,7 @@ service TargetInstances {
   rpc GetTargetInstances(GetTargetInstancesRequest)
       returns (google.cloud.cpp.compute.v1.TargetInstance) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/targetInstances/{target_instance=target_instance}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/targetInstances/{target_instance}"
     };
     option (google.api.method_signature) = "project,zone,target_instance";
   }
@@ -69,7 +69,7 @@ service TargetInstances {
   rpc InsertTargetInstances(InsertTargetInstancesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/targetInstances"
+      post: "/compute/v1/projects/{project}/zones/{zone}/targetInstances"
       body: "target_instance_resource"
     };
     option (google.api.method_signature) =
@@ -82,7 +82,7 @@ service TargetInstances {
   rpc ListTargetInstances(ListTargetInstancesRequest)
       returns (google.cloud.cpp.compute.v1.TargetInstanceList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/targetInstances"
+      get: "/compute/v1/projects/{project}/zones/{zone}/targetInstances"
     };
     option (google.api.method_signature) = "project,zone";
   }

--- a/google/cloud/compute/target_pools/v1/target_pools.proto
+++ b/google/cloud/compute/target_pools/v1/target_pools.proto
@@ -40,7 +40,7 @@ service TargetPools {
   rpc AddHealthCheck(AddHealthCheckRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools/{target_pool=target_pool}/addHealthCheck"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetPools/{target_pool}/addHealthCheck"
       body: "target_pools_add_health_check_request_resource"
     };
     option (google.api.method_signature) =
@@ -52,7 +52,7 @@ service TargetPools {
   rpc AddInstance(AddInstanceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools/{target_pool=target_pool}/addInstance"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetPools/{target_pool}/addInstance"
       body: "target_pools_add_instance_request_resource"
     };
     option (google.api.method_signature) =
@@ -64,7 +64,7 @@ service TargetPools {
   rpc AggregatedListTargetPools(AggregatedListTargetPoolsRequest)
       returns (google.cloud.cpp.compute.v1.TargetPoolAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/targetPools"
+      get: "/compute/v1/projects/{project}/aggregated/targetPools"
     };
     option (google.api.method_signature) = "project";
   }
@@ -73,7 +73,7 @@ service TargetPools {
   rpc DeleteTargetPools(DeleteTargetPoolsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools/{target_pool=target_pool}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/targetPools/{target_pool}"
     };
     option (google.api.method_signature) = "project,region,target_pool";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -83,7 +83,7 @@ service TargetPools {
   rpc GetTargetPools(GetTargetPoolsRequest)
       returns (google.cloud.cpp.compute.v1.TargetPool) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools/{target_pool=target_pool}"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetPools/{target_pool}"
     };
     option (google.api.method_signature) = "project,region,target_pool";
   }
@@ -93,7 +93,7 @@ service TargetPools {
   rpc GetHealth(GetHealthRequest)
       returns (google.cloud.cpp.compute.v1.TargetPoolInstanceHealth) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools/{target_pool=target_pool}/getHealth"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetPools/{target_pool}/getHealth"
       body: "instance_reference_resource"
     };
     option (google.api.method_signature) =
@@ -105,7 +105,7 @@ service TargetPools {
   rpc InsertTargetPools(InsertTargetPoolsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetPools"
       body: "target_pool_resource"
     };
     option (google.api.method_signature) =
@@ -118,7 +118,7 @@ service TargetPools {
   rpc ListTargetPools(ListTargetPoolsRequest)
       returns (google.cloud.cpp.compute.v1.TargetPoolList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetPools"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -127,7 +127,7 @@ service TargetPools {
   rpc RemoveHealthCheck(RemoveHealthCheckRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools/{target_pool=target_pool}/removeHealthCheck"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetPools/{target_pool}/removeHealthCheck"
       body: "target_pools_remove_health_check_request_resource"
     };
     option (google.api.method_signature) =
@@ -139,7 +139,7 @@ service TargetPools {
   rpc RemoveInstance(RemoveInstanceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools/{target_pool=target_pool}/removeInstance"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetPools/{target_pool}/removeInstance"
       body: "target_pools_remove_instance_request_resource"
     };
     option (google.api.method_signature) =
@@ -151,7 +151,7 @@ service TargetPools {
   rpc SetBackup(SetBackupRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetPools/{target_pool=target_pool}/setBackup"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetPools/{target_pool}/setBackup"
       body: "target_reference_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies.proto
+++ b/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies.proto
@@ -40,7 +40,7 @@ service TargetSslProxies {
   rpc DeleteTargetSslProxies(DeleteTargetSslProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/targetSslProxies/{target_ssl_proxy=target_ssl_proxy}"
+      delete: "/compute/v1/projects/{project}/global/targetSslProxies/{target_ssl_proxy}"
     };
     option (google.api.method_signature) = "project,target_ssl_proxy";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -50,7 +50,7 @@ service TargetSslProxies {
   rpc GetTargetSslProxies(GetTargetSslProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetSslProxy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetSslProxies/{target_ssl_proxy=target_ssl_proxy}"
+      get: "/compute/v1/projects/{project}/global/targetSslProxies/{target_ssl_proxy}"
     };
     option (google.api.method_signature) = "project,target_ssl_proxy";
   }
@@ -60,7 +60,7 @@ service TargetSslProxies {
   rpc InsertTargetSslProxies(InsertTargetSslProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetSslProxies"
+      post: "/compute/v1/projects/{project}/global/targetSslProxies"
       body: "target_ssl_proxy_resource"
     };
     option (google.api.method_signature) = "project,target_ssl_proxy_resource";
@@ -72,7 +72,7 @@ service TargetSslProxies {
   rpc ListTargetSslProxies(ListTargetSslProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetSslProxyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetSslProxies"
+      get: "/compute/v1/projects/{project}/global/targetSslProxies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -81,7 +81,7 @@ service TargetSslProxies {
   rpc SetBackendService(SetBackendServiceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetSslProxies/{target_ssl_proxy=target_ssl_proxy}/setBackendService"
+      post: "/compute/v1/projects/{project}/global/targetSslProxies/{target_ssl_proxy}/setBackendService"
       body: "target_ssl_proxies_set_backend_service_request_resource"
     };
     option (google.api.method_signature) =
@@ -93,7 +93,7 @@ service TargetSslProxies {
   rpc SetCertificateMap(SetCertificateMapRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetSslProxies/{target_ssl_proxy=target_ssl_proxy}/setCertificateMap"
+      post: "/compute/v1/projects/{project}/global/targetSslProxies/{target_ssl_proxy}/setCertificateMap"
       body: "target_ssl_proxies_set_certificate_map_request_resource"
     };
     option (google.api.method_signature) =
@@ -105,7 +105,7 @@ service TargetSslProxies {
   rpc SetProxyHeader(SetProxyHeaderRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetSslProxies/{target_ssl_proxy=target_ssl_proxy}/setProxyHeader"
+      post: "/compute/v1/projects/{project}/global/targetSslProxies/{target_ssl_proxy}/setProxyHeader"
       body: "target_ssl_proxies_set_proxy_header_request_resource"
     };
     option (google.api.method_signature) =
@@ -117,7 +117,7 @@ service TargetSslProxies {
   rpc SetSslCertificates(SetSslCertificatesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetSslProxies/{target_ssl_proxy=target_ssl_proxy}/setSslCertificates"
+      post: "/compute/v1/projects/{project}/global/targetSslProxies/{target_ssl_proxy}/setSslCertificates"
       body: "target_ssl_proxies_set_ssl_certificates_request_resource"
     };
     option (google.api.method_signature) =
@@ -132,7 +132,7 @@ service TargetSslProxies {
   rpc SetSslPolicy(SetSslPolicyRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetSslProxies/{target_ssl_proxy=target_ssl_proxy}/setSslPolicy"
+      post: "/compute/v1/projects/{project}/global/targetSslProxies/{target_ssl_proxy}/setSslPolicy"
       body: "ssl_policy_reference_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies.proto
+++ b/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies.proto
@@ -41,7 +41,7 @@ service TargetTcpProxies {
   rpc AggregatedListTargetTcpProxies(AggregatedListTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetTcpProxyAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/targetTcpProxies"
+      get: "/compute/v1/projects/{project}/aggregated/targetTcpProxies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service TargetTcpProxies {
   rpc DeleteTargetTcpProxies(DeleteTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/targetTcpProxies/{target_tcp_proxy=target_tcp_proxy}"
+      delete: "/compute/v1/projects/{project}/global/targetTcpProxies/{target_tcp_proxy}"
     };
     option (google.api.method_signature) = "project,target_tcp_proxy";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -60,7 +60,7 @@ service TargetTcpProxies {
   rpc GetTargetTcpProxies(GetTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetTcpProxy) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetTcpProxies/{target_tcp_proxy=target_tcp_proxy}"
+      get: "/compute/v1/projects/{project}/global/targetTcpProxies/{target_tcp_proxy}"
     };
     option (google.api.method_signature) = "project,target_tcp_proxy";
   }
@@ -70,7 +70,7 @@ service TargetTcpProxies {
   rpc InsertTargetTcpProxies(InsertTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetTcpProxies"
+      post: "/compute/v1/projects/{project}/global/targetTcpProxies"
       body: "target_tcp_proxy_resource"
     };
     option (google.api.method_signature) = "project,target_tcp_proxy_resource";
@@ -82,7 +82,7 @@ service TargetTcpProxies {
   rpc ListTargetTcpProxies(ListTargetTcpProxiesRequest)
       returns (google.cloud.cpp.compute.v1.TargetTcpProxyList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/targetTcpProxies"
+      get: "/compute/v1/projects/{project}/global/targetTcpProxies"
     };
     option (google.api.method_signature) = "project";
   }
@@ -91,7 +91,7 @@ service TargetTcpProxies {
   rpc SetBackendService(SetBackendServiceRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetTcpProxies/{target_tcp_proxy=target_tcp_proxy}/setBackendService"
+      post: "/compute/v1/projects/{project}/global/targetTcpProxies/{target_tcp_proxy}/setBackendService"
       body: "target_tcp_proxies_set_backend_service_request_resource"
     };
     option (google.api.method_signature) =
@@ -103,7 +103,7 @@ service TargetTcpProxies {
   rpc SetProxyHeader(SetProxyHeaderRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/targetTcpProxies/{target_tcp_proxy=target_tcp_proxy}/setProxyHeader"
+      post: "/compute/v1/projects/{project}/global/targetTcpProxies/{target_tcp_proxy}/setProxyHeader"
       body: "target_tcp_proxies_set_proxy_header_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways.proto
+++ b/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways.proto
@@ -40,7 +40,7 @@ service TargetVpnGateways {
   rpc AggregatedListTargetVpnGateways(AggregatedListTargetVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.TargetVpnGatewayAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/targetVpnGateways"
+      get: "/compute/v1/projects/{project}/aggregated/targetVpnGateways"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service TargetVpnGateways {
   rpc DeleteTargetVpnGateways(DeleteTargetVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/targetVpnGateways/{target_vpn_gateway=target_vpn_gateway}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/targetVpnGateways/{target_vpn_gateway}"
     };
     option (google.api.method_signature) = "project,region,target_vpn_gateway";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service TargetVpnGateways {
   rpc GetTargetVpnGateways(GetTargetVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.TargetVpnGateway) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetVpnGateways/{target_vpn_gateway=target_vpn_gateway}"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetVpnGateways/{target_vpn_gateway}"
     };
     option (google.api.method_signature) = "project,region,target_vpn_gateway";
   }
@@ -69,7 +69,7 @@ service TargetVpnGateways {
   rpc InsertTargetVpnGateways(InsertTargetVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetVpnGateways"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetVpnGateways"
       body: "target_vpn_gateway_resource"
     };
     option (google.api.method_signature) =
@@ -82,7 +82,7 @@ service TargetVpnGateways {
   rpc ListTargetVpnGateways(ListTargetVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.TargetVpnGatewayList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/targetVpnGateways"
+      get: "/compute/v1/projects/{project}/regions/{region}/targetVpnGateways"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -92,7 +92,7 @@ service TargetVpnGateways {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/targetVpnGateways/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/regions/{region}/targetVpnGateways/{resource}/setLabels"
       body: "region_set_labels_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/url_maps/v1/url_maps.proto
+++ b/google/cloud/compute/url_maps/v1/url_maps.proto
@@ -41,7 +41,7 @@ service UrlMaps {
   rpc AggregatedListUrlMaps(AggregatedListUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.UrlMapsAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/urlMaps"
+      get: "/compute/v1/projects/{project}/aggregated/urlMaps"
     };
     option (google.api.method_signature) = "project";
   }
@@ -50,7 +50,7 @@ service UrlMaps {
   rpc DeleteUrlMaps(DeleteUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/global/urlMaps/{url_map=url_map}"
+      delete: "/compute/v1/projects/{project}/global/urlMaps/{url_map}"
     };
     option (google.api.method_signature) = "project,url_map";
     option (google.cloud.operation_service) = "GlobalOperations";
@@ -60,7 +60,7 @@ service UrlMaps {
   rpc GetUrlMaps(GetUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.UrlMap) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/urlMaps/{url_map=url_map}"
+      get: "/compute/v1/projects/{project}/global/urlMaps/{url_map}"
     };
     option (google.api.method_signature) = "project,url_map";
   }
@@ -70,7 +70,7 @@ service UrlMaps {
   rpc InsertUrlMaps(InsertUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/urlMaps"
+      post: "/compute/v1/projects/{project}/global/urlMaps"
       body: "url_map_resource"
     };
     option (google.api.method_signature) = "project,url_map_resource";
@@ -83,7 +83,7 @@ service UrlMaps {
   rpc InvalidateCache(InvalidateCacheRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/urlMaps/{url_map=url_map}/invalidateCache"
+      post: "/compute/v1/projects/{project}/global/urlMaps/{url_map}/invalidateCache"
       body: "cache_invalidation_rule_resource"
     };
     option (google.api.method_signature) =
@@ -95,7 +95,7 @@ service UrlMaps {
   rpc ListUrlMaps(ListUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.UrlMapList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/global/urlMaps"
+      get: "/compute/v1/projects/{project}/global/urlMaps"
     };
     option (google.api.method_signature) = "project";
   }
@@ -106,7 +106,7 @@ service UrlMaps {
   rpc PatchUrlMaps(PatchUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      patch: "/compute/v1/projects/{project=project}/global/urlMaps/{url_map=url_map}"
+      patch: "/compute/v1/projects/{project}/global/urlMaps/{url_map}"
       body: "url_map_resource"
     };
     option (google.api.method_signature) = "project,url_map,url_map_resource";
@@ -118,7 +118,7 @@ service UrlMaps {
   rpc UpdateUrlMaps(UpdateUrlMapsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      put: "/compute/v1/projects/{project=project}/global/urlMaps/{url_map=url_map}"
+      put: "/compute/v1/projects/{project}/global/urlMaps/{url_map}"
       body: "url_map_resource"
     };
     option (google.api.method_signature) = "project,url_map,url_map_resource";
@@ -131,7 +131,7 @@ service UrlMaps {
   rpc Validate(ValidateRequest)
       returns (google.cloud.cpp.compute.v1.UrlMapsValidateResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/global/urlMaps/{url_map=url_map}/validate"
+      post: "/compute/v1/projects/{project}/global/urlMaps/{url_map}/validate"
       body: "url_maps_validate_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/vpn_gateways/v1/vpn_gateways.proto
+++ b/google/cloud/compute/vpn_gateways/v1/vpn_gateways.proto
@@ -40,7 +40,7 @@ service VpnGateways {
   rpc AggregatedListVpnGateways(AggregatedListVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.VpnGatewayAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/vpnGateways"
+      get: "/compute/v1/projects/{project}/aggregated/vpnGateways"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service VpnGateways {
   rpc DeleteVpnGateways(DeleteVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnGateways/{vpn_gateway=vpn_gateway}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/vpnGateways/{vpn_gateway}"
     };
     option (google.api.method_signature) = "project,region,vpn_gateway";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service VpnGateways {
   rpc GetVpnGateways(GetVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.VpnGateway) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnGateways/{vpn_gateway=vpn_gateway}"
+      get: "/compute/v1/projects/{project}/regions/{region}/vpnGateways/{vpn_gateway}"
     };
     option (google.api.method_signature) = "project,region,vpn_gateway";
   }
@@ -68,7 +68,7 @@ service VpnGateways {
   rpc GetStatus(GetStatusRequest)
       returns (google.cloud.cpp.compute.v1.VpnGatewaysGetStatusResponse) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnGateways/{vpn_gateway=vpn_gateway}/getStatus"
+      get: "/compute/v1/projects/{project}/regions/{region}/vpnGateways/{vpn_gateway}/getStatus"
     };
     option (google.api.method_signature) = "project,region,vpn_gateway";
   }
@@ -78,7 +78,7 @@ service VpnGateways {
   rpc InsertVpnGateways(InsertVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnGateways"
+      post: "/compute/v1/projects/{project}/regions/{region}/vpnGateways"
       body: "vpn_gateway_resource"
     };
     option (google.api.method_signature) =
@@ -91,7 +91,7 @@ service VpnGateways {
   rpc ListVpnGateways(ListVpnGatewaysRequest)
       returns (google.cloud.cpp.compute.v1.VpnGatewayList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnGateways"
+      get: "/compute/v1/projects/{project}/regions/{region}/vpnGateways"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -101,7 +101,7 @@ service VpnGateways {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnGateways/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/regions/{region}/vpnGateways/{resource}/setLabels"
       body: "region_set_labels_request_resource"
     };
     option (google.api.method_signature) =
@@ -113,7 +113,7 @@ service VpnGateways {
   rpc TestIamPermissions(TestIamPermissionsRequest)
       returns (google.cloud.cpp.compute.v1.TestPermissionsResponse) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnGateways/{resource=resource}/testIamPermissions"
+      post: "/compute/v1/projects/{project}/regions/{region}/vpnGateways/{resource}/testIamPermissions"
       body: "test_permissions_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels.proto
+++ b/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels.proto
@@ -40,7 +40,7 @@ service VpnTunnels {
   rpc AggregatedListVpnTunnels(AggregatedListVpnTunnelsRequest)
       returns (google.cloud.cpp.compute.v1.VpnTunnelAggregatedList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/aggregated/vpnTunnels"
+      get: "/compute/v1/projects/{project}/aggregated/vpnTunnels"
     };
     option (google.api.method_signature) = "project";
   }
@@ -49,7 +49,7 @@ service VpnTunnels {
   rpc DeleteVpnTunnels(DeleteVpnTunnelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnTunnels/{vpn_tunnel=vpn_tunnel}"
+      delete: "/compute/v1/projects/{project}/regions/{region}/vpnTunnels/{vpn_tunnel}"
     };
     option (google.api.method_signature) = "project,region,vpn_tunnel";
     option (google.cloud.operation_service) = "RegionOperations";
@@ -59,7 +59,7 @@ service VpnTunnels {
   rpc GetVpnTunnels(GetVpnTunnelsRequest)
       returns (google.cloud.cpp.compute.v1.VpnTunnel) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnTunnels/{vpn_tunnel=vpn_tunnel}"
+      get: "/compute/v1/projects/{project}/regions/{region}/vpnTunnels/{vpn_tunnel}"
     };
     option (google.api.method_signature) = "project,region,vpn_tunnel";
   }
@@ -69,7 +69,7 @@ service VpnTunnels {
   rpc InsertVpnTunnels(InsertVpnTunnelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnTunnels"
+      post: "/compute/v1/projects/{project}/regions/{region}/vpnTunnels"
       body: "vpn_tunnel_resource"
     };
     option (google.api.method_signature) = "project,region,vpn_tunnel_resource";
@@ -81,7 +81,7 @@ service VpnTunnels {
   rpc ListVpnTunnels(ListVpnTunnelsRequest)
       returns (google.cloud.cpp.compute.v1.VpnTunnelList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnTunnels"
+      get: "/compute/v1/projects/{project}/regions/{region}/vpnTunnels"
     };
     option (google.api.method_signature) = "project,region";
   }
@@ -91,7 +91,7 @@ service VpnTunnels {
   rpc SetLabels(SetLabelsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/regions/{region=region}/vpnTunnels/{resource=resource}/setLabels"
+      post: "/compute/v1/projects/{project}/regions/{region}/vpnTunnels/{resource}/setLabels"
       body: "region_set_labels_request_resource"
     };
     option (google.api.method_signature) =

--- a/google/cloud/compute/zone_operations/v1/zone_operations.proto
+++ b/google/cloud/compute/zone_operations/v1/zone_operations.proto
@@ -41,7 +41,7 @@ service ZoneOperations {
   rpc DeleteZoneOperations(DeleteZoneOperationsRequest)
       returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      delete: "/compute/v1/projects/{project=project}/zones/{zone=zone}/operations/{operation=operation}"
+      delete: "/compute/v1/projects/{project}/zones/{zone}/operations/{operation}"
     };
     option (google.api.method_signature) = "project,zone,operation";
   }
@@ -50,7 +50,7 @@ service ZoneOperations {
   rpc GetZoneOperations(GetZoneOperationsRequest)
       returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/operations/{operation=operation}"
+      get: "/compute/v1/projects/{project}/zones/{zone}/operations/{operation}"
     };
     option (google.api.method_signature) = "project,zone,operation";
   }
@@ -60,7 +60,7 @@ service ZoneOperations {
   rpc ListZoneOperations(ListZoneOperationsRequest)
       returns (google.cloud.cpp.compute.v1.OperationList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}/operations"
+      get: "/compute/v1/projects/{project}/zones/{zone}/operations"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -77,7 +77,7 @@ service ZoneOperations {
   // Be prepared to retry if the operation is not `DONE`.
   rpc Wait(WaitRequest) returns (google.cloud.cpp.compute.v1.Operation) {
     option (google.api.http) = {
-      post: "/compute/v1/projects/{project=project}/zones/{zone=zone}/operations/{operation=operation}/wait"
+      post: "/compute/v1/projects/{project}/zones/{zone}/operations/{operation}/wait"
       body: "*"
     };
     option (google.api.method_signature) = "project,zone,operation";

--- a/google/cloud/compute/zones/v1/zones.proto
+++ b/google/cloud/compute/zones/v1/zones.proto
@@ -38,7 +38,7 @@ service Zones {
   // Returns the specified Zone resource.
   rpc GetZones(GetZonesRequest) returns (google.cloud.cpp.compute.v1.Zone) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones/{zone=zone}"
+      get: "/compute/v1/projects/{project}/zones/{zone}"
     };
     option (google.api.method_signature) = "project,zone";
   }
@@ -47,7 +47,7 @@ service Zones {
   rpc ListZones(ListZonesRequest)
       returns (google.cloud.cpp.compute.v1.ZoneList) {
     option (google.api.http) = {
-      get: "/compute/v1/projects/{project=project}/zones"
+      get: "/compute/v1/projects/{project}/zones"
     };
     option (google.api.method_signature) = "project";
   }


### PR DESCRIPTION
Since the generator now correctly supports multi variable implicit paths, change how the generator emits paths for discovery doc protos.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12202)
<!-- Reviewable:end -->
