### PR TITLE
feat(common): retry loops preserve original message

### DIFF
--- a/google/cloud/internal/async_rest_retry_loop_test.cc
+++ b/google/cloud/internal/async_rest_retry_loop_test.cc
@@ -261,6 +261,8 @@ TEST(AsyncRestRetryLoopTest, TransientFailureNonIdempotent) {
   EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable,
                                HasSubstr("test-message-try-again")));
   auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.original-message",
+                                      "test-message-try-again")));
   EXPECT_THAT(metadata,
               Contains(Pair("gcloud-cpp.retry.reason", "non-idempotent")));
   EXPECT_THAT(metadata,
@@ -289,6 +291,8 @@ TEST(AsyncRestRetryLoopTest, PermanentFailureIdempotent) {
   EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("test-message-uh-oh")));
   auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.original-message",
+                                      "test-message-uh-oh")));
   EXPECT_THAT(metadata,
               Contains(Pair("gcloud-cpp.retry.reason", "permanent-error")));
   EXPECT_THAT(metadata,
@@ -317,6 +321,8 @@ TEST(AsyncRestRetryLoopTest, TooManyTransientFailuresIdempotent) {
   EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable,
                                HasSubstr("test-message-try-again")));
   auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.original-message",
+                                      "test-message-try-again")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.reason",
                                       "retry-policy-exhausted")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.on-entry", "false")));

--- a/google/cloud/internal/async_retry_loop_test.cc
+++ b/google/cloud/internal/async_retry_loop_test.cc
@@ -254,6 +254,8 @@ TEST(AsyncRetryLoopTest, TransientFailureNonIdempotent) {
   EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable,
                                HasSubstr("test-message-try-again")));
   auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.original-message",
+                                      "test-message-try-again")));
   EXPECT_THAT(metadata,
               Contains(Pair("gcloud-cpp.retry.reason", "non-idempotent")));
   EXPECT_THAT(metadata,
@@ -280,6 +282,8 @@ TEST(AsyncRetryLoopTest, PermanentFailureIdempotent) {
   EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("test-message-uh-oh")));
   auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.original-message",
+                                      "test-message-uh-oh")));
   EXPECT_THAT(metadata,
               Contains(Pair("gcloud-cpp.retry.reason", "permanent-error")));
   EXPECT_THAT(metadata,
@@ -308,6 +312,8 @@ TEST(AsyncRetryLoopTest, TooManyTransientFailuresIdempotent) {
   EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable,
                                HasSubstr("test-message-try-again")));
   auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.original-message",
+                                      "test-message-try-again")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.reason",
                                       "retry-policy-exhausted")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.on-entry", "false")));

