### PR TITLE
fix(common): handle expired policies in `*RetryLoop`

### DIFF
--- a/google/cloud/internal/rest_retry_loop.h
+++ b/google/cloud/internal/rest_retry_loop.h
@@ -87,9 +87,8 @@ auto RestRetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
   // The last error cannot be retried, but it is not because the retry
   // policy is exhausted. We call these "permanent errors", and they
   // get a special message.
-  char const* prefix = !retry_policy.IsExhausted()
-                           ? "Permanent error in"
-                           : "Retry policy exhausted in";
+  auto const* prefix = retry_policy.IsExhausted() ? "Retry policy exhausted in"
+                                                  : "Permanent error in";
   return internal::RetryLoopError(prefix, location, last_status);
 }
 

--- a/google/cloud/internal/rest_retry_loop.h
+++ b/google/cloud/internal/rest_retry_loop.h
@@ -18,6 +18,7 @@
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/rest_request.h"
 #include "google/cloud/internal/retry_loop_helpers.h"
@@ -61,41 +62,35 @@ template <
     typename std::enable_if<google::cloud::internal::is_invocable<
                                 Functor, RestContext&, Request const&>::value,
                             int>::type = 0>
-auto RestRetryLoopImpl(std::unique_ptr<RetryPolicy> retry_policy,
-                       std::unique_ptr<BackoffPolicy> backoff_policy,
+auto RestRetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
                        Idempotency idempotency, Functor&& functor,
                        Request const& request, char const* location,
                        Sleeper sleeper)
     -> google::cloud::internal::invoke_result_t<Functor, RestContext&,
                                                 Request const&> {
-  Status last_status;
-  while (!retry_policy->IsExhausted()) {
+  auto last_status = internal::DeadlineExceededError(
+      "Retry policy exhausted before first request attempt", GCP_ERROR_INFO());
+  while (!retry_policy.IsExhausted()) {
     RestContext rest_context;
     auto result = functor(rest_context, request);
-    if (result.ok()) {
-      return result;
-    }
+    if (result.ok()) return result;
     last_status = internal::GetResultStatus(std::move(result));
     if (idempotency == Idempotency::kNonIdempotent) {
       return internal::RetryLoopError("Error in non-idempotent operation",
                                       location, last_status);
     }
-    if (!retry_policy->OnFailure(last_status)) {
-      // The retry policy is exhausted or the error is not retryable, either
-      // way, exit the loop.
-      break;
-    }
-    sleeper(backoff_policy->OnCompletion());
+    // The retry policy is exhausted or the error is not retryable. Either
+    // way, exit the loop.
+    if (!retry_policy.OnFailure(last_status)) break;
+    sleeper(backoff_policy.OnCompletion());
   }
-  if (!retry_policy->IsExhausted()) {
-    // The last error cannot be retried, but it is not because the retry
-    // policy is exhausted, we call these "permanent errors", and they
-    // get a special message.
-    return internal::RetryLoopError("Permanent error in", location,
-                                    last_status);
-  }
-  return internal::RetryLoopError("Retry policy exhausted in", location,
-                                  last_status);
+  // The last error cannot be retried, but it is not because the retry
+  // policy is exhausted. We call these "permanent errors", and they
+  // get a special message.
+  char const* prefix = !retry_policy.IsExhausted()
+                           ? "Permanent error in"
+                           : "Retry policy exhausted in";
+  return internal::RetryLoopError(prefix, location, last_status);
 }
 
 /// @copydoc RestRetryLoopImpl
@@ -113,9 +108,28 @@ auto RestRetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
   std::function<void(std::chrono::milliseconds)> sleeper =
       [](std::chrono::milliseconds p) { std::this_thread::sleep_for(p); };
   sleeper = internal::MakeTracedSleeper(std::move(sleeper));
-  return RestRetryLoopImpl(std::move(retry_policy), std::move(backoff_policy),
-                           idempotency, std::forward<Functor>(functor), request,
-                           location, std::move(sleeper));
+  return RestRetryLoopImpl(*retry_policy, *backoff_policy, idempotency,
+                           std::forward<Functor>(functor), request, location,
+                           std::move(sleeper));
+}
+
+/// @copydoc RestRetryLoopImpl
+template <
+    typename Functor, typename Request,
+    typename std::enable_if<google::cloud::internal::is_invocable<
+                                Functor, RestContext&, Request const&>::value,
+                            int>::type = 0>
+auto RestRetryLoop(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
+                   Idempotency idempotency, Functor&& functor,
+                   Request const& request, char const* location)
+    -> google::cloud::internal::invoke_result_t<Functor, RestContext&,
+                                                Request const&> {
+  std::function<void(std::chrono::milliseconds)> sleeper =
+      [](std::chrono::milliseconds p) { std::this_thread::sleep_for(p); };
+  sleeper = internal::MakeTracedSleeper(std::move(sleeper));
+  return RestRetryLoopImpl(retry_policy, backoff_policy, idempotency,
+                           std::forward<Functor>(functor), request, location,
+                           std::move(sleeper));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -62,8 +62,7 @@ template <typename Functor, typename Request, typename Sleeper,
               google::cloud::internal::is_invocable<
                   Functor, grpc::ClientContext&, Request const&>::value,
               int>::type = 0>
-auto RetryLoopImpl(std::unique_ptr<RetryPolicy> retry_policy,
-                   std::unique_ptr<BackoffPolicy> backoff_policy,
+auto RetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
                    Idempotency idempotency, Functor&& functor,
                    Request const& request, char const* location,
                    Sleeper sleeper)
@@ -71,7 +70,7 @@ auto RetryLoopImpl(std::unique_ptr<RetryPolicy> retry_policy,
                                                 Request const&> {
   auto last_status = internal::DeadlineExceededError(
       "Retry policy exhausted before first request attempt", GCP_ERROR_INFO());
-  while (!retry_policy->IsExhausted()) {
+  while (!retry_policy.IsExhausted()) {
     // Need to create a new context for each retry.
     grpc::ClientContext context;
     ConfigureContext(context, CurrentOptions());
@@ -85,15 +84,14 @@ auto RetryLoopImpl(std::unique_ptr<RetryPolicy> retry_policy,
     }
     // The retry policy is exhausted or the error is not retryable. Either
     // way, exit the loop.
-    if (!retry_policy->OnFailure(last_status)) break;
-    sleeper(backoff_policy->OnCompletion());
+    if (!retry_policy.OnFailure(last_status)) break;
+    sleeper(backoff_policy.OnCompletion());
   }
   // The last error cannot be retried, but it is not because the retry
   // policy is exhausted. We call these "permanent errors", and they
   // get a special message.
-  char const* prefix = !retry_policy->IsExhausted()
-                           ? "Permanent error in"
-                           : "Retry policy exhausted in";
+  auto const* prefix = retry_policy.IsExhausted() ? "Retry policy exhausted in"
+                                                  : "Permanent error in";
   return internal::RetryLoopError(prefix, location, last_status);
 }
 
@@ -112,9 +110,9 @@ auto RetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
   std::function<void(std::chrono::milliseconds)> sleeper =
       [](std::chrono::milliseconds p) { std::this_thread::sleep_for(p); };
   sleeper = MakeTracedSleeper(std::move(sleeper));
-  return RetryLoopImpl(std::move(retry_policy), std::move(backoff_policy),
-                       idempotency, std::forward<Functor>(functor), request,
-                       location, std::move(sleeper));
+  return RetryLoopImpl(*retry_policy, *backoff_policy, idempotency,
+                       std::forward<Functor>(functor), request, location,
+                       std::move(sleeper));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/retry_loop_test.cc
+++ b/google/cloud/internal/retry_loop_test.cc
@@ -123,8 +123,9 @@ TEST(RetryLoopTest, UsesBackoffPolicy) {
   int counter = 0;
   std::vector<ms> sleep_for;
   OptionsSpan span(Options{}.set<StringOption>("UsesBackoffPolicy"));
+  auto retry_policy = TestRetryPolicy();
   StatusOr<int> actual = RetryLoopImpl(
-      TestRetryPolicy(), std::move(mock), Idempotency::kIdempotent,
+      *retry_policy, *mock, Idempotency::kIdempotent,
       [&counter](grpc::ClientContext&, int request) {
         EXPECT_EQ(CurrentOptions().get<StringOption>(), "UsesBackoffPolicy");
         if (++counter <= 3) {

--- a/google/cloud/internal/retry_loop_test.cc
+++ b/google/cloud/internal/retry_loop_test.cc
@@ -29,6 +29,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::MockBackoffPolicy;
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -191,6 +192,24 @@ TEST(RetryLoopTest, TooManyTransientFailuresIdempotent) {
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
   EXPECT_THAT(actual.status().message(), HasSubstr("the answer to everything"));
   EXPECT_THAT(actual.status().message(), HasSubstr("Retry policy exhausted"));
+}
+
+TEST(RetryLoopTest, ExhaustedOnStart) {
+  internal::OptionsSpan span(Options{}.set<StringOption>("ExhaustedOnStart"));
+  auto retry_policy = internal::LimitedTimeRetryPolicy<TestRetryablePolicy>(
+      std::chrono::seconds(0));
+  ASSERT_TRUE(retry_policy.IsExhausted());
+  StatusOr<int> actual = RetryLoop(
+      retry_policy.clone(), TestBackoffPolicy(), Idempotency::kIdempotent,
+      [](grpc::ClientContext&, int) {
+        EXPECT_EQ(internal::CurrentOptions().get<StringOption>(),
+                  "ExhaustedOnStart");
+        return StatusOr<int>(Status(StatusCode::kUnavailable, "try again"));
+      },
+      42, "the answer to everything");
+  internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
+  EXPECT_THAT(actual, StatusIs(StatusCode::kDeadlineExceeded,
+                               HasSubstr("Retry policy exhausted before")));
 }
 
 TEST(RetryLoopTest, ConfigureContext) {


### PR DESCRIPTION
The retry policy may be expired when it enters the retry loop. For example, time-based policies may suffer from poor scheduling luck.

Part of the work for #12294

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12301)
<!-- Reviewable:end -->
