### PR TITLE
impl(generator): determine all depended on discovery types for given type

### DIFF
--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -75,12 +75,6 @@ bool IsDiscoveryNestedType(nlohmann::json const& json) {
          json.contains("properties");
 }
 
-// std::set::merge isn't available until C++17.
-template <typename T>
-void SetMerge(std::set<T>& lhs, std::set<T> const& rhs) {
-  lhs.insert(rhs.begin(), rhs.end());
-}
-
 }  // namespace
 
 StatusOr<std::map<std::string, DiscoveryTypeVertex>> ExtractTypesFromSchema(
@@ -312,7 +306,8 @@ std::set<std::string> FindAllRefValues(nlohmann::json const& json) {
       ref_values.insert(f["$ref"]);
     } else if (IsDiscoveryArrayType(f) || IsDiscoveryMapType(f) ||
                IsDiscoveryNestedType(f)) {
-      SetMerge(ref_values, FindAllRefValues(f));
+      auto new_ref_values = FindAllRefValues(f);
+      ref_values.insert(new_ref_values.begin(), new_ref_values.end());
     }
   }
 

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -88,6 +88,11 @@ Status GenerateProtosFromDiscoveryDoc(
     std::string const& googleapis_proto_path, std::string const& output_path,
     std::set<std::string> operation_services = {});
 
+// Recurses through the json accumulating the values of any $ref fields
+// whether they exist in simple fields, arrays, maps, or nested messages
+// containing any of the aforementioned field types.
+std::set<std::string> FindAllRefValues(nlohmann::json const& json);
+
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -1108,7 +1108,7 @@ TEST(GenerateProtosFromDiscoveryDocTest, ProcessRequestResponseFailure) {
                        HasSubstr("Response name=baz not found in types")));
 }
 
