### PR TITLE
cleanup(common): rm another unused `LogWrapper`

### DIFF
--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -91,20 +91,6 @@ Result LogWrapper(Functor&& functor, Context& context, Request const& request,
 
 template <typename Functor, typename Request,
           typename Result = google::cloud::internal::invoke_result_t<
-              Functor, grpc::ClientContext&, Request const&>,
-          typename std::enable_if<IsUniquePtr<Result>::value, int>::type = 0>
-Result LogWrapper(Functor&& functor, grpc::ClientContext& context,
-                  Request const& request, char const* where,
-                  TracingOptions const& options) {
-  GCP_LOG(DEBUG) << where << "() << " << DebugString(request, options);
-  auto response = functor(context, request);
-  GCP_LOG(DEBUG) << where << "() >> " << (response ? "not null" : "null")
-                 << " stream";
-  return response;
-}
-
-template <typename Functor, typename Request,
-          typename Result = google::cloud::internal::invoke_result_t<
               Functor, std::shared_ptr<grpc::ClientContext>, Request const&>,
           typename std::enable_if<IsUniquePtr<Result>::value, int>::type = 0>
 Result LogWrapper(Functor&& functor,


### PR DESCRIPTION
I am sorry I missed this overload, I should have removed it in a previous pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12386)
<!-- Reviewable:end -->
