### PR TITLE
impl(generator): set dependencies between discovery types

### DIFF
--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -297,8 +297,6 @@ std::set<std::string> FindAllRefValues(nlohmann::json const& json) {
     fields = json["properties"];
   } else if (json.contains("additionalProperties") || json.contains("items")) {
     fields = json;
-  } else {
-    return ref_values;
   }
 
   for (auto const& f : fields) {
@@ -322,8 +320,8 @@ Status EstablishTypeDependencies(
     for (auto const& ref : ref_values) {
       auto ref_iter = types.find(ref);
       if (ref_iter == types.end()) {
-        return internal::InternalError(
-            "Unknown depended upon type",
+        return internal::InvalidArgumentError(
+            absl::StrCat("Unknown depended upon type: ", ref),
             GCP_ERROR_INFO()
                 .WithMetadata("dependent type", type.first)
                 .WithMetadata("depended upon type", ref));

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -93,6 +93,11 @@ Status GenerateProtosFromDiscoveryDoc(
 // containing any of the aforementioned field types.
 std::set<std::string> FindAllRefValues(nlohmann::json const& json);
 
+// Iterates through all types establishing edges based on their dependencies via
+// DiscoveryTypeVertex::AddNeedsType and DiscoveryTypeVertex::AddNeededByType.
+Status EstablishTypeDependencies(
+    std::map<std::string, DiscoveryTypeVertex>& types);
+
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -1408,8 +1408,8 @@ TEST_F(EstablishTypeDependenciesTest, DependedTypeNotFound) {
   ASSERT_TRUE(iter.second);
   auto result = EstablishTypeDependencies(types);
 
-  EXPECT_THAT(result, StatusIs(StatusCode::kInternal,
-                               HasSubstr("Unknown depended upon type")));
+  EXPECT_THAT(result, StatusIs(StatusCode::kInvalidArgument,
+                               HasSubstr("Unknown depended upon type: Foo")));
   EXPECT_THAT(
       result.error_info().metadata(),
       Contains(AllOf(

--- a/generator/internal/discovery_type_vertex.cc
+++ b/generator/internal/discovery_type_vertex.cc
@@ -88,12 +88,11 @@ bool DiscoveryTypeVertex::IsSynthesizedRequestType() const {
   return json_.value("synthesized_request", false);
 }
 
-void DiscoveryTypeVertex::AddNeedsTypeName(std::string type_name) {
-  needs_.insert(std::move(type_name));
+void DiscoveryTypeVertex::AddNeedsType(DiscoveryTypeVertex* type) {
+  needs_type_.insert(type);
 }
-
-void DiscoveryTypeVertex::AddNeededByTypeName(std::string type_name) {
-  needed_by_.insert(std::move(type_name));
+void DiscoveryTypeVertex::AddNeededByType(DiscoveryTypeVertex* type) {
+  needed_by_type_.insert(type);
 }
 
 std::string DiscoveryTypeVertex::DetermineIntroducer(
@@ -465,9 +464,13 @@ StatusOr<std::string> DiscoveryTypeVertex::JsonToProtobufMessage(
 }
 
 std::string DiscoveryTypeVertex::DebugString() const {
-  return absl::StrFormat("name: %s; needs: %s; needed_by: %s", name_,
-                         absl::StrJoin(needs_, ","),
-                         absl::StrJoin(needed_by_, ","));
+  auto formatter = [](std::string* out, DiscoveryTypeVertex* t) {
+    out->append(t->name());
+  };
+  return absl::StrFormat(
+      "name: %s; needs_type_name: %s; needed_by_type_name: %s", name_,
+      absl::StrJoin(needs_type_, ",", formatter),
+      absl::StrJoin(needed_by_type_, ",", formatter));
 }
 
 }  // namespace generator_internal

--- a/generator/internal/discovery_type_vertex.cc
+++ b/generator/internal/discovery_type_vertex.cc
@@ -467,10 +467,10 @@ std::string DiscoveryTypeVertex::DebugString() const {
   auto formatter = [](std::string* out, DiscoveryTypeVertex* t) {
     out->append(t->name());
   };
-  return absl::StrFormat(
-      "name: %s; needs_type_name: %s; needed_by_type_name: %s", name_,
-      absl::StrJoin(needs_type_, ",", formatter),
-      absl::StrJoin(needed_by_type_, ",", formatter));
+  return absl::StrCat(
+      "name: ", absl::StrJoin(needs_type_, ",", formatter),
+      "; needs_type_name: ", absl::StrJoin(needed_by_type_, ",", formatter),
+      "; needed_by_type_name: ", name_);
 }
 
 }  // namespace generator_internal

--- a/generator/internal/discovery_type_vertex.h
+++ b/generator/internal/discovery_type_vertex.h
@@ -44,8 +44,8 @@ class DiscoveryTypeVertex {
   std::string const& name() const { return name_; }
   std::string const& package_name() const { return package_name_; }
   nlohmann::json const& json() const { return json_; }
-  std::set<DiscoveryTypeVertex*> needs_type() { return needs_type_; }
-  std::set<DiscoveryTypeVertex*> needed_by_type() { return needed_by_type_; }
+  std::set<DiscoveryTypeVertex*>& needs_type() { return needs_type_; }
+  std::set<DiscoveryTypeVertex*>& needed_by_type() { return needed_by_type_; }
 
   bool IsSynthesizedRequestType() const;
 

--- a/generator/internal/discovery_type_vertex.h
+++ b/generator/internal/discovery_type_vertex.h
@@ -44,16 +44,16 @@ class DiscoveryTypeVertex {
   std::string const& name() const { return name_; }
   std::string const& package_name() const { return package_name_; }
   nlohmann::json const& json() const { return json_; }
+  std::set<DiscoveryTypeVertex*> needs_type() { return needs_type_; }
+  std::set<DiscoveryTypeVertex*> needed_by_type() { return needed_by_type_; }
 
   bool IsSynthesizedRequestType() const;
 
-  // Adds edge to this vertex for a type name that exists as a field in this
-  // type.
-  void AddNeedsTypeName(std::string type_name);
+  // Adds edge to this vertex for a type that exists as a field in this type.
+  void AddNeedsType(DiscoveryTypeVertex* type);
 
-  // Adds edge to this vertex for a type name that contains this type as a
-  // field.
-  void AddNeededByTypeName(std::string type_name);
+  // Adds edge to this vertex for a type that contains this type as a field.
+  void AddNeededByType(DiscoveryTypeVertex* type);
 
   // Returns "optional ", "repeated ", or an empty string depending on the
   // field type.
@@ -131,8 +131,8 @@ class DiscoveryTypeVertex {
   std::string package_name_;
   nlohmann::json json_;
   google::protobuf::DescriptorPool const* const descriptor_pool_;
-  std::set<std::string> needs_;
-  std::set<std::string> needed_by_;
+  std::set<DiscoveryTypeVertex*> needs_type_;
+  std::set<DiscoveryTypeVertex*> needed_by_type_;
 };
 
 }  // namespace generator_internal


### PR DESCRIPTION
part of the work for #11190 

Add dependency edges between the type vertices for later use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12320)
<!-- Reviewable:end -->
