### PR TITLE
impl(bigquery): Rename QueryResults to PostQueryResults for Query api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_client.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_client.cc
@@ -50,8 +50,8 @@ StatusOr<Job> JobClient::CancelJob(CancelJobRequest const& request,
   return connection_->CancelJob(request);
 }
 
-StatusOr<QueryResults> JobClient::Query(PostQueryRequest const& request,
-                                        Options opts) {
+StatusOr<PostQueryResults> JobClient::Query(PostQueryRequest const& request,
+                                            Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Query(request);
 }

--- a/google/cloud/bigquery/v2/minimal/internal/job_client.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_client.h
@@ -102,8 +102,8 @@ class JobClient {
    * For more details on query reqsponse fields, please see:
    * https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#response-body
    */
-  StatusOr<QueryResults> Query(PostQueryRequest const& request,
-                               Options opts = {});
+  StatusOr<PostQueryResults> Query(PostQueryRequest const& request,
+                                   Options opts = {});
 
  private:
   std::shared_ptr<BigQueryJobConnection> connection_;

--- a/google/cloud/bigquery/v2/minimal/internal/job_client_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_client_test.cc
@@ -30,8 +30,8 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using ::google::cloud::bigquery_v2_minimal_testing::MakePartialJob;
+using ::google::cloud::bigquery_v2_minimal_testing::MakePostQueryResults;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryRequest;
-using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResults;
 using ::google::cloud::rest_internal::HttpStatusCode;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
@@ -167,7 +167,7 @@ TEST(JobClientTest, CancelJobFailure) {
 }
 
 TEST(JobClientTest, QuerySuccess) {
-  auto query_results = MakeQueryResults();
+  auto query_results = MakePostQueryResults();
   auto mock_job_connection = std::make_shared<MockBigQueryJobConnection>();
 
   EXPECT_CALL(*mock_job_connection, Query)

--- a/google/cloud/bigquery/v2/minimal/internal/job_connection.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_connection.cc
@@ -46,7 +46,8 @@ StatusOr<Job> BigQueryJobConnection::CancelJob(CancelJobRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<QueryResults> BigQueryJobConnection::Query(PostQueryRequest const&) {
+StatusOr<PostQueryResults> BigQueryJobConnection::Query(
+    PostQueryRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/job_connection.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_connection.h
@@ -39,7 +39,7 @@ class BigQueryJobConnection {
   virtual StreamRange<ListFormatJob> ListJobs(ListJobsRequest const& request);
   virtual StatusOr<Job> InsertJob(InsertJobRequest const& request);
   virtual StatusOr<Job> CancelJob(CancelJobRequest const& request);
-  virtual StatusOr<QueryResults> Query(PostQueryRequest const& request);
+  virtual StatusOr<PostQueryResults> Query(PostQueryRequest const& request);
 };
 
 std::shared_ptr<BigQueryJobConnection> MakeBigQueryJobConnection(

--- a/google/cloud/bigquery/v2/minimal/internal/job_connection_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_connection_test.cc
@@ -31,9 +31,9 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using ::google::cloud::bigquery_v2_minimal_testing::MakePartialJob;
+using ::google::cloud::bigquery_v2_minimal_testing::MakePostQueryResults;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryRequest;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResponsePayload;
-using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResults;
 using ::google::cloud::bigquery_v2_minimal_testing::MockBigQueryJobRestStub;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AtLeast;
@@ -251,7 +251,7 @@ TEST(JobConnectionTest, QuerySuccess) {
   auto job_result = conn->Query(job_request);
   ASSERT_STATUS_OK(job_result);
 
-  auto expected_query_results = MakeQueryResults();
+  auto expected_query_results = MakePostQueryResults();
 
   bigquery_v2_minimal_testing::AssertEquals(expected_query_results,
                                             *job_result);

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -186,9 +186,9 @@ std::string CancelJobResponse::DebugString(absl::string_view name,
       .Build();
 }
 
-std::string QueryResults::DebugString(absl::string_view name,
-                                      TracingOptions const& options,
-                                      int indent) const {
+std::string PostQueryResults::DebugString(absl::string_view name,
+                                          TracingOptions const& options,
+                                          int indent) const {
   return internal::DebugFormatter(name, options, indent)
       .StringField("kind", kind)
       .StringField("page_token", page_token)
@@ -211,7 +211,7 @@ std::string QueryResponse::DebugString(absl::string_view name,
                                        int indent) const {
   return internal::DebugFormatter(name, options, indent)
       .SubMessage("http_response", http_response)
-      .SubMessage("query_results", query_results)
+      .SubMessage("query_results", post_query_results)
       .Build();
 }
 
@@ -220,7 +220,7 @@ StatusOr<QueryResponse> QueryResponse::BuildFromHttpResponse(
   auto json = parse_json(http_response.payload);
   if (!json) return std::move(json).status();
 
-  QueryResults query_results;
+  PostQueryResults query_results;
   query_results.kind = json->value("kind", "");
   query_results.page_token = json->value("pageToken", "");
   query_results.total_rows = json->at("totalRows").get<std::uint64_t>();
@@ -252,7 +252,7 @@ StatusOr<QueryResponse> QueryResponse::BuildFromHttpResponse(
 
   QueryResponse response;
   response.http_response = http_response;
-  response.query_results = query_results;
+  response.post_query_results = query_results;
 
   return response;
 }
@@ -272,7 +272,7 @@ void from_json(nlohmann::json const& j, SessionInfo& s) {
   SafeGetTo(s.session_id, j, "sessionId");
 }
 
-void to_json(nlohmann::json& j, QueryResults const& q) {
+void to_json(nlohmann::json& j, PostQueryResults const& q) {
   j = nlohmann::json{{"kind", q.kind},
                      {"pageToken", q.page_token},
                      {"totalRows", q.total_rows},
@@ -288,7 +288,7 @@ void to_json(nlohmann::json& j, QueryResults const& q) {
                      {"dmlStats", q.dml_stats}};
 }
 
-void from_json(nlohmann::json const& j, QueryResults& q) {
+void from_json(nlohmann::json const& j, PostQueryResults& q) {
   SafeGetTo(q.kind, j, "kind");
   SafeGetTo(q.page_token, j, "pageToken");
   SafeGetTo(q.total_rows, j, "totalRows");

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -96,7 +96,7 @@ class CancelJobResponse {
   BigQueryHttpResponse http_response;
 };
 
-struct QueryResults {
+struct PostQueryResults {
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
@@ -118,8 +118,8 @@ struct QueryResults {
   SessionInfo session_info;
   DmlStats dml_stats;
 };
-void to_json(nlohmann::json& j, QueryResults const& q);
-void from_json(nlohmann::json const& j, QueryResults& q);
+void to_json(nlohmann::json& j, PostQueryResults const& q);
+void from_json(nlohmann::json const& j, PostQueryResults& q);
 
 class QueryResponse {
  public:
@@ -131,7 +131,7 @@ class QueryResponse {
                           TracingOptions const& options = {},
                           int indent = 0) const;
 
-  QueryResults query_results;
+  PostQueryResults post_query_results;
 
   BigQueryHttpResponse http_response;
 };

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -28,8 +28,8 @@ using ::google::cloud::bigquery_v2_minimal_testing::MakeGetQueryResults;
 using ::google::cloud::bigquery_v2_minimal_testing::
     MakeGetQueryResultsResponsePayload;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeJob;
+using ::google::cloud::bigquery_v2_minimal_testing::MakePostQueryResults;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResponsePayload;
-using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResults;
 
 using ::google::cloud::rest_internal::HttpStatusCode;
 using ::google::cloud::testing_util::StatusIs;
@@ -1866,8 +1866,8 @@ TEST(QueryResponseTest, Success) {
   ASSERT_STATUS_OK(response);
   EXPECT_FALSE(response->http_response.payload.empty());
 
-  auto expected_equery_results = MakeQueryResults();
-  auto actual_query_results = response->query_results;
+  auto expected_equery_results = MakePostQueryResults();
+  auto actual_query_results = response->post_query_results;
 
   bigquery_v2_minimal_testing::AssertEquals(expected_equery_results,
                                             actual_query_results);

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.cc
@@ -103,7 +103,7 @@ StatusOr<Job> BigQueryJobRestConnectionImpl::CancelJob(
   return std::move(result->job);
 }
 
-StatusOr<QueryResults> BigQueryJobRestConnectionImpl::Query(
+StatusOr<PostQueryResults> BigQueryJobRestConnectionImpl::Query(
     PostQueryRequest const& request) {
   auto result = rest_internal::RestRetryLoop(
       retry_policy(), backoff_policy(), idempotency_policy()->Query(request),
@@ -113,7 +113,7 @@ StatusOr<QueryResults> BigQueryJobRestConnectionImpl::Query(
       },
       request, __func__);
   if (!result) return std::move(result).status();
-  return result->query_results;
+  return result->post_query_results;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_connection_impl.h
@@ -45,7 +45,7 @@ class BigQueryJobRestConnectionImpl : public BigQueryJobConnection {
   StreamRange<ListFormatJob> ListJobs(ListJobsRequest const& request) override;
   StatusOr<Job> InsertJob(InsertJobRequest const& request) override;
   StatusOr<Job> CancelJob(CancelJobRequest const& request) override;
-  StatusOr<QueryResults> Query(PostQueryRequest const& request) override;
+  StatusOr<PostQueryResults> Query(PostQueryRequest const& request) override;
 
  private:
   std::unique_ptr<BigQueryJobRetryPolicy> retry_policy() {

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub_test.cc
@@ -38,9 +38,9 @@ using ::google::cloud::bigquery_v2_minimal_testing::MakeGetQueryResults;
 using ::google::cloud::bigquery_v2_minimal_testing::
     MakeGetQueryResultsResponsePayload;
 using ::google::cloud::bigquery_v2_minimal_testing::MakePartialJob;
+using ::google::cloud::bigquery_v2_minimal_testing::MakePostQueryResults;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryRequest;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResponsePayload;
-using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryResults;
 using ::google::cloud::rest_internal::HttpStatusCode;
 using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
 using ::google::cloud::testing_util::MockHttpPayload;
@@ -447,10 +447,10 @@ TEST(BigQueryJobStubTest, QuerySuccess) {
   EXPECT_THAT(result->http_response.http_status_code, Eq(HttpStatusCode::kOk));
   EXPECT_THAT(result->http_response.payload, Eq(job_response_payload));
 
-  auto expected_query_results = MakeQueryResults();
+  auto expected_query_results = MakePostQueryResults();
 
   bigquery_v2_minimal_testing::AssertEquals(expected_query_results,
-                                            result->query_results);
+                                            result->post_query_results);
 }
 
 TEST(BigQueryJobStubTest, QueryRestClientError) {

--- a/google/cloud/bigquery/v2/minimal/mocks/mock_job_connection.h
+++ b/google/cloud/bigquery/v2/minimal/mocks/mock_job_connection.h
@@ -50,8 +50,8 @@ class MockBigQueryJobConnection : public BigQueryJobConnection {
   MOCK_METHOD(StatusOr<Job>, CancelJob, (CancelJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<QueryResults>, Query, (PostQueryRequest const& request),
-              (override));
+  MOCK_METHOD(StatusOr<PostQueryResults>, Query,
+              (PostQueryRequest const& request), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
@@ -30,9 +30,9 @@ using ::google::cloud::bigquery_v2_minimal_internal::DataFormatOptions;
 using ::google::cloud::bigquery_v2_minimal_internal::GetQueryResults;
 using ::google::cloud::bigquery_v2_minimal_internal::GetQueryResultsRequest;
 using ::google::cloud::bigquery_v2_minimal_internal::PostQueryRequest;
+using ::google::cloud::bigquery_v2_minimal_internal::PostQueryResults;
 using ::google::cloud::bigquery_v2_minimal_internal::QueryParameter;
 using ::google::cloud::bigquery_v2_minimal_internal::QueryRequest;
-using ::google::cloud::bigquery_v2_minimal_internal::QueryResults;
 
 using ::google::cloud::bigquery_v2_minimal_testing::MakeConnectionProperty;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeDatasetReference;
@@ -142,8 +142,8 @@ void AssertEquals(bigquery_v2_minimal_internal::PostQueryRequest const& lhs,
   AssertEquals(lhs.query_request(), rhs.query_request());
 }
 
-QueryResults MakeQueryResults() {
-  QueryResults expected;
+PostQueryResults MakePostQueryResults() {
+  PostQueryResults expected;
 
   expected.cache_hit = true;
   expected.dml_stats.deleted_row_count = 10;
@@ -192,7 +192,7 @@ GetQueryResults MakeGetQueryResults() {
 }
 
 std::string MakeQueryResponsePayload() {
-  auto query_results = MakeQueryResults();
+  auto query_results = MakePostQueryResults();
   nlohmann::json j;
   to_json(j, query_results);
   return j.dump();
@@ -205,8 +205,8 @@ std::string MakeGetQueryResultsResponsePayload() {
   return j.dump();
 }
 
-void AssertEquals(bigquery_v2_minimal_internal::QueryResults const& lhs,
-                  bigquery_v2_minimal_internal::QueryResults const& rhs) {
+void AssertEquals(bigquery_v2_minimal_internal::PostQueryResults const& lhs,
+                  bigquery_v2_minimal_internal::PostQueryResults const& rhs) {
   EXPECT_EQ(lhs.cache_hit, rhs.cache_hit);
   EXPECT_EQ(lhs.dml_stats, rhs.dml_stats);
   EXPECT_EQ(lhs.job_complete, rhs.job_complete);

--- a/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.h
+++ b/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.h
@@ -37,10 +37,10 @@ void AssertEquals(bigquery_v2_minimal_internal::PostQueryRequest const& lhs,
                   bigquery_v2_minimal_internal::PostQueryRequest const& rhs);
 
 std::string MakeQueryResponsePayload();
-bigquery_v2_minimal_internal::QueryResults MakeQueryResults();
+bigquery_v2_minimal_internal::PostQueryResults MakePostQueryResults();
 
-void AssertEquals(bigquery_v2_minimal_internal::QueryResults const& lhs,
-                  bigquery_v2_minimal_internal::QueryResults const& rhs);
+void AssertEquals(bigquery_v2_minimal_internal::PostQueryResults const& lhs,
+                  bigquery_v2_minimal_internal::PostQueryResults const& rhs);
 
 std::string MakeGetQueryResultsResponsePayload();
 bigquery_v2_minimal_internal::GetQueryResults MakeGetQueryResults();


### PR DESCRIPTION
This PR renames `QueryResults` response structure to `PostQueryResults` for the `Query` api which currently looks like this
in the `job_connection.h`

```
  virtual StatusOr<QueryResults> Query(PostQueryRequest const& request);
```
After the rename it will look like this
```
  virtual StatusOr<PostQueryResults> Query(PostQueryRequest const& request);
```

The above is done to avoid confusion with the `QueryResults` api which will have a similar response . This api is not yet added to the `job_connection.h` and will be added in subsequent PRs. The api below is needed to retrieve the query results from the above `Query` api if the results are more than a single page.

```
  virtual StreamRange<GetQueryResults> QueryResults(GetQueryResultsRequest const& request);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12262)
<!-- Reviewable:end -->
