### PR TITLE
feat(common): retry loops signal via error info

### DIFF
--- a/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
@@ -43,11 +43,13 @@ using ::google::cloud::testing_util::AsyncSequencer;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
+using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Contains;
 using ::testing::ContainsRegex;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
+using ::testing::Pair;
 using ::testing::Return;
 
 std::shared_ptr<GoldenThingAdminConnection> CreateTestingConnection(
@@ -1234,10 +1236,12 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseTooManyFailures) {
   auto fut = conn->AsyncGetDatabase(dbase);
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto db = fut.get();
-  ASSERT_THAT(db, StatusIs(StatusCode::kDeadlineExceeded,
-                           AllOf(HasSubstr("Retry policy exhausted"),
-                                 HasSubstr("AsyncGetDatabase"),
-                                 HasSubstr("try again"))));
+  ASSERT_THAT(db,
+              StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("try again")));
+  auto const& metadata = db.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", _)));
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.reason",
+                                      "retry-policy-exhausted")));
 }
 
 TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseCancel) {
@@ -1266,10 +1270,8 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseCancel) {
   fut.cancel();
   EXPECT_TRUE(cancel_completed.get());
   auto db = fut.get();
-  ASSERT_THAT(db, StatusIs(StatusCode::kDeadlineExceeded,
-                           AllOf(HasSubstr("Retry loop cancelled"),
-                                 HasSubstr("AsyncGetDatabase"),
-                                 HasSubstr("try again"))));
+  ASSERT_THAT(db,
+              StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("try again")));
 }
 
 TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseSuccess) {
@@ -1318,10 +1320,8 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseFailure) {
   auto fut = conn->AsyncDropDatabase(request);
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto status = fut.get();
-  ASSERT_THAT(status, StatusIs(StatusCode::kDeadlineExceeded,
-                               AllOf(HasSubstr("Retry policy exhausted"),
-                                     HasSubstr("AsyncDropDatabase"),
-                                     HasSubstr("try again"))));
+  ASSERT_THAT(status,
+              StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("try again")));
 }
 
 TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseCancel) {
@@ -1356,10 +1356,11 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseCancel) {
   fut.cancel();
   EXPECT_TRUE(cancel_completed.get());
   auto status = fut.get();
-  ASSERT_THAT(status, StatusIs(StatusCode::kDeadlineExceeded,
-                               AllOf(HasSubstr("Retry loop cancelled"),
-                                     HasSubstr("AsyncDropDatabase"),
-                                     HasSubstr("try again"))));
+  ASSERT_THAT(status,
+              StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("try again")));
+  auto const& metadata = status.error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", _)));
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.reason", "cancelled")));
 }
 
 TEST(GoldenThingAdminConnectionTest, CheckExpectedOptions) {

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -131,7 +131,8 @@ if (BUILD_TESTING)
     set_tests_properties(
         accesscontextmanager_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Permanent error in.*ListAccessLevels:")
+                   "Permanent error.*gcloud-cpp.retry.function=ListAccessLevels"
+    )
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -129,7 +129,7 @@ if (BUILD_TESTING)
     set_tests_properties(
         apigeeconnect_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Permanent error in.*ListConnections:")
+                   "Permanent error.*gcloud-cpp.retry.function=ListConnections")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -130,9 +130,12 @@ if (BUILD_TESTING)
     set_tests_properties(
         assuredworkloads_quickstart
         PROPERTIES
-            LABELS "integration-test;quickstart" ENVIRONMENT
+            LABELS
+            "integration-test;quickstart"
+            ENVIRONMENT
             GOOGLE_CLOUD_CPP_USER_PROJECT=$ENV{GOOGLE_CLOUD_CPP_USER_PROJECT}
-            PASS_REGULAR_EXPRESSION "Permanent error in.*ListWorkloads:")
+            PASS_REGULAR_EXPRESSION
+            "Permanent error.*gcloud-cpp.retry.function=ListWorkloads")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/internal/rest_retry_loop.h
+++ b/google/cloud/internal/rest_retry_loop.h
@@ -68,28 +68,23 @@ auto RestRetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
                        Sleeper sleeper)
     -> google::cloud::internal::invoke_result_t<Functor, RestContext&,
                                                 Request const&> {
-  auto last_status = internal::DeadlineExceededError(
-      "Retry policy exhausted before first request attempt", GCP_ERROR_INFO());
+  auto last_status = Status{};
   while (!retry_policy.IsExhausted()) {
     RestContext rest_context;
     auto result = functor(rest_context, request);
     if (result.ok()) return result;
     last_status = internal::GetResultStatus(std::move(result));
     if (idempotency == Idempotency::kNonIdempotent) {
-      return internal::RetryLoopError("Error in non-idempotent operation",
-                                      location, last_status);
+      return internal::RetryLoopNonIdempotentError(std::move(last_status),
+                                                   location);
     }
     // The retry policy is exhausted or the error is not retryable. Either
     // way, exit the loop.
     if (!retry_policy.OnFailure(last_status)) break;
     sleeper(backoff_policy.OnCompletion());
   }
-  // The last error cannot be retried, but it is not because the retry
-  // policy is exhausted. We call these "permanent errors", and they
-  // get a special message.
-  auto const* prefix = retry_policy.IsExhausted() ? "Retry policy exhausted in"
-                                                  : "Permanent error in";
-  return internal::RetryLoopError(prefix, location, last_status);
+  return internal::RetryLoopError(last_status, location,
+                                  retry_policy.IsExhausted());
 }
 
 /// @copydoc RestRetryLoopImpl

