### PR TITLE
cleanup(common): guard cmake quickstart targets with ENABLE_CXX_EXCEPTIONS

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -582,8 +582,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_$library$_mocks
                        INTERFACE $${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable($library$_quickstart "quickstart/quickstart.cc")
     target_link_libraries($library$_quickstart
                           PRIVATE google-cloud-cpp::$library_prefix$$library$)

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_accesscontextmanager_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(accesscontextmanager_quickstart "quickstart/quickstart.cc")
     target_link_libraries(accesscontextmanager_quickstart
                           PRIVATE google-cloud-cpp::accesscontextmanager)

--- a/google/cloud/advisorynotifications/CMakeLists.txt
+++ b/google/cloud/advisorynotifications/CMakeLists.txt
@@ -116,8 +116,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_advisorynotifications_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(advisorynotifications_quickstart "quickstart/quickstart.cc")
     target_link_libraries(advisorynotifications_quickstart
                           PRIVATE google-cloud-cpp::advisorynotifications)

--- a/google/cloud/aiplatform/CMakeLists.txt
+++ b/google/cloud/aiplatform/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_aiplatform_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(aiplatform_quickstart "quickstart/quickstart.cc")
     target_link_libraries(aiplatform_quickstart
                           PRIVATE google-cloud-cpp::aiplatform)

--- a/google/cloud/alloydb/CMakeLists.txt
+++ b/google/cloud/alloydb/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_alloydb_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(alloydb_quickstart "quickstart/quickstart.cc")
     target_link_libraries(alloydb_quickstart PRIVATE google-cloud-cpp::alloydb)
     google_cloud_cpp_add_common_options(alloydb_quickstart)

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_apigateway_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(apigateway_quickstart "quickstart/quickstart.cc")
     target_link_libraries(apigateway_quickstart
                           PRIVATE google-cloud-cpp::apigateway)

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -114,8 +114,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_apigeeconnect_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(apigeeconnect_quickstart "quickstart/quickstart.cc")
     target_link_libraries(apigeeconnect_quickstart
                           PRIVATE google-cloud-cpp::apigeeconnect)

--- a/google/cloud/apikeys/CMakeLists.txt
+++ b/google/cloud/apikeys/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_apikeys_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(apikeys_quickstart "quickstart/quickstart.cc")
     target_link_libraries(apikeys_quickstart PRIVATE google-cloud-cpp::apikeys)
     google_cloud_cpp_add_common_options(apikeys_quickstart)

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_appengine_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(appengine_quickstart "quickstart/quickstart.cc")
     target_link_libraries(appengine_quickstart
                           PRIVATE google-cloud-cpp::appengine)

--- a/google/cloud/artifactregistry/CMakeLists.txt
+++ b/google/cloud/artifactregistry/CMakeLists.txt
@@ -115,8 +115,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_artifactregistry_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(artifactregistry_quickstart "quickstart/quickstart.cc")
     target_link_libraries(artifactregistry_quickstart
                           PRIVATE google-cloud-cpp::artifactregistry)

--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_asset_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(asset_quickstart "quickstart/quickstart.cc")
     target_link_libraries(asset_quickstart PRIVATE google-cloud-cpp::asset)
     google_cloud_cpp_add_common_options(asset_quickstart)

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -115,8 +115,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_assuredworkloads_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(assuredworkloads_quickstart "quickstart/quickstart.cc")
     target_link_libraries(assuredworkloads_quickstart
                           PRIVATE google-cloud-cpp::assuredworkloads)

--- a/google/cloud/baremetalsolution/CMakeLists.txt
+++ b/google/cloud/baremetalsolution/CMakeLists.txt
@@ -117,8 +117,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_baremetalsolution_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(baremetalsolution_quickstart "quickstart/quickstart.cc")
     target_link_libraries(baremetalsolution_quickstart
                           PRIVATE google-cloud-cpp::baremetalsolution)

--- a/google/cloud/batch/CMakeLists.txt
+++ b/google/cloud/batch/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_batch_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(batch_quickstart "quickstart/quickstart.cc")
     target_link_libraries(batch_quickstart PRIVATE google-cloud-cpp::batch)
     google_cloud_cpp_add_common_options(batch_quickstart)

--- a/google/cloud/beyondcorp/CMakeLists.txt
+++ b/google/cloud/beyondcorp/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_beyondcorp_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(beyondcorp_quickstart "quickstart/quickstart.cc")
     target_link_libraries(beyondcorp_quickstart
                           PRIVATE google-cloud-cpp::beyondcorp)

--- a/google/cloud/billing/CMakeLists.txt
+++ b/google/cloud/billing/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_billing_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(billing_quickstart "quickstart/quickstart.cc")
     target_link_libraries(billing_quickstart PRIVATE google-cloud-cpp::billing)
     google_cloud_cpp_add_common_options(billing_quickstart)

--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -122,8 +122,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_binaryauthorization_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(binaryauthorization_quickstart "quickstart/quickstart.cc")
     target_link_libraries(binaryauthorization_quickstart
                           PRIVATE google-cloud-cpp::binaryauthorization)

--- a/google/cloud/certificatemanager/CMakeLists.txt
+++ b/google/cloud/certificatemanager/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_certificatemanager_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(certificatemanager_quickstart "quickstart/quickstart.cc")
     target_link_libraries(certificatemanager_quickstart
                           PRIVATE google-cloud-cpp::certificatemanager)

--- a/google/cloud/cloudbuild/CMakeLists.txt
+++ b/google/cloud/cloudbuild/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_cloudbuild_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(cloudbuild_quickstart "quickstart/quickstart.cc")
     target_link_libraries(cloudbuild_quickstart
                           PRIVATE google-cloud-cpp::cloudbuild)

--- a/google/cloud/commerce/CMakeLists.txt
+++ b/google/cloud/commerce/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_commerce_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(commerce_quickstart "quickstart/quickstart.cc")
     target_link_libraries(commerce_quickstart
                           PRIVATE google-cloud-cpp::commerce)

--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_composer_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(composer_quickstart "quickstart/quickstart.cc")
     target_link_libraries(composer_quickstart
                           PRIVATE google-cloud-cpp::composer)

--- a/google/cloud/compute/CMakeLists.txt
+++ b/google/cloud/compute/CMakeLists.txt
@@ -220,8 +220,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_compute_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(compute_quickstart "quickstart/quickstart.cc")
     target_link_libraries(compute_quickstart
                           PRIVATE google-cloud-cpp::experimental-compute)

--- a/google/cloud/confidentialcomputing/CMakeLists.txt
+++ b/google/cloud/confidentialcomputing/CMakeLists.txt
@@ -116,8 +116,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_confidentialcomputing_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(confidentialcomputing_quickstart "quickstart/quickstart.cc")
     target_link_libraries(confidentialcomputing_quickstart
                           PRIVATE google-cloud-cpp::confidentialcomputing)

--- a/google/cloud/connectors/CMakeLists.txt
+++ b/google/cloud/connectors/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_connectors_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(connectors_quickstart "quickstart/quickstart.cc")
     target_link_libraries(connectors_quickstart
                           PRIVATE google-cloud-cpp::connectors)

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_contactcenterinsights_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(contactcenterinsights_quickstart "quickstart/quickstart.cc")
     target_link_libraries(contactcenterinsights_quickstart
                           PRIVATE google-cloud-cpp::contactcenterinsights)

--- a/google/cloud/container/CMakeLists.txt
+++ b/google/cloud/container/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_container_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(container_quickstart "quickstart/quickstart.cc")
     target_link_libraries(container_quickstart
                           PRIVATE google-cloud-cpp::container)

--- a/google/cloud/containeranalysis/CMakeLists.txt
+++ b/google/cloud/containeranalysis/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_containeranalysis_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(containeranalysis_quickstart "quickstart/quickstart.cc")
     target_link_libraries(containeranalysis_quickstart
                           PRIVATE google-cloud-cpp::containeranalysis)

--- a/google/cloud/contentwarehouse/CMakeLists.txt
+++ b/google/cloud/contentwarehouse/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_contentwarehouse_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(contentwarehouse_quickstart "quickstart/quickstart.cc")
     target_link_libraries(contentwarehouse_quickstart
                           PRIVATE google-cloud-cpp::contentwarehouse)

--- a/google/cloud/datacatalog/CMakeLists.txt
+++ b/google/cloud/datacatalog/CMakeLists.txt
@@ -113,8 +113,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_datacatalog_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datacatalog_quickstart "quickstart/quickstart.cc")
     target_link_libraries(datacatalog_quickstart
                           PRIVATE google-cloud-cpp::datacatalog)

