### PR TITLE
ci: format common protos earlier

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -50,6 +50,10 @@ if [ -z "${GENERATE_GOLDEN_ONLY}" ]; then
   find "${PROJECT_ROOT}/google/cloud/compute/v1/internal/" -name '*.proto' -a ! -newer "${newer_tmp_file}" -exec git rm {} \;
   rm "${newer_tmp_file}"
 
+  io::log_h2 "Formatting and adding any new google/cloud/compute/v1/internal/common_*.proto"
+  find "${PROJECT_ROOT}/google/cloud/compute/v1/internal" -name '*.proto' -exec clang-format -i {} \;
+  git add "${PROJECT_ROOT}/google/cloud/compute/v1/internal/common_*.proto"
+
   io::log_h2 "Formatting generated protos"
   git ls-files -z -- '*.proto' |
     xargs -P "$(nproc)" -n 1 -0 clang-format -i


### PR DESCRIPTION
Because we remove then add the common protos, if we defer formatting them until after they are added, the results of the formatting shows up as unstaged changes in git, causing the generate-libraries build to fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12352)
<!-- Reviewable:end -->
