### PR TITLE
ci(spanner): stop using ephemeral ports for emulator with cmake

### DIFF
--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -38,7 +38,7 @@ ctest_args=("$@")
 cd "${CMAKE_BINARY_DIR}"
 
 # Starts the emulator and arranges to kill it.
-spanner_emulator::start
+spanner_emulator::start 8787
 trap spanner_emulator::kill EXIT
 
 ctest -R "^spanner_" "${ctest_args[@]}"


### PR DESCRIPTION
Like the bazel builds, use a non-ephemeral port for the Spanner emulator when building with cmake.  Originally, in the bazel case, we used a fixed port so as to not invalidate the test cache.  But this meant that we also used a fixed, non-ephemeral port when adding the second emulator invocation (with HTTP support). Now we do the same with cmake for the second reason, which (largely) eliminates the chance of "Address already in use" errors.

Fixes #11073.

Also make the two invocations look similar, correct some environment variables names, and add the "--copy_emulator_stdout" option in the HTTP case (in case that is useful in future debugging).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12350)
<!-- Reviewable:end -->