--- a/google/cloud/datafusion/CMakeLists.txt
+++ b/google/cloud/datafusion/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_datafusion_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datafusion_quickstart "quickstart/quickstart.cc")
     target_link_libraries(datafusion_quickstart
                           PRIVATE google-cloud-cpp::datafusion)

--- a/google/cloud/datamigration/CMakeLists.txt
+++ b/google/cloud/datamigration/CMakeLists.txt
@@ -114,8 +114,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_datamigration_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datamigration_quickstart "quickstart/quickstart.cc")
     target_link_libraries(datamigration_quickstart
                           PRIVATE google-cloud-cpp::datamigration)

--- a/google/cloud/dataplex/CMakeLists.txt
+++ b/google/cloud/dataplex/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_dataplex_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dataplex_quickstart "quickstart/quickstart.cc")
     target_link_libraries(dataplex_quickstart
                           PRIVATE google-cloud-cpp::dataplex)

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_dataproc_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dataproc_quickstart "quickstart/quickstart.cc")
     target_link_libraries(dataproc_quickstart
                           PRIVATE google-cloud-cpp::dataproc)

--- a/google/cloud/datastore/CMakeLists.txt
+++ b/google/cloud/datastore/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_datastore_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datastore_quickstart "quickstart/quickstart.cc")
     target_link_libraries(datastore_quickstart
                           PRIVATE google-cloud-cpp::datastore)

