### PR TITLE
cleanup(common): explicit options for `TracedAsyncBackoff`

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -82,7 +82,8 @@ void AsyncBulkApplier::OnFinish(Status const& status) {
   }
 
   auto self = this->shared_from_this();
-  internal::TracedAsyncBackoff(cq_, backoff_policy_->OnCompletion())
+  internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(),
+                               backoff_policy_->OnCompletion())
       .then([self](auto result) {
         if (result.get()) {
           self->StartIteration();

--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -214,7 +214,8 @@ void AsyncRowReader::OnStreamFinished(Status status) {
     return;
   }
   auto self = this->shared_from_this();
-  internal::TracedAsyncBackoff(cq_, backoff_policy_->OnCompletion())
+  internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(),
+                               backoff_policy_->OnCompletion())
       .then(
           [self](
               future<StatusOr<std::chrono::system_clock::time_point>> result) {

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -90,7 +90,8 @@ void AsyncRowSampler::OnFinish(Status status) {
 
   samples_.clear();
   auto self = this->shared_from_this();
-  internal::TracedAsyncBackoff(cq_, backoff_policy_->OnCompletion())
+  internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(),
+                               backoff_policy_->OnCompletion())
       .then([self](TimerFuture result) {
         if (result.get()) {
           self->StartIteration();

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -107,9 +107,8 @@ class AsyncPollingLoopImpl
     GCP_LOG(DEBUG) << location_ << "() polling loop waiting "
                    << duration.count() << "ms";
     auto self = shared_from_this();
-    TracedAsyncBackoff(cq_, duration).then([self](TimerResult f) {
-      self->OnTimer(std::move(f));
-    });
+    TracedAsyncBackoff(cq_, CurrentOptions(), duration)
+        .then([self](TimerResult f) { self->OnTimer(std::move(f)); });
   }
 
   void OnTimer(TimerResult f) {

--- a/google/cloud/internal/async_rest_polling_loop.h
+++ b/google/cloud/internal/async_rest_polling_loop.h
@@ -281,9 +281,8 @@ class AsyncRestPollingLoopImpl
     GCP_LOG(DEBUG) << location_ << "() polling loop waiting "
                    << duration.count() << "ms";
     auto self = this->shared_from_this();
-    internal::TracedAsyncBackoff(cq_, duration).then([self](TimerResult f) {
-      self->OnTimer(std::move(f));
-    });
+    internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(), duration)
+        .then([self](TimerResult f) { self->OnTimer(std::move(f)); });
   }
 
   void OnTimer(TimerResult f) {

--- a/google/cloud/internal/async_rest_retry_loop.h
+++ b/google/cloud/internal/async_rest_retry_loop.h
@@ -247,11 +247,12 @@ class AsyncRestRetryLoopImpl
     auto self = this->shared_from_this();
     auto state = StartOperation();
     if (state.cancelled) return;
-    SetPending(state.operation, internal::TracedAsyncBackoff(
-                                    cq_, backoff_policy_->OnCompletion())
-                                    .then([self](future<TimerArgType> f) {
-                                      self->OnBackoff(f.get());
-                                    }));
+    SetPending(state.operation,
+               internal::TracedAsyncBackoff(cq_, call_context_.options,
+                                            backoff_policy_->OnCompletion())
+                   .then([self](future<TimerArgType> f) {
+                     self->OnBackoff(f.get());
+                   }));
   }
 
   void OnAttempt(T result) {

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -246,7 +246,8 @@ class AsyncRetryLoopImpl
     auto state = StartOperation();
     if (state.cancelled) return;
     SetPending(state.operation,
-               TracedAsyncBackoff(cq_, backoff_policy_->OnCompletion())
+               TracedAsyncBackoff(cq_, call_context_.options,
+                                  backoff_policy_->OnCompletion())
                    .then([self](future<TimerArgType> f) {
                      self->OnBackoff(f.get());
                    }));

--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -101,13 +101,15 @@ future<T> EndSpan(
  */
 template <typename Rep, typename Period>
 future<StatusOr<std::chrono::system_clock::time_point>> TracedAsyncBackoff(
-    CompletionQueue& cq, std::chrono::duration<Rep, Period> duration) {
+    CompletionQueue& cq, Options const& options,
+    std::chrono::duration<Rep, Period> duration) {
   auto timer = cq.MakeRelativeTimer(duration);
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-  if (TracingEnabled(CurrentOptions())) {
+  if (TracingEnabled(options)) {
     timer = EndSpan(MakeSpan("Async Backoff"), std::move(timer));
   }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+  (void)options;
   return timer;
 }
 

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -153,8 +153,7 @@ TEST(OpenTelemetry, TracedAsyncBackoffEnabled) {
           make_status_or(std::chrono::system_clock::now())))));
   CompletionQueue cq(mock_cq);
 
-  OptionsSpan span(EnableTracing(Options{}));
-  auto f = TracedAsyncBackoff(cq, duration);
+  auto f = TracedAsyncBackoff(cq, EnableTracing(Options{}), duration);
   EXPECT_STATUS_OK(f.get());
 
   // Verify that a span was made.
@@ -176,8 +175,7 @@ TEST(OpenTelemetry, TracedAsyncBackoffDisabled) {
               CancelledError("cancelled")))));
   CompletionQueue cq(mock_cq);
 
-  OptionsSpan span(DisableTracing(Options{}));
-  auto f = TracedAsyncBackoff(cq, duration);
+  auto f = TracedAsyncBackoff(cq, DisableTracing(Options{}), duration);
   EXPECT_THAT(f.get(), StatusIs(StatusCode::kCancelled, "cancelled"));
 
   // Verify that no spans were made.
@@ -195,7 +193,7 @@ TEST(NoOpenTelemetry, TracedAsyncBackoff) {
           make_status_or(std::chrono::system_clock::now())))));
   CompletionQueue cq(mock_cq);
 
-  auto f = TracedAsyncBackoff(cq, duration);
+  auto f = TracedAsyncBackoff(cq, Options{}, duration);
   EXPECT_STATUS_OK(f.get());
 }
 


### PR DESCRIPTION
Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12372)
<!-- Reviewable:end -->
