### PR TITLE
impl(GCS+gRPC): `GrpcClient` is a `GenericStub`

### DIFF
--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -32,7 +32,7 @@ google::cloud::storage::Client DefaultGrpcClient(Options opts) {
   if (config == "metadata" || config.empty()) {
     opts = google::cloud::storage_internal::DefaultOptionsGrpc(std::move(opts));
     return storage::internal::ClientImplDetails::CreateClient(
-        storage_internal::GrpcClient::Create(std::move(opts)));
+        opts, std::make_unique<storage_internal::GrpcClient>(opts));
   }
   return storage::internal::ClientImplDetails::CreateClient(
       opts, std::make_unique<storage_internal::HybridClient>(opts));

--- a/google/cloud/storage/grpc_plugin_test.cc
+++ b/google/cloud/storage/grpc_plugin_test.cc
@@ -48,7 +48,7 @@ TEST(GrpcPluginTest, MetadataConfigCreatesGrpc) {
   auto impl = ClientImplDetails::GetRawClient(client);
   ASSERT_THAT(impl, NotNull());
   EXPECT_THAT(impl->InspectStackStructure(),
-              ElementsAre("GrpcClient", "GenericStubAdapter", "RetryClient"));
+              ElementsAre("GrpcClient", "RetryClient"));
 }
 
 TEST(GrpcPluginTest, EnvironmentOverrides) {
@@ -75,7 +75,7 @@ TEST(GrpcPluginTest, UnsetConfigCreatesMetadata) {
   auto impl = ClientImplDetails::GetRawClient(client);
   ASSERT_THAT(impl, NotNull());
   EXPECT_THAT(impl->InspectStackStructure(),
-              ElementsAre("GrpcClient", "GenericStubAdapter", "RetryClient"));
+              ElementsAre("GrpcClient", "RetryClient"));
 }
 
 TEST(GrpcPluginTest, NoneConfigCreatesCurl) {

--- a/google/cloud/storage/internal/grpc/client.h
+++ b/google/cloud/storage/internal/grpc/client.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CLIENT_H
 
-#include "google/cloud/storage/internal/raw_client.h"
+#include "google/cloud/storage/internal/generic_stub.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/internal/minimal_iam_credentials_stub.h"
@@ -39,20 +39,13 @@ class StorageStub;
  */
 Options DefaultOptionsGrpc(Options = {});
 
-class GrpcClient : public storage::internal::RawClient {
+class GrpcClient : public GenericStub {
  public:
-  // Creates a new instance, assumes the options have all default values set.
-  static std::shared_ptr<GrpcClient> Create(Options opts);
-
-  // This is used to create a client from a mocked StorageStub.
-  static std::shared_ptr<GrpcClient> CreateMock(
-      std::shared_ptr<storage_internal::StorageStub> stub, Options opts = {});
-
-  // This is used to create a client from a mocked StorageStub.
-  static std::shared_ptr<GrpcClient> CreateMock(
+  explicit GrpcClient(Options opts);
+  explicit GrpcClient(
       std::shared_ptr<storage_internal::StorageStub> stub,
       std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> iam,
-      Options opts = {});
+      Options opts);
 
   ~GrpcClient() override = default;
 
@@ -60,149 +53,199 @@ class GrpcClient : public storage::internal::RawClient {
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
 
-  storage::ClientOptions const& client_options() const override;
   Options options() const override;
 
   StatusOr<storage::internal::ListBucketsResponse> ListBuckets(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::ListBucketsRequest const& request) override;
   StatusOr<storage::BucketMetadata> CreateBucket(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::CreateBucketRequest const& request) override;
   StatusOr<storage::BucketMetadata> GetBucketMetadata(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::GetBucketMetadataRequest const& request) override;
   StatusOr<storage::internal::EmptyResponse> DeleteBucket(
-      storage::internal::DeleteBucketRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::DeleteBucketRequest const& request) override;
   StatusOr<storage::BucketMetadata> UpdateBucket(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::UpdateBucketRequest const& request) override;
   StatusOr<storage::BucketMetadata> PatchBucket(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::PatchBucketRequest const& request) override;
   StatusOr<storage::NativeIamPolicy> GetNativeBucketIamPolicy(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::GetBucketIamPolicyRequest const& request) override;
   StatusOr<storage::NativeIamPolicy> SetNativeBucketIamPolicy(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::SetNativeBucketIamPolicyRequest const& request)
       override;
   StatusOr<storage::internal::TestBucketIamPermissionsResponse>
   TestBucketIamPermissions(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::TestBucketIamPermissionsRequest const& request)
       override;
   StatusOr<storage::BucketMetadata> LockBucketRetentionPolicy(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::LockBucketRetentionPolicyRequest const& request)
       override;
 
   StatusOr<storage::ObjectMetadata> InsertObjectMedia(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::InsertObjectMediaRequest const& request) override;
   StatusOr<storage::ObjectMetadata> CopyObject(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::CopyObjectRequest const& request) override;
   StatusOr<storage::ObjectMetadata> GetObjectMetadata(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::GetObjectMetadataRequest const& request) override;
 
   StatusOr<std::unique_ptr<storage::internal::ObjectReadSource>> ReadObject(
-      storage::internal::ReadObjectRangeRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::ReadObjectRangeRequest const& request) override;
 
   StatusOr<storage::internal::ListObjectsResponse> ListObjects(
-      storage::internal::ListObjectsRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::ListObjectsRequest const& request) override;
   StatusOr<storage::internal::EmptyResponse> DeleteObject(
-      storage::internal::DeleteObjectRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::DeleteObjectRequest const& request) override;
   StatusOr<storage::ObjectMetadata> UpdateObject(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::UpdateObjectRequest const& request) override;
   StatusOr<storage::ObjectMetadata> PatchObject(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::PatchObjectRequest const& request) override;
   StatusOr<storage::ObjectMetadata> ComposeObject(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::ComposeObjectRequest const& request) override;
   StatusOr<storage::internal::RewriteObjectResponse> RewriteObject(
-      storage::internal::RewriteObjectRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::RewriteObjectRequest const& request) override;
 
   StatusOr<storage::internal::CreateResumableUploadResponse>
   CreateResumableUpload(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::ResumableUploadRequest const& request) override;
   StatusOr<storage::internal::QueryResumableUploadResponse>
   QueryResumableUpload(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::QueryResumableUploadRequest const& request) override;
   StatusOr<storage::internal::EmptyResponse> DeleteResumableUpload(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::DeleteResumableUploadRequest const& request) override;
   StatusOr<storage::internal::QueryResumableUploadResponse> UploadChunk(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::UploadChunkRequest const& request) override;
 
   StatusOr<storage::internal::ListBucketAclResponse> ListBucketAcl(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::ListBucketAclRequest const& request) override;
   StatusOr<storage::BucketAccessControl> CreateBucketAcl(
-      storage::internal::CreateBucketAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::CreateBucketAclRequest const& request) override;
   StatusOr<storage::internal::EmptyResponse> DeleteBucketAcl(
-      storage::internal::DeleteBucketAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::DeleteBucketAclRequest const& request) override;
   StatusOr<storage::BucketAccessControl> GetBucketAcl(
-      storage::internal::GetBucketAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::GetBucketAclRequest const& request) override;
   StatusOr<storage::BucketAccessControl> UpdateBucketAcl(
-      storage::internal::UpdateBucketAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::UpdateBucketAclRequest const& request) override;
   StatusOr<storage::BucketAccessControl> PatchBucketAcl(
-      storage::internal::PatchBucketAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::PatchBucketAclRequest const& request) override;
 
   StatusOr<storage::internal::ListObjectAclResponse> ListObjectAcl(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::ListObjectAclRequest const& request) override;
   StatusOr<storage::ObjectAccessControl> CreateObjectAcl(
-      storage::internal::CreateObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::CreateObjectAclRequest const& request) override;
   StatusOr<storage::internal::EmptyResponse> DeleteObjectAcl(
-      storage::internal::DeleteObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::DeleteObjectAclRequest const& request) override;
   StatusOr<storage::ObjectAccessControl> GetObjectAcl(
-      storage::internal::GetObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::GetObjectAclRequest const& request) override;
   StatusOr<storage::ObjectAccessControl> UpdateObjectAcl(
-      storage::internal::UpdateObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::UpdateObjectAclRequest const& request) override;
   StatusOr<storage::ObjectAccessControl> PatchObjectAcl(
-      storage::internal::PatchObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::PatchObjectAclRequest const& request) override;
 
   StatusOr<storage::internal::ListDefaultObjectAclResponse>
   ListDefaultObjectAcl(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::ListDefaultObjectAclRequest const& request) override;
   StatusOr<storage::ObjectAccessControl> CreateDefaultObjectAcl(
-      storage::internal::CreateDefaultObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::CreateDefaultObjectAclRequest const& request) override;
   StatusOr<storage::internal::EmptyResponse> DeleteDefaultObjectAcl(
-      storage::internal::DeleteDefaultObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::DeleteDefaultObjectAclRequest const& request) override;
   StatusOr<storage::ObjectAccessControl> GetDefaultObjectAcl(
-      storage::internal::GetDefaultObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::GetDefaultObjectAclRequest const& request) override;
   StatusOr<storage::ObjectAccessControl> UpdateDefaultObjectAcl(
-      storage::internal::UpdateDefaultObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::UpdateDefaultObjectAclRequest const& request) override;
   StatusOr<storage::ObjectAccessControl> PatchDefaultObjectAcl(
-      storage::internal::PatchDefaultObjectAclRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::PatchDefaultObjectAclRequest const& request) override;
 
   StatusOr<storage::ServiceAccount> GetServiceAccount(
-      storage::internal::GetProjectServiceAccountRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::GetProjectServiceAccountRequest const& request)
+      override;
   StatusOr<storage::internal::ListHmacKeysResponse> ListHmacKeys(
-      storage::internal::ListHmacKeysRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::ListHmacKeysRequest const& request) override;
   StatusOr<storage::internal::CreateHmacKeyResponse> CreateHmacKey(
-      storage::internal::CreateHmacKeyRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::CreateHmacKeyRequest const& request) override;
   StatusOr<storage::internal::EmptyResponse> DeleteHmacKey(
-      storage::internal::DeleteHmacKeyRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::DeleteHmacKeyRequest const& request) override;
   StatusOr<storage::HmacKeyMetadata> GetHmacKey(
-      storage::internal::GetHmacKeyRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::GetHmacKeyRequest const& request) override;
   StatusOr<storage::HmacKeyMetadata> UpdateHmacKey(
-      storage::internal::UpdateHmacKeyRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::UpdateHmacKeyRequest const& request) override;
   StatusOr<storage::internal::SignBlobResponse> SignBlob(
-      storage::internal::SignBlobRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::SignBlobRequest const& request) override;
 
   StatusOr<storage::internal::ListNotificationsResponse> ListNotifications(
-      storage::internal::ListNotificationsRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::ListNotificationsRequest const& request) override;
   StatusOr<storage::NotificationMetadata> CreateNotification(
-      storage::internal::CreateNotificationRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::CreateNotificationRequest const& request) override;
   StatusOr<storage::NotificationMetadata> GetNotification(
-      storage::internal::GetNotificationRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::GetNotificationRequest const& request) override;
   StatusOr<storage::internal::EmptyResponse> DeleteNotification(
-      storage::internal::DeleteNotificationRequest const&) override;
+      rest_internal::RestContext& context, Options const& options,
+      storage::internal::DeleteNotificationRequest const& request) override;
 
   std::vector<std::string> InspectStackStructure() const override;
 
- protected:
-  explicit GrpcClient(Options opts);
-  explicit GrpcClient(
-      std::shared_ptr<storage_internal::StorageStub> stub,
-      std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> iam,
-      Options opts);
-
  private:
   StatusOr<google::storage::v2::Bucket> GetBucketMetadataImpl(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::GetBucketMetadataRequest const& request);
   StatusOr<google::storage::v2::Bucket> PatchBucketImpl(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::PatchBucketRequest const& request);
   StatusOr<google::storage::v2::Object> GetObjectMetadataImpl(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::GetObjectMetadataRequest const& request);
   StatusOr<google::storage::v2::Object> PatchObjectImpl(
+      rest_internal::RestContext& context, Options const& options,
       storage::internal::PatchObjectRequest const& request);
 
   using BucketAccessControlList = google::protobuf::RepeatedPtrField<
@@ -214,6 +257,7 @@ class GrpcClient : public storage::internal::RawClient {
   // lacks such RPCs. This function hijacks the retry loop to implement an OCC
   // loop to make such changes.
   StatusOr<google::storage::v2::Bucket> ModifyBucketAccessControl(
+      Options const& options,
       storage::internal::GetBucketMetadataRequest const& request,
       BucketAclUpdater const& updater);
 
@@ -226,6 +270,7 @@ class GrpcClient : public storage::internal::RawClient {
   // lacks such RPCs. This function hijacks the retry loop to implement an OCC
   // loop to make such changes.
   StatusOr<google::storage::v2::Object> ModifyObjectAccessControl(
+      Options const& options,
       storage::internal::GetObjectMetadataRequest const& request,
       ObjectAclUpdater const& updater);
 
@@ -237,11 +282,11 @@ class GrpcClient : public storage::internal::RawClient {
   // atomically. gRPC lacks such RPCs. This function hijacks the retry loop to
   // implement an OCC loop to make such changes.
   StatusOr<google::storage::v2::Bucket> ModifyDefaultAccessControl(
+      Options const& options,
       storage::internal::GetBucketMetadataRequest const& request,
       DefaultObjectAclUpdater const& updater);
 
   Options options_;
-  storage::ClientOptions backwards_compatibility_options_;
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<storage_internal::GrpcChannelRefresh> refresh_;
   std::shared_ptr<storage_internal::StorageStub> stub_;

--- a/google/cloud/storage/internal/grpc/client_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc/client_insert_object_media_test.cc
@@ -81,8 +81,11 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
     return stream;
   });
 
-  auto client = GrpcClient::CreateMock(mock);
+  std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> unused;
+  auto client = std::make_unique<GrpcClient>(mock, unused, Options{});
+  auto context = rest_internal::RestContext{};
   auto metadata = client->InsertObjectMedia(
+      context, client->options(),
       InsertObjectMediaRequest("test-bucket", "test-object",
                                "The quick brown fox jumps over the lazy dog"));
   ASSERT_STATUS_OK(metadata);
@@ -111,13 +114,15 @@ TEST(GrpcClientInsertObjectMediaTest, StallTimeoutWrite) {
           make_status_or(std::chrono::system_clock::now())))));
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}
-                .set<TransferStallTimeoutOption>(expected)
-                .set<GrpcCompletionQueueOption>(cq));
-  google::cloud::internal::OptionsSpan const span(
-      Options{}.set<TransferStallTimeoutOption>(expected));
+  std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> unused;
+  auto client = std::make_unique<GrpcClient>(
+      mock, unused,
+      Options{}
+          .set<TransferStallTimeoutOption>(expected)
+          .set<GrpcCompletionQueueOption>(cq));
+  auto context = rest_internal::RestContext{};
   auto metadata = client->InsertObjectMedia(
+      context, client->options(),
       InsertObjectMediaRequest("test-bucket", "test-object",
                                "The quick brown fox jumps over the lazy dog"));
   EXPECT_THAT(metadata,
@@ -147,13 +152,15 @@ TEST(GrpcClientInsertObjectMediaTest, StallTimeoutClose) {
           make_status_or(std::chrono::system_clock::now())))));
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}
-                .set<TransferStallTimeoutOption>(expected)
-                .set<GrpcCompletionQueueOption>(cq));
-  google::cloud::internal::OptionsSpan const span(
-      Options{}.set<TransferStallTimeoutOption>(expected));
+  std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> unused;
+  auto client = std::make_unique<GrpcClient>(
+      mock, unused,
+      Options{}
+          .set<TransferStallTimeoutOption>(expected)
+          .set<GrpcCompletionQueueOption>(cq));
+  auto context = rest_internal::RestContext{};
   auto metadata = client->InsertObjectMedia(
+      context, client->options(),
       InsertObjectMediaRequest("test-bucket", "test-object",
                                "The quick brown fox jumps over the lazy dog"));
   EXPECT_THAT(metadata,

--- a/google/cloud/storage/internal/grpc/client_upload_chunk_test.cc
+++ b/google/cloud/storage/internal/grpc/client_upload_chunk_test.cc
@@ -66,14 +66,18 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
           make_status_or(std::chrono::system_clock::now())))));
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}
-                .set<TransferStallTimeoutOption>(expected)
-                .set<GrpcCompletionQueueOption>(cq));
+  std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> unused;
+  auto client = std::make_unique<GrpcClient>(
+      mock, unused,
+      Options{}
+          .set<TransferStallTimeoutOption>(expected)
+          .set<GrpcCompletionQueueOption>(cq));
   google::cloud::internal::OptionsSpan const span(
       Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
+  auto context = rest_internal::RestContext{};
   auto response = client->UploadChunk(
+      context, client->options(),
       UploadChunkRequest("test-only-upload-id", /*offset=*/0,
                          {ConstBuffer{payload}}, CreateNullHashFunction()));
   EXPECT_THAT(response,
@@ -104,15 +108,19 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
           make_status_or(std::chrono::system_clock::now())))));
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}
-                .set<TransferStallTimeoutOption>(expected)
-                .set<GrpcCompletionQueueOption>(cq));
+  std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> unused;
+  auto client = std::make_unique<GrpcClient>(
+      mock, unused,
+      Options{}
+          .set<TransferStallTimeoutOption>(expected)
+          .set<GrpcCompletionQueueOption>(cq));
   google::cloud::internal::OptionsSpan const span(
       Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(
       kExpectedWriteSize + UploadChunkRequest::kChunkSizeQuantum, 'A');
+  auto context = rest_internal::RestContext{};
   auto response = client->UploadChunk(
+      context, client->options(),
       UploadChunkRequest("test-only-upload-id", /*offset=*/0,
                          {ConstBuffer{payload}}, CreateNullHashFunction()));
   EXPECT_THAT(response,
@@ -146,15 +154,19 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutClose) {
           make_status_or(std::chrono::system_clock::now())))));
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}
-                .set<TransferStallTimeoutOption>(expected)
-                .set<GrpcCompletionQueueOption>(cq));
+  std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> unused;
+  auto client = std::make_unique<GrpcClient>(
+      mock, unused,
+      Options{}
+          .set<TransferStallTimeoutOption>(expected)
+          .set<GrpcCompletionQueueOption>(cq));
   google::cloud::internal::OptionsSpan const span(
       Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(
       kExpectedWriteSize + UploadChunkRequest::kChunkSizeQuantum, 'A');
+  auto context = rest_internal::RestContext{};
   auto response = client->UploadChunk(
+      context, client->options(),
       UploadChunkRequest("test-only-upload-id", /*offset=*/0,
                          {ConstBuffer{payload}}, CreateNullHashFunction()));
   EXPECT_THAT(response,

--- a/google/cloud/storage/internal/grpc/configure_client_context.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context.cc
@@ -20,6 +20,19 @@ namespace cloud {
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+auto constexpr kIdempotencyTokenHeader = "x-goog-gcs-idempotency-token";
+
+void AddIdempotencyToken(grpc::ClientContext& ctx,
+                         rest_internal::RestContext const& context) {
+  auto const& headers = context.headers();
+  auto const l = headers.find(kIdempotencyTokenHeader);
+  if (l != headers.end()) {
+    for (auto const& v : l->second) {
+      ctx.AddMetadata(kIdempotencyTokenHeader, v);
+    }
+  }
+}
+
 void ApplyRoutingHeaders(
     grpc::ClientContext& context,
     storage::internal::InsertObjectMediaRequest const& request) {

--- a/google/cloud/storage/internal/grpc/object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser_test.cc
@@ -320,12 +320,13 @@ TEST(GrpcObjectRequestParser, ReadObjectRangeRequestReadLastZero) {
   auto const actual = ToProto(req).value();
   EXPECT_THAT(actual, IsProtoEqual(expected));
 
-  auto client = GrpcClient::Create(DefaultOptionsGrpc(
+  auto client = std::make_unique<GrpcClient>(DefaultOptionsGrpc(
       Options{}
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>("localhost:1")));
+  rest_internal::RestContext context;
   StatusOr<std::unique_ptr<storage::internal::ObjectReadSource>> reader =
-      client->ReadObject(req);
+      client->ReadObject(context, client->options(), req);
   EXPECT_THAT(reader, StatusIs(StatusCode::kOutOfRange));
 }
 

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -25,7 +25,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 HybridClient::HybridClient(Options const& options)
-    : grpc_(GrpcClient::Create(DefaultOptionsGrpc(options))),
+    : grpc_(std::make_unique<GrpcClient>(DefaultOptionsGrpc(options))),
       rest_(std::make_unique<storage::internal::RestClient>(
           storage::internal::DefaultOptionsWithCredentials(options))) {}
 
@@ -93,9 +93,9 @@ StatusOr<storage::BucketMetadata> HybridClient::LockBucketRetentionPolicy(
 }
 
 StatusOr<storage::ObjectMetadata> HybridClient::InsertObjectMedia(
-    rest_internal::RestContext&, Options const&,
+    rest_internal::RestContext& context, Options const& options,
     storage::internal::InsertObjectMediaRequest const& request) {
-  return grpc_->InsertObjectMedia(request);
+  return grpc_->InsertObjectMedia(context, options, request);
 }
 
 StatusOr<storage::ObjectMetadata> HybridClient::CopyObject(
@@ -112,9 +112,9 @@ StatusOr<storage::ObjectMetadata> HybridClient::GetObjectMetadata(
 
 StatusOr<std::unique_ptr<storage::internal::ObjectReadSource>>
 HybridClient::ReadObject(
-    rest_internal::RestContext&, Options const&,
+    rest_internal::RestContext& context, Options const& options,
     storage::internal::ReadObjectRangeRequest const& request) {
-  return grpc_->ReadObject(request);
+  return grpc_->ReadObject(context, options, request);
 }
 
 StatusOr<storage::internal::ListObjectsResponse> HybridClient::ListObjects(
@@ -155,16 +155,16 @@ StatusOr<storage::internal::RewriteObjectResponse> HybridClient::RewriteObject(
 
 StatusOr<storage::internal::CreateResumableUploadResponse>
 HybridClient::CreateResumableUpload(
-    rest_internal::RestContext&, Options const&,
+    rest_internal::RestContext& context, Options const& options,
     storage::internal::ResumableUploadRequest const& request) {
-  return grpc_->CreateResumableUpload(request);
+  return grpc_->CreateResumableUpload(context, options, request);
 }
 
 StatusOr<storage::internal::QueryResumableUploadResponse>
 HybridClient::QueryResumableUpload(
-    rest_internal::RestContext&, Options const&,
+    rest_internal::RestContext& context, Options const& options,
     storage::internal::QueryResumableUploadRequest const& request) {
-  return grpc_->QueryResumableUpload(request);
+  return grpc_->QueryResumableUpload(context, options, request);
 }
 
 StatusOr<storage::internal::EmptyResponse> HybridClient::DeleteResumableUpload(
@@ -173,14 +173,14 @@ StatusOr<storage::internal::EmptyResponse> HybridClient::DeleteResumableUpload(
   if (absl::StartsWith(request.upload_session_url(), "https://")) {
     return rest_->DeleteResumableUpload(context, options, request);
   }
-  return grpc_->DeleteResumableUpload(request);
+  return grpc_->DeleteResumableUpload(context, options, request);
 }
 
 StatusOr<storage::internal::QueryResumableUploadResponse>
 HybridClient::UploadChunk(
-    rest_internal::RestContext&, Options const&,
+    rest_internal::RestContext& context, Options const& options,
     storage::internal::UploadChunkRequest const& request) {
-  return grpc_->UploadChunk(request);
+  return grpc_->UploadChunk(context, options, request);
 }
 
 StatusOr<storage::internal::ListBucketAclResponse> HybridClient::ListBucketAcl(

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HYBRID_CLIENT_H
 
 #include "google/cloud/storage/internal/generic_stub.h"
-#include "google/cloud/storage/internal/generic_stub_adapter.h"
 #include "google/cloud/storage/version.h"
 #include <memory>
 #include <string>
@@ -213,7 +212,7 @@ class HybridClient : public GenericStub {
   std::vector<std::string> InspectStackStructure() const override;
 
  private:
-  std::shared_ptr<storage::internal::RawClient> grpc_;
+  std::shared_ptr<storage_internal::GenericStub> grpc_;
   std::unique_ptr<storage_internal::GenericStub> rest_;
 };
 


### PR DESCRIPTION
And as a `GenericStub`, it receives the `rest_internal::RestContext` and can propagate the idempotency token header to the service. In the case of operations emulated via OCC loops (most of the *AccessControl modifiers), we want the latest value after each iteration in the OCC loop. That is, the idempotency token should not be propagated in this case.

Part of the work for #12294.  Sorry for the overly large PR. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12343)
<!-- Reviewable:end -->
