### PR TITLE
impl(storage): testable decorator stack

### DIFF
--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
-#include "google/cloud/storage/internal/curl/client.h"
-#include "google/cloud/storage/internal/rest/client.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
@@ -35,6 +33,8 @@ using ::google::cloud::storage::internal::ClientImplDetails;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::MockBackoffPolicy;
 using ::google::cloud::testing_util::ScopedEnvironment;
+using ::testing::ElementsAre;
+using ::testing::NotNull;
 using ::testing::Return;
 
 class ObservableRetryPolicy : public LimitedErrorCountRetryPolicy {
@@ -164,13 +164,10 @@ TEST_F(ClientTest, DefaultDecoratorsCurlClient) {
                  .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
                  .set<TracingComponentsOption>({}));
 
-  EXPECT_TRUE(ClientImplDetails::GetRawClient(tested) != nullptr);
-  auto* retry = dynamic_cast<internal::RetryClient*>(
-      ClientImplDetails::GetRawClient(tested).get());
-  ASSERT_TRUE(retry != nullptr);
-
-  auto* curl = dynamic_cast<internal::CurlClient*>(retry->client().get());
-  ASSERT_TRUE(curl != nullptr);
+  auto const impl = ClientImplDetails::GetRawClient(tested);
+  ASSERT_THAT(impl, NotNull());
+  EXPECT_THAT(impl->InspectStackStructure(),
+              ElementsAre("CurlClient", "RetryClient"));
 }
 
 /// @test Verify the constructor creates the right set of RawClient decorations.
@@ -184,16 +181,10 @@ TEST_F(ClientTest, LoggingDecoratorsCurlClient) {
                  .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
                  .set<TracingComponentsOption>({"raw-client"}));
 
-  EXPECT_TRUE(ClientImplDetails::GetRawClient(tested) != nullptr);
-  auto* retry = dynamic_cast<internal::RetryClient*>(
-      ClientImplDetails::GetRawClient(tested).get());
-  ASSERT_TRUE(retry != nullptr);
-
-  auto* logging = dynamic_cast<internal::LoggingClient*>(retry->client().get());
-  ASSERT_TRUE(logging != nullptr);
-
-  auto* curl = dynamic_cast<internal::CurlClient*>(logging->client().get());
-  ASSERT_TRUE(curl != nullptr);
+  auto const impl = ClientImplDetails::GetRawClient(tested);
+  ASSERT_THAT(impl, NotNull());
+  EXPECT_THAT(impl->InspectStackStructure(),
+              ElementsAre("CurlClient", "LoggingClient", "RetryClient"));
 }
 
 /// @test Verify the constructor creates the right set of RawClient decorations.
@@ -207,13 +198,10 @@ TEST_F(ClientTest, DefaultDecoratorsRestClient) {
                  .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
                  .set<TracingComponentsOption>({}));
 
-  EXPECT_TRUE(ClientImplDetails::GetRawClient(tested) != nullptr);
-  auto* retry = dynamic_cast<internal::RetryClient*>(
-      ClientImplDetails::GetRawClient(tested).get());
-  ASSERT_TRUE(retry != nullptr);
-
-  auto* rest = dynamic_cast<internal::RestClient*>(retry->client().get());
-  ASSERT_TRUE(rest != nullptr);
+  auto const impl = ClientImplDetails::GetRawClient(tested);
+  ASSERT_THAT(impl, NotNull());
+  EXPECT_THAT(impl->InspectStackStructure(),
+              ElementsAre("RestClient", "RetryClient"));
 }
 
 /// @test Verify the constructor creates the right set of RawClient decorations.
@@ -225,16 +213,10 @@ TEST_F(ClientTest, LoggingDecoratorsRestClient) {
                  .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
                  .set<TracingComponentsOption>({"raw-client"}));
 
-  EXPECT_TRUE(ClientImplDetails::GetRawClient(tested) != nullptr);
-  auto* retry = dynamic_cast<internal::RetryClient*>(
-      ClientImplDetails::GetRawClient(tested).get());
-  ASSERT_TRUE(retry != nullptr);
-
-  auto* logging = dynamic_cast<internal::LoggingClient*>(retry->client().get());
-  ASSERT_TRUE(logging != nullptr);
-
-  auto* rest = dynamic_cast<internal::RestClient*>(logging->client().get());
-  ASSERT_TRUE(rest != nullptr);
+  auto const impl = ClientImplDetails::GetRawClient(tested);
+  ASSERT_THAT(impl, NotNull());
+  EXPECT_THAT(impl->InspectStackStructure(),
+              ElementsAre("RestClient", "LoggingClient", "RetryClient"));
 }
 
 #include "google/cloud/internal/disable_deprecation_warnings.inc"

