### PR TITLE
impl(storage): populate idempotency token header

### DIFF
--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -126,6 +126,8 @@ Status PartialWriteStatus(int error_count, int upload_count,
   return Status{StatusCode::kDeadlineExceeded, std::move(os).str()};
 }
 
+auto constexpr kIdempotencyTokenHeader = "x-goog-gcs-idempotency-token";
+
 }  // namespace
 
 std::shared_ptr<RetryClient> RetryClient::Create(
@@ -154,8 +156,10 @@ StatusOr<ListBucketsResponse> RetryClient::ListBuckets(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ListBuckets(context, current, request);
       },
       request, __func__);
@@ -168,8 +172,10 @@ StatusOr<BucketMetadata> RetryClient::CreateBucket(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->CreateBucket(context, current, request);
       },
       request, __func__);
@@ -182,8 +188,10 @@ StatusOr<BucketMetadata> RetryClient::GetBucketMetadata(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetBucketMetadata(context, current, request);
       },
       request, __func__);
@@ -196,8 +204,10 @@ StatusOr<EmptyResponse> RetryClient::DeleteBucket(
                          : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->DeleteBucket(context, current, request);
       },
       request, __func__);
@@ -210,8 +220,10 @@ StatusOr<BucketMetadata> RetryClient::UpdateBucket(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->UpdateBucket(context, current, request);
       },
       request, __func__);
@@ -224,8 +236,10 @@ StatusOr<BucketMetadata> RetryClient::PatchBucket(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->PatchBucket(context, current, request);
       },
       request, __func__);
@@ -238,8 +252,10 @@ StatusOr<NativeIamPolicy> RetryClient::GetNativeBucketIamPolicy(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetNativeBucketIamPolicy(context, current, request);
       },
       request, __func__);
@@ -252,8 +268,10 @@ StatusOr<NativeIamPolicy> RetryClient::SetNativeBucketIamPolicy(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->SetNativeBucketIamPolicy(context, current, request);
       },
       request, __func__);
@@ -267,8 +285,10 @@ RetryClient::TestBucketIamPermissions(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->TestBucketIamPermissions(context, current, request);
       },
       request, __func__);
@@ -281,8 +301,10 @@ StatusOr<BucketMetadata> RetryClient::LockBucketRetentionPolicy(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->LockBucketRetentionPolicy(context, current, request);
       },
       request, __func__);
@@ -295,8 +317,10 @@ StatusOr<ObjectMetadata> RetryClient::InsertObjectMedia(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->InsertObjectMedia(context, current, request);
       },
       request, __func__);
@@ -309,8 +333,10 @@ StatusOr<ObjectMetadata> RetryClient::CopyObject(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->CopyObject(context, current, request);
       },
       request, __func__);
@@ -323,8 +349,10 @@ StatusOr<ObjectMetadata> RetryClient::GetObjectMetadata(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetObjectMetadata(context, current, request);
       },
       request, __func__);
@@ -338,8 +366,10 @@ StatusOr<std::unique_ptr<ObjectReadSource>> RetryClient::ReadObjectNotWrapped(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       retry_policy, backoff_policy, idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ReadObject(context, current, request);
       },
       request, __func__);
@@ -366,8 +396,10 @@ StatusOr<ListObjectsResponse> RetryClient::ListObjects(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ListObjects(context, current, request);
       },
       request, __func__);
@@ -380,8 +412,10 @@ StatusOr<EmptyResponse> RetryClient::DeleteObject(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->DeleteObject(context, current, request);
       },
       request, __func__);
@@ -394,8 +428,10 @@ StatusOr<ObjectMetadata> RetryClient::UpdateObject(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->UpdateObject(context, current, request);
       },
       request, __func__);
@@ -408,8 +444,10 @@ StatusOr<ObjectMetadata> RetryClient::PatchObject(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->PatchObject(context, current, request);
       },
       request, __func__);
@@ -422,8 +460,10 @@ StatusOr<ObjectMetadata> RetryClient::ComposeObject(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ComposeObject(context, current, request);
       },
       request, __func__);
@@ -436,8 +476,10 @@ StatusOr<RewriteObjectResponse> RetryClient::RewriteObject(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->RewriteObject(context, current, request);
       },
       request, __func__);
