### PR TITLE
cleanup: generalize landing dox wrt gRPC vs. REST

### DIFF
--- a/ci/generate-markdown/update-library-landing-dox.sh
+++ b/ci/generate-markdown/update-library-landing-dox.sh
@@ -108,11 +108,11 @@ application.
 _EOF_
   else
     cat <<'_EOF_'
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/aiplatform/doc/main.dox
+++ b/google/cloud/aiplatform/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the Vertex AI API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/appengine/doc/main.dox
+++ b/google/cloud/appengine/doc/main.dox
@@ -20,11 +20,11 @@ which should give you a taste of the App Engine Admin API C++ client library API
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Cloud AutoML API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/beyondcorp/doc/main.dox
+++ b/google/cloud/beyondcorp/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the BeyondCorp API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/bigquery/doc/main.dox
+++ b/google/cloud/bigquery/doc/main.dox
@@ -20,11 +20,11 @@ the Cloud BigQuery C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Cloud Billing Budget API C++ client library
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/binaryauthorization/doc/main.dox
+++ b/google/cloud/binaryauthorization/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Binary Authorization API C++ client library
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/channel/doc/main.dox
+++ b/google/cloud/channel/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the Cloud Channel API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/cloudbuild/doc/main.dox
+++ b/google/cloud/cloudbuild/doc/main.dox
@@ -20,11 +20,11 @@ which should give you a taste of the Cloud Build API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/composer/doc/main.dox
+++ b/google/cloud/composer/doc/main.dox
@@ -20,11 +20,11 @@ which should give you a taste of the Cloud Composer C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/compute/doc/main.dox
+++ b/google/cloud/compute/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Cloud Compute Engine API C++ client library
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/containeranalysis/doc/main.dox
+++ b/google/cloud/containeranalysis/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the Container Analysis API C++ client library A
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/contentwarehouse/doc/main.dox
+++ b/google/cloud/contentwarehouse/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Document AI Warehouse API C++ client librar
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/datacatalog/doc/main.dox
+++ b/google/cloud/datacatalog/doc/main.dox
@@ -20,11 +20,11 @@ which should give you a taste of the Google Cloud Data Catalog API C++ client li
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/dataplex/doc/main.dox
+++ b/google/cloud/dataplex/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Cloud Dataplex API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Cloud Dataproc API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/datastore/doc/main.dox
+++ b/google/cloud/datastore/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Cloud Datastore API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Dialogflow API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Dialogflow API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -20,11 +20,11 @@ which should give you a taste of the Eventarc API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/functions/doc/main.dox
+++ b/google/cloud/functions/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the Cloud Functions API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/gkemulticloud/doc/main.dox
+++ b/google/cloud/gkemulticloud/doc/main.dox
@@ -27,11 +27,11 @@ which should give you a taste of the Anthos Multi-Cloud API C++ client library A
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/iam/doc/main.dox
+++ b/google/cloud/iam/doc/main.dox
@@ -20,11 +20,11 @@ the Cloud IAM C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/iap/doc/main.dox
+++ b/google/cloud/iap/doc/main.dox
@@ -20,11 +20,11 @@ which should give you a taste of the Cloud Identity-Aware Proxy API C++ client l
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the KMS C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Cloud Logging API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/metastore/doc/main.dox
+++ b/google/cloud/metastore/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the Dataproc Metastore API C++ client library A
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Cloud Monitoring API C++ client library API
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Notebooks API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the OS Config API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the Pub/Sub Lite API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Cloud Resource Manager API C++ client libra
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the Retail API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/run/doc/main.dox
+++ b/google/cloud/run/doc/main.dox
@@ -29,11 +29,11 @@ which should give you a taste of the Cloud Run Admin API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/servicecontrol/doc/main.dox
+++ b/google/cloud/servicecontrol/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Service Control API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/servicedirectory/doc/main.dox
+++ b/google/cloud/servicedirectory/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Service Directory API C++ client library AP
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -20,11 +20,11 @@ which should give you a taste of the Cloud Speech-to-Text API C++ client library
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/sql/doc/main.dox
+++ b/google/cloud/sql/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Cloud SQL Admin API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/support/doc/main.dox
+++ b/google/cloud/support/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Google Cloud Support API C++ client library
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/talent/doc/main.dox
+++ b/google/cloud/talent/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Cloud Talent Solution C++ client library AP
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Cloud TPU API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/trace/doc/main.dox
+++ b/google/cloud/trace/doc/main.dox
@@ -23,11 +23,11 @@ which should give you a taste of the Cloud Trace API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/video/doc/main.dox
+++ b/google/cloud/video/doc/main.dox
@@ -27,11 +27,11 @@ which should give you a taste of the video services C++ client library.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -22,11 +22,11 @@ which should give you a taste of the Cloud Vision API C++ client library API.
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -21,11 +21,11 @@ which should give you a taste of the Workflow Executions API C++ client library 
 ## Main classes
 
 <!-- inject-client-list-start -->
-This library offers multiple `*Client` classes, which are listed below. Each
-one of these classes exposes all the RPCs for a gRPC `service` as member
-functions of the class. This library groups multiple gRPC services because they
-are part of the same product or are often used together. A typical example may
-be the administrative and data plane operations for a single product.
+This library offers multiple `*Client` classes, which are listed below. Each one
+of these classes exposes all the RPCs for a service as member functions of the
+class. This library groups multiple services because they are part of the same
+product or are often used together. A typical example may be the administrative
+and data plane operations for a single product.
 
 The library also has other classes that provide helpers, configuration
 parameters, and infrastructure to mock the `*Client` classes when testing your


### PR DESCRIPTION
Generalize the concept of service so that the docs work for gRPC or REST (compute).

This is a follow up to: https://github.com/googleapis/google-cloud-cpp/pull/12124#discussion_r1286443116

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12341)
<!-- Reviewable:end -->