--- a/google/cloud/internal/rest_retry_loop_test.cc
+++ b/google/cloud/internal/rest_retry_loop_test.cc
@@ -32,8 +32,10 @@ namespace {
 using ::google::cloud::Idempotency;
 using ::google::cloud::testing_util::MockBackoffPolicy;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
+using ::testing::Pair;
 using ::testing::Return;
 
 struct StringOption {
@@ -159,12 +161,14 @@ TEST(RestRetryLoopTest, TransientFailureNonIdempotent) {
                   "TransientFailureNonIdempotent");
         return StatusOr<int>(Status(StatusCode::kUnavailable, "try again"));
       },
-      42, "the answer to everything");
+      42, __func__);
   internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
-  EXPECT_THAT(actual.status().message(), HasSubstr("the answer to everything"));
-  EXPECT_THAT(actual.status().message(), HasSubstr("Error in non-idempotent"));
+  auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata,
+              Contains(Pair("gcloud-cpp.retry.reason", "non-idempotent")));
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", __func__)));
 }
 
 TEST(RestRetryLoopTest, PermanentFailureFailureIdempotent) {
@@ -177,12 +181,14 @@ TEST(RestRetryLoopTest, PermanentFailureFailureIdempotent) {
                   "PermanentFailureFailureIdempotent");
         return StatusOr<int>(Status(StatusCode::kPermissionDenied, "uh oh"));
       },
-      42, "the answer to everything");
+      42, __func__);
   internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
   EXPECT_THAT(actual.status().message(), HasSubstr("uh oh"));
-  EXPECT_THAT(actual.status().message(), HasSubstr("the answer to everything"));
-  EXPECT_THAT(actual.status().message(), HasSubstr("Permanent error"));
+  auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata,
+              Contains(Pair("gcloud-cpp.retry.reason", "permanent-error")));
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", __func__)));
 }
 
 TEST(RestRetryLoopTest, TooManyTransientFailuresIdempotent) {
@@ -195,12 +201,15 @@ TEST(RestRetryLoopTest, TooManyTransientFailuresIdempotent) {
                   "TransientFailureNonIdempotent");
         return StatusOr<int>(Status(StatusCode::kUnavailable, "try again"));
       },
-      42, "the answer to everything");
+      42, __func__);
   internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