@@ -450,8 +492,10 @@ StatusOr<CreateResumableUploadResponse> RetryClient::CreateResumableUpload(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->CreateResumableUpload(context, current, request);
       },
       request, __func__);
@@ -462,8 +506,10 @@ StatusOr<QueryResumableUploadResponse> RetryClient::QueryResumableUpload(
   auto const idempotency = Idempotency::kIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->QueryResumableUpload(context, current, request);
       },
       request, __func__);
@@ -474,8 +520,10 @@ StatusOr<EmptyResponse> RetryClient::DeleteResumableUpload(
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(),
       Idempotency::kIdempotent,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->DeleteResumableUpload(context, current, request);
       },
       request, __func__);
@@ -558,7 +606,9 @@ StatusOr<QueryResumableUploadResponse> RetryClient::UploadChunk(
   int upload_count = 0;
   auto upload = Action(
       [&upload_count, &current, &request, this](std::uint64_t committed_size) {
-        // TODO(#12294) - use a unique invocation id for each call.
+        // There is no need to use an idempotency token for this function, as
+        // we do not "retry" the operation. On transient failures we call
+        // QueryResumableUpload() before trying the request again.
         rest_internal::RestContext context;
         ++upload_count;
         return stub_->UploadChunk(context, current,
@@ -655,8 +705,10 @@ StatusOr<ListBucketAclResponse> RetryClient::ListBucketAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ListBucketAcl(context, current, request);
       },
       request, __func__);
@@ -669,8 +721,10 @@ StatusOr<BucketAccessControl> RetryClient::GetBucketAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetBucketAcl(context, current, request);
       },
       request, __func__);
@@ -683,8 +737,10 @@ StatusOr<BucketAccessControl> RetryClient::CreateBucketAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->CreateBucketAcl(context, current, request);
       },
       request, __func__);
@@ -697,8 +753,10 @@ StatusOr<EmptyResponse> RetryClient::DeleteBucketAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->DeleteBucketAcl(context, current, request);
       },
       request, __func__);
@@ -711,8 +769,10 @@ StatusOr<ListObjectAclResponse> RetryClient::ListObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ListObjectAcl(context, current, request);
       },
       request, __func__);
@@ -725,8 +785,10 @@ StatusOr<BucketAccessControl> RetryClient::UpdateBucketAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->UpdateBucketAcl(context, current, request);
       },
       request, __func__);
@@ -739,8 +801,10 @@ StatusOr<BucketAccessControl> RetryClient::PatchBucketAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->PatchBucketAcl(context, current, request);
       },
       request, __func__);
@@ -753,8 +817,10 @@ StatusOr<ObjectAccessControl> RetryClient::CreateObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->CreateObjectAcl(context, current, request);
       },
       request, __func__);
@@ -767,8 +833,10 @@ StatusOr<EmptyResponse> RetryClient::DeleteObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->DeleteObjectAcl(context, current, request);
       },
       request, __func__);
@@ -781,8 +849,10 @@ StatusOr<ObjectAccessControl> RetryClient::GetObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetObjectAcl(context, current, request);
       },
       request, __func__);
@@ -795,8 +865,10 @@ StatusOr<ObjectAccessControl> RetryClient::UpdateObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->UpdateObjectAcl(context, current, request);
       },
       request, __func__);
@@ -809,8 +881,10 @@ StatusOr<ObjectAccessControl> RetryClient::PatchObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->PatchObjectAcl(context, current, request);
       },
       request, __func__);
@@ -823,8 +897,10 @@ StatusOr<ListDefaultObjectAclResponse> RetryClient::ListDefaultObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ListDefaultObjectAcl(context, current, request);
       },
       request, __func__);
@@ -837,8 +913,10 @@ StatusOr<ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->CreateDefaultObjectAcl(context, current, request);
       },
       request, __func__);
@@ -851,8 +929,10 @@ StatusOr<EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->DeleteDefaultObjectAcl(context, current, request);
       },
       request, __func__);
@@ -865,8 +945,10 @@ StatusOr<ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetDefaultObjectAcl(context, current, request);
       },
       request, __func__);
@@ -879,8 +961,10 @@ StatusOr<ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->UpdateDefaultObjectAcl(context, current, request);
       },
       request, __func__);
@@ -893,8 +977,10 @@ StatusOr<ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->PatchDefaultObjectAcl(context, current, request);
       },
       request, __func__);
