### PR TITLE
Revert "feat(storage): all operations are idempotent"

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -227,12 +227,8 @@ struct ClientImplDetails;
  *
  * The default policies are to continue retrying for up to 15 minutes, and to
  * use truncated (at 5 minutes) exponential backoff, doubling the maximum
- * backoff period between retries.
- *
- * By default, all operations are treated as idempotent. The client library
- * sends the `x-goog-gcs-idempotency-token` header with a unique value for
- * each group of retried RPCs. If the service receives a request with a token
- * that it has previously seen, it will simply resend the matching response.
+ * backoff period between retries. Likewise, the idempotency policy is
+ * configured to retry all operations.
  *
  * The application can override these policies when constructing objects of this
  * class. The documentation for the constructors show examples of this in
@@ -312,6 +308,9 @@ class Client {
    *     `Projection`, and `UserProject`. `OverrideDefaultProject` is accepted,
    *     but has no effect.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_samples.cc list buckets for project
    */
@@ -345,6 +344,9 @@ class Client {
    *     Valid types for this operation include `MaxResults`, `Prefix`,
    *     `Projection`, `UserProject`, and `OverrideDefaultProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_samples.cc list buckets
    */
@@ -374,6 +376,9 @@ class Client {
    *     Valid types for this operation include `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, `UserProject`,
    *     and `OverrideDefaultProject`.
+   *
+   * @par Idempotency
+   * This operation is always idempotent. It fails if the bucket already exists.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc create bucket
@@ -415,6 +420,9 @@ class Client {
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *     `OverrideDefaultProject` is accepted, but has no effect.
    *
+   * @par Idempotency
+   * This operation is always idempotent. It fails if the bucket already exists.
+   *
    * @par Example
    * @snippet storage_bucket_samples.cc create bucket for project
    *
@@ -449,6 +457,9 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `UserProject`, and `Projection`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_samples.cc get bucket metadata
    */
@@ -469,6 +480,10 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc delete bucket
@@ -498,6 +513,10 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case,`IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc update bucket
@@ -545,6 +564,10 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
+   *
    * @par Example
    * @snippet storage_bucket_samples.cc patch bucket storage class
    *
@@ -586,6 +609,10 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc patch bucket storage class with builder
@@ -633,6 +660,9 @@ class Client {
    * @param bucket_name query metadata information about this bucket.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_iam_samples.cc native get bucket iam policy
@@ -683,6 +713,10 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
+   *
    * @par Example: adding a new member
    * @snippet storage_bucket_iam_samples.cc native add bucket iam member
    *
@@ -723,6 +757,9 @@ class Client {
    * @param permissions the list of permissions to check.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_iam_samples.cc test bucket iam permissions
@@ -766,6 +803,10 @@ class Client {
    *     current value.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is always idempotent because the `metageneration` parameter
+   * is always required, and it acts as a pre-condition on the operation.
    *
    * @par Example: lock the retention policy
    * @snippet storage_retention_policy_samples.cc lock retention policy
@@ -824,6 +865,10 @@ class Client {
    *     `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `KmsKeyName`, `MD5HashValue`,
    *     `PredefinedAcl`, `Projection`, `UserProject`, and `WithObjectMetadata`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc insert object
@@ -892,6 +937,10 @@ class Client {
    *     `IfSourceMetagenerationNotMatch`, `Projection`, `SourceGeneration`,
    *     `SourceEncryptionKey`, `UserProject`, and `WithObjectMetadata`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
+   *
    * @par Example
    * @snippet storage_object_samples.cc copy object
    *
@@ -927,6 +976,9 @@ class Client {
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_object_samples.cc get object metadata
    */
@@ -949,6 +1001,9 @@ class Client {
    *     Valid types for this operation include `MaxResults`, `Prefix`,
    *     `Delimiter`, `IncludeTrailingDelimiter`, `StartOffset`, `EndOffset`,
    *     `Projection`, `UserProject`, and `Versions`.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc list objects
@@ -978,6 +1033,9 @@ class Client {
    *     `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `UserProject`,
    *     `Projection`, `Prefix`, `Delimiter`, `IncludeTrailingDelimiter`,
    *     `StartOffset`, `EndOffset`, and `Versions`.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc list objects and prefixes
@@ -1028,6 +1086,9 @@ class Client {
    *     `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `ReadFromOffset`, `ReadRange`, `ReadLast`,
    *     `UserProject`, and `AcceptEncoding`.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc read object
@@ -1106,6 +1167,10 @@ class Client {
    *   `UseResumableUploadSession`, `UserProject`, `WithObjectMetadata`,
    *   `UploadContentLength`, `AutoFinalize`, and `UploadBufferSize`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
+   *
    * @par Example
    * @snippet storage_object_samples.cc write object
    *
@@ -1156,6 +1221,10 @@ class Client {
    *   `MD5HashValue`, `PredefinedAcl`, `Projection`, `UserProject`,
    *   `UploadFromOffset`, `UploadLimit` and `WithObjectMetadata`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
+   *
    * @par Example
    * @snippet storage_object_file_transfer_samples.cc upload file
    *
@@ -1185,6 +1254,10 @@ class Client {
    * `ObjectWriteStream::resumable_session_id`.
    * @param options a list of optional query parameters and/or request headers.
    *   Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is always idempotent because it only acts on a specific
+   * `upload_session_url`.
    */
   template <typename... Options>
   Status DeleteResumableUpload(std::string const& upload_session_url,
@@ -1209,6 +1282,9 @@ class Client {
    *   `IfMetagenerationNotMatch`, `Generation`, `ReadFromOffset`, `ReadRange`,
    *   and `UserProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_object_file_transfer_samples.cc download file
    */
@@ -1232,6 +1308,11 @@ class Client {
    *     Valid types for this operation include `Generation`,
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if:
+   * - restricted by pre-conditions, in this case, `IfGenerationMatch`
+   * - or, if it applies to only one object version via `Generation`.
    *
    * @par Example
    * @snippet storage_object_samples.cc delete object
@@ -1260,6 +1341,10 @@ class Client {
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`, `Projection`, and
    *     `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc update object metadata
@@ -1296,6 +1381,10 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
+   *
    * @par Example
    * @snippet storage_object_samples.cc patch object delete metadata
    */
@@ -1330,6 +1419,10 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`, `EncryptionKey`,
    *     `Projection`, and `UserProject`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
+   *
    * @par Example
    * @snippet storage_object_samples.cc patch object content type
    */
@@ -1357,6 +1450,10 @@ class Client {
    *      `DestinationPredefinedAcl`, `EncryptionKey`, `IfGenerationMatch`,
    *      `IfMetagenerationMatch`, `KmsKeyName`, `UserProject`, and
    *      `WithObjectMetadata`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc compose object
@@ -1404,6 +1501,10 @@ class Client {
    *      `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
    *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_rewrite_samples.cc rewrite object non blocking
@@ -1456,6 +1557,10 @@ class Client {
    *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
+   *
    * @par Example
    * @snippet storage_object_rewrite_samples.cc rewrite object resume
    */
@@ -1505,6 +1610,10 @@ class Client {
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
    * @return The metadata of the newly created object.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_rewrite_samples.cc rewrite object
@@ -1567,6 +1676,9 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc list bucket acl
    */
@@ -1592,6 +1704,10 @@ class Client {
    * @param role the role of the entity.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc create bucket acl
@@ -1621,6 +1737,10 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc delete bucket acl
    *
@@ -1644,6 +1764,9 @@ class Client {
    * @param entity the name of the entity to query.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc get bucket acl
@@ -1677,6 +1800,10 @@ class Client {
    *   will be modified by the server.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc update bucket acl
@@ -1723,6 +1850,10 @@ class Client {
    *     Valid types for this operation include `UserProject`, and the standard
    *     options available to all operations.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc patch bucket acl
    *
@@ -1764,6 +1895,10 @@ class Client {
    * @param options a list of optional query parameters and/or request
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc patch bucket acl no-read
@@ -1817,6 +1952,9 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_object_acl_samples.cc list object acl
    */
@@ -1844,6 +1982,10 @@ class Client {
    * @param role the role of the entity.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc create object acl
@@ -1877,6 +2019,10 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_object_acl_samples.cc delete object acl
    *
@@ -1902,6 +2048,9 @@ class Client {
    * @param entity the name of the entity added to the ACL.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc print file acl for user
@@ -1937,6 +2086,10 @@ class Client {
    *   will be modified by the server.
    * @param options a list of optional query parameters and/or request
    *     Valid types for this operation include `Generation`, and `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc update object acl
@@ -1983,6 +2136,10 @@ class Client {
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_object_acl_samples.cc patch object acl
    *
@@ -2025,6 +2182,10 @@ class Client {
    * @param options a list of optional query parameters and/or request
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc patch object acl no-read
@@ -2076,6 +2237,9 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch` and `UserProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc list default object acl
    *
@@ -2107,6 +2271,10 @@ class Client {
    * @param role the role of the entity.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc create default object acl
@@ -2140,6 +2308,10 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc delete default object acl
    *
@@ -2169,6 +2341,9 @@ class Client {
    * @param entity the name of the entity.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc get default object acl
@@ -2207,6 +2382,10 @@ class Client {
    *   will be modified by the server.
    * @param options a list of optional query parameters and/or request
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc update default object acl
@@ -2254,6 +2433,10 @@ class Client {
    *     as the standard parameters, such as `IfMatchEtag`, and
    *     `IfNoneMatchEtag`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc patch default object acl
    *
@@ -2298,6 +2481,10 @@ class Client {
    *     headers. Valid types for this operation include `UserProject`, as well
    *     as the standard parameters, such as `IfMatchEtag`, and
    *     `IfNoneMatchEtag`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc patch no-read
@@ -2347,6 +2534,9 @@ class Client {
    *     Valid types for this operation include `UserProject`.
    *     `OverrideDefaultProject` is accepted, but has no effect.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_service_account_samples.cc get service account for project
    *
@@ -2382,6 +2572,9 @@ class Client {
    *     Valid types for this operation include `UserProject`,
    *     and `OverrideDefaultProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_service_account_samples.cc get service account
    *
@@ -2412,6 +2605,9 @@ class Client {
    *     and `ServiceAccountFilter`.
    *
    * @return A range to iterate over the available HMAC keys.
+   *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_service_account_samples.cc list hmac keys
@@ -2460,6 +2656,10 @@ class Client {
    *   secret (encoded as a base64 string). This is the only request that
    *   returns the secret.
    *
+   * @par Idempotency
+   * This operation is not idempotent. Retrying the operation will create a new
+   * key each time.
+   *
    * @par Example
    * @snippet storage_service_account_samples.cc create hmac key
    *
@@ -2502,6 +2702,10 @@ class Client {
    *
    * @return This operation returns the new HMAC key metadata.
    *
+   * @par Idempotency
+   * This operation is always idempotent. An access id identifies a single HMAC
+   * key, calling the operation multiple times can succeed only once.
+   *
    * @par Example
    * @snippet storage_service_account_samples.cc delete hmac key
    *
@@ -2536,6 +2740,9 @@ class Client {
    *     accepts `OverrideDefaultProject`.
    *
    * @return This operation returns the new HMAC key metadata.
+   *
+   * @par Idempotency
+   * This is a read-only operation and therefore it is always idempotent.
    *
    * @par Example
    * @snippet storage_service_account_samples.cc get hmac key
@@ -2575,6 +2782,10 @@ class Client {
    *     accepts `OverrideDefaultProject`.
    *
    * @return This operation returns the new HMAC key metadata.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if the `etag` attribute in @p resource
+   * is set, or if the `IfMatchEtag` option is set.
    *
    * @par Example
    * @snippet storage_service_account_samples.cc update hmac key
@@ -2842,6 +3053,9 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_notification_samples.cc list notifications
    */
@@ -2874,6 +3088,10 @@ class Client {
    *     as the list of event types, or any custom attributes.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_notification_samples.cc create notification
@@ -2915,6 +3133,10 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_notification_samples.cc create notification
    *
@@ -2950,6 +3172,9 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @par Idempotency
+   * This is a read-only operation and is always idempotent.
+   *
    * @par Example
    * @snippet storage_notification_samples.cc get notification
    *
@@ -2982,6 +3207,11 @@ class Client {
    * @param notification_id the id of the notification config.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is always idempotent because it only acts on a specific
+   * `notification_id`, the state after calling this function multiple times is
+   * to delete that notification.  New notifications get different ids.
    *
    * @par Example
    * @snippet storage_notification_samples.cc delete notification
@@ -3438,6 +3668,11 @@ class ScopedDeleter {
  *     `EncryptionKey`, `IfGenerationMatch`, `IfMetagenerationMatch`
  *     `KmsKeyName`, `QuotaUser`, `UserIp`, `UserProject` and
  *     `WithObjectMetadata`.
+ *
+ * @par Idempotency
+ * This operation is not idempotent. While each request performed by this
+ * function is retried based on the client policies, the operation itself stops
+ * on the first request that fails.
  *
  * @par Example
  * @snippet storage_object_samples.cc compose object from many

--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -237,6 +237,290 @@ std::unique_ptr<IdempotencyPolicy> StrictIdempotencyPolicy::clone() const {
   return std::make_unique<StrictIdempotencyPolicy>(*this);
 }
 
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListBucketsRequest const&) const {
+  // Read operations are always idempotent.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateBucketRequest const&) const {
+  // Creating a bucket is idempotent because you cannot create a new version
+  // of a bucket, it succeeds only once.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetBucketMetadataRequest const&) const {
+  // Read operations are always idempotent.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteBucketRequest const& request) const {
+  return (request.HasOption<IfMatchEtag>() ||
+          request.HasOption<IfMetagenerationMatch>());
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateBucketRequest const& request) const {
+  return (request.HasOption<IfMatchEtag>() ||
+          request.HasOption<IfMetagenerationMatch>());
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchBucketRequest const& request) const {
+  return (request.HasOption<IfMatchEtag>() ||
+          request.HasOption<IfMetagenerationMatch>());
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetBucketIamPolicyRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::SetNativeBucketIamPolicyRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::TestBucketIamPermissionsRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::LockBucketRetentionPolicyRequest const&) const {
+  // This request type always requires a metageneration pre-condition.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::InsertObjectMediaRequest const& request) const {
+  return request.HasOption<IfGenerationMatch>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CopyObjectRequest const& request) const {
+  // Only the pre-conditions on the destination matter. If they are not set, it
+  // is possible for the request to succeed more than once, even if the source
+  // pre-conditions are set. If they are set, the operation can only succeed
+  // once, but the results may be different.
+  return request.HasOption<IfGenerationMatch>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetObjectMetadataRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ReadObjectRangeRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListObjectsRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteObjectRequest const& request) const {
+  return request.HasOption<Generation>() ||
+         request.HasOption<IfGenerationMatch>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateObjectRequest const& request) const {
+  return request.HasOption<IfMatchEtag>() ||
+         request.HasOption<IfMetagenerationMatch>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchObjectRequest const& request) const {
+  return request.HasOption<IfMatchEtag>() ||
+         request.HasOption<IfMetagenerationMatch>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ComposeObjectRequest const& request) const {
+  // Only the pre-conditions on the destination matter. If they are not set, it
+  // is possible for the request to succeed more than once, even if the source
+  // pre-conditions are set. If they are set, the operation can only succeed
+  // once, but the results may be different.
+  return request.HasOption<IfGenerationMatch>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::RewriteObjectRequest const& request) const {
+  // Only the pre-conditions on the destination matter. If they are not set, it
+  // is possible for the request to succeed more than once, even if the source
+  // pre-conditions are set. If they are set, the operation can only succeed
+  // once, but the results may be different.
+  return request.HasOption<IfGenerationMatch>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ResumableUploadRequest const& request) const {
+  // Only the pre-conditions on the destination matter. If they are not set, it
+  // is possible for the request to succeed more than once, even if the source
+  // pre-conditions are set. If they are set, the operation can only succeed
+  // once, but the results may be different.
+  return request.HasOption<IfGenerationMatch>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UploadChunkRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListBucketAclRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateBucketAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteBucketAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetBucketAclRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateBucketAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchBucketAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListObjectAclRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetObjectAclRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListDefaultObjectAclRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateDefaultObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteDefaultObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetDefaultObjectAclRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateDefaultObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchDefaultObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetProjectServiceAccountRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListHmacKeysRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateHmacKeyRequest const&) const {
+  return false;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteHmacKeyRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetHmacKeyRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateHmacKeyRequest const& request) const {
+  // The plan of record is to support `If-Match-Etag` headers *and* the `etag`
+  // attribute on the payload as preconditions for `HmacKeys: update`.
+  return !request.resource().etag().empty() || request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::SignBlobRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListNotificationsRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateNotificationRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetNotificationRequest const&) const {
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteNotificationRequest const&) const {
+  return true;
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/idempotency_policy.h
+++ b/google/cloud/storage/idempotency_policy.h
@@ -322,15 +322,132 @@ class AlwaysRetryIdempotencyPolicy : public IdempotencyPolicy {
 
 /**
  * A IdempotencyPolicy that only retries strictly idempotent requests.
- *
- * With the introduction of the idempotency token, all GCS operations are
- * idempotent.
  */
-class StrictIdempotencyPolicy : public AlwaysRetryIdempotencyPolicy {
+class StrictIdempotencyPolicy : public IdempotencyPolicy {
  public:
   StrictIdempotencyPolicy() = default;
 
   std::unique_ptr<IdempotencyPolicy> clone() const override;
+
+  ///@{
+  /// @name Bucket resource operations
+  bool IsIdempotent(internal::ListBucketsRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateBucketRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetBucketMetadataRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteBucketRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateBucketRequest const& request) const override;
+  bool IsIdempotent(internal::PatchBucketRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetBucketIamPolicyRequest const& request) const override;
+  bool IsIdempotent(
+      internal::SetNativeBucketIamPolicyRequest const& request) const override;
+  bool IsIdempotent(
+      internal::TestBucketIamPermissionsRequest const& request) const override;
+  bool IsIdempotent(
+      internal::LockBucketRetentionPolicyRequest const& request) const override;
+  ///@}
+
+  ///@{
+  /// @name Object resource operations
+  bool IsIdempotent(
+      internal::InsertObjectMediaRequest const& request) const override;
+  bool IsIdempotent(internal::CopyObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetObjectMetadataRequest const& request) const override;
+  bool IsIdempotent(
+      internal::ReadObjectRangeRequest const& request) const override;
+  bool IsIdempotent(internal::ListObjectsRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateObjectRequest const& request) const override;
+  bool IsIdempotent(internal::PatchObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::ComposeObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::RewriteObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::ResumableUploadRequest const& request) const override;
+  bool IsIdempotent(internal::UploadChunkRequest const& request) const override;
+  ///@}
+
+  ///@{
+  /// @name BucketAccessControls resource operations
+  bool IsIdempotent(
+      internal::ListBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::PatchBucketAclRequest const& request) const override;
+  ///@}
+
+  ///@{
+  /// @name ObjectAccessControls operations
+  bool IsIdempotent(
+      internal::ListObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::PatchObjectAclRequest const& request) const override;
+  ///@}
+
+  ///@{
+  /// @name DefaultObjectAccessControls operations.
+  bool IsIdempotent(
+      internal::ListDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::PatchDefaultObjectAclRequest const& request) const override;
+  ///@}
+
+  ///@{
+  bool IsIdempotent(
+      internal::GetProjectServiceAccountRequest const& request) const override;
+  bool IsIdempotent(
+      internal::ListHmacKeysRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateHmacKeyRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteHmacKeyRequest const& request) const override;
+  bool IsIdempotent(internal::GetHmacKeyRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateHmacKeyRequest const& request) const override;
+  bool IsIdempotent(internal::SignBlobRequest const& request) const override;
+  ///@}
+
+  ///@{
+  bool IsIdempotent(
+      internal::ListNotificationsRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateNotificationRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetNotificationRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteNotificationRequest const& request) const override;
+  ///@}
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -44,7 +44,7 @@ TEST(StrictIdempotencyPolicyTest, GetBucketMetadata) {
 TEST(StrictIdempotencyPolicyTest, DeleteBucket) {
   StrictIdempotencyPolicy policy;
   internal::DeleteBucketRequest request("test-bucket-name");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, DeleteBucketIfEtag) {
@@ -65,7 +65,7 @@ TEST(StrictIdempotencyPolicyTest, UpdateBucket) {
   StrictIdempotencyPolicy policy;
   internal::UpdateBucketRequest request(
       BucketMetadata().set_name("test-bucket-name"));
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, UpdateBucketIfEtag) {
@@ -88,7 +88,7 @@ TEST(StrictIdempotencyPolicyTest, PatchBucket) {
   StrictIdempotencyPolicy policy;
   internal::PatchBucketRequest request("test-bucket-name",
                                        BucketMetadataPatchBuilder());
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, PatchBucketIfEtag) {
@@ -117,7 +117,7 @@ TEST(StrictIdempotencyPolicyTest, SetNativeBucketIamPolicy) {
   StrictIdempotencyPolicy policy;
   internal::SetNativeBucketIamPolicyRequest request(
       "test-bucket-name", NativeIamPolicy(std::vector<NativeIamBinding>()));
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, SetNativeBucketIamPolicyIfEtag) {
@@ -138,7 +138,7 @@ TEST(StrictIdempotencyPolicyTest, InsertObjectMedia) {
   StrictIdempotencyPolicy policy;
   internal::InsertObjectMediaRequest request("test-bucket-name",
                                              "test-object-name", "test-data");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, InsertObjectMediaIfGenerationMatch) {
@@ -154,7 +154,7 @@ TEST(StrictIdempotencyPolicyTest, CopyObject) {
   internal::CopyObjectRequest request("test-source-bucket",
                                       "test-source-object", "test-bucket-name",
                                       "test-object-name");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, CopyObjectIfGenerationMatch) {
@@ -189,7 +189,7 @@ TEST(StrictIdempotencyPolicyTest, ListObjects) {
 TEST(StrictIdempotencyPolicyTest, DeleteObject) {
   StrictIdempotencyPolicy policy;
   internal::DeleteObjectRequest request("test-bucket-name", "test-object-name");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, DeleteObjectIfGenerationMatch) {
@@ -210,7 +210,7 @@ TEST(StrictIdempotencyPolicyTest, UpdateObject) {
   StrictIdempotencyPolicy policy;
   internal::UpdateObjectRequest request("test-bucket-name", "test-object-name",
                                         ObjectMetadata());
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, UpdateObjectIfEtag) {
@@ -233,7 +233,7 @@ TEST(StrictIdempotencyPolicyTest, PatchObject) {
   StrictIdempotencyPolicy policy;
   internal::PatchObjectRequest request("test-bucket-name", "test-object-name",
                                        ObjectMetadataPatchBuilder());
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, PatchObjectIfEtag) {
@@ -257,7 +257,7 @@ TEST(StrictIdempotencyPolicyTest, ComposeObject) {
   internal::ComposeObjectRequest request(
       "test-bucket-name", {ComposeSourceObject{"source-1", {}, {}}},
       "test-object-name");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, ComposeObjectIfGenerationMatch) {
@@ -274,7 +274,7 @@ TEST(StrictIdempotencyPolicyTest, RewriteObject) {
   internal::RewriteObjectRequest request(
       "test-source-bucket", "test-source-object", "test-bucket-name",
       "test-object-name", std::string{});
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, RewriteObjectIfGenerationMatch) {
@@ -296,7 +296,7 @@ TEST(StrictIdempotencyPolicyTest, CreateBucketAcl) {
   StrictIdempotencyPolicy policy;
   internal::CreateBucketAclRequest request("test-bucket-name",
                                            "test-entity-name", "READER");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, CreateBucketAclIfMatchEtag) {
@@ -311,7 +311,7 @@ TEST(StrictIdempotencyPolicyTest, DeleteBucketAcl) {
   StrictIdempotencyPolicy policy;
   internal::DeleteBucketAclRequest request("test-bucket-name",
                                            "test-entity-name");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, DeleteBucketAclIfMatchEtag) {
@@ -332,7 +332,7 @@ TEST(StrictIdempotencyPolicyTest, UpdateBucketAcl) {
   StrictIdempotencyPolicy policy;
   internal::UpdateBucketAclRequest request("test-bucket-name",
                                            "test-entity-name", "READER");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, UpdateBucketAclIfMatchEtag) {
@@ -348,7 +348,7 @@ TEST(StrictIdempotencyPolicyTest, PatchBucketAcl) {
   internal::PatchBucketAclRequest request("test-bucket-name",
                                           "test-entity-name",
                                           BucketAccessControlPatchBuilder());
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, PatchBucketAclIfMatchEtag) {
@@ -371,7 +371,7 @@ TEST(StrictIdempotencyPolicyTest, CreateObjectAcl) {
   StrictIdempotencyPolicy policy;
   internal::CreateObjectAclRequest request(
       "test-bucket-name", "test-object-name", "test-entity-name", "READER");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, CreateObjectAclIfMatchEtag) {
@@ -386,7 +386,7 @@ TEST(StrictIdempotencyPolicyTest, DeleteObjectAcl) {
   StrictIdempotencyPolicy policy;
   internal::DeleteObjectAclRequest request(
       "test-bucket-name", "test-object-name", "test-entity-name");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, DeleteObjectAclIfMatchEtag) {
@@ -408,7 +408,7 @@ TEST(StrictIdempotencyPolicyTest, UpdateObjectAcl) {
   StrictIdempotencyPolicy policy;
   internal::UpdateObjectAclRequest request(
       "test-bucket-name", "test-object-name", "test-entity-name", "READER");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, UpdateObjectAclIfMatchEtag) {
@@ -424,7 +424,7 @@ TEST(StrictIdempotencyPolicyTest, PatchObjectAcl) {
   internal::PatchObjectAclRequest request(
       "test-bucket-name", "test-object-name", "test-entity-name",
       ObjectAccessControlPatchBuilder());
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, PatchObjectAclIfMatchEtag) {
@@ -446,7 +446,7 @@ TEST(StrictIdempotencyPolicyTest, CreateDefaultObjectAcl) {
   StrictIdempotencyPolicy policy;
   internal::CreateDefaultObjectAclRequest request("test-bucket-name",
                                                   "test-entity-name", "READER");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, CreateDefaultObjectAclIfMatchEtag) {
@@ -461,7 +461,7 @@ TEST(StrictIdempotencyPolicyTest, DeleteDefaultObjectAcl) {
   StrictIdempotencyPolicy policy;
   internal::DeleteDefaultObjectAclRequest request("test-bucket-name",
                                                   "test-entity-name");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, DeleteDefaultObjectAclIfMatchEtag) {
@@ -483,7 +483,7 @@ TEST(StrictIdempotencyPolicyTest, UpdateDefaultObjectAcl) {
   StrictIdempotencyPolicy policy;
   internal::UpdateDefaultObjectAclRequest request("test-bucket-name",
                                                   "test-entity-name", "READER");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, UpdateDefaultObjectAclIfMatchEtag) {
@@ -499,7 +499,7 @@ TEST(StrictIdempotencyPolicyTest, PatchDefaultObjectAcl) {
   internal::PatchDefaultObjectAclRequest request(
       "test-bucket-name", "test-entity-name",
       ObjectAccessControlPatchBuilder());
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, PatchDefaultObjectAclIfMatchEtag) {
@@ -527,7 +527,7 @@ TEST(StrictIdempotencyPolicyTest, CreateHmacKey) {
   StrictIdempotencyPolicy policy;
   internal::CreateHmacKeyRequest request("test-project-id",
                                          "test-service-account");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, DeleteHmacKey) {
@@ -547,7 +547,7 @@ TEST(StrictIdempotencyPolicyTest, UpdateHmacKey) {
   internal::UpdateHmacKeyRequest request(
       "test-project-id", "test-access-id",
       HmacKeyMetadata().set_state("INACTIVE"));
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, UpdateHmacKeyWithEtag) {
@@ -604,7 +604,7 @@ TEST(StrictIdempotencyPolicyTest, ResumableUpload) {
   StrictIdempotencyPolicy policy;
   internal::ResumableUploadRequest request("test-bucket-name",
                                            "test-object-name");
-  EXPECT_TRUE(policy.IsIdempotent(request));
+  EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
 TEST(StrictIdempotencyPolicyTest, ResumableUploadIfGenerationMatch) {

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -52,14 +52,6 @@ Options BasicTestPolicies() {
       .set<IdempotencyPolicyOption>(AlwaysRetryIdempotencyPolicy{}.clone());
 }
 
-class CustomIdempotencyPolicy : public AlwaysRetryIdempotencyPolicy {
- public:
-  std::unique_ptr<IdempotencyPolicy> clone() const override {
-    return std::make_unique<CustomIdempotencyPolicy>();
-  }
-  bool IsIdempotent(DeleteObjectRequest const&) const override { return false; }
-};
-
 /// @test Verify that non-idempotent operations return on the first failure.
 TEST(RetryClientTest, NonIdempotentErrorHandling) {
   auto mock = std::make_unique<MockGenericStub>();
@@ -70,8 +62,10 @@ TEST(RetryClientTest, NonIdempotentErrorHandling) {
   auto client = RetryClient::Create(std::move(mock));
   google::cloud::internal::OptionsSpan const span(
       BasicTestPolicies().set<IdempotencyPolicyOption>(
-          CustomIdempotencyPolicy().clone()));
+          StrictIdempotencyPolicy().clone()));
 
+  // Use a delete operation because this is idempotent only if it has
+  // the IfGenerationMatch() and/or Generation() option set.
   StatusOr<EmptyResponse> result =
       client->DeleteObject(DeleteObjectRequest("test-bucket", "test-object"));
   EXPECT_THAT(result, StatusIs(TransientError().code()));


### PR DESCRIPTION
Turns out that more work is needed in the service.


Reverts googleapis/google-cloud-cpp#12347

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12365)
<!-- Reviewable:end -->
