### PR TITLE
impl(bigquery): Response object for GetQueryResults api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -304,6 +304,105 @@ void from_json(nlohmann::json const& j, QueryResults& q) {
   SafeGetTo(q.dml_stats, j, "dmlStats");
 }
 
+void to_json(nlohmann::json& j, GetQueryResults const& q) {
+  j = nlohmann::json{{"kind", q.kind},
+                     {"etag", q.etag},
+                     {"pageToken", q.page_token},
+                     {"totalRows", q.total_rows},
+                     {"totalBytesProcessed", q.total_bytes_processed},
+                     {"numDmlAffectedRows", q.num_dml_affected_rows},
+                     {"jobComplete", q.job_complete},
+                     {"cacheHit", q.cache_hit},
+                     {"schema", q.schema},
+                     {"jobReference", q.job_reference},
+                     {"rows", q.rows},
+                     {"errors", q.errors}};
+}
+void from_json(nlohmann::json const& j, GetQueryResults& q) {
+  SafeGetTo(q.kind, j, "kind");
+  SafeGetTo(q.etag, j, "etag");
+  SafeGetTo(q.page_token, j, "pageToken");
+  SafeGetTo(q.total_rows, j, "totalRows");
+  SafeGetTo(q.total_bytes_processed, j, "totalBytesProcessed");
+  SafeGetTo(q.num_dml_affected_rows, j, "numDmlAffectedRows");
+  SafeGetTo(q.job_complete, j, "jobComplete");
+  SafeGetTo(q.cache_hit, j, "cacheHit");
+  SafeGetTo(q.schema, j, "schema");
+  SafeGetTo(q.job_reference, j, "jobReference");
+  SafeGetTo(q.rows, j, "rows");
+  SafeGetTo(q.errors, j, "errors");
+}
+
+std::string GetQueryResults::DebugString(absl::string_view name,
+                                         TracingOptions const& options,
+                                         int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("kind", kind)
+      .StringField("etag", etag)
+      .StringField("page_token", page_token)
+      .Field("total_rows", total_rows)
+      .Field("total_bytes_processed", total_bytes_processed)
+      .Field("num_dml_affected_rows", num_dml_affected_rows)
+      .Field("job_complete", job_complete)
+      .Field("cache_hit", cache_hit)
+      .Field("rows", rows)
+      .Field("errors", errors)
+      .SubMessage("schema", schema)
+      .SubMessage("job_reference", job_reference)
+      .Build();
+}
+
+std::string GetQueryResultsResponse::DebugString(absl::string_view name,
+                                                 TracingOptions const& options,
+                                                 int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .SubMessage("http_response", http_response)
+      .SubMessage("get_query_results", get_query_results)
+      .Build();
+}
+
+StatusOr<GetQueryResultsResponse>
+GetQueryResultsResponse::BuildFromHttpResponse(
+    BigQueryHttpResponse const& http_response) {
+  auto json = parse_json(http_response.payload);
+  if (!json) return std::move(json).status();
+
+  GetQueryResults get_query_results;
+  get_query_results.kind = json->value("kind", "");
+  get_query_results.etag = json->value("etag", "");
+  get_query_results.page_token = json->value("pageToken", "");
+  get_query_results.total_rows = json->at("totalRows").get<std::uint64_t>();
+  get_query_results.total_bytes_processed =
+      json->at("totalBytesProcessed").get<std::int64_t>();
+  get_query_results.num_dml_affected_rows =
+      json->at("numDmlAffectedRows").get<std::int64_t>();
+
+  get_query_results.job_complete = json->at("jobComplete").get<bool>();
+  get_query_results.cache_hit = json->at("cacheHit").get<bool>();
+
+  get_query_results.schema = json->at("schema").get<TableSchema>();
+  get_query_results.job_reference =
+      json->at("jobReference").get<JobReference>();
+
+  for (auto const& kv : json->at("rows").items()) {
+    auto const& json_struct_obj = kv.value();
+    auto const& row = json_struct_obj.get<Struct>();
+    get_query_results.rows.push_back(row);
+  }
+
+  for (auto const& kv : json->at("errors").items()) {
+    auto const& json_error_proto_obj = kv.value();
+    auto const& error = json_error_proto_obj.get<ErrorProto>();
+    get_query_results.errors.push_back(error);
+  }
+
+  GetQueryResultsResponse response;
+  response.http_response = http_response;
+  response.get_query_results = get_query_results;
+
+  return response;
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -136,6 +136,46 @@ class QueryResponse {
   BigQueryHttpResponse http_response;
 };
 
+struct GetQueryResults {
+  std::string kind;
+  std::string etag;
+  std::string page_token;
+
+  TableSchema schema;
+  JobReference job_reference;
+
+  std::int64_t total_bytes_processed = 0;
+  std::uint64_t total_rows = 0;
+  std::int64_t num_dml_affected_rows = 0;
+
+  bool job_complete = false;
+  bool cache_hit = false;
+
+  std::vector<Struct> rows;
+  std::vector<ErrorProto> errors;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
+};
+void to_json(nlohmann::json& j, GetQueryResults const& q);
+void from_json(nlohmann::json const& j, GetQueryResults& q);
+
+class GetQueryResultsResponse {
+ public:
+  GetQueryResultsResponse() = default;
+  static StatusOr<GetQueryResultsResponse> BuildFromHttpResponse(
+      BigQueryHttpResponse const& http_response);
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
+
+  GetQueryResults get_query_results;
+
+  BigQueryHttpResponse http_response;
+};
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -24,6 +24,9 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+using ::google::cloud::bigquery_v2_minimal_testing::MakeGetQueryResults;
+using ::google::cloud::bigquery_v2_minimal_testing::
+    MakeGetQueryResultsResponsePayload;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeJob;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResponsePayload;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResults;
@@ -2015,6 +2018,166 @@ TEST(QueryResponseTest, DebugString) {
       inserted_row_count: 10
       deleted_row_count: 10
       updated_row_count: 10
+    }
+  }
+})");
+}
+
+TEST(GetQueryResultsResponseTest, Success) {
+  BigQueryHttpResponse http_response;
+  http_response.payload = MakeGetQueryResultsResponsePayload();
+  auto const response =
+      GetQueryResultsResponse::BuildFromHttpResponse(http_response);
+  ASSERT_STATUS_OK(response);
+  EXPECT_FALSE(response->http_response.payload.empty());
+
+  auto expected_get_equery_results = MakeGetQueryResults();
+  auto actual_get_query_results = response->get_query_results;
+
+  bigquery_v2_minimal_testing::AssertEquals(expected_get_equery_results,
+                                            actual_get_query_results);
+}
+
+TEST(GetQueryResultsResponseTest, EmptyPayload) {
+  BigQueryHttpResponse http_response;
+  auto const response =
+      GetQueryResultsResponse::BuildFromHttpResponse(http_response);
+  EXPECT_THAT(response, StatusIs(StatusCode::kInternal,
+                                 HasSubstr("Empty payload in HTTP response")));
+}
+
+TEST(GetQueryResultsResponseTest, InvalidJson) {
+  BigQueryHttpResponse http_response;
+  http_response.payload = "Help! I am not json";
+  auto const response =
+      GetQueryResultsResponse::BuildFromHttpResponse(http_response);
+  EXPECT_THAT(response,
+              StatusIs(StatusCode::kInternal,
+                       HasSubstr("Error parsing Json from response payload")));
+}
+
+TEST(GetQueryResultsResponseTest, DebugString) {
+  BigQueryHttpResponse http_response;
+  http_response.payload = MakeGetQueryResultsResponsePayload();
+  auto const response =
+      GetQueryResultsResponse::BuildFromHttpResponse(http_response);
+  ASSERT_STATUS_OK(response);
+
+  EXPECT_EQ(
+      response->DebugString("GetQueryResultsResponse", TracingOptions{}),
+      R"(GetQueryResultsResponse {)"
+      R"( http_response {)"
+      R"( status_code: 200)"
+      R"( payload: REDACTED)"
+      R"( })"
+      R"( get_query_results {)"
+      R"( kind: "query-kind")"
+      R"( etag: "query-etag")"
+      R"( page_token: "np123")"
+      R"( total_rows: 1000)"
+      R"( total_bytes_processed: 1000)"
+      R"( num_dml_affected_rows: 5)"
+      R"( job_complete: true)"
+      R"( cache_hit: true)"
+      R"( rows { fields {)"
+      R"( key: "bool-key")"
+      R"( value { value_kind: true } })"
+      R"( fields { key: "double-key")"
+      R"( value { value_kind: 3.4 })"
+      R"( } fields { key: "string-key" value { value_kind: "val3" } } })"
+      R"( schema { fields {)"
+      R"( name: "fname-1" type: "" mode: "fmode" description: "")"
+      R"( collation: "" default_value_expression: "" max_length: 0)"
+      R"( precision: 0 scale: 0)"
+      R"( categories { } policy_tags { })"
+      R"( rounding_mode { value: "" } range_element_type { type: "" } } })"
+      R"( job_reference { project_id: "p123" job_id: "j123" location: "useast" } } })");
+
+  EXPECT_EQ(
+      response->DebugString(
+          "GetQueryResultsResponse",
+          TracingOptions{}.SetOptions("truncate_string_field_longer_than=7")),
+      R"(GetQueryResultsResponse { http_response {)"
+      R"( status_code: 200 payload: REDACTED })"
+      R"( get_query_results { kind: "query-k...<truncated>...")"
+      R"( etag: "query-e...<truncated>...")"
+      R"( page_token: "np123" total_rows: 1000)"
+      R"( total_bytes_processed: 1000 num_dml_affected_rows: 5)"
+      R"( job_complete: true cache_hit: true)"
+      R"( rows { fields { key: "bool-key" value { value_kind: true } })"
+      R"( fields { key: "double-key" value { value_kind: 3.4 } })"
+      R"( fields { key: "string-key" value { value_kind: "val3" } } })"
+      R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
+      R"( description: "" collation: "" default_value_expression: "")"
+      R"( max_length: 0 precision: 0 scale: 0 categories { })"
+      R"( policy_tags { })"
+      R"( rounding_mode { value: "" } range_element_type { type: "" } } })"
+      R"( job_reference { project_id: "p123" job_id: "j123" location: "useast" } } })");
+
+  EXPECT_EQ(
+      response->DebugString("GetQueryResultsResponse",
+                            TracingOptions{}.SetOptions("single_line_mode=F")),
+      R"(GetQueryResultsResponse {
+  http_response {
+    status_code: 200
+    payload: REDACTED
+  }
+  get_query_results {
+    kind: "query-kind"
+    etag: "query-etag"
+    page_token: "np123"
+    total_rows: 1000
+    total_bytes_processed: 1000
+    num_dml_affected_rows: 5
+    job_complete: true
+    cache_hit: true
+    rows {
+      fields {
+        key: "bool-key"
+        value {
+          value_kind: true
+        }
+      }
+      fields {
+        key: "double-key"
+        value {
+          value_kind: 3.4
+        }
+      }
+      fields {
+        key: "string-key"
+        value {
+          value_kind: "val3"
+        }
+      }
+    }
+    schema {
+      fields {
+        name: "fname-1"
+        type: ""
+        mode: "fmode"
+        description: ""
+        collation: ""
+        default_value_expression: ""
+        max_length: 0
+        precision: 0
+        scale: 0
+        categories {
+        }
+        policy_tags {
+        }
+        rounding_mode {
+          value: ""
+        }
+        range_element_type {
+          type: ""
+        }
+      }
+    }
+    job_reference {
+      project_id: "p123"
+      job_id: "j123"
+      location: "useast"
     }
   }
 })");

