### PR TITLE
impl(bigquery): Makes pageToken optional in the List response

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/dataset_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_response.cc
@@ -35,8 +35,7 @@ bool valid_list_format_dataset(nlohmann::json const& j) {
 }
 
 bool valid_datasets_list(nlohmann::json const& j) {
-  return (j.contains("kind") && j.contains("etag") &&
-          j.contains("nextPageToken") && j.contains("datasets"));
+  return (j.contains("kind") && j.contains("etag") && j.contains("datasets"));
 }
 
 StatusOr<nlohmann::json> parse_json(std::string const& payload) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -37,8 +37,7 @@ bool valid_list_format_job(nlohmann::json const& j) {
 }
 
 bool valid_jobs_list(nlohmann::json const& j) {
-  return (j.contains("kind") && j.contains("etag") &&
-          j.contains("nextPageToken") && j.contains("jobs"));
+  return (j.contains("kind") && j.contains("etag") && j.contains("jobs"));
 }
 
 StatusOr<nlohmann::json> parse_json(std::string const& payload) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -126,7 +126,7 @@ TEST(GetJobResponseTest, InvalidJob) {
                                      HasSubstr("Not a valid Json Job object")));
 }
 
-TEST(ListJobsResponseTest, Success) {
+TEST(ListJobsResponseTest, SuccessMultiplePages) {
   BigQueryHttpResponse http_response;
   http_response.payload =
       R"({"etag": "tag-1",
@@ -154,6 +154,47 @@ TEST(ListJobsResponseTest, Success) {
   EXPECT_EQ(list_jobs_response->kind, "kind-1");
   EXPECT_EQ(list_jobs_response->etag, "tag-1");
   EXPECT_EQ(list_jobs_response->next_page_token, "npt-123");
+
+  auto const jobs = list_jobs_response->jobs;
+  ASSERT_EQ(jobs.size(), 1);
+  EXPECT_EQ(jobs[0].id, "1");
+  EXPECT_EQ(jobs[0].kind, "kind-2");
+  EXPECT_EQ(jobs[0].status.state, "DONE");
+  EXPECT_EQ(jobs[0].state, "DONE");
+  EXPECT_EQ(jobs[0].user_email, "user-email");
+  EXPECT_EQ(jobs[0].job_reference.project_id, "p123");
+  EXPECT_EQ(jobs[0].job_reference.job_id, "j123");
+  EXPECT_EQ(jobs[0].configuration.job_type, "QUERY");
+  EXPECT_EQ(jobs[0].configuration.query.query, "select 1;");
+}
+
+TEST(ListJobsResponseTest, SuccessSinglePage) {
+  BigQueryHttpResponse http_response;
+  http_response.payload =
+      R"({"etag": "tag-1",
+          "kind": "kind-1",
+          "jobs": [
+              {
+                "id": "1",
+                "kind": "kind-2",
+                "jobReference": {"projectId": "p123", "jobId": "j123"},
+                "state": "DONE",
+                "configuration": {
+                   "jobType": "QUERY",
+                   "query": {"query": "select 1;"}
+                },
+                "status": {"state": "DONE"},
+                "user_email": "user-email",
+                "principal_subject": "principal-subj"
+              }
+  ]})";
+  auto const list_jobs_response =
+      ListJobsResponse::BuildFromHttpResponse(http_response);
+  ASSERT_STATUS_OK(list_jobs_response);
+  EXPECT_FALSE(list_jobs_response->http_response.payload.empty());
+  EXPECT_EQ(list_jobs_response->kind, "kind-1");
+  EXPECT_EQ(list_jobs_response->etag, "tag-1");
+  EXPECT_THAT(list_jobs_response->next_page_token, IsEmpty());
 
   auto const jobs = list_jobs_response->jobs;
   ASSERT_EQ(jobs.size(), 1);

--- a/google/cloud/bigquery/v2/minimal/internal/project_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_response.cc
@@ -31,8 +31,7 @@ bool valid_project(nlohmann::json const& j) {
 }
 
 bool valid_projects_list(nlohmann::json const& j) {
-  return (j.contains("kind") && j.contains("etag") &&
-          j.contains("nextPageToken") && j.contains("projects"));
+  return (j.contains("kind") && j.contains("etag") && j.contains("projects"));
 }
 
 StatusOr<nlohmann::json> parse_json(std::string const& payload) {

--- a/google/cloud/bigquery/v2/minimal/internal/table_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_response.cc
@@ -36,8 +36,7 @@ bool valid_list_format_table(nlohmann::json const& j) {
 }
 
 bool valid_tables_list(nlohmann::json const& j) {
-  return (j.contains("kind") && j.contains("etag") &&
-          j.contains("nextPageToken") && j.contains("tables"));
+  return (j.contains("kind") && j.contains("etag") && j.contains("tables"));
 }
 
 StatusOr<nlohmann::json> parse_json(std::string const& payload) {

--- a/google/cloud/bigquery/v2/minimal/testing/project_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/project_test_utils.cc
@@ -62,6 +62,15 @@ std::string MakeListProjectsResponseJsonText() {
          projects_json_txt + R"(]})";
 }
 
+std::string MakeListProjectsResponseNoPageTokenJsonText() {
+  auto projects_json_txt = MakeProjectJsonText();
+  return R"({"etag": "tag-1",
+          "kind": "kind-1",
+          "totalItems": "1",
+          "projects": [)" +
+         projects_json_txt + R"(]})";
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_testing
 }  // namespace cloud

--- a/google/cloud/bigquery/v2/minimal/testing/project_test_utils.h
+++ b/google/cloud/bigquery/v2/minimal/testing/project_test_utils.h
@@ -29,6 +29,7 @@ void AssertEquals(bigquery_v2_minimal_internal::Project const& lhs,
                   bigquery_v2_minimal_internal::Project const& rhs);
 std::string MakeProjectJsonText();
 std::string MakeListProjectsResponseJsonText();
+std::string MakeListProjectsResponseNoPageTokenJsonText();
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_testing

--- a/google/cloud/bigquery/v2/minimal/testing/table_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/table_test_utils.cc
@@ -326,6 +326,16 @@ std::string MakeListTablesResponseJsonText() {
          tables_json_txt + R"(]})";
 }
 
+std::string MakeListTablesResponseNoPageTokenJsonText() {
+  auto tables_json_txt =
+      bigquery_v2_minimal_testing::MakeListFormatTableJsonText();
+  return R"({"etag": "tag-1",
+          "kind": "kind-1",
+          "totalItems": "1",
+          "tables": [)" +
+         tables_json_txt + R"(]})";
+}
+
 bigquery_v2_minimal_internal::GetTableRequest MakeGetTableRequest() {
   std::vector<std::string> fields;
   fields.emplace_back("f1");

--- a/google/cloud/bigquery/v2/minimal/testing/table_test_utils.h
+++ b/google/cloud/bigquery/v2/minimal/testing/table_test_utils.h
@@ -34,6 +34,7 @@ void AssertEquals(bigquery_v2_minimal_internal::ListFormatTable const& lhs,
 std::string MakeTableJsonText();
 std::string MakeListFormatTableJsonText();
 std::string MakeListTablesResponseJsonText();
+std::string MakeListTablesResponseNoPageTokenJsonText();
 
 bigquery_v2_minimal_internal::GetTableRequest MakeGetTableRequest();
 bigquery_v2_minimal_internal::ListTablesRequest MakeListTablesRequest();


### PR DESCRIPTION
This PR fixes GitHub issue https://github.com/googleapis/google-cloud-cpp/issues/12269

The `List*` apis currently assume `nextPageToken` to be a required response field with value empty for single page and non-empty for multiple pages. But from E2E testing it was revealed that `nextPageToken` is completely omitted for single page.

This PR addresses the above and makes `nextPageToken` field optional for all List apis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12276)
<!-- Reviewable:end -->
