### PR TITLE
ci: build compute with clang-tidy separately instead of all

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy-compute.sh
+++ b/ci/cloudbuild/builds/clang-tidy-compute.sh
@@ -27,8 +27,7 @@ export CXX=clang++
 export CTCACHE_DIR=~/.cache/ctcache
 
 mapfile -t cmake_args < <(cmake::common_args)
-ENABLED_FEATURES="compute"
-readonly ENABLED_FEATURES
+readonly ENABLED_FEATURES="compute"
 
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache
 # Note: we use C++14 for this build because we don't want tidy suggestions that

--- a/ci/cloudbuild/builds/clang-tidy-compute.sh
+++ b/ci/cloudbuild/builds/clang-tidy-compute.sh
@@ -27,7 +27,7 @@ export CXX=clang++
 export CTCACHE_DIR=~/.cache/ctcache
 
 mapfile -t cmake_args < <(cmake::common_args)
-read -r ENABLED_FEATURES < <(features::list_full_cmake)
+ENABLED_FEATURES="compute"
 readonly ENABLED_FEATURES
 
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache


### PR DESCRIPTION
Building everything with clang-tidy wasn't completing even with a 10 hour timeout. Lower our expectations and build compute with clang-tidy which after splitting the protos has a "more reasonable" duration. 

The intent is to run this as a daily ci build as it still takes over an hour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12382)
<!-- Reviewable:end -->
