### PR TITLE
impl(bigquery): Idempotency policies for GetQueryResults api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.cc
@@ -59,6 +59,11 @@ Idempotency BigQueryJobIdempotencyPolicy::Query(
   return Idempotency::kNonIdempotent;
 }
 
+Idempotency BigQueryJobIdempotencyPolicy::GetQueryResults(
+    GetQueryResultsRequest const&) {
+  return Idempotency::kIdempotent;
+}
+
 std::unique_ptr<BigQueryJobIdempotencyPolicy>
 MakeDefaultBigQueryJobIdempotencyPolicy() {
   return std::make_unique<BigQueryJobIdempotencyPolicy>();

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy.h
@@ -42,6 +42,9 @@ class BigQueryJobIdempotencyPolicy {
   virtual google::cloud::Idempotency CancelJob(CancelJobRequest const& request);
 
   virtual google::cloud::Idempotency Query(PostQueryRequest const& request);
+
+  virtual google::cloud::Idempotency GetQueryResults(
+      GetQueryResultsRequest const& request);
 };
 
 std::unique_ptr<BigQueryJobIdempotencyPolicy>

--- a/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_idempotency_policy_test.cc
@@ -75,6 +75,14 @@ TEST(JobIdempotencyPolicytTest, QueryIdempotent) {
   EXPECT_EQ(actual->Query(request), expected);
 }
 
+TEST(JobIdempotencyPolicytTest, GetQueryResults) {
+  auto actual = MakeDefaultBigQueryJobIdempotencyPolicy();
+  auto expected = Idempotency::kIdempotent;
+
+  GetQueryResultsRequest request;
+  EXPECT_EQ(actual->GetQueryResults(request), expected);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud


### PR DESCRIPTION
Implements Idempotency policy for GetQueryResults api, with unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12250)
<!-- Reviewable:end -->