--- a/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
@@ -27,6 +27,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using ::google::cloud::bigquery_v2_minimal_internal::ConnectionProperty;
 using ::google::cloud::bigquery_v2_minimal_internal::DataFormatOptions;
+using ::google::cloud::bigquery_v2_minimal_internal::GetQueryResults;
 using ::google::cloud::bigquery_v2_minimal_internal::GetQueryResultsRequest;
 using ::google::cloud::bigquery_v2_minimal_internal::PostQueryRequest;
 using ::google::cloud::bigquery_v2_minimal_internal::QueryParameter;
@@ -167,10 +168,40 @@ QueryResults MakeQueryResults() {
   return expected;
 }
 
+GetQueryResults MakeGetQueryResults() {
+  GetQueryResults expected;
+
+  expected.cache_hit = true;
+  expected.job_complete = true;
+
+  expected.job_reference.project_id = "p123";
+  expected.job_reference.location = "useast";
+  expected.job_reference.job_id = "j123";
+
+  expected.kind = "query-kind";
+  expected.etag = "query-etag";
+  expected.num_dml_affected_rows = 5;
+  expected.page_token = "np123";
+  expected.rows.push_back(MakeSystemVariables().values);
+
+  expected.schema = MakeTable().schema;
+  expected.total_bytes_processed = 1000;
+  expected.total_rows = 1000;
+
+  return expected;
+}
+
 std::string MakeQueryResponsePayload() {
   auto query_results = MakeQueryResults();
   nlohmann::json j;
   to_json(j, query_results);
+  return j.dump();
+}
+
+std::string MakeGetQueryResultsResponsePayload() {
+  auto get_query_results = MakeGetQueryResults();
+  nlohmann::json j;
+  to_json(j, get_query_results);
   return j.dump();
 }
 
