### PR TITLE
cleanup(bigquery): drop grpc_utils dep

### DIFF
--- a/google/cloud/bigquery/BUILD.bazel
+++ b/google/cloud/bigquery/BUILD.bazel
@@ -109,7 +109,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",
-        "//:grpc_utils",
         "//google/cloud:google_cloud_cpp_rest_internal",
     ],
 )

--- a/google/cloud/bigquery/bigquery_rest.cmake
+++ b/google/cloud/bigquery/bigquery_rest.cmake
@@ -148,9 +148,8 @@ target_include_directories(
            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
            $<INSTALL_INTERFACE:include>)
 target_link_libraries(
-    google_cloud_cpp_bigquery_rest
-    PUBLIC google-cloud-cpp::rest_internal google-cloud-cpp::grpc_utils
-           google-cloud-cpp::common)
+    google_cloud_cpp_bigquery_rest PUBLIC google-cloud-cpp::rest_internal
+                                          google-cloud-cpp::common)
 google_cloud_cpp_add_common_options(google_cloud_cpp_bigquery_rest)
 set_target_properties(
     google_cloud_cpp_bigquery_rest

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_logging.cc
@@ -15,8 +15,6 @@
 #include "google/cloud/bigquery/v2/minimal/internal/dataset_logging.h"
 #include "google/cloud/bigquery/v2/minimal/internal/log_wrapper.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
-#include "google/cloud/internal/debug_string.h"
-#include "google/cloud/internal/debug_string_status.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/rest_context.h"
 #include "google/cloud/log.h"

--- a/google/cloud/bigquery/v2/minimal/internal/log_wrapper.h
+++ b/google/cloud/bigquery/v2/minimal/internal/log_wrapper.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/debug_string.h"
-#include "google/cloud/internal/debug_string_status.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/rest_context.h"
 #include "google/cloud/log.h"
@@ -50,8 +49,7 @@ Result LogWrapper(Functor&& functor, rest_internal::RestContext& context,
 
   auto response = functor(context, request);
   if (!response) {
-    GCP_LOG(DEBUG) << where << "() >> status="
-                   << internal::DebugString(response.status(), options);
+    GCP_LOG(DEBUG) << where << "() >> status=" << response.status();
   } else {
     GCP_LOG(DEBUG) << where << "() >> response="
                    << response->DebugString(response_name, options);

--- a/google/cloud/bigquery/v2/minimal/internal/table_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_logging.cc
@@ -15,8 +15,6 @@
 #include "google/cloud/bigquery/v2/minimal/internal/table_logging.h"
 #include "google/cloud/bigquery/v2/minimal/internal/log_wrapper.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
-#include "google/cloud/internal/debug_string.h"
-#include "google/cloud/internal/debug_string_status.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/rest_context.h"
 #include "google/cloud/log.h"


### PR DESCRIPTION
Part of the work for #12210 

cc: @jsrinnn @sachinpro 

Stream the status, instead of calling `DebugString(status, options)`.

Note that no behavior is changed, as:

1. the implementation is to stream the status as is

https://github.com/googleapis/google-cloud-cpp/blob/6dcf55e64db842b781f8f2f0a45b15d005e023bd/google/cloud/internal/debug_string_status.cc#L36-L38

2. the payload is empty for `g::c::Status`es that do not originate from an RPC status.

https://github.com/googleapis/google-cloud-cpp/blob/6dcf55e64db842b781f8f2f0a45b15d005e023bd/google/cloud/internal/debug_string_status.cc#L39-L42

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12215)
<!-- Reviewable:end -->
