### PR TITLE
impl(generator): apply resource labels to types

### DIFF
--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -72,12 +72,12 @@ DiscoveryResource::DiscoveryResource(std::string name, std::string package_name,
       json_(std::move(json)) {}
 
 void DiscoveryResource::AddRequestType(std::string name,
-                                       DiscoveryTypeVertex const* type) {
+                                       DiscoveryTypeVertex* type) {
   request_types_.insert(std::make_pair(std::move(name), type));
 }
 
 void DiscoveryResource::AddResponseType(std::string name,
-                                        DiscoveryTypeVertex const* type) {
+                                        DiscoveryTypeVertex* type) {
   response_types_.insert(std::make_pair(std::move(name), type));
 }
 

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -33,11 +33,11 @@ class DiscoveryResource {
   std::string const& name() const { return name_; }
   std::string const& package_name() const { return package_name_; }
   nlohmann::json const& json() const { return json_; }
-  std::map<std::string, DiscoveryTypeVertex*> const& response_types() const {
-    return response_types_;
-  }
   std::map<std::string, DiscoveryTypeVertex*> const& request_types() {
     return request_types_;
+  }
+  std::map<std::string, DiscoveryTypeVertex*> const& response_types() const {
+    return response_types_;
   }
 
   bool RequiresEmptyImport() const { return has_empty_request_or_response_; }

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -33,9 +33,11 @@ class DiscoveryResource {
   std::string const& name() const { return name_; }
   std::string const& package_name() const { return package_name_; }
   nlohmann::json const& json() const { return json_; }
-  std::map<std::string, DiscoveryTypeVertex const*> const& response_types()
-      const {
+  std::map<std::string, DiscoveryTypeVertex*> const& response_types() const {
     return response_types_;
+  }
+  std::map<std::string, DiscoveryTypeVertex*> const& request_types() {
+    return request_types_;
   }
 
   bool RequiresEmptyImport() const { return has_empty_request_or_response_; }
@@ -43,10 +45,10 @@ class DiscoveryResource {
     return response_types_.find("Operation") != response_types_.end();
   }
 
-  void AddRequestType(std::string name, DiscoveryTypeVertex const* type);
+  void AddRequestType(std::string name, DiscoveryTypeVertex* type);
   void AddEmptyRequestType() { has_empty_request_or_response_ = true; }
 
-  void AddResponseType(std::string name, DiscoveryTypeVertex const* type);
+  void AddResponseType(std::string name, DiscoveryTypeVertex* type);
   void AddEmptyResponseType() { has_empty_request_or_response_ = true; }
 
   std::vector<DiscoveryTypeVertex const*> GetRequestTypesList() const;
@@ -86,8 +88,8 @@ class DiscoveryResource {
   std::string package_name_;
   bool has_empty_request_or_response_;
   nlohmann::json json_;
-  std::map<std::string, DiscoveryTypeVertex const*> request_types_;
-  std::map<std::string, DiscoveryTypeVertex const*> response_types_;
+  std::map<std::string, DiscoveryTypeVertex*> request_types_;
+  std::map<std::string, DiscoveryTypeVertex*> response_types_;
 };
 
 }  // namespace generator_internal

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -43,7 +43,7 @@ std::map<std::string, DiscoveryResource> ExtractResources(
 
 // Determines the name of the response type for each method and verifies it
 // exists in the collection of DiscoveryTypeVertex objects.
-StatusOr<DiscoveryTypeVertex const*> DetermineAndVerifyResponseType(
+StatusOr<DiscoveryTypeVertex*> DetermineAndVerifyResponseType(
     nlohmann::json const& method_json, DiscoveryResource& resource,
     std::map<std::string, DiscoveryTypeVertex>& types);
 
@@ -97,6 +97,12 @@ std::set<std::string> FindAllRefValues(nlohmann::json const& json);
 // DiscoveryTypeVertex::AddNeedsType and DiscoveryTypeVertex::AddNeededByType.
 Status EstablishTypeDependencies(
     std::map<std::string, DiscoveryTypeVertex>& types);
+
+// Starting with the request and response types for every rpc of each
+// resource, traverse the graph of `DiscoveryTypeVertex` via the "needs_type"
+// edges and add the name of the resource to each type.
+void ApplyResourceLabelsToTypes(
+    std::map<std::string, DiscoveryResource>& resources);
 
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/discovery_type_vertex.cc
+++ b/generator/internal/discovery_type_vertex.cc
@@ -95,6 +95,10 @@ void DiscoveryTypeVertex::AddNeededByType(DiscoveryTypeVertex* type) {
   needed_by_type_.insert(type);
 }
 
+void DiscoveryTypeVertex::AddNeededByResource(std::string resource_name) {
+  needed_by_resource_.insert(std::move(resource_name));
+}
+
 std::string DiscoveryTypeVertex::DetermineIntroducer(
     nlohmann::json const& field) {
   if (field.empty()) return "";

--- a/generator/internal/discovery_type_vertex.h
+++ b/generator/internal/discovery_type_vertex.h
@@ -46,6 +46,9 @@ class DiscoveryTypeVertex {
   nlohmann::json const& json() const { return json_; }
   std::set<DiscoveryTypeVertex*>& needs_type() { return needs_type_; }
   std::set<DiscoveryTypeVertex*>& needed_by_type() { return needed_by_type_; }
+  std::set<std::string> const& needed_by_resource() const {
+    return needed_by_resource_;
+  }
 
   bool IsSynthesizedRequestType() const;
 
@@ -54,6 +57,10 @@ class DiscoveryTypeVertex {
 
   // Adds edge to this vertex for a type that contains this type as a field.
   void AddNeededByType(DiscoveryTypeVertex* type);
+
+  // Adds the name of the resource that either directly or transitively depends
+  // on this type.
+  void AddNeededByResource(std::string resource_name);
 
   // Returns "optional ", "repeated ", or an empty string depending on the
   // field type.
@@ -133,6 +140,7 @@ class DiscoveryTypeVertex {
   google::protobuf::DescriptorPool const* const descriptor_pool_;
   std::set<DiscoveryTypeVertex*> needs_type_;
   std::set<DiscoveryTypeVertex*> needed_by_type_;
+  std::set<std::string> needed_by_resource_;
 };
 
 }  // namespace generator_internal


### PR DESCRIPTION
part of the work for #11190 

For every type a resource depends on, add its name as a label to the depended upon type. The generator uses this information later to group types into common proto files and to determine import paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12329)
<!-- Reviewable:end -->
