### PR TITLE
Reduce TimerCancel gRPC test load to 1000 iterations

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -87,7 +87,7 @@ TEST(CompletionQueueTest, TimerCancel) {
 
   using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
   auto worker = [&](CompletionQueue cq) {
-    for (int i = 0; i != 10000; ++i) {
+    for (int i = 0; i != 1000; ++i) {
       std::vector<TimerFuture> timers;
       for (int j = 0; j != 10; ++j) {
         timers.push_back(cq.MakeRelativeTimer(std::chrono::microseconds(10)));


### PR DESCRIPTION
This is a gRPC test that relied on the high performance of an uncommon (synthetic) gRPC Alarm usage pattern. Per the test comments, this change will reduce the likelihood of seeing a regression in gRPC from 99% of runs, to 10% of runs. I think this should still be sufficient to identify problems. Running this test with the next generation of gRPC Alarm implementations, in 100 runs, this `TimerCancel` test never exceeded 10 seconds in the `asan-pr` docker environment (most commonly: 5 to 7s).