### PR TITLE
chore(bigtable): update feature flags

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -49,6 +49,7 @@ std::string FeaturesMetadata() {
   static auto const* const kFeatures = new auto([] {
     google::bigtable::v2::FeatureFlags proto;
     proto.set_reverse_scans(true);
+    proto.set_last_scanned_row_responses(true);
     return internal::UrlsafeBase64Encode(proto.SerializeAsString());
   }());
   return *kFeatures;

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -49,7 +49,7 @@ using ::testing::Pair;
 using ::testing::Return;
 
 MATCHER(IsWebSafeBase64, "") {
-  std::regex regex(R"re([A-Z0-9_-]*)re");
+  std::regex regex(R"re([A-Za-z0-9_-]*)re");
   return std::regex_match(arg, regex);
 }
 


### PR DESCRIPTION
Tell the bigtable server that our client supports resuming from the last scanned row key.

Note that lowercase characters are part of the base64 alphabet. I just forgot to include them earlier: https://datatracker.ietf.org/doc/html/rfc4648#section-4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12270)
<!-- Reviewable:end -->
