### PR TITLE
test: remove the bazel limit on the size of test output

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,6 +32,10 @@ build:macos --host_cxxopt=-std=c++14
 # the project separately.
 build --experimental_convenience_symlinks=ignore
 
+# It is frustrating when long-running builds/tests fail, but it is even more
+# frustrating when they fail and don't give any output. So, remove the limit.
+build --experimental_ui_max_stdouterr_bytes=-1
+
 # Inject ${GTEST_SHUFFLE} and ${GTEST_RANDOM_SEED} into the test environment
 # if they are set in the enclosing environment. This allows for running tests
 # in a random order to help expose undesirable interdependencies.


### PR DESCRIPTION
Bazel limits the "size of the stdout / stderr files that will be printed to the console."  The default limit is 1MB, but I've seen our logging can exceed that, so let's try removing the limit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12259)
<!-- Reviewable:end -->