-TEST(FindAllRefValues, NonRefField) {
+TEST(FindAllRefValuesTest, NonRefField) {
   auto constexpr kTypeJson = R"""({
   "properties": {
     "field_name_1": {
@@ -1123,7 +1123,7 @@ TEST(FindAllRefValues, NonRefField) {
   EXPECT_THAT(result, IsEmpty());
 }
 
-TEST(FindAllRefValues, SimpleRefField) {
+TEST(FindAllRefValuesTest, SimpleRefField) {
   auto constexpr kTypeJson = R"""({
   "properties": {
     "field_name_1": {
@@ -1138,7 +1138,7 @@ TEST(FindAllRefValues, SimpleRefField) {
   EXPECT_THAT(result, UnorderedElementsAre("Foo"));
 }
 
-TEST(FindAllRefValues, MultipleSimpleRefFields) {
+TEST(FindAllRefValuesTest, MultipleSimpleRefFields) {
   auto constexpr kTypeJson = R"""({
   "properties": {
     "field_name_1": {
@@ -1156,7 +1156,7 @@ TEST(FindAllRefValues, MultipleSimpleRefFields) {
   EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
 }
 
-TEST(FindAllRefValues, ArrayRefFields) {
+TEST(FindAllRefValuesTest, ArrayRefFields) {
   auto constexpr kTypeJson = R"""({
   "properties": {
     "array_field_name_1": {
@@ -1180,7 +1180,7 @@ TEST(FindAllRefValues, ArrayRefFields) {
   EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
 }
 
-TEST(FindAllRefValues, MapRefFields) {
+TEST(FindAllRefValuesTest, MapRefFields) {
   auto constexpr kTypeJson = R"""({
   "properties": {
     "map_field_name_1": {
@@ -1204,7 +1204,7 @@ TEST(FindAllRefValues, MapRefFields) {
   EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
 }
 
-TEST(FindAllRefValues, SingleNestedRefField) {
+TEST(FindAllRefValuesTest, SingleNestedRefField) {
   auto constexpr kTypeJson = R"""({
   "properties": {
     "field_name_1": {
@@ -1224,7 +1224,7 @@ TEST(FindAllRefValues, SingleNestedRefField) {
   EXPECT_THAT(result, UnorderedElementsAre("Foo"));
 }
 
-TEST(FindAllRefValues, MultipleNestedRefFields) {
+TEST(FindAllRefValuesTest, MultipleNestedRefFields) {
   auto constexpr kTypeJson = R"""({
   "properties": {
     "field_name_1": {
@@ -1247,7 +1247,7 @@ TEST(FindAllRefValues, MultipleNestedRefFields) {
   EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
 }
 
-TEST(FindAllRefValues, SingleNestedNestedRefField) {
+TEST(FindAllRefValuesTest, SingleNestedNestedRefField) {
   auto constexpr kTypeJson = R"""({
   "properties": {
     "field_name_1": {
@@ -1275,7 +1275,7 @@ TEST(FindAllRefValues, SingleNestedNestedRefField) {
   EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
 }
 
-TEST(FindAllRefValues, ComplexJsonWithRefTypes) {
+TEST(FindAllRefValuesTest, ComplexJsonWithRefTypes) {
   auto constexpr kOperationJson = R"""({
       "type": "object",
       "properties": {
@@ -1384,6 +1384,7 @@ TEST(FindAllRefValues, ComplexJsonWithRefTypes) {
                           "LocalizedMessage", "QuotaExceededInfo", "ErrorInfo",
                           "Help", "Timestamp", "Label", "Label2"));
 }
+
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -1108,6 +1108,282 @@ TEST(GenerateProtosFromDiscoveryDocTest, ProcessRequestResponseFailure) {
                        HasSubstr("Response name=baz not found in types")));
 }
 
+TEST(FindAllRefValues, NonRefField) {
+  auto constexpr kTypeJson = R"""({
+  "properties": {
+    "field_name_1": {
+      "type": "string"
+    }
+  }
+})""";
+
+  auto const parsed_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, IsEmpty());
+}
+
+TEST(FindAllRefValues, SimpleRefField) {
+  auto constexpr kTypeJson = R"""({
+  "properties": {
+    "field_name_1": {
+      "$ref": "Foo"
+    }
+  }
+})""";
+
+  auto const parsed_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, UnorderedElementsAre("Foo"));
+}
+
+TEST(FindAllRefValues, MultipleSimpleRefFields) {
+  auto constexpr kTypeJson = R"""({
+  "properties": {
+    "field_name_1": {
+      "$ref": "Foo"
+    },
+    "field_name_2": {
+      "$ref": "Bar"
+    }
+  }
+})""";
+
+  auto const parsed_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
+}
+
+TEST(FindAllRefValues, ArrayRefFields) {
+  auto constexpr kTypeJson = R"""({
+  "properties": {
+    "array_field_name_1": {
+      "type": "array",
+      "items": {
+        "$ref": "Foo"
+      }
+    },
+    "array_field_name_2": {
+      "type": "array",
+      "items": {
+        "$ref": "Bar"
+      }
+    }
+  }
+})""";
+
+  auto const parsed_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
+}
+
+TEST(FindAllRefValues, MapRefFields) {
+  auto constexpr kTypeJson = R"""({
+  "properties": {
+    "map_field_name_1": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "Foo"
+      }
+    },
+    "map_field_name_2": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "Bar"
+      }
+    }
+  }
+})""";
+
+  auto const parsed_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
+}
+
+TEST(FindAllRefValues, SingleNestedRefField) {
+  auto constexpr kTypeJson = R"""({
+  "properties": {
+    "field_name_1": {
+      "type": "object",
+      "properties": {
+        "nested_field_1": {
+          "$ref": "Foo"
+        }
+      }
+    }
+  }
+})""";
+
+  auto const parsed_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, UnorderedElementsAre("Foo"));
+}
+
+TEST(FindAllRefValues, MultipleNestedRefFields) {
+  auto constexpr kTypeJson = R"""({
+  "properties": {
+    "field_name_1": {
+      "type": "object",
+      "properties": {
+        "nested_field_1": {
+          "$ref": "Foo"
+        },
+        "nested_field_2": {
+          "$ref": "Bar"
+        }
+      }
+    }
+  }
+})""";
+
+  auto const parsed_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
+}
+
+TEST(FindAllRefValues, SingleNestedNestedRefField) {
+  auto constexpr kTypeJson = R"""({
+  "properties": {
+    "field_name_1": {
+      "type": "object",
+      "properties": {
+        "nested_field_1": {
+          "$ref": "Foo"
+        },
+        "nested_field_2": {
+          "type": "object",
+          "properties": {
+            "nested_nested_field_1": {
+              "$ref": "Bar"
+            }
+          }
+        }
+      }
+    }
+  }
+})""";
+
+  auto const parsed_json = nlohmann::json::parse(kTypeJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, UnorderedElementsAre("Foo", "Bar"));
+}
+
+TEST(FindAllRefValues, ComplexJsonWithRefTypes) {
+  auto constexpr kOperationJson = R"""({
+      "type": "object",
+      "properties": {
+        "operationGroupId": {
+          "type": "string"
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "items": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "errorDetails": {
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "localizedMessage": {
+                          "$ref": "LocalizedMessage"
+                        },
+                        "quotaInfo": {
+                          "$ref": "QuotaExceededInfo"
+                        },
+                        "errorInfo": {
+                          "$ref": "ErrorInfo"
+                        },
+                        "help": {
+                          "$ref": "Help"
+                        },
+                        "labels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "$ref": "Label2"
+                          }
+                        }
+                      }
+                    },
+                    "type": "array"
+                  }
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "clientOperationId": {
+          "type": "string"
+        },
+        "httpErrorStatusCode": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "DONE",
+            "PENDING",
+            "RUNNING"
+          ],
+          "enumDescriptions": [
+            "",
+            "",
+            ""
+          ]
+        },
+        "progress": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "creationTimestamp": {
+          "$ref": "Timestamp"
+        },
+        "insertTime": {
+          "$ref": "Timestamp"
+        },
+        "endTime": {
+          "$ref": "Timestamp"
+        },
+        "zone": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "Label"
+          }
+        }
+      },
+      "id": "Operation"
+})""";
+
+  auto const parsed_json =
+      nlohmann::json::parse(kOperationJson, nullptr, false);
+  ASSERT_TRUE(parsed_json.is_object());
+  auto result = FindAllRefValues(parsed_json);
+  EXPECT_THAT(result, UnorderedElementsAre(
+                          "LocalizedMessage", "QuotaExceededInfo", "ErrorInfo",
+                          "Help", "Timestamp", "Label", "Label2"));
+}
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud


### PR DESCRIPTION
part of the work for #11190 

In order to eventually add the appropriate import statements between proto files, the generator needs to determine all the $ref types present in the discovery document for a given type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12317)
<!-- Reviewable:end -->