--- a/google/cloud/datastream/CMakeLists.txt
+++ b/google/cloud/datastream/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_datastream_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datastream_quickstart "quickstart/quickstart.cc")
     target_link_libraries(datastream_quickstart
                           PRIVATE google-cloud-cpp::datastream)

--- a/google/cloud/deploy/CMakeLists.txt
+++ b/google/cloud/deploy/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_deploy_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(deploy_quickstart "quickstart/quickstart.cc")
     target_link_libraries(deploy_quickstart PRIVATE google-cloud-cpp::deploy)
     google_cloud_cpp_add_common_options(deploy_quickstart)

--- a/google/cloud/documentai/CMakeLists.txt
+++ b/google/cloud/documentai/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_documentai_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(documentai_quickstart "quickstart/quickstart.cc")
     target_link_libraries(documentai_quickstart
                           PRIVATE google-cloud-cpp::documentai)

--- a/google/cloud/domains/CMakeLists.txt
+++ b/google/cloud/domains/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_domains_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(domains_quickstart "quickstart/quickstart.cc")
     target_link_libraries(domains_quickstart PRIVATE google-cloud-cpp::domains)
     google_cloud_cpp_add_common_options(domains_quickstart)

--- a/google/cloud/edgecontainer/CMakeLists.txt
+++ b/google/cloud/edgecontainer/CMakeLists.txt
@@ -115,8 +115,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_edgecontainer_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(edgecontainer_quickstart "quickstart/quickstart.cc")
     target_link_libraries(edgecontainer_quickstart
                           PRIVATE google-cloud-cpp::edgecontainer)

--- a/google/cloud/essentialcontacts/CMakeLists.txt
+++ b/google/cloud/essentialcontacts/CMakeLists.txt
@@ -114,8 +114,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_essentialcontacts_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(essentialcontacts_quickstart "quickstart/quickstart.cc")
     target_link_libraries(essentialcontacts_quickstart
                           PRIVATE google-cloud-cpp::essentialcontacts)

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_eventarc_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(eventarc_quickstart "quickstart/quickstart.cc")
     target_link_libraries(eventarc_quickstart
                           PRIVATE google-cloud-cpp::eventarc)

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_filestore_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(filestore_quickstart "quickstart/quickstart.cc")
     target_link_libraries(filestore_quickstart
                           PRIVATE google-cloud-cpp::filestore)

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_functions_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(functions_quickstart "quickstart/quickstart.cc")
     target_link_libraries(functions_quickstart
                           PRIVATE google-cloud-cpp::functions)

