### PR TITLE
cleanup(common): `internal::CallContext` supports explicit options

### DIFF
--- a/google/cloud/internal/async_rest_retry_loop.h
+++ b/google/cloud/internal/async_rest_retry_loop.h
@@ -183,7 +183,8 @@ class AsyncRestRetryLoopImpl
         cq_(std::move(cq)),
         functor_(std::forward<Functor>(functor)),
         request_(std::move(request)),
-        location_(location) {}
+        location_(location),
+        call_context_(internal::CurrentOptions()) {}
 
   AsyncRestRetryLoopImpl(AsyncRestRetryLoopImpl const&) = delete;
   AsyncRestRetryLoopImpl(AsyncRestRetryLoopImpl&&) = delete;

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -183,7 +183,8 @@ class AsyncRetryLoopImpl
         cq_(std::move(cq)),
         functor_(std::forward<Functor>(functor)),
         request_(std::move(request)),
-        location_(location) {}
+        location_(location),
+        call_context_(CurrentOptions()) {}
 
   using ReturnType = ::google::cloud::internal::invoke_result_t<
       Functor, google::cloud::CompletionQueue&,


### PR DESCRIPTION
Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12369)
<!-- Reviewable:end -->