--- a/google/cloud/storage/internal/curl/client.cc
+++ b/google/cloud/storage/internal/curl/client.cc
@@ -1092,6 +1092,10 @@ StatusOr<EmptyResponse> CurlClient::DeleteNotification(
       std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
+std::vector<std::string> CurlClient::InspectStackStructure() const {
+  return {"CurlClient"};
+}
+
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
     InsertObjectMediaRequest const& request) {
   // To perform a multipart upload we need to separate the parts as described

--- a/google/cloud/storage/internal/curl/client.h
+++ b/google/cloud/storage/internal/curl/client.h
@@ -176,6 +176,8 @@ class CurlClient : public RawClient {
   StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) override;
 
+  std::vector<std::string> InspectStackStructure() const override;
+
  protected:
   // The constructor is private because the class must always be created
   // as a shared_ptr<>.

--- a/google/cloud/storage/internal/generic_stub.h
+++ b/google/cloud/storage/internal/generic_stub.h
@@ -250,6 +250,9 @@ class GenericStub {
       rest_internal::RestContext&, Options const&,
       storage::internal::DeleteNotificationRequest const&) = 0;
   ///@}
+
+  // Test-only. Returns the names of the decorator stack elements.
+  virtual std::vector<std::string> InspectStackStructure() const = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/generic_stub_adapter.cc
+++ b/google/cloud/storage/internal/generic_stub_adapter.cc
@@ -317,6 +317,12 @@ class GenericStubAdapter : public GenericStub {
     return impl_->DeleteNotification(request);
   }
 
+  std::vector<std::string> InspectStackStructure() const override {
+    auto stack = impl_->InspectStackStructure();
+    stack.emplace_back("GenericStubAdapter");
+    return stack;
+  }
+
  private:
   std::shared_ptr<storage::internal::RawClient> impl_;
 };

--- a/google/cloud/storage/internal/grpc/client.cc
+++ b/google/cloud/storage/internal/grpc/client.cc
@@ -1116,6 +1116,10 @@ StatusOr<storage::internal::EmptyResponse> GrpcClient::DeleteNotification(
   return storage::internal::EmptyResponse{};
 }
 