--- a/google/cloud/internal/rest_retry_loop_test.cc
+++ b/google/cloud/internal/rest_retry_loop_test.cc
@@ -181,6 +181,8 @@ TEST(RestRetryLoopTest, TransientFailureNonIdempotent) {
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
   auto const& metadata = actual.status().error_info().metadata();
   EXPECT_THAT(metadata,
+              Contains(Pair("gcloud-cpp.retry.original-message", "try again")));
+  EXPECT_THAT(metadata,
               Contains(Pair("gcloud-cpp.retry.reason", "non-idempotent")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", __func__)));
 }
@@ -200,6 +202,8 @@ TEST(RestRetryLoopTest, PermanentFailureFailureIdempotent) {
   EXPECT_THAT(actual.status().message(), HasSubstr("uh oh"));
   auto const& metadata = actual.status().error_info().metadata();
   EXPECT_THAT(metadata,
+              Contains(Pair("gcloud-cpp.retry.original-message", "uh oh")));
+  EXPECT_THAT(metadata,
               Contains(Pair("gcloud-cpp.retry.reason", "permanent-error")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", __func__)));
 }
@@ -218,6 +222,8 @@ TEST(RestRetryLoopTest, TooManyTransientFailuresIdempotent) {
   EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
   auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata,
+              Contains(Pair("gcloud-cpp.retry.original-message", "try again")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.reason",
                                       "retry-policy-exhausted")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.on-entry", "false")));

--- a/google/cloud/internal/retry_loop_helpers_test.cc
+++ b/google/cloud/internal/retry_loop_helpers_test.cc
@@ -47,6 +47,8 @@ TEST(RetryLoopHelpers, RetryLoopNonIdempotentError) {
   EXPECT_THAT(actual.error_info().domain(), ei.domain());
   EXPECT_THAT(actual.error_info().metadata(), IsSupersetOf(ei.metadata()));
   EXPECT_THAT(actual.error_info().metadata(),
+              Contains(Pair("gcloud-cpp.retry.original-message", message)));
+  EXPECT_THAT(actual.error_info().metadata(),
               Contains(Pair("gcloud-cpp.retry.function", "SomeFunction")));
   EXPECT_THAT(actual.error_info().metadata(),
               Contains(Pair("gcloud-cpp.retry.reason", "non-idempotent")));
@@ -63,6 +65,8 @@ TEST(RetryLoopHelpers, RetryLoopPolicyErrorExhausted) {
   EXPECT_THAT(actual.error_info().reason(), ei.reason());
   EXPECT_THAT(actual.error_info().domain(), ei.domain());
   EXPECT_THAT(actual.error_info().metadata(), IsSupersetOf(ei.metadata()));
+  EXPECT_THAT(actual.error_info().metadata(),
+              Contains(Pair("gcloud-cpp.retry.original-message", message)));
   EXPECT_THAT(actual.error_info().metadata(),
               Contains(Pair("gcloud-cpp.retry.function", "SomeFunction")));
   EXPECT_THAT(
@@ -98,6 +102,8 @@ TEST(RetryLoopHelpers, RetryLoopPolicyErrorNotExhausted) {
   EXPECT_THAT(actual.error_info().domain(), ei.domain());
   EXPECT_THAT(actual.error_info().metadata(), IsSupersetOf(ei.metadata()));
   EXPECT_THAT(actual.error_info().metadata(),
+              Contains(Pair("gcloud-cpp.retry.original-message", message)));
+  EXPECT_THAT(actual.error_info().metadata(),
               Contains(Pair("gcloud-cpp.retry.function", "SomeFunction")));
   EXPECT_THAT(actual.error_info().metadata(),
               Contains(Pair("gcloud-cpp.retry.reason", "permanent-error")));
@@ -122,6 +128,8 @@ TEST(RetryLoopHelpers, RetryLoopErrorCancelled) {
   EXPECT_THAT(actual.error_info().reason(), ei.reason());
   EXPECT_THAT(actual.error_info().domain(), ei.domain());
   EXPECT_THAT(actual.error_info().metadata(), IsSupersetOf(ei.metadata()));
+  EXPECT_THAT(actual.error_info().metadata(),
+              Contains(Pair("gcloud-cpp.retry.original-message", message)));
   EXPECT_THAT(actual.error_info().metadata(),
               Contains(Pair("gcloud-cpp.retry.function", "SomeFunction")));
   EXPECT_THAT(actual.error_info().metadata(),

--- a/google/cloud/internal/retry_loop_test.cc
+++ b/google/cloud/internal/retry_loop_test.cc
@@ -159,6 +159,8 @@ TEST(RetryLoopTest, TransientFailureNonIdempotent) {
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
   auto const& metadata = actual.status().error_info().metadata();
   EXPECT_THAT(metadata,
+              Contains(Pair("gcloud-cpp.retry.original-message", "try again")));
+  EXPECT_THAT(metadata,
               Contains(Pair("gcloud-cpp.retry.reason", "non-idempotent")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", __func__)));
 }
@@ -179,6 +181,8 @@ TEST(RetryLoopTest, PermanentFailureFailureIdempotent) {
   EXPECT_THAT(actual.status().message(), HasSubstr("uh oh"));
   auto const& metadata = actual.status().error_info().metadata();
   EXPECT_THAT(metadata,
+              Contains(Pair("gcloud-cpp.retry.original-message", "uh oh")));
+  EXPECT_THAT(metadata,
               Contains(Pair("gcloud-cpp.retry.reason", "permanent-error")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.function", __func__)));
 }
@@ -198,6 +202,8 @@ TEST(RetryLoopTest, TooManyTransientFailuresIdempotent) {
   EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
   auto const& metadata = actual.status().error_info().metadata();
+  EXPECT_THAT(metadata,
+              Contains(Pair("gcloud-cpp.retry.original-message", "try again")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.reason",
                                       "retry-policy-exhausted")));
   EXPECT_THAT(metadata, Contains(Pair("gcloud-cpp.retry.on-entry", "false")));


### PR DESCRIPTION
Some applications want to have access to the original message, even after a retry failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12368)
<!-- Reviewable:end -->