@@ -907,8 +993,10 @@ StatusOr<ServiceAccount> RetryClient::GetServiceAccount(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetServiceAccount(context, current, request);
       },
       request, __func__);
@@ -921,8 +1009,10 @@ StatusOr<ListHmacKeysResponse> RetryClient::ListHmacKeys(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ListHmacKeys(context, current, request);
       },
       request, __func__);
@@ -935,8 +1025,10 @@ StatusOr<CreateHmacKeyResponse> RetryClient::CreateHmacKey(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->CreateHmacKey(context, current, request);
       },
       request, __func__);
@@ -949,8 +1041,10 @@ StatusOr<EmptyResponse> RetryClient::DeleteHmacKey(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->DeleteHmacKey(context, current, request);
       },
       request, __func__);
@@ -963,8 +1057,10 @@ StatusOr<HmacKeyMetadata> RetryClient::GetHmacKey(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetHmacKey(context, current, request);
       },
       request, __func__);
@@ -977,8 +1073,10 @@ StatusOr<HmacKeyMetadata> RetryClient::UpdateHmacKey(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->UpdateHmacKey(context, current, request);
       },
       request, __func__);
@@ -991,8 +1089,10 @@ StatusOr<SignBlobResponse> RetryClient::SignBlob(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->SignBlob(context, current, request);
       },
       request, __func__);
@@ -1005,8 +1105,10 @@ StatusOr<ListNotificationsResponse> RetryClient::ListNotifications(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->ListNotifications(context, current, request);
       },
       request, __func__);
@@ -1019,8 +1121,10 @@ StatusOr<NotificationMetadata> RetryClient::CreateNotification(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->CreateNotification(context, current, request);
       },
       request, __func__);
@@ -1033,8 +1137,10 @@ StatusOr<NotificationMetadata> RetryClient::GetNotification(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->GetNotification(context, current, request);
       },
       request, __func__);