-  EXPECT_THAT(actual.status().message(), HasSubstr("the answer to everything"));
-  EXPECT_THAT(actual.status().message(), HasSubstr("Retry policy exhausted"));
+  auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.reason",
+                                      "retry-policy-exhausted")));
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.on-entry", "false")));
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", __func__)));
 }
 
 TEST(RestRetryLoopTest, ExhaustedOnStart) {
@@ -215,10 +224,14 @@ TEST(RestRetryLoopTest, ExhaustedOnStart) {
                   "ExhaustedOnStart");
         return StatusOr<int>(Status(StatusCode::kUnavailable, "try again"));
       },
-      42, "the answer to everything");
+      42, __func__);
   internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
-  EXPECT_THAT(actual, StatusIs(StatusCode::kDeadlineExceeded,
-                               HasSubstr("Retry policy exhausted before")));
+  EXPECT_THAT(actual, StatusIs(StatusCode::kDeadlineExceeded));
+  auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.reason",
+                                      "retry-policy-exhausted")));
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.on-entry", "true")));
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", __func__)));
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/internal/retry_loop_helpers.cc
+++ b/google/cloud/internal/retry_loop_helpers.cc
@@ -13,18 +13,92 @@
 // limitations under the License.
 
 #include "google/cloud/internal/retry_loop_helpers.h"
