### PR TITLE
cleanup: guard cmake quickstart targets with ENABLE_CXX_EXCEPTIONS

### DIFF
--- a/google/cloud/dialogflow_cx/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/CMakeLists.txt
@@ -102,8 +102,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_dialogflow_cx_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dialogflow_cx_quickstart "quickstart/quickstart.cc")
     target_link_libraries(dialogflow_cx_quickstart
                           PRIVATE google-cloud-cpp::dialogflow_cx)

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -100,8 +100,7 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_dialogflow_es_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dialogflow_es_quickstart "quickstart/quickstart.cc")
     target_link_libraries(dialogflow_es_quickstart
                           PRIVATE google-cloud-cpp::dialogflow_es)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12396)
<!-- Reviewable:end -->