@@ -1047,8 +1153,10 @@ StatusOr<EmptyResponse> RetryClient::DeleteNotification(
                                : Idempotency::kNonIdempotent;
   return RestRetryLoop(
       current_retry_policy(), current_backoff_policy(), idempotency,
-      [this](rest_internal::RestContext& context, auto const& request) {
+      [token = MakeIdempotencyToken(), this](
+          rest_internal::RestContext& context, auto const& request) {
         auto const& current = google::cloud::internal::CurrentOptions();
+        context.AddHeader(kIdempotencyTokenHeader, token);
         return stub_->DeleteNotification(context, current, request);
       },
       request, __func__);

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/idempotency_policy.h"
 #include "google/cloud/storage/internal/generic_stub.h"
+#include "google/cloud/storage/internal/invocation_id_generator.h"
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/version.h"
@@ -164,9 +165,14 @@ class RetryClient : public RawClient,
   static std::unique_ptr<BackoffPolicy> current_backoff_policy();
   static IdempotencyPolicy& current_idempotency_policy();
 
+  std::string MakeIdempotencyToken() {
+    return invocation_id_generator_.MakeInvocationId();
+  }
+
   std::unique_ptr<storage_internal::GenericStub> stub_;
   Options options_;
   ClientOptions client_options_;  // For backwards compatibility
+  InvocationIdGenerator invocation_id_generator_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client_bucket_acl_test.cc
+++ b/google/cloud/storage/internal/retry_client_bucket_acl_test.cc
@@ -27,143 +27,156 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
+using ::google::cloud::storage::testing::MockRetryClientFunction;
 using ::google::cloud::storage::testing::RetryClientTestOptions;
+using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::Return;
 
 TEST(RetryClient, ListBucketAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListBucketAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, ListBucketAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListBucketAcl(ListBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListBucketAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListBucketAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListBucketAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, ListBucketAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListBucketAcl(ListBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListBucketAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateBucketAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateBucketAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, CreateBucketAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateBucketAcl(CreateBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateBucketAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateBucketAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateBucketAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, CreateBucketAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateBucketAcl(CreateBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateBucketAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteBucketAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteBucketAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, DeleteBucketAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteBucketAcl(DeleteBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteBucketAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteBucketAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteBucketAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, DeleteBucketAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteBucketAcl(DeleteBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteBucketAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetBucketAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetBucketAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, GetBucketAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetBucketAcl(GetBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetBucketAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetBucketAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetBucketAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetBucketAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetBucketAcl(GetBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetBucketAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateBucketAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateBucketAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, UpdateBucketAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateBucketAcl(UpdateBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateBucketAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateBucketAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateBucketAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, UpdateBucketAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateBucketAcl(UpdateBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateBucketAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchBucketAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchBucketAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, PatchBucketAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchBucketAcl(PatchBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchBucketAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchBucketAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchBucketAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, PatchBucketAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchBucketAcl(PatchBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchBucketAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_client_bucket_test.cc
+++ b/google/cloud/storage/internal/retry_client_bucket_test.cc
@@ -27,232 +27,255 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
+using ::google::cloud::storage::testing::MockRetryClientFunction;
 using ::google::cloud::storage::testing::RetryClientTestOptions;
+using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::Return;
 
 TEST(RetryClient, ListBucketsTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListBuckets)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, ListBuckets).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListBuckets(ListBucketsRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListBuckets"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListBucketPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListBuckets).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, ListBuckets).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListBuckets(ListBucketsRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListBuckets"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateBucketTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateBucket)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, CreateBucket).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateBucket(CreateBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateBucket"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateBucketPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateBucket).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, CreateBucket).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateBucket(CreateBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateBucket"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteBucketTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteBucket)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, DeleteBucket).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteBucket(DeleteBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteBucket"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteBucketPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteBucket).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, DeleteBucket).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteBucket(DeleteBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteBucket"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetBucketTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetBucketMetadata)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, GetBucketMetadata).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetBucketMetadata(GetBucketMetadataRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetBucketMetadata"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetBucketPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetBucketMetadata).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetBucketMetadata).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetBucketMetadata(GetBucketMetadataRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetBucketMetadata"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateBucketTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateBucket)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, UpdateBucket).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateBucket(UpdateBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateBucket"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateBucketPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateBucket).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, UpdateBucket).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateBucket(UpdateBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateBucket"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchBucketTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchBucket)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, PatchBucket).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchBucket(PatchBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchBucket"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchBucketPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchBucket).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, PatchBucket).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchBucket(PatchBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchBucket"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetNativeBucketIamPolicyTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetNativeBucketIamPolicy)
       .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+      .WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetNativeBucketIamPolicy(GetBucketIamPolicyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetNativeBucketIamPolicy"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetNativeBucketIamPolicyPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetNativeBucketIamPolicy)
-      .WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetNativeBucketIamPolicy).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetNativeBucketIamPolicy(GetBucketIamPolicyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetNativeBucketIamPolicy"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, SetNativeBucketIamPolicyTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, SetNativeBucketIamPolicy)
       .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+      .WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->SetNativeBucketIamPolicy(SetNativeBucketIamPolicyRequest())
           .status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("SetNativeBucketIamPolicy"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, SetNativeBucketIamPolicyPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, SetNativeBucketIamPolicy)
-      .WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, SetNativeBucketIamPolicy).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->SetNativeBucketIamPolicy(SetNativeBucketIamPolicyRequest())
           .status();
   EXPECT_THAT(response, StoppedOnPermanentError("SetNativeBucketIamPolicy"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, TestBucketIamPermissionsTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, TestBucketIamPermissions)
       .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+      .WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->TestBucketIamPermissions(TestBucketIamPermissionsRequest())
           .status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("TestBucketIamPermissions"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, TestBucketIamPermissionsPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, TestBucketIamPermissions)
-      .WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, TestBucketIamPermissions).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->TestBucketIamPermissions(TestBucketIamPermissionsRequest())
           .status();
   EXPECT_THAT(response, StoppedOnPermanentError("TestBucketIamPermissions"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, LockBucketRetentionPolicyTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, LockBucketRetentionPolicy)
       .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+      .WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
@@ -260,19 +283,21 @@ TEST(RetryClient, LockBucketRetentionPolicyTooManyFailures) {
           .status();
   EXPECT_THAT(response,
               StoppedOnTooManyTransients("LockBucketRetentionPolicy"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, LockBucketRetentionPolicyPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, LockBucketRetentionPolicy)
-      .WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, LockBucketRetentionPolicy).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->LockBucketRetentionPolicy(LockBucketRetentionPolicyRequest())
           .status();
   EXPECT_THAT(response, StoppedOnPermanentError("LockBucketRetentionPolicy"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_client_default_object_acl_test.cc
+++ b/google/cloud/storage/internal/retry_client_default_object_acl_test.cc
@@ -27,155 +27,168 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
+using ::google::cloud::storage::testing::MockRetryClientFunction;
 using ::google::cloud::storage::testing::RetryClientTestOptions;
+using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::Return;
 
 TEST(RetryClient, ListDefaultObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListDefaultObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, ListDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->ListDefaultObjectAcl(ListDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListDefaultObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListDefaultObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListDefaultObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, ListDefaultObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->ListDefaultObjectAcl(ListDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListDefaultObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateDefaultObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateDefaultObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, CreateDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateDefaultObjectAcl(CreateDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateDefaultObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateDefaultObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateDefaultObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, CreateDefaultObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateDefaultObjectAcl(CreateDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateDefaultObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteDefaultObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteDefaultObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, DeleteDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteDefaultObjectAcl(DeleteDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteDefaultObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteDefaultObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteDefaultObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, DeleteDefaultObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteDefaultObjectAcl(DeleteDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteDefaultObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetDefaultObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetDefaultObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, GetDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetDefaultObjectAcl(GetDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetDefaultObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetDefaultObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetDefaultObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetDefaultObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetDefaultObjectAcl(GetDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetDefaultObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateDefaultObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateDefaultObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, UpdateDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->UpdateDefaultObjectAcl(UpdateDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateDefaultObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateDefaultObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateDefaultObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, UpdateDefaultObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->UpdateDefaultObjectAcl(UpdateDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateDefaultObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchDefaultObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchDefaultObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, PatchDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->PatchDefaultObjectAcl(PatchDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchDefaultObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchDefaultObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchDefaultObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, PatchDefaultObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->PatchDefaultObjectAcl(PatchDefaultObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchDefaultObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_client_notifications_test.cc
+++ b/google/cloud/storage/internal/retry_client_notifications_test.cc
@@ -27,105 +27,114 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
+using ::google::cloud::storage::testing::MockRetryClientFunction;
 using ::google::cloud::storage::testing::RetryClientTestOptions;
+using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::Return;
 
 TEST(RetryClient, ListNotificationTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListNotifications)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, ListNotifications).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->ListNotifications(ListNotificationsRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListNotifications"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListNotificationPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListNotifications).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, ListNotifications).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->ListNotifications(ListNotificationsRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListNotifications"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateNotificationTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateNotification)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, CreateNotification).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateNotification(CreateNotificationRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateNotification"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateNotificationPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateNotification).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, CreateNotification).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateNotification(CreateNotificationRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateNotification"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteNotificationTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteNotification)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, DeleteNotification).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteNotification(DeleteNotificationRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteNotification"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteNotificationPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteNotification).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, DeleteNotification).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteNotification(DeleteNotificationRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteNotification"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetNotificationTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetNotification)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, GetNotification).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetNotification(GetNotificationRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetNotification"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetNotificationPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetNotification).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetNotification).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetNotification(GetNotificationRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetNotification"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_client_object_acl_test.cc
+++ b/google/cloud/storage/internal/retry_client_object_acl_test.cc
@@ -27,143 +27,156 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
+using ::google::cloud::storage::testing::MockRetryClientFunction;
 using ::google::cloud::storage::testing::RetryClientTestOptions;
+using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::Return;
 
 TEST(RetryClient, ListObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, ListObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListObjectAcl(ListObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, ListObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListObjectAcl(ListObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, CreateObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateObjectAcl(CreateObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, CreateObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateObjectAcl(CreateObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, DeleteObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteObjectAcl(DeleteObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, DeleteObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteObjectAcl(DeleteObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, GetObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetObjectAcl(GetObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetObjectAcl(GetObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, UpdateObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateObjectAcl(UpdateObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, UpdateObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateObjectAcl(UpdateObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchObjectAclTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchObjectAcl)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, PatchObjectAcl).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchObjectAcl(PatchObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchObjectAcl"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchObjectAclPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchObjectAcl).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, PatchObjectAcl).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchObjectAcl(PatchObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchObjectAcl"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_client_object_copy_test.cc
+++ b/google/cloud/storage/internal/retry_client_object_copy_test.cc
@@ -27,77 +27,84 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
+using ::google::cloud::storage::testing::MockRetryClientFunction;
 using ::google::cloud::storage::testing::RetryClientTestOptions;
+using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::Return;
 
 TEST(RetryClient, CopyObjectTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CopyObject)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, CopyObject).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CopyObject(CopyObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CopyObject"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CopyObjectPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CopyObject).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, CopyObject).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CopyObject(CopyObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CopyObject"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ComposeObjectTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ComposeObject)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, ComposeObject).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ComposeObject(ComposeObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ComposeObject"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ComposeObjectPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ComposeObject).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, ComposeObject).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ComposeObject(ComposeObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ComposeObject"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, RewriteObjectTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, RewriteObject)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, RewriteObject).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->RewriteObject(RewriteObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("RewriteObject"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, RewriteObjectPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, RewriteObject).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, RewriteObject).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->RewriteObject(RewriteObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("RewriteObject"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_client_object_test.cc
+++ b/google/cloud/storage/internal/retry_client_object_test.cc
@@ -27,218 +27,262 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
+using ::google::cloud::storage::testing::MockRetryClientFunction;
 using ::google::cloud::storage::testing::RetryClientTestOptions;
+using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::ByMove;
-using ::testing::Return;
 
 TEST(RetryClient, InsertObjectMediaTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, InsertObjectMedia)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, InsertObjectMedia).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->InsertObjectMedia(InsertObjectMediaRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("InsertObjectMedia"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, InsertObjectMediaPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, InsertObjectMedia).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, InsertObjectMedia).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->InsertObjectMedia(InsertObjectMediaRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("InsertObjectMedia"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetObjectMetadataTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetObjectMetadata)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, GetObjectMetadata).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetObjectMetadata(GetObjectMetadataRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetObjectMetadata"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetObjectMetadataPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetObjectMetadata).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetObjectMetadata).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetObjectMetadata(GetObjectMetadataRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetObjectMetadata"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListObjectsTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListObjects)
-      .Times(3)
-      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, ListObjects).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListObjects(ListObjectsRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListObjects"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListObjectsPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListObjects).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, ListObjects).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListObjects(ListObjectsRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListObjects"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ReadObjectTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ReadObject).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, ReadObject).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ReadObject(ReadObjectRangeRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ReadObjectNotWrapped"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ReadObjectPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ReadObject).WillOnce(Return(ByMove(PermanentError())));
+  EXPECT_CALL(*mock, ReadObject).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ReadObject(ReadObjectRangeRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ReadObjectNotWrapped"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateResumableUploadTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateResumableUpload).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, CreateResumableUpload).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateResumableUpload(ResumableUploadRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateResumableUpload"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateResumableUploadPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateResumableUpload).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, CreateResumableUpload).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateResumableUpload(ResumableUploadRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateResumableUpload"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
+}
+
+TEST(RetryClient, QueryResumableUploadTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
+  auto mock = std::make_unique<MockGenericStub>();
+  EXPECT_CALL(*mock, options);
+  EXPECT_CALL(*mock, QueryResumableUpload).Times(3).WillRepeatedly(transient);
+  auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
+  google::cloud::internal::OptionsSpan span(client->options());
+  auto response =
+      client->QueryResumableUpload(QueryResumableUploadRequest()).status();
+  EXPECT_THAT(response, StoppedOnTooManyTransients("QueryResumableUpload"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
+}
+
+TEST(RetryClient, QueryResumableUploadPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
+  auto mock = std::make_unique<MockGenericStub>();
+  EXPECT_CALL(*mock, options);
+  EXPECT_CALL(*mock, QueryResumableUpload).WillOnce(permanent);
+  auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
+  google::cloud::internal::OptionsSpan span(client->options());
+  auto response =
+      client->QueryResumableUpload(QueryResumableUploadRequest()).status();
+  EXPECT_THAT(response, StoppedOnPermanentError("QueryResumableUpload"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteResumableUploadTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteResumableUpload).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, DeleteResumableUpload).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteResumableUpload(DeleteResumableUploadRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteResumableUpload"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteResumableUploadPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteResumableUpload).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, DeleteResumableUpload).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteResumableUpload(DeleteResumableUploadRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteResumableUpload"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteObjectTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteObject).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, DeleteObject).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteObject(DeleteObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteObject"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteObjectPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteObject).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, DeleteObject).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteObject(DeleteObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteObject"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateObjectTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateObject).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, UpdateObject).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateObject(UpdateObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateObject"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateObjectPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateObject).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, UpdateObject).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateObject(UpdateObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateObject"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchObjectTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchObject).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, PatchObject).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchObject(PatchObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchObject"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, PatchObjectPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, PatchObject).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, PatchObject).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchObject(PatchObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchObject"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_client_service_account_test.cc
+++ b/google/cloud/storage/internal/retry_client_service_account_test.cc
@@ -27,145 +27,158 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
+using ::google::cloud::storage::testing::MockRetryClientFunction;
 using ::google::cloud::storage::testing::RetryClientTestOptions;
+using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::Return;
 
 TEST(RetryClient, GetServiceAccountTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetServiceAccount).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, GetServiceAccount).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetServiceAccount(GetProjectServiceAccountRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetServiceAccount"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetServiceAccountPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetServiceAccount).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetServiceAccount).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetServiceAccount(GetProjectServiceAccountRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetServiceAccount"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListHmacKeysTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListHmacKeys).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, ListHmacKeys).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListHmacKeys(ListHmacKeysRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListHmacKeys"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, ListHmacKeysPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, ListHmacKeys).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, ListHmacKeys).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListHmacKeys(ListHmacKeysRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListHmacKeys"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateHmacKeyTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateHmacKey).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, CreateHmacKey).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateHmacKey(CreateHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateHmacKey"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, CreateHmacKeyPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, CreateHmacKey).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, CreateHmacKey).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateHmacKey(CreateHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateHmacKey"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteHmacKeyTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteHmacKey).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, DeleteHmacKey).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteHmacKey(DeleteHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteHmacKey"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, DeleteHmacKeyPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, DeleteHmacKey).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, DeleteHmacKey).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteHmacKey(DeleteHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteHmacKey"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetHmacKeyTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetHmacKey).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, GetHmacKey).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetHmacKey(GetHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetHmacKey"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, GetHmacKeyPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, GetHmacKey).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, GetHmacKey).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetHmacKey(GetHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetHmacKey"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateHmacKeyTooManyFailures) {
+  auto transient = MockRetryClientFunction(TransientError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateHmacKey).Times(3).WillRepeatedly([] {
-    return TransientError();
-  });
+  EXPECT_CALL(*mock, UpdateHmacKey).Times(3).WillRepeatedly(transient);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateHmacKey(UpdateHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateHmacKey"));
+  EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 TEST(RetryClient, UpdateHmacKeyPermanentFailure) {
+  auto permanent = MockRetryClientFunction(PermanentError());
   auto mock = std::make_unique<MockGenericStub>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, UpdateHmacKey).WillOnce(Return(PermanentError()));
+  EXPECT_CALL(*mock, UpdateHmacKey).WillOnce(permanent);
   auto client = RetryClient::Create(std::move(mock), RetryClientTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateHmacKey(UpdateHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateHmacKey"));
+  EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
 }
 
 }  // namespace

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -67,9 +67,12 @@ class MockRetryClientFunction {
   }
 
  private:
+  Status status_;
+  // This must be shared between copied instances. We use this class as mock
+  // functions for `.WillOnce()` and `.WillRepeatedly()`, both of which make a
+  // copy, and then we examine the contents of this (shared) member variable.
   std::shared_ptr<std::vector<std::string>> tokens_ =
       std::make_shared<std::vector<std::string>>();
-  Status status_;
 };
 
 }  // namespace testing


### PR DESCRIPTION
With this change the `RetryClient` loops populate the idempotency token header. More PRs are required to propagate this value to the stubs.

Part of the work for #12294

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12327)
<!-- Reviewable:end -->