--- a/google/cloud/gkebackup/CMakeLists.txt
+++ b/google/cloud/gkebackup/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_gkebackup_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(gkebackup_quickstart "quickstart/quickstart.cc")
     target_link_libraries(gkebackup_quickstart
                           PRIVATE google-cloud-cpp::gkebackup)

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_gkehub_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(gkehub_quickstart "quickstart/quickstart.cc")
     target_link_libraries(gkehub_quickstart PRIVATE google-cloud-cpp::gkehub)
     google_cloud_cpp_add_common_options(gkehub_quickstart)

--- a/google/cloud/gkemulticloud/CMakeLists.txt
+++ b/google/cloud/gkemulticloud/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_gkemulticloud_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(gkemulticloud_quickstart "quickstart/quickstart.cc")
     target_link_libraries(gkemulticloud_quickstart
                           PRIVATE google-cloud-cpp::gkemulticloud)

--- a/google/cloud/iap/CMakeLists.txt
+++ b/google/cloud/iap/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_iap_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(iap_quickstart "quickstart/quickstart.cc")
     target_link_libraries(iap_quickstart PRIVATE google-cloud-cpp::iap)
     google_cloud_cpp_add_common_options(iap_quickstart)

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -108,8 +108,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_ids_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(ids_quickstart "quickstart/quickstart.cc")
     target_link_libraries(ids_quickstart PRIVATE google-cloud-cpp::ids)
     google_cloud_cpp_add_common_options(ids_quickstart)

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_kms_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(kms_quickstart "quickstart/quickstart.cc")
     target_link_libraries(kms_quickstart PRIVATE google-cloud-cpp::kms)
     google_cloud_cpp_add_common_options(kms_quickstart)

--- a/google/cloud/language/CMakeLists.txt
+++ b/google/cloud/language/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_language_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(language_quickstart "quickstart/quickstart.cc")
     target_link_libraries(language_quickstart
                           PRIVATE google-cloud-cpp::language)

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -98,7 +98,6 @@ target_compile_options(google_cloud_cpp_logging_mocks
 
 add_subdirectory(integration_tests)
 
-include(CTest)
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(logging_quickstart "quickstart/quickstart.cc")
     target_link_libraries(logging_quickstart PRIVATE google-cloud-cpp::logging)

--- a/google/cloud/managedidentities/CMakeLists.txt
+++ b/google/cloud/managedidentities/CMakeLists.txt
@@ -119,8 +119,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_managedidentities_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(managedidentities_quickstart "quickstart/quickstart.cc")
     target_link_libraries(managedidentities_quickstart
                           PRIVATE google-cloud-cpp::managedidentities)

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_memcache_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(memcache_quickstart "quickstart/quickstart.cc")
     target_link_libraries(memcache_quickstart
                           PRIVATE google-cloud-cpp::memcache)

--- a/google/cloud/metastore/CMakeLists.txt
+++ b/google/cloud/metastore/CMakeLists.txt
@@ -109,8 +109,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_metastore_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(metastore_quickstart "quickstart/quickstart.cc")
     target_link_libraries(metastore_quickstart
                           PRIVATE google-cloud-cpp::metastore)

--- a/google/cloud/migrationcenter/CMakeLists.txt
+++ b/google/cloud/migrationcenter/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_migrationcenter_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(migrationcenter_quickstart "quickstart/quickstart.cc")
     target_link_libraries(migrationcenter_quickstart
                           PRIVATE google-cloud-cpp::migrationcenter)

--- a/google/cloud/monitoring/CMakeLists.txt
+++ b/google/cloud/monitoring/CMakeLists.txt
@@ -101,8 +101,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_monitoring_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(monitoring_quickstart "quickstart/quickstart.cc")
     target_link_libraries(monitoring_quickstart
                           PRIVATE google-cloud-cpp::monitoring)

--- a/google/cloud/networkconnectivity/CMakeLists.txt
+++ b/google/cloud/networkconnectivity/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_networkconnectivity_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networkconnectivity_quickstart "quickstart/quickstart.cc")
     target_link_libraries(networkconnectivity_quickstart
                           PRIVATE google-cloud-cpp::networkconnectivity)

