### PR TITLE
cleanup(storage): rename `RetryClientTestOptions()`

### DIFF
--- a/google/cloud/storage/internal/connection_impl_bucket_acl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_bucket_acl_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -42,7 +42,7 @@ TEST(StorageConnectionImpl, ListBucketAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListBucketAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListBucketAcl(ListBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListBucketAcl"));
@@ -56,7 +56,7 @@ TEST(StorageConnectionImpl, ListBucketAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListBucketAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListBucketAcl(ListBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListBucketAcl"));
@@ -70,7 +70,7 @@ TEST(StorageConnectionImpl, CreateBucketAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateBucketAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateBucketAcl(CreateBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateBucketAcl"));
@@ -84,7 +84,7 @@ TEST(StorageConnectionImpl, CreateBucketAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateBucketAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateBucketAcl(CreateBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateBucketAcl"));
@@ -98,7 +98,7 @@ TEST(StorageConnectionImpl, DeleteBucketAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteBucketAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteBucketAcl(DeleteBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteBucketAcl"));
@@ -112,7 +112,7 @@ TEST(StorageConnectionImpl, DeleteBucketAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteBucketAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteBucketAcl(DeleteBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteBucketAcl"));
@@ -126,7 +126,7 @@ TEST(StorageConnectionImpl, GetBucketAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetBucketAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetBucketAcl(GetBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetBucketAcl"));
@@ -140,7 +140,7 @@ TEST(StorageConnectionImpl, GetBucketAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetBucketAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetBucketAcl(GetBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetBucketAcl"));
@@ -154,7 +154,7 @@ TEST(StorageConnectionImpl, UpdateBucketAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateBucketAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateBucketAcl(UpdateBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateBucketAcl"));
@@ -168,7 +168,7 @@ TEST(StorageConnectionImpl, UpdateBucketAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateBucketAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateBucketAcl(UpdateBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateBucketAcl"));
@@ -182,7 +182,7 @@ TEST(StorageConnectionImpl, PatchBucketAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchBucketAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchBucketAcl(PatchBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchBucketAcl"));
@@ -196,7 +196,7 @@ TEST(StorageConnectionImpl, PatchBucketAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchBucketAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchBucketAcl(PatchBucketAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchBucketAcl"));

--- a/google/cloud/storage/internal/connection_impl_bucket_test.cc
+++ b/google/cloud/storage/internal/connection_impl_bucket_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -42,7 +42,7 @@ TEST(StorageConnectionImpl, ListBucketsTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListBuckets).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListBuckets(ListBucketsRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListBuckets"));
@@ -56,7 +56,7 @@ TEST(StorageConnectionImpl, ListBucketPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListBuckets).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListBuckets(ListBucketsRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListBuckets"));
@@ -70,7 +70,7 @@ TEST(StorageConnectionImpl, CreateBucketTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateBucket).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateBucket(CreateBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateBucket"));
@@ -84,7 +84,7 @@ TEST(StorageConnectionImpl, CreateBucketPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateBucket).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateBucket(CreateBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateBucket"));
@@ -98,7 +98,7 @@ TEST(StorageConnectionImpl, DeleteBucketTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteBucket).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteBucket(DeleteBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteBucket"));
@@ -112,7 +112,7 @@ TEST(StorageConnectionImpl, DeleteBucketPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteBucket).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteBucket(DeleteBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteBucket"));
@@ -126,7 +126,7 @@ TEST(StorageConnectionImpl, GetBucketTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetBucketMetadata).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetBucketMetadata(GetBucketMetadataRequest()).status();
@@ -141,7 +141,7 @@ TEST(StorageConnectionImpl, GetBucketPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetBucketMetadata).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetBucketMetadata(GetBucketMetadataRequest()).status();
@@ -156,7 +156,7 @@ TEST(StorageConnectionImpl, UpdateBucketTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateBucket).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateBucket(UpdateBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateBucket"));
@@ -170,7 +170,7 @@ TEST(StorageConnectionImpl, UpdateBucketPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateBucket).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateBucket(UpdateBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateBucket"));
@@ -184,7 +184,7 @@ TEST(StorageConnectionImpl, PatchBucketTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchBucket).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchBucket(PatchBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchBucket"));
@@ -198,7 +198,7 @@ TEST(StorageConnectionImpl, PatchBucketPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchBucket).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchBucket(PatchBucketRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchBucket"));
@@ -214,7 +214,7 @@ TEST(StorageConnectionImpl, GetNativeBucketIamPolicyTooManyFailures) {
       .Times(3)
       .WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetNativeBucketIamPolicy(GetBucketIamPolicyRequest()).status();
@@ -229,7 +229,7 @@ TEST(StorageConnectionImpl, GetNativeBucketIamPolicyPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetNativeBucketIamPolicy).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetNativeBucketIamPolicy(GetBucketIamPolicyRequest()).status();
@@ -246,7 +246,7 @@ TEST(StorageConnectionImpl, SetNativeBucketIamPolicyTooManyFailures) {
       .Times(3)
       .WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->SetNativeBucketIamPolicy(SetNativeBucketIamPolicyRequest())
@@ -262,7 +262,7 @@ TEST(StorageConnectionImpl, SetNativeBucketIamPolicyPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, SetNativeBucketIamPolicy).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->SetNativeBucketIamPolicy(SetNativeBucketIamPolicyRequest())
@@ -280,7 +280,7 @@ TEST(StorageConnectionImpl, TestBucketIamPermissionsTooManyFailures) {
       .Times(3)
       .WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->TestBucketIamPermissions(TestBucketIamPermissionsRequest())
@@ -296,7 +296,7 @@ TEST(StorageConnectionImpl, TestBucketIamPermissionsPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, TestBucketIamPermissions).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->TestBucketIamPermissions(TestBucketIamPermissionsRequest())
@@ -314,7 +314,7 @@ TEST(StorageConnectionImpl, LockBucketRetentionPolicyTooManyFailures) {
       .Times(3)
       .WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->LockBucketRetentionPolicy(LockBucketRetentionPolicyRequest())
@@ -331,7 +331,7 @@ TEST(StorageConnectionImpl, LockBucketRetentionPolicyPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, LockBucketRetentionPolicy).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->LockBucketRetentionPolicy(LockBucketRetentionPolicyRequest())

--- a/google/cloud/storage/internal/connection_impl_default_object_acl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_default_object_acl_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -42,7 +42,7 @@ TEST(StorageConnectionImpl, ListDefaultObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->ListDefaultObjectAcl(ListDefaultObjectAclRequest()).status();
@@ -57,7 +57,7 @@ TEST(StorageConnectionImpl, ListDefaultObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListDefaultObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->ListDefaultObjectAcl(ListDefaultObjectAclRequest()).status();
@@ -72,7 +72,7 @@ TEST(StorageConnectionImpl, CreateDefaultObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateDefaultObjectAcl(CreateDefaultObjectAclRequest()).status();
@@ -87,7 +87,7 @@ TEST(StorageConnectionImpl, CreateDefaultObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateDefaultObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateDefaultObjectAcl(CreateDefaultObjectAclRequest()).status();
@@ -102,7 +102,7 @@ TEST(StorageConnectionImpl, DeleteDefaultObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteDefaultObjectAcl(DeleteDefaultObjectAclRequest()).status();
@@ -117,7 +117,7 @@ TEST(StorageConnectionImpl, DeleteDefaultObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteDefaultObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteDefaultObjectAcl(DeleteDefaultObjectAclRequest()).status();
@@ -132,7 +132,7 @@ TEST(StorageConnectionImpl, GetDefaultObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetDefaultObjectAcl(GetDefaultObjectAclRequest()).status();
@@ -147,7 +147,7 @@ TEST(StorageConnectionImpl, GetDefaultObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetDefaultObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetDefaultObjectAcl(GetDefaultObjectAclRequest()).status();
@@ -162,7 +162,7 @@ TEST(StorageConnectionImpl, UpdateDefaultObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->UpdateDefaultObjectAcl(UpdateDefaultObjectAclRequest()).status();
@@ -177,7 +177,7 @@ TEST(StorageConnectionImpl, UpdateDefaultObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateDefaultObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->UpdateDefaultObjectAcl(UpdateDefaultObjectAclRequest()).status();
@@ -192,7 +192,7 @@ TEST(StorageConnectionImpl, PatchDefaultObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchDefaultObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->PatchDefaultObjectAcl(PatchDefaultObjectAclRequest()).status();
@@ -207,7 +207,7 @@ TEST(StorageConnectionImpl, PatchDefaultObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchDefaultObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->PatchDefaultObjectAcl(PatchDefaultObjectAclRequest()).status();

--- a/google/cloud/storage/internal/connection_impl_notifications_test.cc
+++ b/google/cloud/storage/internal/connection_impl_notifications_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -42,7 +42,7 @@ TEST(StorageConnectionImpl, ListNotificationTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListNotifications).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->ListNotifications(ListNotificationsRequest()).status();
@@ -57,7 +57,7 @@ TEST(StorageConnectionImpl, ListNotificationPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListNotifications).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->ListNotifications(ListNotificationsRequest()).status();
@@ -72,7 +72,7 @@ TEST(StorageConnectionImpl, CreateNotificationTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateNotification).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateNotification(CreateNotificationRequest()).status();
@@ -87,7 +87,7 @@ TEST(StorageConnectionImpl, CreateNotificationPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateNotification).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateNotification(CreateNotificationRequest()).status();
@@ -102,7 +102,7 @@ TEST(StorageConnectionImpl, DeleteNotificationTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteNotification).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteNotification(DeleteNotificationRequest()).status();
@@ -117,7 +117,7 @@ TEST(StorageConnectionImpl, DeleteNotificationPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteNotification).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteNotification(DeleteNotificationRequest()).status();
@@ -132,7 +132,7 @@ TEST(StorageConnectionImpl, GetNotificationTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetNotification).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetNotification(GetNotificationRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetNotification"));
@@ -146,7 +146,7 @@ TEST(StorageConnectionImpl, GetNotificationPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetNotification).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetNotification(GetNotificationRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetNotification"));

--- a/google/cloud/storage/internal/connection_impl_object_acl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_object_acl_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -42,7 +42,7 @@ TEST(StorageConnectionImpl, ListObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListObjectAcl(ListObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListObjectAcl"));
@@ -56,7 +56,7 @@ TEST(StorageConnectionImpl, ListObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListObjectAcl(ListObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListObjectAcl"));
@@ -70,7 +70,7 @@ TEST(StorageConnectionImpl, CreateObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateObjectAcl(CreateObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateObjectAcl"));
@@ -84,7 +84,7 @@ TEST(StorageConnectionImpl, CreateObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateObjectAcl(CreateObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateObjectAcl"));
@@ -98,7 +98,7 @@ TEST(StorageConnectionImpl, DeleteObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteObjectAcl(DeleteObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteObjectAcl"));
@@ -112,7 +112,7 @@ TEST(StorageConnectionImpl, DeleteObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteObjectAcl(DeleteObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteObjectAcl"));
@@ -126,7 +126,7 @@ TEST(StorageConnectionImpl, GetObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetObjectAcl(GetObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetObjectAcl"));
@@ -140,7 +140,7 @@ TEST(StorageConnectionImpl, GetObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetObjectAcl(GetObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetObjectAcl"));
@@ -154,7 +154,7 @@ TEST(StorageConnectionImpl, UpdateObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateObjectAcl(UpdateObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateObjectAcl"));
@@ -168,7 +168,7 @@ TEST(StorageConnectionImpl, UpdateObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateObjectAcl(UpdateObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateObjectAcl"));
@@ -182,7 +182,7 @@ TEST(StorageConnectionImpl, PatchObjectAclTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchObjectAcl).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchObjectAcl(PatchObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchObjectAcl"));
@@ -196,7 +196,7 @@ TEST(StorageConnectionImpl, PatchObjectAclPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchObjectAcl).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchObjectAcl(PatchObjectAclRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchObjectAcl"));

--- a/google/cloud/storage/internal/connection_impl_object_copy_test.cc
+++ b/google/cloud/storage/internal/connection_impl_object_copy_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -42,7 +42,7 @@ TEST(StorageConnectionImpl, CopyObjectTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CopyObject).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CopyObject(CopyObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CopyObject"));
@@ -56,7 +56,7 @@ TEST(StorageConnectionImpl, CopyObjectPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CopyObject).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CopyObject(CopyObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CopyObject"));
@@ -70,7 +70,7 @@ TEST(StorageConnectionImpl, ComposeObjectTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ComposeObject).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ComposeObject(ComposeObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ComposeObject"));
@@ -84,7 +84,7 @@ TEST(StorageConnectionImpl, ComposeObjectPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ComposeObject).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ComposeObject(ComposeObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ComposeObject"));
@@ -98,7 +98,7 @@ TEST(StorageConnectionImpl, RewriteObjectTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, RewriteObject).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->RewriteObject(RewriteObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("RewriteObject"));
@@ -112,7 +112,7 @@ TEST(StorageConnectionImpl, RewriteObjectPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, RewriteObject).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->RewriteObject(RewriteObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("RewriteObject"));

--- a/google/cloud/storage/internal/connection_impl_object_test.cc
+++ b/google/cloud/storage/internal/connection_impl_object_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -43,7 +43,7 @@ TEST(StorageConnectionImpl, InsertObjectMediaTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, InsertObjectMedia).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->InsertObjectMedia(InsertObjectMediaRequest()).status();
@@ -58,7 +58,7 @@ TEST(StorageConnectionImpl, InsertObjectMediaPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, InsertObjectMedia).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->InsertObjectMedia(InsertObjectMediaRequest()).status();
@@ -73,7 +73,7 @@ TEST(StorageConnectionImpl, GetObjectMetadataTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetObjectMetadata).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetObjectMetadata(GetObjectMetadataRequest()).status();
@@ -88,7 +88,7 @@ TEST(StorageConnectionImpl, GetObjectMetadataPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetObjectMetadata).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetObjectMetadata(GetObjectMetadataRequest()).status();
@@ -103,7 +103,7 @@ TEST(StorageConnectionImpl, ListObjectsTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListObjects).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListObjects(ListObjectsRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListObjects"));
@@ -117,7 +117,7 @@ TEST(StorageConnectionImpl, ListObjectsPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListObjects).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListObjects(ListObjectsRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListObjects"));
@@ -131,7 +131,7 @@ TEST(StorageConnectionImpl, ReadObjectTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ReadObject).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ReadObject(ReadObjectRangeRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ReadObjectNotWrapped"));
@@ -145,7 +145,7 @@ TEST(StorageConnectionImpl, ReadObjectPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ReadObject).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ReadObject(ReadObjectRangeRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ReadObjectNotWrapped"));
@@ -159,7 +159,7 @@ TEST(StorageConnectionImpl, CreateResumableUploadTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateResumableUpload).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateResumableUpload(ResumableUploadRequest()).status();
@@ -174,7 +174,7 @@ TEST(StorageConnectionImpl, CreateResumableUploadPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateResumableUpload).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->CreateResumableUpload(ResumableUploadRequest()).status();
@@ -189,7 +189,7 @@ TEST(StorageConnectionImpl, QueryResumableUploadTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, QueryResumableUpload).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->QueryResumableUpload(QueryResumableUploadRequest()).status();
@@ -204,7 +204,7 @@ TEST(StorageConnectionImpl, QueryResumableUploadPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, QueryResumableUpload).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->QueryResumableUpload(QueryResumableUploadRequest()).status();
@@ -219,7 +219,7 @@ TEST(StorageConnectionImpl, DeleteResumableUploadTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteResumableUpload).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteResumableUpload(DeleteResumableUploadRequest()).status();
@@ -234,7 +234,7 @@ TEST(StorageConnectionImpl, DeleteResumableUploadPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteResumableUpload).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->DeleteResumableUpload(DeleteResumableUploadRequest()).status();
@@ -252,7 +252,7 @@ TEST(StorageConnectionImpl, UploadChunkTooManyFailures) {
     return QueryResumableUploadResponse{absl::nullopt, absl::nullopt};
   });
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto request = UploadChunkRequest(/*upload_session_url=*/"unused",
                                     /*offset=*/0, /*payload=*/{{"test-data"}},
@@ -271,7 +271,7 @@ TEST(StorageConnectionImpl, UploadChunkPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UploadChunk).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto request = UploadChunkRequest(/*upload_session_url=*/"unused",
                                     /*offset=*/0, /*payload=*/{{"test-data"}},
@@ -290,7 +290,7 @@ TEST(StorageConnectionImpl, DeleteObjectTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteObject).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteObject(DeleteObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteObject"));
@@ -304,7 +304,7 @@ TEST(StorageConnectionImpl, DeleteObjectPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteObject).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteObject(DeleteObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteObject"));
@@ -318,7 +318,7 @@ TEST(StorageConnectionImpl, UpdateObjectTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateObject).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateObject(UpdateObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateObject"));
@@ -332,7 +332,7 @@ TEST(StorageConnectionImpl, UpdateObjectPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateObject).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateObject(UpdateObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateObject"));
@@ -346,7 +346,7 @@ TEST(StorageConnectionImpl, PatchObjectTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchObject).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchObject(PatchObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("PatchObject"));
@@ -360,7 +360,7 @@ TEST(StorageConnectionImpl, PatchObjectPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, PatchObject).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->PatchObject(PatchObjectRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("PatchObject"));

--- a/google/cloud/storage/internal/connection_impl_service_account_test.cc
+++ b/google/cloud/storage/internal/connection_impl_service_account_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -42,7 +42,7 @@ TEST(StorageConnectionImpl, GetServiceAccountTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetServiceAccount).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetServiceAccount(GetProjectServiceAccountRequest()).status();
@@ -57,7 +57,7 @@ TEST(StorageConnectionImpl, GetServiceAccountPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetServiceAccount).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response =
       client->GetServiceAccount(GetProjectServiceAccountRequest()).status();
@@ -72,7 +72,7 @@ TEST(StorageConnectionImpl, ListHmacKeysTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListHmacKeys).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListHmacKeys(ListHmacKeysRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("ListHmacKeys"));
@@ -86,7 +86,7 @@ TEST(StorageConnectionImpl, ListHmacKeysPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, ListHmacKeys).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ListHmacKeys(ListHmacKeysRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("ListHmacKeys"));
@@ -100,7 +100,7 @@ TEST(StorageConnectionImpl, CreateHmacKeyTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateHmacKey).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateHmacKey(CreateHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("CreateHmacKey"));
@@ -114,7 +114,7 @@ TEST(StorageConnectionImpl, CreateHmacKeyPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, CreateHmacKey).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->CreateHmacKey(CreateHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("CreateHmacKey"));
@@ -128,7 +128,7 @@ TEST(StorageConnectionImpl, DeleteHmacKeyTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteHmacKey).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteHmacKey(DeleteHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("DeleteHmacKey"));
@@ -142,7 +142,7 @@ TEST(StorageConnectionImpl, DeleteHmacKeyPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, DeleteHmacKey).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->DeleteHmacKey(DeleteHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("DeleteHmacKey"));
@@ -156,7 +156,7 @@ TEST(StorageConnectionImpl, GetHmacKeyTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetHmacKey).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetHmacKey(GetHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("GetHmacKey"));
@@ -170,7 +170,7 @@ TEST(StorageConnectionImpl, GetHmacKeyPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, GetHmacKey).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->GetHmacKey(GetHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("GetHmacKey"));
@@ -184,7 +184,7 @@ TEST(StorageConnectionImpl, UpdateHmacKeyTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateHmacKey).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateHmacKey(UpdateHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("UpdateHmacKey"));
@@ -198,7 +198,7 @@ TEST(StorageConnectionImpl, UpdateHmacKeyPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, UpdateHmacKey).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->UpdateHmacKey(UpdateHmacKeyRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("UpdateHmacKey"));

--- a/google/cloud/storage/internal/connection_impl_sign_blob_test.cc
+++ b/google/cloud/storage/internal/connection_impl_sign_blob_test.cc
@@ -28,9 +28,9 @@ namespace {
 
 using ::google::cloud::storage::testing::MockGenericStub;
 using ::google::cloud::storage::testing::MockRetryClientFunction;
-using ::google::cloud::storage::testing::RetryClientTestOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesOptions;
 using ::google::cloud::storage::testing::RetryLoopUsesSingleToken;
+using ::google::cloud::storage::testing::RetryTestOptions;
 using ::google::cloud::storage::testing::StoppedOnPermanentError;
 using ::google::cloud::storage::testing::StoppedOnTooManyTransients;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
@@ -42,7 +42,7 @@ TEST(StorageConnectionImpl, SignBlobTooManyFailures) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, SignBlob).Times(3).WillRepeatedly(transient);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->SignBlob(SignBlobRequest()).status();
   EXPECT_THAT(response, StoppedOnTooManyTransients("SignBlob"));
@@ -56,7 +56,7 @@ TEST(StorageConnectionImpl, SignBlobPermanentFailure) {
   EXPECT_CALL(*mock, options);
   EXPECT_CALL(*mock, SignBlob).WillOnce(permanent);
   auto client =
-      StorageConnectionImpl::Create(std::move(mock), RetryClientTestOptions());
+      StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->SignBlob(SignBlobRequest()).status();
   EXPECT_THAT(response, StoppedOnPermanentError("SignBlob"));

--- a/google/cloud/storage/testing/retry_tests.cc
+++ b/google/cloud/storage/testing/retry_tests.cc
@@ -43,7 +43,7 @@ auto constexpr kTooManyFailuresCount = 2;
 auto constexpr kIdempotencyTokenHeader = "x-goog-gcs-idempotency-token";
 auto constexpr kTestAuthority = "test-only-authority.googleapis.com";
 
-Options RetryClientTestOptions() {
+Options RetryTestOptions() {
   return Options{}
       .set<RetryPolicyOption>(
           LimitedErrorCountRetryPolicy(kTooManyFailuresCount).clone())

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -35,7 +35,7 @@ namespace testing {
  * backoff policy uses very short backoffs. This works well in unit tests. The
  * idempotency policy retries all operations.
  */
-Options RetryClientTestOptions();
+Options RetryTestOptions();
 
 /// Validates the `Status` produced in a "too many transients" test.
 ::testing::Matcher<Status> StoppedOnTooManyTransients(char const* api_name);


### PR DESCRIPTION
Part of the work for #12340

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12387)
<!-- Reviewable:end -->
