### PR TITLE
cleanup(otel): omit invalid parent span IDs

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -322,15 +322,18 @@ void Recordable::SetIdentityImpl(
   std::array<char, 2 * opentelemetry::trace::SpanId::kSize> span;
   span_context.span_id().ToLowerBase16(span);
 
-  std::array<char, 2 * opentelemetry::trace::SpanId::kSize> parent_span;
-  parent_span_id.ToLowerBase16(parent_span);
-
   span_.set_name(absl::StrCat(project_.FullName(), "/traces/",
                               absl::string_view{trace.data(), trace.size()},
                               "/spans/",
                               absl::string_view{span.data(), span.size()}));
   span_.set_span_id({span.data(), span.size()});
-  span_.set_parent_span_id({parent_span.data(), parent_span.size()});
+
+  if (parent_span_id.IsValid()) {
+    std::array<char, 2 * opentelemetry::trace::SpanId::kSize> parent_span;
+    parent_span_id.ToLowerBase16(parent_span);
+
+    span_.set_parent_span_id({parent_span.data(), parent_span.size()});
+  }
 }
 
 void Recordable::AddEventImpl(

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -14,7 +14,8 @@
 
 #include "google/cloud/opentelemetry/internal/recordable.h"
 #include "google/cloud/internal/time_utils.h"
-#include "google/cloud/version.h" #include "absl/time/clock.h"
+#include "google/cloud/version.h"
+#include "absl/time/clock.h"
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 #include <opentelemetry/sdk/resource/resource.h>


### PR DESCRIPTION
When the Cloud Trace UI changed, it started showing parent spans with null ids.

![image](https://github.com/googleapis/google-cloud-cpp/assets/23088558/3c9fff78-eeae-4ddf-ac12-a9ee87f3b8e3)

So stop setting the field on our end, in that case.

![image](https://github.com/googleapis/google-cloud-cpp/assets/23088558/e22ad3ff-62ea-41e6-8171-b2c8d3377104)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12323)
<!-- Reviewable:end -->