--- a/google/cloud/networkmanagement/CMakeLists.txt
+++ b/google/cloud/networkmanagement/CMakeLists.txt
@@ -116,8 +116,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_networkmanagement_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networkmanagement_quickstart "quickstart/quickstart.cc")
     target_link_libraries(networkmanagement_quickstart
                           PRIVATE google-cloud-cpp::networkmanagement)

--- a/google/cloud/networksecurity/CMakeLists.txt
+++ b/google/cloud/networksecurity/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_networksecurity_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networksecurity_quickstart "quickstart/quickstart.cc")
     target_link_libraries(networksecurity_quickstart
                           PRIVATE google-cloud-cpp::networksecurity)

--- a/google/cloud/networkservices/CMakeLists.txt
+++ b/google/cloud/networkservices/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_networkservices_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networkservices_quickstart "quickstart/quickstart.cc")
     target_link_libraries(networkservices_quickstart
                           PRIVATE google-cloud-cpp::networkservices)

--- a/google/cloud/notebooks/CMakeLists.txt
+++ b/google/cloud/notebooks/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_notebooks_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(notebooks_quickstart "quickstart/quickstart.cc")
     target_link_libraries(notebooks_quickstart
                           PRIVATE google-cloud-cpp::notebooks)

--- a/google/cloud/optimization/CMakeLists.txt
+++ b/google/cloud/optimization/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_optimization_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(optimization_quickstart "quickstart/quickstart.cc")
     target_link_libraries(optimization_quickstart
                           PRIVATE google-cloud-cpp::optimization)

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_osconfig_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(osconfig_quickstart "quickstart/quickstart.cc")
     target_link_libraries(osconfig_quickstart
                           PRIVATE google-cloud-cpp::osconfig)

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_oslogin_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(oslogin_quickstart "quickstart/quickstart.cc")
     target_link_libraries(oslogin_quickstart PRIVATE google-cloud-cpp::oslogin)
     google_cloud_cpp_add_common_options(oslogin_quickstart)

--- a/google/cloud/policysimulator/CMakeLists.txt
+++ b/google/cloud/policysimulator/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_policysimulator_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(policysimulator_quickstart "quickstart/quickstart.cc")
     target_link_libraries(policysimulator_quickstart
                           PRIVATE google-cloud-cpp::policysimulator)

--- a/google/cloud/policytroubleshooter/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_policytroubleshooter_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(policytroubleshooter_quickstart "quickstart/quickstart.cc")
     target_link_libraries(policytroubleshooter_quickstart
                           PRIVATE google-cloud-cpp::policytroubleshooter)

--- a/google/cloud/privateca/CMakeLists.txt
+++ b/google/cloud/privateca/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_privateca_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(privateca_quickstart "quickstart/quickstart.cc")
     target_link_libraries(privateca_quickstart
                           PRIVATE google-cloud-cpp::privateca)

--- a/google/cloud/profiler/CMakeLists.txt
+++ b/google/cloud/profiler/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_profiler_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(profiler_quickstart "quickstart/quickstart.cc")
     target_link_libraries(profiler_quickstart
                           PRIVATE google-cloud-cpp::profiler)