+std::vector<std::string> GrpcClient::InspectStackStructure() const {
+  return {"GrpcClient"};
+}
+
 StatusOr<google::storage::v2::Bucket> GrpcClient::GetBucketMetadataImpl(
     storage::internal::GetBucketMetadataRequest const& request) {
   auto proto = ToProto(request);

--- a/google/cloud/storage/internal/grpc/client.h
+++ b/google/cloud/storage/internal/grpc/client.h
@@ -186,6 +186,8 @@ class GrpcClient : public storage::internal::RawClient {
   StatusOr<storage::internal::EmptyResponse> DeleteNotification(
       storage::internal::DeleteNotificationRequest const&) override;
 
+  std::vector<std::string> InspectStackStructure() const override;
+
  protected:
   explicit GrpcClient(Options opts);
   explicit GrpcClient(

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/grpc/client.h"
 #include "google/cloud/storage/internal/rest/client.h"
 #include "absl/strings/match.h"
+#include <iterator>
 
 namespace google {
 namespace cloud {
@@ -311,6 +312,15 @@ StatusOr<storage::NotificationMetadata> HybridClient::GetNotification(
 StatusOr<storage::internal::EmptyResponse> HybridClient::DeleteNotification(
     storage::internal::DeleteNotificationRequest const& request) {
   return rest_->DeleteNotification(request);
+}
+
+std::vector<std::string> HybridClient::InspectStackStructure() const {
+  auto grpc = grpc_->InspectStackStructure();
+  auto rest = rest_->InspectStackStructure();
+  grpc.insert(grpc.end(), std::make_move_iterator(rest.begin()),
+              std::make_move_iterator(rest.end()));
+  grpc.emplace_back("HybridClient");
+  return grpc;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -155,6 +155,8 @@ class HybridClient : public storage::internal::RawClient {
   StatusOr<storage::internal::EmptyResponse> DeleteNotification(
       storage::internal::DeleteNotificationRequest const&) override;
 
+  std::vector<std::string> InspectStackStructure() const override;
+
  private:
   explicit HybridClient(Options const& options);
 

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -363,6 +363,12 @@ StatusOr<EmptyResponse> LoggingClient::DeleteNotification(
   return MakeCall(*client_, &RawClient::DeleteNotification, request, __func__);
 }
 
+std::vector<std::string> LoggingClient::InspectStackStructure() const {
+  auto stack = client_->InspectStackStructure();
+  stack.emplace_back("LoggingClient");
+  return stack;
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -142,7 +142,7 @@ class LoggingClient : public RawClient {
   StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) override;
 
-  std::shared_ptr<RawClient> client() const { return client_; }
+  std::vector<std::string> InspectStackStructure() const override;
 
  private:
   std::shared_ptr<RawClient> client_;

--- a/google/cloud/storage/internal/raw_client.cc
+++ b/google/cloud/storage/internal/raw_client.cc
@@ -20,6 +20,8 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
+std::vector<std::string> RawClient::InspectStackStructure() const { return {}; }
+
 StatusOr<CreateOrResumeResponse> CreateOrResume(
     RawClient& client, ResumableUploadRequest const& request) {
   auto session_id = request.GetOption<UseResumableUploadSession>().value_or("");

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -37,6 +37,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -180,6 +181,9 @@ class RawClient {
   virtual StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) = 0;
   ///@}
+
+  // Test-only. Returns the names of the decorator stack elements.
+  virtual std::vector<std::string> InspectStackStructure() const;
 };
 
 struct CreateOrResumeResponse {

--- a/google/cloud/storage/internal/rest/client.cc
+++ b/google/cloud/storage/internal/rest/client.cc
@@ -1246,6 +1246,10 @@ StatusOr<EmptyResponse> RestClient::DeleteNotification(
       storage_rest_client_->Delete(context, std::move(builder).BuildRequest()));
 }
 
+std::vector<std::string> RestClient::InspectStackStructure() const {
+  return {"RestClient"};
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/rest/client.h
+++ b/google/cloud/storage/internal/rest/client.h
@@ -165,6 +165,8 @@ class RestClient : public RawClient {
   StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) override;
 
+  std::vector<std::string> InspectStackStructure() const override;
+
  protected:
   explicit RestClient(
       std::shared_ptr<google::cloud::rest_internal::RestClient>

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -997,6 +997,12 @@ StatusOr<EmptyResponse> RetryClient::DeleteNotification(
       request, __func__);
 }
 
+std::vector<std::string> RetryClient::InspectStackStructure() const {
+  auto stack = client_->InspectStackStructure();
+  stack.emplace_back("RetryClient");
+  return stack;
+}
+
 std::unique_ptr<RetryPolicy> RetryClient::current_retry_policy() {
   return google::cloud::internal::CurrentOptions()
       .get<RetryPolicyOption>()

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -152,7 +152,7 @@ class RetryClient : public RawClient,
   StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) override;
 
-  std::shared_ptr<RawClient> client() const { return client_; }
+  std::vector<std::string> InspectStackStructure() const override;
 
  private:
   explicit RetryClient(std::shared_ptr<RawClient> client, Options options);

--- a/google/cloud/storage/internal/tracing_client.cc
+++ b/google/cloud/storage/internal/tracing_client.cc
@@ -422,6 +422,12 @@ StatusOr<storage::internal::EmptyResponse> TracingClient::DeleteNotification(
   return internal::EndSpan(*span, impl_->DeleteNotification(request));
 }
 
+std::vector<std::string> TracingClient::InspectStackStructure() const {
+  auto stack = impl_->InspectStackStructure();
+  stack.emplace_back("TracingClient");
+  return stack;
+}
+
 std::shared_ptr<storage::internal::RawClient> MakeTracingClient(
     std::shared_ptr<storage::internal::RawClient> impl) {
   return std::make_shared<TracingClient>(std::move(impl));

--- a/google/cloud/storage/internal/tracing_client.h
+++ b/google/cloud/storage/internal/tracing_client.h
@@ -158,6 +158,8 @@ class TracingClient : public storage::internal::RawClient {
   StatusOr<storage::internal::EmptyResponse> DeleteNotification(
       storage::internal::DeleteNotificationRequest const& request) override;
 
+  std::vector<std::string> InspectStackStructure() const override;
+
  private:
   std::shared_ptr<RawClient> impl_;
 };

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -162,6 +162,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
       StatusOr<std::string>, AuthorizationHeader,
       (std::shared_ptr<google::cloud::storage::oauth2::Credentials> const&));
 
+  MOCK_METHOD(std::vector<std::string>, InspectStackStructure, (),
+              (const, override));
+
  private:
   ClientOptions client_options_;
 };

--- a/google/cloud/storage/testing/mock_generic_stub.h
+++ b/google/cloud/storage/testing/mock_generic_stub.h
@@ -260,6 +260,9 @@ class MockGenericStub : public storage_internal::GenericStub {
               (rest_internal::RestContext&, Options const&,
                storage::internal::DeleteNotificationRequest const&),
               (override));
+
+  MOCK_METHOD(std::vector<std::string>, InspectStackStructure, (),
+              (const, override));
 };
 
 }  // namespace testing


### PR DESCRIPTION
Make the decorator stack easier to test. A new member function returns the elements in the stack, by name, we can then inspect the names in the tests.

Part of the work #12294

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12307)
<!-- Reviewable:end -->
