### PR TITLE
cleanup: simplify CMake functions to compile protos

### DIFF
--- a/google/cloud/pubsub/samples/CMakeLists.txt
+++ b/google/cloud/pubsub/samples/CMakeLists.txt
@@ -75,7 +75,7 @@ export_list_to_bazel("pubsub_client_unit_samples.bzl"
 
 google_cloud_cpp_proto_library(
     pubsub_samples_protos "testdata/schema.proto" PROTO_PATH_DIRECTORIES
-    "${CMAKE_CURRENT_SOURCE_DIR}/testdata" LOCAL_INCLUDE)
+    "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Generate a target for each integration test.
 foreach (fname ${pubsub_client_integration_samples})

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -83,7 +83,7 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
     google_cloud_cpp_proto_library(
         google_cloud_cpp_storage_tests_conformance_protos
         conformance_tests.proto PROTO_PATH_DIRECTORIES
-        ${CMAKE_CURRENT_SOURCE_DIR} LOCAL_INCLUDE)
+        ${CMAKE_CURRENT_SOURCE_DIR})
 endif ()
 
 foreach (fname ${storage_client_integration_tests})


### PR DESCRIPTION
The `LOCAL_INCLUDE` option was no longer needed, and actually caused problems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12286)
<!-- Reviewable:end -->