--- a/google/cloud/rapidmigrationassessment/CMakeLists.txt
+++ b/google/cloud/rapidmigrationassessment/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_rapidmigrationassessment_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(rapidmigrationassessment_quickstart
                    "quickstart/quickstart.cc")
     target_link_libraries(rapidmigrationassessment_quickstart

--- a/google/cloud/recaptchaenterprise/CMakeLists.txt
+++ b/google/cloud/recaptchaenterprise/CMakeLists.txt
@@ -116,8 +116,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_recaptchaenterprise_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(recaptchaenterprise_quickstart "quickstart/quickstart.cc")
     target_link_libraries(recaptchaenterprise_quickstart
                           PRIVATE google-cloud-cpp::recaptchaenterprise)

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_recommender_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(recommender_quickstart "quickstart/quickstart.cc")
     target_link_libraries(recommender_quickstart
                           PRIVATE google-cloud-cpp::recommender)

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_redis_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(redis_quickstart "quickstart/quickstart.cc")
     target_link_libraries(redis_quickstart PRIVATE google-cloud-cpp::redis)
     google_cloud_cpp_add_common_options(redis_quickstart)

--- a/google/cloud/resourcemanager/CMakeLists.txt
+++ b/google/cloud/resourcemanager/CMakeLists.txt
@@ -115,8 +115,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_resourcemanager_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(resourcemanager_quickstart "quickstart/quickstart.cc")
     target_link_libraries(resourcemanager_quickstart
                           PRIVATE google-cloud-cpp::resourcemanager)

--- a/google/cloud/resourcesettings/CMakeLists.txt
+++ b/google/cloud/resourcesettings/CMakeLists.txt
@@ -115,8 +115,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_resourcesettings_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(resourcesettings_quickstart "quickstart/quickstart.cc")
     target_link_libraries(resourcesettings_quickstart
                           PRIVATE google-cloud-cpp::resourcesettings)

--- a/google/cloud/run/CMakeLists.txt
+++ b/google/cloud/run/CMakeLists.txt
@@ -108,8 +108,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_run_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(run_quickstart "quickstart/quickstart.cc")
     target_link_libraries(run_quickstart PRIVATE google-cloud-cpp::run)
     google_cloud_cpp_add_common_options(run_quickstart)

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_scheduler_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(scheduler_quickstart "quickstart/quickstart.cc")
     target_link_libraries(scheduler_quickstart
                           PRIVATE google-cloud-cpp::scheduler)

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -114,8 +114,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_secretmanager_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(secretmanager_quickstart "quickstart/quickstart.cc")
     target_link_libraries(secretmanager_quickstart
                           PRIVATE google-cloud-cpp::secretmanager)

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -115,8 +115,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_securitycenter_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(securitycenter_quickstart "quickstart/quickstart.cc")
     target_link_libraries(securitycenter_quickstart
                           PRIVATE google-cloud-cpp::securitycenter)

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -114,8 +114,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_servicecontrol_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(servicecontrol_quickstart "quickstart/quickstart.cc")
     target_link_libraries(servicecontrol_quickstart
                           PRIVATE google-cloud-cpp::servicecontrol)

--- a/google/cloud/servicedirectory/CMakeLists.txt
+++ b/google/cloud/servicedirectory/CMakeLists.txt
@@ -115,8 +115,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_servicedirectory_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(servicedirectory_quickstart "quickstart/quickstart.cc")
     target_link_libraries(servicedirectory_quickstart
                           PRIVATE google-cloud-cpp::servicedirectory)

--- a/google/cloud/servicemanagement/CMakeLists.txt
+++ b/google/cloud/servicemanagement/CMakeLists.txt
@@ -116,8 +116,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_servicemanagement_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(servicemanagement_quickstart "quickstart/quickstart.cc")
     target_link_libraries(servicemanagement_quickstart
                           PRIVATE google-cloud-cpp::servicemanagement)

--- a/google/cloud/serviceusage/CMakeLists.txt
+++ b/google/cloud/serviceusage/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_serviceusage_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(serviceusage_quickstart "quickstart/quickstart.cc")
     target_link_libraries(serviceusage_quickstart
                           PRIVATE google-cloud-cpp::serviceusage)

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_shell_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(shell_quickstart "quickstart/quickstart.cc")
     target_link_libraries(shell_quickstart PRIVATE google-cloud-cpp::shell)
     google_cloud_cpp_add_common_options(shell_quickstart)

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_speech_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(speech_quickstart "quickstart/quickstart.cc")
     target_link_libraries(speech_quickstart PRIVATE google-cloud-cpp::speech)
     google_cloud_cpp_add_common_options(speech_quickstart)

--- a/google/cloud/sql/CMakeLists.txt
+++ b/google/cloud/sql/CMakeLists.txt
@@ -111,8 +111,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_sql_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(sql_quickstart "quickstart/quickstart.cc")
     target_link_libraries(sql_quickstart
                           PRIVATE google-cloud-cpp::experimental-sql)

--- a/google/cloud/storageinsights/CMakeLists.txt
+++ b/google/cloud/storageinsights/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_storageinsights_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(storageinsights_quickstart "quickstart/quickstart.cc")
     target_link_libraries(storageinsights_quickstart
                           PRIVATE google-cloud-cpp::storageinsights)

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -114,8 +114,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_storagetransfer_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(storagetransfer_quickstart "quickstart/quickstart.cc")
     target_link_libraries(storagetransfer_quickstart
                           PRIVATE google-cloud-cpp::storagetransfer)

--- a/google/cloud/support/CMakeLists.txt
+++ b/google/cloud/support/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_support_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(support_quickstart "quickstart/quickstart.cc")
     target_link_libraries(support_quickstart PRIVATE google-cloud-cpp::support)
     google_cloud_cpp_add_common_options(support_quickstart)

--- a/google/cloud/talent/CMakeLists.txt
+++ b/google/cloud/talent/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_talent_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(talent_quickstart "quickstart/quickstart.cc")
     target_link_libraries(talent_quickstart PRIVATE google-cloud-cpp::talent)
     google_cloud_cpp_add_common_options(talent_quickstart)

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_tasks_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(tasks_quickstart "quickstart/quickstart.cc")
     target_link_libraries(tasks_quickstart PRIVATE google-cloud-cpp::tasks)
     google_cloud_cpp_add_common_options(tasks_quickstart)

--- a/google/cloud/timeseriesinsights/CMakeLists.txt
+++ b/google/cloud/timeseriesinsights/CMakeLists.txt
@@ -116,8 +116,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_timeseriesinsights_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(timeseriesinsights_quickstart "quickstart/quickstart.cc")
     target_link_libraries(timeseriesinsights_quickstart
                           PRIVATE google-cloud-cpp::timeseriesinsights)

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -108,8 +108,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_tpu_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(tpu_quickstart "quickstart/quickstart.cc")
     target_link_libraries(tpu_quickstart PRIVATE google-cloud-cpp::tpu)
     google_cloud_cpp_add_common_options(tpu_quickstart)

--- a/google/cloud/video/CMakeLists.txt
+++ b/google/cloud/video/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_video_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(video_quickstart "quickstart/quickstart.cc")
     target_link_libraries(video_quickstart PRIVATE google-cloud-cpp::video)
     google_cloud_cpp_add_common_options(video_quickstart)

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_vmmigration_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vmmigration_quickstart "quickstart/quickstart.cc")
     target_link_libraries(vmmigration_quickstart
                           PRIVATE google-cloud-cpp::vmmigration)

