### PR TITLE
impl(bigquery): Update json parsing for time fields

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
@@ -24,14 +24,28 @@ void FromJson(std::chrono::milliseconds& field, nlohmann::json const& j,
   auto const l = j.find(name);
   if (l == j.end()) return;
   std::int64_t m;
-  l->get_to(m);
-  field = std::chrono::milliseconds(m);
+  if (l->is_string()) {
+    std::string s;
+    l->get_to(s);
+    char* end;
+    m = std::strtoll(s.c_str(), &end, 10);
+  } else {
+    l->get_to(m);
+  }
+  if (m >= 0) {
+    field = std::chrono::milliseconds(m);
+  }
 }
 
 void ToJson(std::chrono::milliseconds const& field, nlohmann::json& j,
-            char const* name) {
-  j[name] = static_cast<std::int64_t>(
+            char const* name, bool is_number) {
+  auto m = static_cast<std::int64_t>(
       std::chrono::duration_cast<std::chrono::milliseconds>(field).count());
+  if (is_number) {
+    j[name] = m;
+  } else {
+    j[name] = std::to_string(m);
+  }
 }
 
 void FromJson(std::chrono::hours& field, nlohmann::json const& j,
@@ -39,14 +53,28 @@ void FromJson(std::chrono::hours& field, nlohmann::json const& j,
   auto const l = j.find(name);
   if (l == j.end()) return;
   std::int64_t m;
-  l->get_to(m);
-  field = std::chrono::hours(m);
+  if (l->is_string()) {
+    std::string s;
+    l->get_to(s);
+    char* end;
+    m = std::strtoll(s.c_str(), &end, 10);
+  } else {
+    l->get_to(m);
+  }
+  if (m >= 0) {
+    field = std::chrono::hours(m);
+  }
 }
 
 void ToJson(std::chrono::hours const& field, nlohmann::json& j,
-            char const* name) {
-  j[name] = static_cast<std::int64_t>(
+            char const* name, bool is_number) {
+  auto m = static_cast<std::int64_t>(
       std::chrono::duration_cast<std::chrono::hours>(field).count());
+  if (is_number) {
+    j[name] = m;
+  } else {
+    j[name] = std::to_string(m);
+  }
 }
 
 void FromJson(std::chrono::system_clock::time_point& field,
@@ -54,17 +82,31 @@ void FromJson(std::chrono::system_clock::time_point& field,
   auto const l = j.find(name);
   if (l == j.end()) return;
   std::int64_t m;
-  l->get_to(m);
-  field =
-      std::chrono::system_clock::from_time_t(0) + std::chrono::milliseconds(m);
+  if (l->is_string()) {
+    std::string s;
+    l->get_to(s);
+    char* end;
+    m = std::strtoll(s.c_str(), &end, 10);
+  } else {
+    l->get_to(m);
+  }
+  if (m >= 0) {
+    field = std::chrono::system_clock::from_time_t(0) +
+            std::chrono::milliseconds(m);
+  }
 }
 
 void ToJson(std::chrono::system_clock::time_point const& field,
-            nlohmann::json& j, char const* name) {
-  j[name] = static_cast<std::int64_t>(
+            nlohmann::json& j, char const* name, bool is_number) {
+  auto m = static_cast<std::int64_t>(
       std::chrono::duration_cast<std::chrono::milliseconds>(
           field - std::chrono::system_clock::from_time_t(0))
           .count());
+  if (is_number) {
+    j[name] = m;
+  } else {
+    j[name] = std::to_string(m);
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.h
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.h
@@ -28,19 +28,19 @@ void FromJson(std::chrono::milliseconds& field, nlohmann::json const& j,
               char const* name);
 
 void ToJson(std::chrono::milliseconds const& field, nlohmann::json& j,
-            char const* name);
+            char const* name, bool is_number = true);
 
 void FromJson(std::chrono::system_clock::time_point& field,
               nlohmann::json const& j, char const* name);
 
 void ToJson(std::chrono::system_clock::time_point const& field,
-            nlohmann::json& j, char const* name);
+            nlohmann::json& j, char const* name, bool is_number = true);
 
 void FromJson(std::chrono::hours& field, nlohmann::json const& j,
               char const* name);
 
 void ToJson(std::chrono::hours const& field, nlohmann::json& j,
-            char const* name);
+            char const* name, bool is_number = true);
 
 // Suppress recursive clang-tidy warnings
 //

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -25,7 +25,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 using ::testing::IsNull;
 using ::testing::Not;
 
-TEST(JsonUtilsTest, FromJsonMilliseconds) {
+TEST(JsonUtilsTest, FromJsonMillisecondsNumber) {
   auto const* const name = "start_time";
   auto const* json_text = R"({"start_time":10})";
   auto json = nlohmann::json::parse(json_text, nullptr, false);
@@ -37,7 +37,7 @@ TEST(JsonUtilsTest, FromJsonMilliseconds) {
   EXPECT_EQ(field, std::chrono::milliseconds(10));
 }
 
-TEST(JsonUtilsTest, ToJsonMilliseconds) {
+TEST(JsonUtilsTest, ToJsonMillisecondsNumber) {
   auto const* const name = "start_time";
   auto const* json_text = R"({"start_time":10})";
   auto expected_json = nlohmann::json::parse(json_text, nullptr, false);
@@ -50,7 +50,32 @@ TEST(JsonUtilsTest, ToJsonMilliseconds) {
   EXPECT_EQ(expected_json, actual_json);
 }
 
-TEST(JsonUtilsTest, FromJsonHours) {
+TEST(JsonUtilsTest, FromJsonMillisecondsString) {
+  auto const* const name = "start_time";
+  auto const* json_text = R"({"start_time":"10"})";
+  auto json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::chrono::milliseconds field;
+  FromJson(field, json, name);
+
+  EXPECT_EQ(field, std::chrono::milliseconds(10));
+}
+
+TEST(JsonUtilsTest, ToJsonMillisecondsString) {
+  auto const* const name = "start_time";
+  auto const* json_text = R"({"start_time":"10"})";
+  auto expected_json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(expected_json.is_object());
+
+  auto field = std::chrono::milliseconds{10};
+  nlohmann::json actual_json;
+  ToJson(field, actual_json, name, false);
+
+  EXPECT_EQ(expected_json, actual_json);
+}
+
+TEST(JsonUtilsTest, FromJsonHoursNumber) {
   auto const* const name = "start_time";
   auto const* json_text = R"({"start_time":10})";
   auto json = nlohmann::json::parse(json_text, nullptr, false);
@@ -62,7 +87,7 @@ TEST(JsonUtilsTest, FromJsonHours) {
   EXPECT_EQ(field, std::chrono::hours(10));
 }
 
-TEST(JsonUtilsTest, ToJsonHours) {
+TEST(JsonUtilsTest, ToJsonHoursNumber) {
   auto const* const name = "start_time";
   auto const* json_text = R"({"start_time":10})";
   auto expected_json = nlohmann::json::parse(json_text, nullptr, false);
@@ -75,7 +100,32 @@ TEST(JsonUtilsTest, ToJsonHours) {
   EXPECT_EQ(expected_json, actual_json);
 }
 
-TEST(JsonUtilsTest, FromJsonTimepoint) {
+TEST(JsonUtilsTest, FromJsonHoursString) {
+  auto const* const name = "start_time";
+  auto const* json_text = R"({"start_time":"10"})";
+  auto json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::chrono::hours field;
+  FromJson(field, json, name);
+
+  EXPECT_EQ(field, std::chrono::hours(10));
+}
+
+TEST(JsonUtilsTest, ToJsonHoursString) {
+  auto const* const name = "start_time";
+  auto const* json_text = R"({"start_time":"10"})";
+  auto expected_json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(expected_json.is_object());
+
+  auto field = std::chrono::hours{10};
+  nlohmann::json actual_json;
+  ToJson(field, actual_json, name, false);
+
+  EXPECT_EQ(expected_json, actual_json);
+}
+
+TEST(JsonUtilsTest, FromJsonTimepointNumber) {
   auto const* const name = "start_time";
   auto const* json_text = R"({"start_time":10})";
   auto json = nlohmann::json::parse(json_text, nullptr, false);
@@ -88,7 +138,7 @@ TEST(JsonUtilsTest, FromJsonTimepoint) {
                        std::chrono::milliseconds(10)});
 }
 
-TEST(JsonUtilsTest, ToJsonTimepoint) {
+TEST(JsonUtilsTest, ToJsonTimepointNumber) {
   auto const* const name = "start_time";
   auto const* json_text = R"({"start_time":10})";
   auto expected_json = nlohmann::json::parse(json_text, nullptr, false);
@@ -98,6 +148,33 @@ TEST(JsonUtilsTest, ToJsonTimepoint) {
       std::chrono::system_clock::time_point{std::chrono::milliseconds(10)};
   nlohmann::json actual_json;
   ToJson(field, actual_json, name);
+
+  EXPECT_EQ(expected_json, actual_json);
+}
+
+TEST(JsonUtilsTest, FromJsonTimepointString) {
+  auto const* const name = "start_time";
+  auto const* json_text = R"({"start_time":"10"})";
+  auto json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::chrono::system_clock::time_point field;
+  FromJson(field, json, name);
+
+  EXPECT_EQ(field, std::chrono::system_clock::time_point{
+                       std::chrono::milliseconds(10)});
+}
+
+TEST(JsonUtilsTest, ToJsonTimepointString) {
+  auto const* const name = "start_time";
+  auto const* json_text = R"({"start_time":"10"})";
+  auto expected_json = nlohmann::json::parse(json_text, nullptr, false);
+  EXPECT_TRUE(expected_json.is_object());
+
+  auto field =
+      std::chrono::system_clock::time_point{std::chrono::milliseconds(10)};
+  nlohmann::json actual_json;
+  ToJson(field, actual_json, name, false);
 
   EXPECT_EQ(expected_json, actual_json);
 }


### PR DESCRIPTION
This PR fixes https://github.com/googleapis/google-cloud-cpp/issues/12268

Currently all time fields in the response are expected to be numbers for parsing into chrono fields, but in actual they are being sent as strings (or numbers within quotes).

This PR modifies the `to_json` and `from_json1 methods for chrono fields to accomodate both strings and numbers as it is not guaranteed that all time fields would be sent as strings in the future as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12278)
<!-- Reviewable:end -->
