### PR TITLE
cleanup(storage): consistent error-handling in samples

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -283,7 +283,7 @@ DownloadDetail DownloadOneObject(
   }
   stream.Close();
   // Flush the logs, if any.
-  if (!stream.status().ok()) google::cloud::LogSink::Instance().Flush();
+  if (stream.bad()) google::cloud::LogSink::Instance().Flush();
   auto const object_elapsed =
       duration_cast<microseconds>(clock::now() - object_start);
   auto p = stream.headers().find(":grpc-context-peer");

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -315,7 +315,7 @@ Status Client::DownloadFileImpl(internal::ReadObjectRangeRequest const& request,
   };
 
   auto stream = ReadObjectImpl(request);
-  if (!stream.status().ok()) {
+  if (stream.bad()) {
     return report_error(__func__, "cannot open download source object",
                         stream.status());
   }
@@ -340,7 +340,7 @@ Status Client::DownloadFileImpl(internal::ReadObjectRangeRequest const& request,
     return report_error(__func__, "cannot close download destination file",
                         Status(StatusCode::kUnknown, "ofstream::close()"));
   }
-  if (!stream.status().ok()) {
+  if (stream.bad()) {
     return report_error(__func__, "error reading download source object",
                         stream.status());
   }

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -148,6 +148,7 @@ void ReadObjectRequesterPays(google::cloud::storage::Client client,
     while (std::getline(stream, line, '\n')) {
       std::cout << line << "\n";
     }
+    if (stream.bad()) throw google::cloud::Status(stream.status());
   }
   // [END storage_download_file_requester_pays]
   //! [read object requester pays]

--- a/google/cloud/storage/examples/storage_grpc_samples.cc
+++ b/google/cloud/storage/examples/storage_grpc_samples.cc
@@ -43,6 +43,7 @@ void GrpcReadWrite(std::string const& bucket_name) {
   auto input = client.ReadObject(bucket_name, "lorem.txt",
                                  gcs::Generation(object->generation()));
   std::string const actual(std::istreambuf_iterator<char>{input}, {});
+  if (input.bad()) throw google::cloud::Status(input.status());
   std::cout << "The contents read back are:\n"
             << actual
             << "\nThe received checksums are: " << input.received_hash()

--- a/google/cloud/storage/examples/storage_object_csek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_csek_samples.cc
@@ -104,6 +104,7 @@ void ReadEncryptedObject(google::cloud::storage::Client client,
                           gcs::EncryptionKey::FromBase64Key(base64_aes256_key));
 
     std::string data(std::istreambuf_iterator<char>{stream}, {});
+    if (stream.bad()) throw google::cloud::Status(stream.status());
     std::cout << "The object contents are: " << data << "\n";
   }
   //! [read encrypted object] [END storage_download_encrypted_file]

--- a/google/cloud/storage/examples/storage_object_preconditions_samples.cc
+++ b/google/cloud/storage/examples/storage_object_preconditions_samples.cc
@@ -56,7 +56,7 @@ void ReadObjectIfGenerationMatch(google::cloud::storage::Client client,
     while (std::getline(is, line)) {
       std::cout << line << "\n";
     }
-    if (!is.status().ok()) throw google::cloud::Status(is.status());
+    if (is.bad()) throw google::cloud::Status(is.status());
   }
   //! [read-object-if-generation-match]
   (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
@@ -75,7 +75,7 @@ void ReadObjectIfMetagenerationMatch(google::cloud::storage::Client client,
     while (std::getline(is, line)) {
       std::cout << line << "\n";
     }
-    if (!is.status().ok()) throw google::cloud::Status(is.status());
+    if (is.bad()) throw google::cloud::Status(is.status());
   }
   //! [read-object-if-metageneration-match]
   (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
@@ -94,7 +94,7 @@ void ReadObjectIfGenerationNotMatch(google::cloud::storage::Client client,
     while (std::getline(is, line)) {
       std::cout << line << "\n";
     }
-    if (!is.status().ok()) throw google::cloud::Status(is.status());
+    if (is.bad()) throw google::cloud::Status(is.status());
   }
   //! [read-object-if-generation-not-match]
   (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
@@ -113,7 +113,7 @@ void ReadObjectIfMetagenerationNotMatch(google::cloud::storage::Client client,
     while (std::getline(is, line)) {
       std::cout << line << "\n";
     }
-    if (!is.status().ok()) throw google::cloud::Status(is.status());
+    if (is.bad()) throw google::cloud::Status(is.status());
   }
   //! [read-object-if-metageneration-not-match]
   (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -255,6 +255,7 @@ void ReadObject(google::cloud::storage::Client client,
     while (std::getline(stream, line, '\n')) {
       ++count;
     }
+    if (stream.bad()) throw google::cloud::Status(stream.status());
 
     std::cout << "The object has " << count << " lines\n";
   }
@@ -278,6 +279,7 @@ void ReadObjectRange(google::cloud::storage::Client client,
       std::cout << line << "\n";
       ++count;
     }
+    if (stream.bad()) throw google::cloud::Status(stream.status());
 
     std::cout << "The requested range has " << count << " lines\n";
   }
@@ -295,6 +297,7 @@ void ReadObjectIntoMemory(google::cloud::storage::Client client,
     gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
     std::string buffer{std::istream_iterator<char>(stream),
                        std::istream_iterator<char>()};
+    if (stream.bad()) throw google::cloud::Status(stream.status());
 
     std::cout << "The object has " << buffer.size() << " characters\n";
   }
@@ -311,7 +314,7 @@ void ReadObjectGzip(google::cloud::storage::Client client,
     auto is =
         client.ReadObject(bucket_name, object_name, gcs::AcceptEncodingGzip());
     auto const contents = std::string{std::istream_iterator<char>(is), {}};
-    if (!is.status().ok()) throw google::cloud::Status(is.status());
+    if (is.bad()) throw google::cloud::Status(is.status());
     std::cout << "The object has " << contents.size() << " characters\n";
   }
   //! [read object gzip]

--- a/google/cloud/storage/examples/storage_public_object_samples.cc
+++ b/google/cloud/storage/examples/storage_public_object_samples.cc
@@ -61,6 +61,7 @@ void ReadObjectUnauthenticated(std::vector<std::string> const& argv) {
     while (std::getline(stream, line, '\n')) {
       ++count;
     }
+    if (stream.bad()) throw google::cloud::Status(stream.status());
     std::cout << "The object has " << count << " lines\n";
   }
   //! [download_public_file] [END storage_download_public_file]

--- a/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
@@ -88,7 +88,7 @@ TEST_F(SlowReaderChunkIntegrationTest, LongPauses) {
               << std::flush;
     std::this_thread::sleep_for(slow_reader_period);
     stream.read(buffer.data(), size);
-    if (!stream.status().ok()) {
+    if (stream.bad()) {
       std::cout << " restart after (" << stream.status() << ")" << std::flush;
       stream = make_reader(offset);
       continue;


### PR DESCRIPTION
Prefer `is.bad()` over `!is.status().ok()` because the former should be more familiar to C++ programmers, and one of the invariants in the library is that if `!is.status().ok()` then `is.bad()` is true.

Add missing error handling to several examples.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12289)
<!-- Reviewable:end -->