--- a/google/cloud/vmwareengine/CMakeLists.txt
+++ b/google/cloud/vmwareengine/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_vmwareengine_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vmwareengine_quickstart "quickstart/quickstart.cc")
     target_link_libraries(vmwareengine_quickstart
                           PRIVATE google-cloud-cpp::vmwareengine)

--- a/google/cloud/vpcaccess/CMakeLists.txt
+++ b/google/cloud/vpcaccess/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_vpcaccess_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vpcaccess_quickstart "quickstart/quickstart.cc")
     target_link_libraries(vpcaccess_quickstart
                           PRIVATE google-cloud-cpp::vpcaccess)

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -118,8 +118,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_websecurityscanner_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(websecurityscanner_quickstart "quickstart/quickstart.cc")
     target_link_libraries(websecurityscanner_quickstart
                           PRIVATE google-cloud-cpp::websecurityscanner)

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -112,8 +112,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_workflows_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(workflows_quickstart "quickstart/quickstart.cc")
     target_link_libraries(workflows_quickstart
                           PRIVATE google-cloud-cpp::workflows)

--- a/google/cloud/workstations/CMakeLists.txt
+++ b/google/cloud/workstations/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_workstations_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(workstations_quickstart "quickstart/quickstart.cc")
     target_link_libraries(workstations_quickstart
                           PRIVATE google-cloud-cpp::workstations)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12393)
<!-- Reviewable:end -->
