### PR TITLE
impl(generator): create descriptor pool and plumb through

### DIFF
--- a/generator/internal/discovery_file.cc
+++ b/generator/internal/discovery_file.cc
@@ -51,10 +51,13 @@ std::string GeneratedProtoPreamble() {
 }  // namespace
 
 DiscoveryFile::DiscoveryFile(DiscoveryResource const* resource,
-                             std::string file_path, std::string package_name,
+                             std::string file_path,
+                             std::string relative_proto_path,
+                             std::string package_name,
                              std::vector<DiscoveryTypeVertex const*> types)
     : resource_(resource),
       file_path_(std::move(file_path)),
+      relative_proto_path_(std::move(relative_proto_path)),
       package_name_(std::move(package_name)),
       types_(std::move(types)) {}
 

--- a/generator/internal/discovery_file.h
+++ b/generator/internal/discovery_file.h
@@ -34,10 +34,13 @@ class DiscoveryFile {
 
   // Set resources == nullptr to indicate the file only contains messages.
   DiscoveryFile(DiscoveryResource const* resource, std::string file_path,
-                std::string package_name,
+                std::string relative_proto_path, std::string package_name,
                 std::vector<DiscoveryTypeVertex const*> types);
 
   std::string const& file_path() const { return file_path_; }
+  std::string const& relative_proto_path() const {
+    return relative_proto_path_;
+  }
   std::string const& package_name() const { return package_name_; }
   std::string resource_name() const {
     return (resource_ ? resource_->name() : "");
@@ -62,6 +65,7 @@ class DiscoveryFile {
  private:
   DiscoveryResource const* resource_;
   std::string file_path_;
+  std::string relative_proto_path_;
   std::string package_name_;
   std::set<std::string> import_paths_;
   std::vector<DiscoveryTypeVertex const*> types_;

--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -183,6 +183,12 @@ StatusOr<std::string> DiscoveryResource::FormatOAuthScopes() const {
 std::string DiscoveryResource::FormatFilePath(
     std::string const& product_name, std::string const& version,
     std::string const& output_path) const {
+  if (output_path.empty()) {
+    return absl::StrJoin(
+        {std::string("google/cloud"), product_name, CamelCaseToSnakeCase(name_),
+         version, absl::StrCat(CamelCaseToSnakeCase(name_), ".proto")},
+        "/");
+  }
   return absl::StrJoin({output_path, std::string("google/cloud"), product_name,
                         CamelCaseToSnakeCase(name_), version,
                         absl::StrCat(CamelCaseToSnakeCase(name_), ".proto")},

--- a/generator/internal/discovery_resource_test.cc
+++ b/generator/internal/discovery_resource_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "generator/internal/discovery_resource.h"
+#include "generator/testing/descriptor_pool_fixture.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -25,7 +26,10 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 
-TEST(DiscoveryResourceTest, HasEmptyRequest) {
+class DiscoveryResourceTest : public generator_testing::DescriptorPoolFixture {
+};
+
+TEST_F(DiscoveryResourceTest, HasEmptyRequest) {
   auto constexpr kResourceJson = R"""({})""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
@@ -35,7 +39,7 @@ TEST(DiscoveryResourceTest, HasEmptyRequest) {
   EXPECT_TRUE(r.RequiresEmptyImport());
 }
 
-TEST(DiscoveryResourceTest, HasEmptyResponse) {
+TEST_F(DiscoveryResourceTest, HasEmptyResponse) {
   auto constexpr kResourceJson = R"""({})""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
@@ -45,7 +49,7 @@ TEST(DiscoveryResourceTest, HasEmptyResponse) {
   EXPECT_TRUE(r.RequiresEmptyImport());
 }
 
-TEST(DiscoveryResourceTest, RequiresLROImport) {
+TEST_F(DiscoveryResourceTest, RequiresLROImport) {
   auto constexpr kResourceJson = R"""({})""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
@@ -54,7 +58,7 @@ TEST(DiscoveryResourceTest, RequiresLROImport) {
   EXPECT_TRUE(r.RequiresLROImport());
 }
 
-TEST(DiscoveryResourceTest, FormatUrlPath) {
+TEST_F(DiscoveryResourceTest, FormatUrlPath) {
   EXPECT_THAT(DiscoveryResource::FormatUrlPath("base/path/test"),
               Eq("base/path/test"));
   EXPECT_THAT(DiscoveryResource::FormatUrlPath(
@@ -72,7 +76,7 @@ TEST(DiscoveryResourceTest, FormatUrlPath) {
          "{foo_id}:method1"));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
   auto constexpr kTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "path": "projects/{project}/regions/{region}/myTests/{foo}",
@@ -93,13 +97,13 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetRegion) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsPatchZone) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsPatchZone) {
   auto constexpr kTypeJson = R"""({
   "request_resource_field_name": "my_request_resource"
 })""";
@@ -127,13 +131,13 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPatchZone) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegion) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsPutRegion) {
   auto constexpr kTypeJson = R"""({
   "request_resource_field_name": "my_request_resource"
 })""";
@@ -161,13 +165,13 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegion) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobal) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsPostGlobal) {
   auto constexpr kTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "path": "projects/{project}/global/myTests/{foo}:cancel",
@@ -188,13 +192,13 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobal) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationResponse) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationResponse) {
   auto constexpr kTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "path": "projects/{project}/global/myTests/{foo}:cancel",
@@ -219,13 +223,13 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationResponse) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsGetNoParams) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsGetNoParams) {
   auto constexpr kTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "path": "resources/global/list",
@@ -240,13 +244,13 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetNoParams) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsGetNoParamsOperation) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsGetNoParamsOperation) {
   auto constexpr kTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
     "path": "doFoo",
@@ -266,13 +270,13 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsGetNoParamsOperation) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsMissingPath) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsMissingPath) {
   auto constexpr kTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "httpMethod": "GET"
@@ -282,7 +286,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsMissingPath) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   EXPECT_THAT(
       options,
@@ -290,7 +294,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsMissingPath) {
                HasSubstr("Method does not define httpMethod and/or path.")));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsMissingHttpMethod) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsMissingHttpMethod) {
   auto constexpr kTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "path": "resources/global/list"
@@ -300,7 +304,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsMissingHttpMethod) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("myTests", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options = r.FormatRpcOptions(method_json, "base/path", {}, &t);
   EXPECT_THAT(
       options,
@@ -308,7 +312,7 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsMissingHttpMethod) {
                HasSubstr("Method does not define httpMethod and/or path.")));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegionOperationService) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsPutRegionOperationService) {
   auto constexpr kTypeJson = R"""({
   "request_resource_field_name": "my_request_resource"
 })""";
@@ -335,14 +339,14 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPutRegionOperationService) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("regionOperations", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options =
       r.FormatRpcOptions(method_json, "base/path", {"RegionOperations"}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationService) {
+TEST_F(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationService) {
   auto constexpr kTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "path": "projects/{project}/global/myTests/{foo}:cancel",
@@ -366,14 +370,14 @@ TEST(DiscoveryResourceTest, FormatRpcOptionsPostGlobalOperationService) {
   auto type_json = nlohmann::json::parse(kTypeJson, nullptr, false);
   ASSERT_TRUE(type_json.is_object());
   DiscoveryResource r("GlobalOperations", "", method_json);
-  DiscoveryTypeVertex t("myType", "", type_json);
+  DiscoveryTypeVertex t("myType", "", type_json, &pool());
   auto options =
       r.FormatRpcOptions(method_json, "base/path", {"GlobalOperations"}, &t);
   ASSERT_STATUS_OK(options);
   EXPECT_THAT(*options, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatOAuthScopesPresent) {
+TEST_F(DiscoveryResourceTest, FormatOAuthScopesPresent) {
   auto constexpr kResourceJson = R"""({
   "methods": {
     "method1": {
@@ -401,7 +405,7 @@ TEST(DiscoveryResourceTest, FormatOAuthScopesPresent) {
   EXPECT_THAT(*scopes, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, FormatOAuthScopesZeroScopes) {
+TEST_F(DiscoveryResourceTest, FormatOAuthScopesZeroScopes) {
   auto constexpr kResourceJson = R"""({
 "methods": {
   "method0": {
@@ -420,7 +424,7 @@ TEST(DiscoveryResourceTest, FormatOAuthScopesZeroScopes) {
                HasSubstr("No OAuth scopes found for service: myTests.")));
 }
 
-TEST(DiscoveryResourceTest, FormatOAuthScopesNotPresent) {
+TEST_F(DiscoveryResourceTest, FormatOAuthScopesNotPresent) {
   auto constexpr kResourceJson = R"""({
 "methods": {
   "methodNone": {
@@ -437,7 +441,7 @@ TEST(DiscoveryResourceTest, FormatOAuthScopesNotPresent) {
                HasSubstr("No OAuth scopes found for service: myTests.")));
 }
 
-TEST(DiscoveryResourceTest, FormatFilePath) {
+TEST_F(DiscoveryResourceTest, FormatFilePath) {
   auto constexpr kResourceJson = R"""({})""";
   auto json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
@@ -446,7 +450,16 @@ TEST(DiscoveryResourceTest, FormatFilePath) {
               Eq("/tmp/google/cloud/product/my_tests/v2/my_tests.proto"));
 }
 
-TEST(DiscoveryResourceTest, FormatMethodName) {
+TEST_F(DiscoveryResourceTest, FormatFilePathEmptyOutputPath) {
+  auto constexpr kResourceJson = R"""({})""";
+  auto json = nlohmann::json::parse(kResourceJson, nullptr, false);
+  ASSERT_TRUE(json.is_object());
+  DiscoveryResource r("myTests", "", json);
+  EXPECT_THAT(r.FormatFilePath("product", "v2", {}),
+              Eq("google/cloud/product/my_tests/v2/my_tests.proto"));
+}
+
+TEST_F(DiscoveryResourceTest, FormatMethodName) {
   auto constexpr kResourceJson = R"""({})""";
   auto json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
@@ -462,7 +475,7 @@ TEST(DiscoveryResourceTest, FormatMethodName) {
   EXPECT_THAT(r.FormatMethodName("testPermissions"), Eq("TestPermissions"));
 }
 
-TEST(DiscoveryResourceTest, JsonToProtobufService) {
+TEST_F(DiscoveryResourceTest, JsonToProtobufService) {
   auto constexpr kOperationTypeJson = R"""({})""";
   auto constexpr kGetRequestTypeJson = R"""({})""";
   auto constexpr kDoFooRequestTypeJson = R"""({
@@ -549,12 +562,13 @@ service MyResources {
   ASSERT_TRUE(do_foo_request_type_json.is_object());
   DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryTypeVertex t("GetMyResourcesRequest", "this.package",
-                        get_request_type_json);
+                        get_request_type_json, &pool());
   DiscoveryTypeVertex t2("DoFooRequest", "this.package",
-                         do_foo_request_type_json);
+                         do_foo_request_type_json, &pool());
   r.AddRequestType("GetMyResourcesRequest", &t);
   r.AddRequestType("DoFooRequest", &t2);
-  DiscoveryTypeVertex t3("Operation", "other.package", operation_type_json);
+  DiscoveryTypeVertex t3("Operation", "other.package", operation_type_json,
+                         &pool());
   r.AddResponseType("Operation", &t3);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}};
@@ -563,7 +577,7 @@ service MyResources {
   EXPECT_THAT(*emitted_proto, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingOAuthScopes) {
+TEST_F(DiscoveryResourceTest, JsonToProtobufServiceMissingOAuthScopes) {
   auto constexpr kGetRequestTypeJson = R"""({})""";
   auto constexpr kResourceJson = R"""({
     "methods": {
@@ -585,7 +599,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingOAuthScopes) {
   ASSERT_TRUE(get_request_type_json.is_object());
   DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryTypeVertex t("GetMyResourcesRequest", "this.package",
-                        get_request_type_json);
+                        get_request_type_json, &pool());
   r.AddRequestType("GetMyResourcesRequest", &t);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}};
@@ -596,7 +610,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingOAuthScopes) {
                HasSubstr("No OAuth scopes found for service: myResources.")));
 }
 
-TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingRequestType) {
+TEST_F(DiscoveryResourceTest, JsonToProtobufServiceMissingRequestType) {
   auto constexpr kResourceJson = R"""({
     "methods": {
       "doFoo": {
@@ -634,7 +648,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceMissingRequestType) {
           HasSubstr("Cannot find request_type_name=DoFooRequest in type_map")));
 }
 
-TEST(DiscoveryResourceTest, JsonToProtobufServiceEmptyRequestType) {
+TEST_F(DiscoveryResourceTest, JsonToProtobufServiceEmptyRequestType) {
   auto constexpr kResourceJson = R"""({
     "methods": {
       "noop": {
@@ -671,7 +685,7 @@ service MyResources {
   EXPECT_THAT(*emitted_proto, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryResourceTest, JsonToProtobufServiceErrorFormattingRpcOptions) {
+TEST_F(DiscoveryResourceTest, JsonToProtobufServiceErrorFormattingRpcOptions) {
   auto constexpr kGetRequestTypeJson = R"""({})""";
   auto constexpr kResourceJson = R"""({
     "methods": {
@@ -695,7 +709,7 @@ TEST(DiscoveryResourceTest, JsonToProtobufServiceErrorFormattingRpcOptions) {
   ASSERT_TRUE(get_request_type_json.is_object());
   DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryTypeVertex t("GetMyResourcesRequest", "this.package",
-                        get_request_type_json);
+                        get_request_type_json, &pool());
   r.AddRequestType("GetMyResourcesRequest", &t);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}};

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -32,7 +32,8 @@ namespace generator_internal {
 // Discovery Document.
 StatusOr<std::map<std::string, DiscoveryTypeVertex>> ExtractTypesFromSchema(
     DiscoveryDocumentProperties const& document_properties,
-    nlohmann::json const& discovery_doc);
+    nlohmann::json const& discovery_doc,
+    google::protobuf::DescriptorPool const* descriptor_pool);
 
 // Creates a DiscoveryResource for every resource defined in the Discovery
 // Document.
@@ -49,13 +50,15 @@ StatusOr<DiscoveryTypeVertex const*> DetermineAndVerifyResponseType(
 // Creates a type from the method parameters to represent the request.
 StatusOr<DiscoveryTypeVertex> SynthesizeRequestType(
     nlohmann::json const& method_json, DiscoveryResource const& resource,
-    std::string const& response_type_name, std::string method_name);
+    std::string const& response_type_name, std::string method_name,
+    google::protobuf::DescriptorPool const* descriptor_pool);
 
 // Iterate through all the methods in all the resources and invoke
 // DetermineAndVerifyResponseTypeName and SynthesizeRequestType as needed.
 Status ProcessMethodRequestsAndResponses(
     std::map<std::string, DiscoveryResource>& resources,
-    std::map<std::string, DiscoveryTypeVertex>& types);
+    std::map<std::string, DiscoveryTypeVertex>& types,
+    google::protobuf::DescriptorPool const* descriptor_pool);
 
 // Creates a DiscoveryFile object for each DiscoveryResource in resources.
 std::vector<DiscoveryFile> CreateFilesFromResources(

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "generator/internal/discovery_to_proto.h"
+#include "generator/testing/descriptor_pool_fixture.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
@@ -35,7 +36,10 @@ using ::testing::Key;
 using ::testing::SizeIs;
 using ::testing::UnorderedElementsAre;
 
-TEST(ExtractTypesFromSchemaTest, Success) {
+class ExtractTypesFromSchemaTest
+    : public generator_testing::DescriptorPoolFixture {};
+
+TEST_F(ExtractTypesFromSchemaTest, Success) {
   auto constexpr kDiscoveryDocWithCorrectSchema = R"""(
 {
   "schemas": {
@@ -54,12 +58,12 @@ TEST(ExtractTypesFromSchemaTest, Success) {
   auto parsed_json =
       nlohmann::json::parse(kDiscoveryDocWithCorrectSchema, nullptr, false);
   ASSERT_TRUE(parsed_json.is_object());
-  auto types = ExtractTypesFromSchema({}, parsed_json);
+  auto types = ExtractTypesFromSchema({}, parsed_json, &pool());
   ASSERT_THAT(types, IsOk());
   EXPECT_THAT(*types, UnorderedElementsAre(Key("Foo"), Key("Bar")));
 }
 
-TEST(ExtractTypesFromSchemaTest, MissingSchema) {
+TEST_F(ExtractTypesFromSchemaTest, MissingSchema) {
   auto constexpr kDiscoveryDocMissingSchema = R"""(
 {
 }
@@ -68,12 +72,12 @@ TEST(ExtractTypesFromSchemaTest, MissingSchema) {
   auto parsed_json =
       nlohmann::json::parse(kDiscoveryDocMissingSchema, nullptr, false);
   ASSERT_TRUE(parsed_json.is_object());
-  auto types = ExtractTypesFromSchema({}, parsed_json);
+  auto types = ExtractTypesFromSchema({}, parsed_json, &pool());
   EXPECT_THAT(types, StatusIs(StatusCode::kInvalidArgument,
                               HasSubstr("does not contain schemas element")));
 }
 
-TEST(ExtractTypesFromSchemaTest, SchemaIdMissing) {
+TEST_F(ExtractTypesFromSchemaTest, SchemaIdMissing) {
   auto constexpr kDiscoveryDocSchemaIdMissing = R"""(
 {
   "schemas": {
@@ -92,7 +96,7 @@ TEST(ExtractTypesFromSchemaTest, SchemaIdMissing) {
   auto parsed_json =
       nlohmann::json::parse(kDiscoveryDocSchemaIdMissing, nullptr, false);
   ASSERT_TRUE(parsed_json.is_object());
-  auto types = ExtractTypesFromSchema({}, parsed_json);
+  auto types = ExtractTypesFromSchema({}, parsed_json, &pool());
   EXPECT_THAT(types, StatusIs(StatusCode::kInvalidArgument,
                               HasSubstr("schema without id")));
   auto const log_lines = log.ExtractLines();
@@ -101,7 +105,7 @@ TEST(ExtractTypesFromSchemaTest, SchemaIdMissing) {
       Contains(HasSubstr("current schema has no id. last schema with id=Foo")));
 }
 
-TEST(ExtractTypesFromSchemaTest, SchemaIdEmpty) {
+TEST_F(ExtractTypesFromSchemaTest, SchemaIdEmpty) {
   auto constexpr kDiscoveryDocSchemaIdEmpty = R"""(
 {
   "schemas": {
@@ -121,7 +125,7 @@ TEST(ExtractTypesFromSchemaTest, SchemaIdEmpty) {
   auto parsed_json =
       nlohmann::json::parse(kDiscoveryDocSchemaIdEmpty, nullptr, false);
   ASSERT_TRUE(parsed_json.is_object());
-  auto types = ExtractTypesFromSchema({}, parsed_json);
+  auto types = ExtractTypesFromSchema({}, parsed_json, &pool());
   EXPECT_THAT(types, StatusIs(StatusCode::kInvalidArgument,
                               HasSubstr("schema without id")));
   auto const log_lines = log.ExtractLines();
@@ -130,7 +134,7 @@ TEST(ExtractTypesFromSchemaTest, SchemaIdEmpty) {
                   "current schema has no id. last schema with id=(none)")));
 }
 
-TEST(ExtractTypesFromSchemaTest, SchemaMissingType) {
+TEST_F(ExtractTypesFromSchemaTest, SchemaMissingType) {
   auto constexpr kDiscoveryDocWithMissingType = R"""(
 {
   "schemas": {
@@ -145,7 +149,7 @@ TEST(ExtractTypesFromSchemaTest, SchemaMissingType) {
   auto parsed_json =
       nlohmann::json::parse(kDiscoveryDocWithMissingType, nullptr, false);
   ASSERT_TRUE(parsed_json.is_object());
-  auto types = ExtractTypesFromSchema({}, parsed_json);
+  auto types = ExtractTypesFromSchema({}, parsed_json, &pool());
   EXPECT_THAT(types, StatusIs(StatusCode::kInvalidArgument,
                               HasSubstr("contains non object schema")));
   auto const log_lines = log.ExtractLines();
@@ -154,7 +158,7 @@ TEST(ExtractTypesFromSchemaTest, SchemaMissingType) {
       Contains(HasSubstr("MissingType not type:object; is instead untyped")));
 }
 
-TEST(ExtractTypesFromSchemaTest, SchemaNonObject) {
+TEST_F(ExtractTypesFromSchemaTest, SchemaNonObject) {
   auto constexpr kDiscoveryDocWithNonObjectSchema = R"""(
 {
   "schemas": {
@@ -170,7 +174,7 @@ TEST(ExtractTypesFromSchemaTest, SchemaNonObject) {
   auto parsed_json =
       nlohmann::json::parse(kDiscoveryDocWithNonObjectSchema, nullptr, false);
   ASSERT_TRUE(parsed_json.is_object());
-  auto types = ExtractTypesFromSchema({}, parsed_json);
+  auto types = ExtractTypesFromSchema({}, parsed_json, &pool());
   EXPECT_THAT(types, StatusIs(StatusCode::kInvalidArgument,
                               HasSubstr("contains non object schema")));
   auto const log_lines = log.ExtractLines();
@@ -200,7 +204,10 @@ TEST(ExtractResourcesTest, NonEmptyResources) {
               UnorderedElementsAre(Key("resource1"), Key("resource2")));
 }
 
-TEST(DetermineAndVerifyResponseTypeNameTest, ResponseWithRef) {
+class DetermineAndVerifyResponseTypeNameTest
+    : public generator_testing::DescriptorPoolFixture {};
+
+TEST_F(DetermineAndVerifyResponseTypeNameTest, ResponseWithRef) {
   auto constexpr kResponseTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "response": {
@@ -214,13 +221,14 @@ TEST(DetermineAndVerifyResponseTypeNameTest, ResponseWithRef) {
   ASSERT_TRUE(method_json.is_object());
   DiscoveryResource resource;
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "", response_type_json});
+  types.emplace("Foo",
+                DiscoveryTypeVertex{"Foo", "", response_type_json, &pool()});
   auto response = DetermineAndVerifyResponseType(method_json, resource, types);
   ASSERT_STATUS_OK(response);
   EXPECT_THAT((*response)->name(), Eq("Foo"));
 }
 
-TEST(DetermineAndVerifyResponseTypeNameTest, ResponseMissingRef) {
+TEST_F(DetermineAndVerifyResponseTypeNameTest, ResponseMissingRef) {
   auto constexpr kResponseTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({
   "response": {
@@ -233,13 +241,14 @@ TEST(DetermineAndVerifyResponseTypeNameTest, ResponseMissingRef) {
   ASSERT_TRUE(method_json.is_object());
   DiscoveryResource resource;
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "", response_type_json});
+  types.emplace("Foo",
+                DiscoveryTypeVertex{"Foo", "", response_type_json, &pool()});
   auto response = DetermineAndVerifyResponseType(method_json, resource, types);
   EXPECT_THAT(response, StatusIs(StatusCode::kInvalidArgument,
                                  HasSubstr("Missing $ref field in response")));
 }
 
-TEST(DetermineAndVerifyResponseTypeNameTest, ResponseFieldMissing) {
+TEST_F(DetermineAndVerifyResponseTypeNameTest, ResponseFieldMissing) {
   auto constexpr kResponseTypeJson = R"""({})""";
   auto constexpr kMethodJson = R"""({})""";
   auto response_type_json =
@@ -249,12 +258,16 @@ TEST(DetermineAndVerifyResponseTypeNameTest, ResponseFieldMissing) {
   ASSERT_TRUE(method_json.is_object());
   DiscoveryResource resource;
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "", response_type_json});
+  types.emplace("Foo",
+                DiscoveryTypeVertex{"Foo", "", response_type_json, &pool()});
   auto response = DetermineAndVerifyResponseType(method_json, resource, types);
   EXPECT_THAT(response, IsOkAndHolds(IsNull()));
 }
 
-TEST(SynthesizeRequestTypeTest, OperationResponseWithRefRequestField) {
+class SynthesizeRequestTypeTest
+    : public generator_testing::DescriptorPoolFixture {};
+
+TEST_F(SynthesizeRequestTypeTest, OperationResponseWithRefRequestField) {
   auto constexpr kResourceJson = R"""({})""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
@@ -320,14 +333,14 @@ TEST(SynthesizeRequestTypeTest, OperationResponseWithRefRequestField) {
       nlohmann::json::parse(kExpectedRequestTypeJson, nullptr, false);
   ASSERT_TRUE(expected_request_type_json.is_object());
   DiscoveryResource resource("foos", "", resource_json);
-  auto result =
-      SynthesizeRequestType(method_json, resource, "Operation", "create");
+  auto result = SynthesizeRequestType(method_json, resource, "Operation",
+                                      "create", &pool());
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(result->json(), Eq(expected_request_type_json));
 }
 
-TEST(SynthesizeRequestTypeTest,
-     OperationResponseWithRefRequestFieldEndingInResource) {
+TEST_F(SynthesizeRequestTypeTest,
+       OperationResponseWithRefRequestFieldEndingInResource) {
   auto constexpr kResourceJson = R"""({})""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
@@ -393,13 +406,13 @@ TEST(SynthesizeRequestTypeTest,
       nlohmann::json::parse(kExpectedRequestTypeJson, nullptr, false);
   ASSERT_TRUE(expected_request_type_json.is_object());
   DiscoveryResource resource("foos", "", resource_json);
-  auto result =
-      SynthesizeRequestType(method_json, resource, "Operation", "create");
+  auto result = SynthesizeRequestType(method_json, resource, "Operation",
+                                      "create", &pool());
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(result->json(), Eq(expected_request_type_json));
 }
 
-TEST(SynthesizeRequestTypeTest, NonOperationWithoutRequestField) {
+TEST_F(SynthesizeRequestTypeTest, NonOperationWithoutRequestField) {
   auto constexpr kResourceJson = R"""({})""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
@@ -454,12 +467,13 @@ TEST(SynthesizeRequestTypeTest, NonOperationWithoutRequestField) {
       nlohmann::json::parse(kExpectedRequestTypeJson, nullptr, false);
   ASSERT_TRUE(expected_request_type_json.is_object());
   DiscoveryResource resource("foos", "", resource_json);
-  auto result = SynthesizeRequestType(method_json, resource, "Foo", "get");
+  auto result =
+      SynthesizeRequestType(method_json, resource, "Foo", "get", &pool());
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(result->json(), Eq(expected_request_type_json));
 }
 
-TEST(SynthesizeRequestTypeTest, MethodJsonMissingParameters) {
+TEST_F(SynthesizeRequestTypeTest, MethodJsonMissingParameters) {
   auto constexpr kResourceJson = R"""({})""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
@@ -473,8 +487,8 @@ TEST(SynthesizeRequestTypeTest, MethodJsonMissingParameters) {
   auto method_json = nlohmann::json::parse(kMethodJson, nullptr, false);
   ASSERT_TRUE(method_json.is_object());
   DiscoveryResource resource("foos", "", resource_json);
-  auto result =
-      SynthesizeRequestType(method_json, resource, "Operation", "create");
+  auto result = SynthesizeRequestType(method_json, resource, "Operation",
+                                      "create", &pool());
   EXPECT_THAT(
       result,
       StatusIs(StatusCode::kInternal,
@@ -484,7 +498,7 @@ TEST(SynthesizeRequestTypeTest, MethodJsonMissingParameters) {
                     Contains(Key("json"))));
 }
 
-TEST(SynthesizeRequestTypeTest, OperationResponseMissingRefInRequest) {
+TEST_F(SynthesizeRequestTypeTest, OperationResponseMissingRefInRequest) {
   auto constexpr kResourceJson = R"""({})""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
@@ -548,8 +562,8 @@ TEST(SynthesizeRequestTypeTest, OperationResponseMissingRefInRequest) {
       nlohmann::json::parse(kExpectedRequestTypeJson, nullptr, false);
   ASSERT_TRUE(expected_request_type_json.is_object());
   DiscoveryResource resource("foos", "", resource_json);
-  auto result =
-      SynthesizeRequestType(method_json, resource, "Operation", "create");
+  auto result = SynthesizeRequestType(method_json, resource, "Operation",
+                                      "create", &pool());
   EXPECT_THAT(
       result,
       StatusIs(
@@ -557,7 +571,10 @@ TEST(SynthesizeRequestTypeTest, OperationResponseMissingRefInRequest) {
           HasSubstr("resource foos has method Create with non $ref request")));
 }
 
-TEST(ProcessMethodRequestsAndResponsesTest, RequestWithOperationResponse) {
+class ProcessMethodRequestsAndResponsesTest
+    : public generator_testing::DescriptorPoolFixture {};
+
+TEST_F(ProcessMethodRequestsAndResponsesTest, RequestWithOperationResponse) {
   auto constexpr kResourceJson = R"""({
   "methods": {
     "create": {
@@ -579,6 +596,114 @@ TEST(ProcessMethodRequestsAndResponsesTest, RequestWithOperationResponse) {
       },
       "response": {
         "$ref": "Operation"
+      },
+      "request": {
+        "$ref": "Foo"
+      },
+      "parameterOrder": [
+        "project",
+        "zone",
+        "fooId"
+      ]
+    }
+  }
+})""";
+  auto const resource_json =
+      nlohmann::json::parse(kResourceJson, nullptr, false);
+  ASSERT_TRUE(resource_json.is_object());
+  auto constexpr kOperationTypeJson = R"""({
+})""";
+  auto const operation_type_json =
+      nlohmann::json::parse(kOperationTypeJson, nullptr, false);
+  ASSERT_TRUE(operation_type_json.is_object());
+  std::map<std::string, DiscoveryResource> resources;
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
+  std::map<std::string, DiscoveryTypeVertex> types;
+  types.emplace("Operation", DiscoveryTypeVertex("Operation", "",
+                                                 operation_type_json, &pool()));
+  auto result = ProcessMethodRequestsAndResponses(resources, types, &pool());
+  ASSERT_STATUS_OK(result);
+  EXPECT_THAT(
+      types, UnorderedElementsAre(Key("Foos.CreateRequest"), Key("Operation")));
+  EXPECT_THAT(resources.begin()->second.response_types(),
+              UnorderedElementsAre(Key("Operation")));
+  EXPECT_TRUE(resources.begin()->second.RequiresLROImport());
+}
+
+TEST_F(ProcessMethodRequestsAndResponsesTest, MethodWithEmptyRequest) {
+  auto constexpr kResourceJson = R"""({
+  "methods": {
+    "noop": {
+      "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+      ],
+      "path": "projects/myResources",
+      "httpMethod": "POST"
+    }
+  }
+})""";
+  auto const resource_json =
+      nlohmann::json::parse(kResourceJson, nullptr, false);
+  ASSERT_TRUE(resource_json.is_object());
+  std::map<std::string, DiscoveryResource> resources;
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
+  std::map<std::string, DiscoveryTypeVertex> types;
+  auto result = ProcessMethodRequestsAndResponses(resources, types, &pool());
+  ASSERT_STATUS_OK(result);
+  EXPECT_THAT(types, IsEmpty());
+  EXPECT_TRUE(resources.begin()->second.RequiresEmptyImport());
+}
+
+TEST_F(ProcessMethodRequestsAndResponsesTest, MethodWithEmptyResponse) {
+  auto constexpr kResourceJson = R"""({
+  "methods": {
+    "cancel": {
+      "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+      ],
+      "path": "projects/myResources",
+      "httpMethod": "POST",
+      "parameters": {
+        "project": {
+          "type": "string"
+        }
+      }
+    }
+  }
+})""";
+  auto const resource_json =
+      nlohmann::json::parse(kResourceJson, nullptr, false);
+  ASSERT_TRUE(resource_json.is_object());
+  std::map<std::string, DiscoveryResource> resources;
+  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
+  std::map<std::string, DiscoveryTypeVertex> types;
+  auto result = ProcessMethodRequestsAndResponses(resources, types, &pool());
+  ASSERT_STATUS_OK(result);
+  EXPECT_THAT(types, Not(IsEmpty()));
+  EXPECT_TRUE(resources.begin()->second.RequiresEmptyImport());
+}
+
+TEST_F(ProcessMethodRequestsAndResponsesTest, ResponseError) {
+  auto constexpr kResourceJson = R"""({
+  "methods": {
+    "create": {
+      "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+      ],
+      "path": "projects/{project}/zones/{zone}/myResources/{fooId}",
+      "httpMethod": "POST",
+      "parameters": {
+        "project": {
+          "type": "string"
+        },
+        "zone": {
+          "type": "string"
+        },
+        "fooId": {
+          "type": "string"
+        }
+      },
+      "response": {
       },
       "request": {
         "$ref": "Foo"
@@ -603,122 +728,15 @@ TEST(ProcessMethodRequestsAndResponsesTest, RequestWithOperationResponse) {
   resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
   types.emplace("Operation",
-                DiscoveryTypeVertex("Operation", "", operation_type_json));
-  auto result = ProcessMethodRequestsAndResponses(resources, types);
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(
-      types, UnorderedElementsAre(Key("Foos.CreateRequest"), Key("Operation")));
-  EXPECT_THAT(resources.begin()->second.response_types(),
-              UnorderedElementsAre(Key("Operation")));
-  EXPECT_TRUE(resources.begin()->second.RequiresLROImport());
-}
-
-TEST(ProcessMethodRequestsAndResponsesTest, MethodWithEmptyRequest) {
-  auto constexpr kResourceJson = R"""({
-  "methods": {
-    "noop": {
-      "scopes": [
-        "https://www.googleapis.com/auth/cloud-platform"
-      ],
-      "path": "projects/myResources",
-      "httpMethod": "POST"
-    }
-  }
-})""";
-  auto const resource_json =
-      nlohmann::json::parse(kResourceJson, nullptr, false);
-  ASSERT_TRUE(resource_json.is_object());
-  std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
-  std::map<std::string, DiscoveryTypeVertex> types;
-  auto result = ProcessMethodRequestsAndResponses(resources, types);
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(types, IsEmpty());
-  EXPECT_TRUE(resources.begin()->second.RequiresEmptyImport());
-}
-
-TEST(ProcessMethodRequestsAndResponsesTest, MethodWithEmptyResponse) {
-  auto constexpr kResourceJson = R"""({
-  "methods": {
-    "cancel": {
-      "scopes": [
-        "https://www.googleapis.com/auth/cloud-platform"
-      ],
-      "path": "projects/myResources",
-      "httpMethod": "POST",
-      "parameters": {
-        "project": {
-          "type": "string"
-        }
-      }
-    }
-  }
-})""";
-  auto const resource_json =
-      nlohmann::json::parse(kResourceJson, nullptr, false);
-  ASSERT_TRUE(resource_json.is_object());
-  std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
-  std::map<std::string, DiscoveryTypeVertex> types;
-  auto result = ProcessMethodRequestsAndResponses(resources, types);
-  ASSERT_STATUS_OK(result);
-  EXPECT_THAT(types, Not(IsEmpty()));
-  EXPECT_TRUE(resources.begin()->second.RequiresEmptyImport());
-}
-
-TEST(ProcessMethodRequestsAndResponsesTest, ResponseError) {
-  auto constexpr kResourceJson = R"""({
-  "methods": {
-    "create": {
-      "scopes": [
-        "https://www.googleapis.com/auth/cloud-platform"
-      ],
-      "path": "projects/{project}/zones/{zone}/myResources/{fooId}",
-      "httpMethod": "POST",
-      "parameters": {
-        "project": {
-          "type": "string"
-        },
-        "zone": {
-          "type": "string"
-        },
-        "fooId": {
-          "type": "string"
-        }
-      },
-      "response": {
-      },
-      "request": {
-        "$ref": "Foo"
-      },
-      "parameterOrder": [
-        "project",
-        "zone",
-        "fooId"
-      ]
-    }
-  }
-})""";
-  auto const resource_json =
-      nlohmann::json::parse(kResourceJson, nullptr, false);
-  ASSERT_TRUE(resource_json.is_object());
-  auto constexpr kOperationTypeJson = R"""({
-})""";
-  auto const operation_type_json =
-      nlohmann::json::parse(kOperationTypeJson, nullptr, false);
-  ASSERT_TRUE(operation_type_json.is_object());
-  std::map<std::string, DiscoveryResource> resources;
-  resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
-  std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Operation", DiscoveryTypeVertex("", "", operation_type_json));
-  auto result = ProcessMethodRequestsAndResponses(resources, types);
+                DiscoveryTypeVertex("", "", operation_type_json, &pool()));
+  auto result = ProcessMethodRequestsAndResponses(resources, types, &pool());
   EXPECT_THAT(result, StatusIs(StatusCode::kInvalidArgument,
                                HasSubstr("Missing $ref field in response")));
   EXPECT_THAT(result.error_info().metadata(),
               AllOf(Contains(Key("resource")), Contains(Key("method"))));
 }
 
-TEST(ProcessMethodRequestsAndResponsesTest, RequestError) {
+TEST_F(ProcessMethodRequestsAndResponsesTest, RequestError) {
   auto constexpr kResourceJson = R"""({
   "methods": {
     "create": {
@@ -762,13 +780,14 @@ TEST(ProcessMethodRequestsAndResponsesTest, RequestError) {
   std::map<std::string, DiscoveryResource> resources;
   resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Operation", DiscoveryTypeVertex("", "", operation_type_json));
-  auto result = ProcessMethodRequestsAndResponses(resources, types);
+  types.emplace("Operation",
+                DiscoveryTypeVertex("", "", operation_type_json, &pool()));
+  auto result = ProcessMethodRequestsAndResponses(resources, types, &pool());
   EXPECT_THAT(result, StatusIs(StatusCode::kInvalidArgument,
                                HasSubstr("with non $ref request")));
 }
 
-TEST(ProcessMethodRequestsAndResponsesTest, TypeInsertError) {
+TEST_F(ProcessMethodRequestsAndResponsesTest, TypeInsertError) {
   auto constexpr kResourceJson = R"""({
   "methods": {
     "create": {
@@ -818,11 +837,11 @@ TEST(ProcessMethodRequestsAndResponsesTest, TypeInsertError) {
   std::map<std::string, DiscoveryResource> resources;
   resources.emplace("foos", DiscoveryResource("foos", "", resource_json));
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Operation",
-                DiscoveryTypeVertex("Operation", "", operation_type_json));
+  types.emplace("Operation", DiscoveryTypeVertex("Operation", "",
+                                                 operation_type_json, &pool()));
   types.emplace("Foos.CreateRequest",
-                DiscoveryTypeVertex("", "", empty_type_json));
-  auto result = ProcessMethodRequestsAndResponses(resources, types);
+                DiscoveryTypeVertex("", "", empty_type_json, &pool()));
+  auto result = ProcessMethodRequestsAndResponses(resources, types, &pool());
   EXPECT_THAT(result,
               StatusIs(StatusCode::kInternal,
                        HasSubstr("Unable to insert type Foos.CreateRequest")));
@@ -889,8 +908,11 @@ TEST(CreateFilesFromResourcesTest, EmptyResources) {
   EXPECT_THAT(result, IsEmpty());
 }
 
-TEST(AssignResourcesAndTypesToFilesTest,
-     TypesContainsBothSynthesizedAndNonsynthesizedTypes) {
+class AssignResourcesAndTypesToFilesTest
+    : public generator_testing::DescriptorPoolFixture {};
+
+TEST_F(AssignResourcesAndTypesToFilesTest,
+       TypesContainsBothSynthesizedAndNonsynthesizedTypes) {
   auto constexpr kResourceJson = R"""({
   "methods": {
     "create": {
@@ -938,14 +960,14 @@ TEST(AssignResourcesAndTypesToFilesTest,
   ASSERT_TRUE(synthesized_type_json.is_object());
   types.emplace(
       "Foos.CreateRequest",
-      DiscoveryTypeVertex("CreateRequest", "", synthesized_type_json));
+      DiscoveryTypeVertex("CreateRequest", "", synthesized_type_json, &pool()));
   auto constexpr kOperationTypeJson = R"""({
 })""";
   auto const operation_type_json =
       nlohmann::json::parse(kOperationTypeJson, nullptr, false);
   ASSERT_TRUE(operation_type_json.is_object());
-  types.emplace("Operation",
-                DiscoveryTypeVertex("Operation", "", operation_type_json));
+  types.emplace("Operation", DiscoveryTypeVertex("Operation", "",
+                                                 operation_type_json, &pool()));
   DiscoveryDocumentProperties props{"", "", "product_name", "version", "",
                                     "", {}};
   auto result =

--- a/generator/internal/discovery_type_vertex.cc
+++ b/generator/internal/discovery_type_vertex.cc
@@ -36,11 +36,9 @@ absl::optional<std::string> CheckForScalarType(nlohmann::json const& j) {
 
 }  // namespace
 
-DiscoveryTypeVertex::DiscoveryTypeVertex() : json_("") {}
-
-DiscoveryTypeVertex::DiscoveryTypeVertex(std::string name,
-                                         std::string package_name,
-                                         nlohmann::json json)
+DiscoveryTypeVertex::DiscoveryTypeVertex(
+    std::string name, std::string package_name, nlohmann::json json,
+    google::protobuf::DescriptorPool const*)
     : name_(std::move(name)),
       package_name_(std::move(package_name)),
       json_(std::move(json)) {}

--- a/generator/internal/discovery_type_vertex.h
+++ b/generator/internal/discovery_type_vertex.h
@@ -34,9 +34,11 @@ namespace generator_internal {
 // of edges are unidirectional, and both of the resulting graphs are acyclic.
 class DiscoveryTypeVertex {
  public:
-  DiscoveryTypeVertex();
+  // descriptor_pool should never be NULL, and the constructor will assert if it
+  // is.
   DiscoveryTypeVertex(std::string name, std::string package_name,
-                      nlohmann::json json);
+                      nlohmann::json json,
+                      google::protobuf::DescriptorPool const* descriptor_pool);
 
   std::string const& name() const { return name_; }
   std::string const& package_name() const { return package_name_; }

--- a/generator/internal/discovery_type_vertex_test.cc
+++ b/generator/internal/discovery_type_vertex_test.cc
@@ -274,7 +274,10 @@ INSTANTIATE_TEST_SUITE_P(
             "field: testField is array with items having neither $ref nor "
             "type."}));
 
-TEST(DiscoveryTypeVertexTest, JsonToProtobufScalarTypes) {
+class DiscoveryTypeVertexDescriptorTest
+    : public generator_testing::DescriptorPoolFixture {};
+
+TEST_F(DiscoveryTypeVertexDescriptorTest, JsonToProtobufScalarTypes) {
   auto constexpr kSchemaJson = R"""(
 {
   "id": "TestSchema",
@@ -339,15 +342,15 @@ TEST(DiscoveryTypeVertexTest, JsonToProtobufScalarTypes) {
 
   auto json = nlohmann::json::parse(kSchemaJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryTypeVertex t("TestSchema", "test.package", json);
+  DiscoveryTypeVertex t("TestSchema", "test.package", json, &pool());
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}});
+  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}, &pool()});
   auto result = t.JsonToProtobufMessage(types, "test.package");
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(*result, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryTypeVertexTest, JsonToProtobufMapType) {
+TEST_F(DiscoveryTypeVertexDescriptorTest, JsonToProtobufMapType) {
   auto constexpr kSchemaJson = R"""(
 {
   "id": "TestSchema",
@@ -405,15 +408,15 @@ TEST(DiscoveryTypeVertexTest, JsonToProtobufMapType) {
 
   auto json = nlohmann::json::parse(kSchemaJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryTypeVertex t("TestSchema", "test.package", json);
+  DiscoveryTypeVertex t("TestSchema", "test.package", json, &pool());
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}});
+  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}, &pool()});
   auto result = t.JsonToProtobufMessage(types, "test.package");
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(*result, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryTypeVertexTest, JsonToProtobufArrayTypes) {
+TEST_F(DiscoveryTypeVertexDescriptorTest, JsonToProtobufArrayTypes) {
   auto constexpr kSchemaJson = R"""(
 {
   "id": "TestSchema",
@@ -531,15 +534,15 @@ TEST(DiscoveryTypeVertexTest, JsonToProtobufArrayTypes) {
 
   auto json = nlohmann::json::parse(kSchemaJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryTypeVertex t("TestSchema", "test.package", json);
+  DiscoveryTypeVertex t("TestSchema", "test.package", json, &pool());
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}});
+  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}, &pool()});
   auto result = t.JsonToProtobufMessage(types, "test.package");
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(*result, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryTypeVertexTest, JsonToProtobufMessageNoDescription) {
+TEST_F(DiscoveryTypeVertexDescriptorTest, JsonToProtobufMessageNoDescription) {
   auto constexpr kSchemaJson = R"""(
 {
   "type": "object",
@@ -635,16 +638,18 @@ TEST(DiscoveryTypeVertexTest, JsonToProtobufMessageNoDescription) {
 
   auto json = nlohmann::json::parse(kSchemaJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryTypeVertex t("TestSchema", "test.package", json);
+  DiscoveryTypeVertex t("TestSchema", "test.package", json, &pool());
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}});
-  types.emplace("Bar", DiscoveryTypeVertex{"Bar", "other.package", {}});
+  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}, &pool()});
+  types.emplace("Bar",
+                DiscoveryTypeVertex{"Bar", "other.package", {}, &pool()});
   auto result = t.JsonToProtobufMessage(types, "test.package");
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(*result, Eq(kExpectedProto));
 }
 
-TEST(DiscoveryTypeVertexTest, JsonToProtobufMessageWithDescription) {
+TEST_F(DiscoveryTypeVertexDescriptorTest,
+       JsonToProtobufMessageWithDescription) {
   auto constexpr kSchemaJson = R"""(
 {
   "description": "Description of the message.",
@@ -668,16 +673,13 @@ message TestSchema {
 
   auto json = nlohmann::json::parse(kSchemaJson, nullptr, false);
   ASSERT_TRUE(json.is_object());
-  DiscoveryTypeVertex t("TestSchema", "test.package", json);
+  DiscoveryTypeVertex t("TestSchema", "test.package", json, &pool());
   std::map<std::string, DiscoveryTypeVertex> types;
-  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}});
+  types.emplace("Foo", DiscoveryTypeVertex{"Foo", "test.package", {}, &pool()});
   auto result = t.JsonToProtobufMessage(types, "test.package");
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(*result, Eq(kExpectedProto));
 }
-
-class DiscoveryTypeVertexDescriptorTest
-    : public generator_testing::DescriptorPoolFixture {};
 
 TEST_F(DiscoveryTypeVertexDescriptorTest, DetermineReservedAndMaxFieldNumbers) {
   auto constexpr kProtoFile = R"""(


### PR DESCRIPTION
part of the work for #11095 

ThisPR creates the descriptor pool for the current generation of compute protos and plumbs the pointer down to DiscoveryTypeVertex where it will be used later (in a follow up PR) to determine field numbers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12230)
<!-- Reviewable:end -->