@@ -199,6 +230,32 @@ void AssertEquals(bigquery_v2_minimal_internal::QueryResults const& lhs,
 
   EXPECT_TRUE(std::equal(lhs.rows.begin(), lhs.rows.end(), rhs.rows.begin()));
 }
+
+void AssertEquals(bigquery_v2_minimal_internal::GetQueryResults const& lhs,
+                  bigquery_v2_minimal_internal::GetQueryResults const& rhs) {
+  EXPECT_EQ(lhs.cache_hit, rhs.cache_hit);
+  EXPECT_EQ(lhs.job_complete, rhs.job_complete);
+  EXPECT_EQ(lhs.job_reference.job_id, rhs.job_reference.job_id);
+  EXPECT_EQ(lhs.job_reference.project_id, rhs.job_reference.project_id);
+  EXPECT_EQ(lhs.job_reference.location, rhs.job_reference.location);
+  EXPECT_EQ(lhs.kind, rhs.kind);
+  EXPECT_EQ(lhs.etag, rhs.etag);
+  EXPECT_EQ(lhs.num_dml_affected_rows, rhs.num_dml_affected_rows);
+  EXPECT_EQ(lhs.page_token, rhs.page_token);
+
+  ASSERT_THAT(lhs.schema.fields, Not(IsEmpty()));
+  ASSERT_THAT(rhs.schema.fields, Not(IsEmpty()));
+  EXPECT_EQ(lhs.schema.fields.size(), rhs.schema.fields.size());
+
+  EXPECT_EQ(lhs.total_bytes_processed, rhs.total_bytes_processed);
+  EXPECT_EQ(lhs.total_rows, rhs.total_rows);
+
+  EXPECT_TRUE(
+      std::equal(lhs.errors.begin(), lhs.errors.end(), rhs.errors.begin()));
+
+  EXPECT_TRUE(std::equal(lhs.rows.begin(), lhs.rows.end(), rhs.rows.begin()));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_testing
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.h
+++ b/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.h
@@ -42,6 +42,11 @@ bigquery_v2_minimal_internal::QueryResults MakeQueryResults();
 void AssertEquals(bigquery_v2_minimal_internal::QueryResults const& lhs,
                   bigquery_v2_minimal_internal::QueryResults const& rhs);
 
+std::string MakeGetQueryResultsResponsePayload();
+bigquery_v2_minimal_internal::GetQueryResults MakeGetQueryResults();
+void AssertEquals(bigquery_v2_minimal_internal::GetQueryResults const& lhs,
+                  bigquery_v2_minimal_internal::GetQueryResults const& rhs);
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_testing
 }  // namespace cloud


### PR DESCRIPTION
This PR Implements the [GetQueryResultsResponse](https://source.corp.google.com/piper///depot/google3/google/cloud/bigquery/v2/job.proto;l=646;rcl=544196886) object for the `GetQueryResults` api, with unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12249)
<!-- Reviewable:end -->
