### PR TITLE
impl(bigquery): Stub and Decorator changes for GetQueryResults api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.cc
@@ -97,6 +97,20 @@ StatusOr<QueryResponse> BigQueryJobLogging::Query(
       tracing_options_);
 }
 
+StatusOr<GetQueryResultsResponse> BigQueryJobLogging::GetQueryResults(
+    rest_internal::RestContext& rest_context,
+    GetQueryResultsRequest const& request) {
+  return LogWrapper(
+      [this](rest_internal::RestContext& rest_context,
+             GetQueryResultsRequest const& request) {
+        return child_->GetQueryResults(rest_context, request);
+      },
+      rest_context, request, __func__,
+      "google.cloud.bigquery.v2.minimal.internal.GetQueryResultsRequest",
+      "google.cloud.bigquery.v2.minimal.internal.GetQueryResultsResponse",
+      tracing_options_);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging.h
@@ -49,6 +49,10 @@ class BigQueryJobLogging : public BigQueryJobRestStub {
   StatusOr<QueryResponse> Query(rest_internal::RestContext& rest_context,
                                 PostQueryRequest const& request) override;
 
+  StatusOr<GetQueryResultsResponse> GetQueryResults(
+      rest_internal::RestContext& rest_context,
+      GetQueryResultsRequest const& request) override;
+
  private:
   std::shared_ptr<BigQueryJobRestStub> child_;
   TracingOptions tracing_options_;

--- a/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_logging_test.cc
@@ -28,6 +28,8 @@ namespace cloud {
 namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+using ::google::cloud::bigquery_v2_minimal_testing::
+    MakeGetQueryResultsResponsePayload;
 using ::google::cloud::bigquery_v2_minimal_testing::MakePartialJob;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryRequest;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResponsePayload;
@@ -314,6 +316,52 @@ TEST(JobLoggingClientTest, Query) {
               Contains(HasSubstr(R"(project_id: "p123")")).Times(2));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(QueryResponse)")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "query-kind")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(job_id: "j123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(page_token: "np123")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-1")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(name: "header-2")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(value: "value-2")")));
+}
+
+TEST(JobLoggingClientTest, GetQueryResults) {
+  ScopedLog log;
+
+  auto mock_stub = std::make_shared<MockBigQueryJobRestStub>();
+  auto expected_payload = MakeGetQueryResultsResponsePayload();
+
+  EXPECT_CALL(*mock_stub, GetQueryResults)
+      .WillOnce([&](rest_internal::RestContext&,
+                    GetQueryResultsRequest const& request)
+                    -> StatusOr<GetQueryResultsResponse> {
+        EXPECT_THAT(request.project_id(), Not(IsEmpty()));
+        EXPECT_THAT(request.job_id(), Not(IsEmpty()));
+        BigQueryHttpResponse http_response;
+        http_response.payload = expected_payload;
+        return GetQueryResultsResponse::BuildFromHttpResponse(
+            std::move(http_response));
+      });
+
+  auto client = CreateMockJobLogging(std::move(mock_stub));
+  GetQueryResultsRequest request("p123", "j123");
+
+  rest_internal::RestContext context;
+  context.AddHeader("header-1", "value-1");
+  context.AddHeader("header-2", "value-2");
+
+  client->GetQueryResults(context, request);
+
+  auto actual_lines = log.ExtractLines();
+
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(" << ")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetQueryResultsRequest)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(job_id: "j123")")).Times(2));
+  EXPECT_THAT(actual_lines,
+              Contains(HasSubstr(R"(project_id: "p123")")).Times(2));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(GetQueryResultsResponse)")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(kind: "query-kind")")));
+  EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(etag: "query-etag")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(job_id: "j123")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(page_token: "np123")")));
   EXPECT_THAT(actual_lines, Contains(HasSubstr(R"(Context)")));

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
@@ -63,6 +63,13 @@ StatusOr<QueryResponse> BigQueryJobMetadata::Query(
   return child_->Query(context, request);
 }
 
+StatusOr<GetQueryResultsResponse> BigQueryJobMetadata::GetQueryResults(
+    rest_internal::RestContext& context,
+    GetQueryResultsRequest const& request) {
+  SetMetadata(context);
+  return child_->GetQueryResults(context, request);
+}
+
 void BigQueryJobMetadata::SetMetadata(rest_internal::RestContext& rest_context,
                                       std::vector<std::string> const& params) {
   rest_context.AddHeader("x-goog-api-client", api_client_header_);

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.h
@@ -46,6 +46,10 @@ class BigQueryJobMetadata : public BigQueryJobRestStub {
   StatusOr<QueryResponse> Query(rest_internal::RestContext& rest_context,
                                 PostQueryRequest const& request) override;
 
+  StatusOr<GetQueryResultsResponse> GetQueryResults(
+      rest_internal::RestContext& rest_context,
+      GetQueryResultsRequest const& request) override;
+
  private:
   void SetMetadata(rest_internal::RestContext& context,
                    std::vector<std::string> const& params = {});

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -111,6 +111,19 @@ StatusOr<QueryResponse> DefaultBigQueryJobRestStub::Query(
                        {absl::MakeConstSpan(json_payload.dump())}));
 }
 
+StatusOr<GetQueryResultsResponse> DefaultBigQueryJobRestStub::GetQueryResults(
+    rest_internal::RestContext& rest_context,
+    GetQueryResultsRequest const& request) {
+  // Prepare the RestRequest from GetQueryResultsRequest.
+  auto rest_request =
+      PrepareRestRequest<GetQueryResultsRequest>(rest_context, request);
+
+  // Call the rest stub and parse the RestResponse.
+  rest_internal::RestContext context;
+  return ParseFromRestResponse<GetQueryResultsResponse>(
+      rest_stub_->Get(context, std::move(*rest_request)));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.h
@@ -48,6 +48,9 @@ class BigQueryJobRestStub {
   virtual StatusOr<QueryResponse> Query(
       rest_internal::RestContext& rest_context,
       PostQueryRequest const& request) = 0;
+  virtual StatusOr<GetQueryResultsResponse> GetQueryResults(
+      rest_internal::RestContext& rest_context,
+      GetQueryResultsRequest const& request) = 0;
 };
 
 class DefaultBigQueryJobRestStub : public BigQueryJobRestStub {
@@ -70,6 +73,10 @@ class DefaultBigQueryJobRestStub : public BigQueryJobRestStub {
 
   StatusOr<QueryResponse> Query(rest_internal::RestContext& rest_context,
                                 PostQueryRequest const& request) override;
+
+  StatusOr<GetQueryResultsResponse> GetQueryResults(
+      rest_internal::RestContext& rest_context,
+      GetQueryResultsRequest const& request) override;
 
  private:
   std::unique_ptr<rest_internal::RestClient> rest_stub_;

--- a/google/cloud/bigquery/v2/minimal/testing/mock_job_rest_stub.h
+++ b/google/cloud/bigquery/v2/minimal/testing/mock_job_rest_stub.h
@@ -49,6 +49,12 @@ class MockBigQueryJobRestStub
               (rest_internal::RestContext & rest_context,
                bigquery_v2_minimal_internal::PostQueryRequest const& request),
               (override));
+  MOCK_METHOD(
+      StatusOr<bigquery_v2_minimal_internal::GetQueryResultsResponse>,
+      GetQueryResults,
+      (rest_internal::RestContext & rest_context,
+       bigquery_v2_minimal_internal::GetQueryResultsRequest const& request),
+      (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
This implements Rest stub, logging and metadata decorators for GetQueryResults() api with unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12261)
<!-- Reviewable:end -->
