### PR TITLE
refactor(common): repetitive code in LogWrapper

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -199,7 +199,7 @@ TEST_F(LoggingDecoratorTest, StreamingReadRpcNoRpcStreams) {
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("StreamingRead(")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr("null stream")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(">> not null")));
   EXPECT_THAT(log_lines, Not(Contains(StartsWith("Read("))));
 }
 
@@ -215,7 +215,7 @@ TEST_F(LoggingDecoratorTest, StreamingReadRpcWithRpcStreams) {
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("StreamingRead(")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr("null stream")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(">> not null")));
   EXPECT_THAT(log_lines, Contains(StartsWith("Read(")));
 }
 

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -102,6 +102,7 @@ google_cloud_cpp_grpc_utils_srcs = [
     "internal/grpc_opentelemetry.cc",
     "internal/grpc_request_metadata.cc",
     "internal/grpc_service_account_authentication.cc",
+    "internal/log_wrapper.cc",
     "internal/minimal_iam_credentials_stub.cc",
     "internal/populate_grpc_options.cc",
     "internal/streaming_read_rpc.cc",

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -83,6 +83,7 @@ add_library(
     internal/grpc_request_metadata.h
     internal/grpc_service_account_authentication.cc
     internal/grpc_service_account_authentication.h
+    internal/log_wrapper.cc
     internal/log_wrapper.h
     internal/minimal_iam_credentials_stub.cc
     internal/minimal_iam_credentials_stub.h

--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -26,15 +26,15 @@ Status LogResponse(Status response, absl::string_view prefix,
   return response;
 }
 
-future<Status> LogResponse(future<Status> response, absl::string_view prefix,
-                           TracingOptions const& options) {
+future<Status> LogResponse(future<Status> response, std::string prefix,
+                           std::string args, TracingOptions const& options) {
   GCP_LOG(DEBUG) << prefix << " >> future_status="
                  << DebugFutureStatus(
                         response.wait_for(std::chrono::microseconds(0)));
-  return response.then(
-      [prefix = std::move(prefix), options = std::move(options)](auto f) {
-        return LogResponse(f.get(), prefix, "", options);
-      });
+  return response.then([prefix = std::move(prefix), args = std::move(args),
+                        options = std::move(options)](auto f) {
+    return LogResponse(f.get(), prefix, args, options);
+  });
 }
 
 }  // namespace internal

--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -19,9 +19,14 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
+void LogRequest(absl::string_view where, absl::string_view args,
+                absl::string_view message) {
+  GCP_LOG(DEBUG) << where << '(' << args << ')' << " << status=" << message;
+}
+
 Status LogResponse(Status response, absl::string_view where,
                    absl::string_view args, TracingOptions const& options) {
-  GCP_LOG(DEBUG) << where << args
+  GCP_LOG(DEBUG) << where << '(' << args << ')'
                  << " >> status=" << DebugString(response, options);
   return response;
 }
@@ -29,7 +34,7 @@ Status LogResponse(Status response, absl::string_view where,
 void LogResponseFuture(std::future_status status, absl::string_view where,
                        absl::string_view args,
                        TracingOptions const& /*options*/) {
-  GCP_LOG(DEBUG) << where << args
+  GCP_LOG(DEBUG) << where << '(' << args << ')'
                  << " >> future_status=" << DebugFutureStatus(status);
 }
 
@@ -44,9 +49,9 @@ future<Status> LogResponse(future<Status> response, std::string where,
 }
 
 void LogResponsePtr(bool not_null, absl::string_view where,
-                    absl::string_view args, TracingOptions const& options) {
-  GCP_LOG(DEBUG) << where << args << " >> " << (not_null ? "not " : "")
-                 << " null stream";
+                    absl::string_view args, TracingOptions const& /*options*/) {
+  GCP_LOG(DEBUG) << where << '(' << args << ')' << " >> "
+                 << (not_null ? "not " : "") << "null";
 }
 
 }  // namespace internal

--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/log_wrapper.h"
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+Status LogResponse(Status response, absl::string_view prefix,
+                   absl::string_view args, TracingOptions const& options) {
+  GCP_LOG(DEBUG) << prefix << args
+                 << " >> status=" << DebugString(response, options);
+  return response;
+}
+
+future<Status> LogResponse(future<Status> response, absl::string_view prefix,
+                           TracingOptions const& options) {
+  GCP_LOG(DEBUG) << prefix << " >> future_status="
+                 << DebugFutureStatus(
+                        response.wait_for(std::chrono::microseconds(0)));
+  return response.then(
+      [prefix = std::move(prefix), options = std::move(options)](auto f) {
+        return LogResponse(f.get(), prefix, "", options);
+      });
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -152,7 +152,7 @@ TEST(LogWrapper, FutureStatusWithContextAndCQ) {
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
   EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("),
-                             HasSubstr(" >> response=" + status_as_string))));
+                             HasSubstr(" >> status=" + status_as_string))));
   EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
                                         HasSubstr(" >> future_status="))));
 }
@@ -229,7 +229,7 @@ TEST(LogWrapper, FutureStatusWithTestContextAndCQ) {
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
   EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("),
-                             HasSubstr(" >> response=" + status_as_string))));
+                             HasSubstr(" >> status=" + status_as_string))));
   EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
                                         HasSubstr(" >> future_status="))));
 }


### PR DESCRIPTION
Move repetitive code in `internal::LogWrapper` to an overload set that only knows how to log responses.

Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12389)
<!-- Reviewable:end -->