-#include <sstream>
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/make_status.h"
 
 namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+namespace {
 
-Status RetryLoopError(char const* loop_message, char const* location,
-                      Status const& status) {
-  std::ostringstream os;
-  os << loop_message << " " << location << ": " << status.message();
-  return Status(status.code(), std::move(os).str(), status.error_info());
+void AddErrorMetadata(ErrorInfo& ei, char const* location, char const* reason) {
+  AddMetadata(ei, "gcloud-cpp.retry.function", location);
+  AddMetadata(ei, "gcloud-cpp.retry.reason", reason);
+}
+
+void AddOnEntry(ErrorInfo& ei, char const* value) {
+  AddMetadata(ei, "gcloud-cpp.retry.on-entry", value);
+}
+
+ErrorInfoBuilder AddErrorMetadata(ErrorInfoBuilder b, char const* location,
+                                  char const* reason) {
+  return std::move(b)
+      .WithMetadata("gcloud-cpp.retry.function", location)
+      .WithMetadata("gcloud-cpp.retry.reason", reason);
+}
+
+}  // namespace
+
+Status RetryLoopNonIdempotentError(Status status, char const* location) {
+  if (status.ok()) return status;
+  auto ei = status.error_info();
+  AddErrorMetadata(ei, location, "non-idempotent");
+  auto message =
+      absl::StrCat("Error in non-idempotent operation: ", status.message());
+  return Status(status.code(), std::move(message), std::move(ei));
+}
+
+Status RetryLoopError(Status const& status, char const* location,
+                      bool exhausted) {
+  if (exhausted) return RetryLoopPolicyExhaustedError(status, location);
+  // If the error cannot be retried, and the retry policy is not exhausted we
+  // call the error a "permanent error".
+  return RetryLoopPermanentError(status, location);
+}
+
+Status RetryLoopPermanentError(Status const& status, char const* location) {
+  if (status.ok()) {
+    return UnknownError(
+        absl::StrCat("Retry policy treats kOkay as permanent error"),
+        AddErrorMetadata(GCP_ERROR_INFO(), location, "permanent-error"));
+  }
+  auto ei = status.error_info();
+  AddErrorMetadata(ei, location, "permanent-error");
+  auto message = absl::StrCat("Permanent error, with a last message of ",
+                              status.message());
+  return Status(status.code(), std::move(message), std::move(ei));
+}
+
+Status RetryLoopPolicyExhaustedError(Status const& status,
+                                     char const* location) {
+  if (status.ok()) {
+    // This indicates the retry loop never made a request.
+    return DeadlineExceededError(
+        absl::StrCat("Retry policy exhausted before first request attempt"),
+        AddErrorMetadata(GCP_ERROR_INFO(), location, "retry-policy-exhausted")
+            .WithMetadata("gcloud-cpp.retry.on-entry", "true"));
+  }
+  auto ei = status.error_info();
+  AddErrorMetadata(ei, location, "retry-policy-exhausted");
+  AddOnEntry(ei, "false");
+  auto message = absl::StrCat("Retry policy exhausted, with a last message of ",
+                              status.message());
+  return Status(status.code(), std::move(message), std::move(ei));
+}
+
+Status RetryLoopCancelled(Status const& status, char const* location) {
+  if (status.ok()) {
+    // This indicates the retry loop never made a request.
+    return CancelledError(
+        absl::StrCat("Retry policy cancelled"),
+        AddErrorMetadata(GCP_ERROR_INFO(), location, "cancelled"));
+  }
+  auto ei = status.error_info();
+  AddErrorMetadata(ei, location, "cancelled");
+  auto message = absl::StrCat("Retry loop cancelled, with a last message of ",
+                              status.message());
+  return Status(status.code(), std::move(message), std::move(ei));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/retry_loop_helpers.cc
+++ b/google/cloud/internal/retry_loop_helpers.cc
@@ -60,7 +60,7 @@ Status RetryLoopError(Status const& status, char const* location,
 Status RetryLoopPermanentError(Status const& status, char const* location) {
   if (status.ok()) {
     return UnknownError(
-        absl::StrCat("Retry policy treats kOkay as permanent error"),
+        absl::StrCat("Retry policy treats kOk as permanent error"),
         AddErrorMetadata(GCP_ERROR_INFO(), location, "permanent-error"));
   }
   auto ei = status.error_info();

--- a/google/cloud/internal/retry_loop_helpers.h
+++ b/google/cloud/internal/retry_loop_helpers.h
@@ -32,9 +32,26 @@ Status GetResultStatus(StatusOr<T> result) {
   return std::move(result).status();
 }
 
-/// Generate an error Status for `RetryLoop()` and `AsyncRetryLoop()`
-Status RetryLoopError(char const* loop_message, char const* location,
-                      Status const& status);
+/// Use this if the retry loop detects any error on a non-idempotent RPC.
+Status RetryLoopNonIdempotentError(Status status, char const* location);
+
+/// Use this if the retry loop finished with an error.
+///
+/// Set @p exhausted to true if the retry policy has been exhausted
+Status RetryLoopError(Status const& s, char const* location, bool exhausted);
+
+/// Use this if the retry loop detects any permanent errors.
+Status RetryLoopPermanentError(Status const& status, char const* location);
+
+/// Use this if the retry loop exits as the retry policy has been exhausted.
+Status RetryLoopPolicyExhaustedError(Status const& status,
+                                     char const* location);
+
+/// Use this if the retry loop is cancelled by the caller.
+///
+/// This is only applicable for asynchronous RPCs, as unary RPCs cannot be
+/// cancelled.
+Status RetryLoopCancelled(Status const& status, char const* location);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/retry_loop_helpers.h
+++ b/google/cloud/internal/retry_loop_helpers.h
@@ -37,13 +37,14 @@ Status RetryLoopNonIdempotentError(Status status, char const* location);
 
 /// Use this if the retry loop finished with an error.
 ///
-/// Set @p exhausted to true if the retry policy has been exhausted
+/// Set @p exhausted to true if the retry policy has been exhausted.
 Status RetryLoopError(Status const& s, char const* location, bool exhausted);
 
 /// Use this if the retry loop detects any permanent errors.
 Status RetryLoopPermanentError(Status const& status, char const* location);
 
-/// Use this if the retry loop exits as the retry policy has been exhausted.
+/// Use this if the retry loop exits because the retry policy has been
+/// exhausted.
 Status RetryLoopPolicyExhaustedError(Status const& status,
                                      char const* location);
 

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -123,7 +123,7 @@ if (BUILD_TESTING)
     set_tests_properties(
         oslogin_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Permanent error in.*GetLoginProfile:")
+                   "Permanent error.*gcloud-cpp.retry.function=GetLoginProfile")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/pubsub/internal/subscriber_connection_impl.cc
+++ b/google/cloud/pubsub/internal/subscriber_connection_impl.cc
@@ -93,12 +93,8 @@ StatusOr<pubsub::PullResponse> SubscriberConnectionImpl::Pull() {
     return google::cloud::internal::UnavailableError("no messages returned",
                                                      GCP_ERROR_INFO());
   }
-  if (retry_policy->IsExhausted()) {
-    return google::cloud::internal::RetryLoopError("Retry policy exhausted in",
-                                                   __func__, last_status);
-  }
-  return google::cloud::internal::RetryLoopError("Permanent error in", __func__,
-                                                 last_status);
+  return google::cloud::internal::RetryLoopError(last_status, __func__,
+                                                 retry_policy->IsExhausted());
 }
 
 Options SubscriberConnectionImpl::options() { return opts_; }

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -127,7 +127,7 @@ if (BUILD_TESTING)
     set_tests_properties(
         servicecontrol_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Error in non-idempotent.*operation Check:")
+                   "Error in non-idempotent.*gcloud-cpp.retry.function=Check")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -122,7 +122,7 @@ if (BUILD_TESTING)
     set_tests_properties(
         shell_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Permanent error in GetEnvironment:")
+                   "Permanent error.*gcloud-cpp.retry.function=GetEnvironment")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/status.cc
+++ b/google/cloud/status.cc
@@ -96,11 +96,11 @@ class Status::Impl {
   StatusCode code() const { return code_; }
   std::string const& message() const { return message_; }
   ErrorInfo const& error_info() const { return error_info_; }
-  PayloadType const& payload() const { return payload_; };
+  PayloadType const& payload() const { return payload_; }
 
   // Allows mutable access to payload, which is needed in the
   // `internal::SetPayload()` function.
-  PayloadType& payload() { return payload_; };
+  PayloadType& payload() { return payload_; }
 
   friend inline bool operator==(Impl const& a, Impl const& b) {
     return a.code_ == b.code_ && a.message_ == b.message_ &&
@@ -177,6 +177,10 @@ std::ostream& operator<<(std::ostream& os, Status const& s) {
 }
 
 namespace internal {
+
+void AddMetadata(ErrorInfo& ei, std::string const& key, std::string value) {
+  ei.metadata_[key] = std::move(value);
+}
 
 // Sets the given `payload`, indexed by the given `key`, on the given `Status`,
 // IFF the status is not OK. Payloads are considered in equality comparisons.

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -194,7 +194,9 @@ std::string StatusCodeToString(StatusCode code);
 std::ostream& operator<<(std::ostream& os, StatusCode code);
 
 class Status;
+class ErrorInfo;
 namespace internal {
+void AddMetadata(ErrorInfo&, std::string const& key, std::string value);
 void SetPayload(Status&, std::string key, std::string payload);
 absl::optional<std::string> GetPayload(Status const&, std::string const& key);
 }  // namespace internal
@@ -271,6 +273,9 @@ class ErrorInfo {
   friend bool operator!=(ErrorInfo const&, ErrorInfo const&);
 
  private:
+  friend void internal::AddMetadata(ErrorInfo&, std::string const& key,
+                                    std::string value);
+
   std::string reason_;
   std::string domain_;
   std::unordered_map<std::string, std::string> metadata_;

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -99,9 +99,8 @@ bool UploadChunkOnFailure(RetryPolicy& retry_policy, Status const& status) {
 
 Status RetryError(Status const& status, RetryPolicy const& retry_policy,
                   char const* function_name) {
-  auto const* msg =
-      retry_policy.IsExhausted() ? "Retry policy exhausted" : "Permanent error";
-  return google::cloud::internal::RetryLoopError(msg, function_name, status);
+  return google::cloud::internal::RetryLoopError(status, function_name,
+                                                 retry_policy.IsExhausted());
 }
 
 Status MissingCommittedSize(int error_count, int upload_count, int reset_count,


### PR DESCRIPTION
Use the `Status::error_info()` to signal details about why a retry loop fails. We were using the contents of the message.

Fixes #12303

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12313)
<!-- Reviewable:end -->
