### PR TITLE
refactor(generator): use ParsePathTemplate when processing http extension

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
@@ -46,7 +46,7 @@ DefaultGoldenKitchenSinkRestStub::GenerateAccessToken(
       google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::GenerateAccessTokenResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), ":generateAccessToken"));
+      absl::StrCat("/", "v1", "/", request.name(), ":generateAccessToken"));
 }
 
 StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
@@ -73,7 +73,7 @@ DefaultGoldenKitchenSinkRestStub::ListLogs(
       google::test::admin::database::v1::ListLogsRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListLogsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v2/", request.parent(), "/logs"),
+      absl::StrCat("/", "v2", "/", request.parent(), "/", "logs"),
       {std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
 }
@@ -84,7 +84,7 @@ DefaultGoldenKitchenSinkRestStub::ListServiceAccountKeys(
       google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListServiceAccountKeysResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), "/keys"), {});
+      absl::StrCat("/", "v1", "/", request.name(), "/", "keys"), {});
 }
 
 Status DefaultGoldenKitchenSinkRestStub::DoNothing(
@@ -100,7 +100,7 @@ Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting1(
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return rest_internal::Post(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.table_name(), ":explicitRouting1"));
+      absl::StrCat("/", "v1", "/", request.table_name(), ":explicitRouting1"));
 }
 
 Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting2(
@@ -108,7 +108,7 @@ Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting2(
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return rest_internal::Post(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.table_name(), ":explicitRouting2"));
+      absl::StrCat("/", "v1", "/", request.table_name(), ":explicitRouting2"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultGoldenThingAdminRestStub::ListDatabases(
       google::test::admin::database::v1::ListDatabasesRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListDatabasesResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/databases"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
       {std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
 }
@@ -66,7 +66,7 @@ DefaultGoldenThingAdminRestStub::AsyncCreateDatabase(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request,
-          absl::StrCat("/v1/", request.parent(), "/databases")));
+          absl::StrCat("/", "v1", "/", request.parent(), "/", "databases")));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -82,7 +82,7 @@ DefaultGoldenThingAdminRestStub::GetDatabase(
       google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::Database>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), ""), {});
+      absl::StrCat("/", "v1", "/", request.name()), {});
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -95,7 +95,7 @@ DefaultGoldenThingAdminRestStub::AsyncUpdateDatabaseDdl(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Patch<google::longrunning::Operation>(
           *service, *rest_context, request,
-          absl::StrCat("/v1/", request.database(), "/ddl")));
+          absl::StrCat("/", "v1", "/", request.database(), "/", "ddl")));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -110,7 +110,7 @@ Status DefaultGoldenThingAdminRestStub::DropDatabase(
       google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return rest_internal::Delete(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.database(), ""));
+      absl::StrCat("/", "v1", "/", request.database()));
 }
 
 StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
@@ -119,7 +119,7 @@ DefaultGoldenThingAdminRestStub::GetDatabaseDdl(
       google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::GetDatabaseDdlResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.database(), "/ddl"), {});
+      absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"), {});
 }
 
 StatusOr<google::iam::v1::Policy>
@@ -128,7 +128,7 @@ DefaultGoldenThingAdminRestStub::SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":setIamPolicy"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":setIamPolicy"));
 }
 
 StatusOr<google::iam::v1::Policy>
@@ -137,7 +137,7 @@ DefaultGoldenThingAdminRestStub::GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":getIamPolicy"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":getIamPolicy"));
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
@@ -146,7 +146,7 @@ DefaultGoldenThingAdminRestStub::TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) {
   return rest_internal::Post<google::iam::v1::TestIamPermissionsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":testIamPermissions"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":testIamPermissions"));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -159,7 +159,7 @@ DefaultGoldenThingAdminRestStub::AsyncCreateBackup(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request.backup(),
-          absl::StrCat("/v1/", request.parent(), "/backups")));
+          absl::StrCat("/", "v1", "/", request.parent(), "/", "backups")));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -175,7 +175,7 @@ DefaultGoldenThingAdminRestStub::GetBackup(
       google::test::admin::database::v1::GetBackupRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::Backup>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), ""), {});
+      absl::StrCat("/", "v1", "/", request.name()), {});
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
@@ -184,7 +184,7 @@ DefaultGoldenThingAdminRestStub::UpdateBackup(
       google::test::admin::database::v1::UpdateBackupRequest const& request) {
   return rest_internal::Patch<google::test::admin::database::v1::Backup>(
       *service_, rest_context, request.backup(),
-      absl::StrCat("/v1/", request.backup().name(), ""));
+      absl::StrCat("/", "v1", "/", request.backup().name()));
 }
 
 Status DefaultGoldenThingAdminRestStub::DeleteBackup(
@@ -192,7 +192,7 @@ Status DefaultGoldenThingAdminRestStub::DeleteBackup(
       google::test::admin::database::v1::DeleteBackupRequest const& request) {
   return rest_internal::Delete(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), ""));
+      absl::StrCat("/", "v1", "/", request.name()));
 }
 
 StatusOr<google::test::admin::database::v1::ListBackupsResponse>
@@ -201,7 +201,7 @@ DefaultGoldenThingAdminRestStub::ListBackups(
       google::test::admin::database::v1::ListBackupsRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListBackupsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/backups"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
@@ -217,7 +217,7 @@ DefaultGoldenThingAdminRestStub::AsyncRestoreDatabase(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request,
-          absl::StrCat("/v1/", request.parent(), "/databases:restore")));
+          absl::StrCat("/", "v1", "/", request.parent(), "/", "databases", ":restore")));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -233,7 +233,7 @@ DefaultGoldenThingAdminRestStub::ListDatabaseOperations(
       google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListDatabaseOperationsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/databaseOperations"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseOperations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
@@ -245,7 +245,7 @@ DefaultGoldenThingAdminRestStub::ListBackupOperations(
       google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListBackupOperationsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/backupOperations"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "backupOperations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
@@ -261,7 +261,7 @@ DefaultGoldenThingAdminRestStub::AsyncGetDatabase(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Get<google::test::admin::database::v1::Database>(
           *service, *rest_context, request,
-          absl::StrCat("/v1/", request.name(), ""), {}));
+          absl::StrCat("/", "v1", "/", request.name()), {}));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -281,7 +281,7 @@ DefaultGoldenThingAdminRestStub::AsyncDropDatabase(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Delete<google::protobuf::Empty>(
           *service, *rest_context, request,
-          absl::StrCat("/v1/", request.database(), "")));
+          absl::StrCat("/", "v1", "/", request.database())));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -910,7 +910,7 @@ INSTANTIATE_TEST_SUITE_P(
                              "kNonIdempotent"),
         MethodVarsTestValues(
             "google.protobuf.Service.Method5", "method_rest_path",
-            "absl::StrCat(\"/v1/\", request.parent(), \"/databases\")"),
+            R"""(absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"))"""),
         // Method6
         MethodVarsTestValues("google.protobuf.Service.Method6",
                              "method_request_params",
@@ -958,7 +958,7 @@ INSTANTIATE_TEST_SUITE_P(
                              "request_resource", "request.namespace_()"),
         MethodVarsTestValues(
             "google.protobuf.Service.Method8", "method_rest_path",
-            "absl::StrCat(\"/v1/\", request.namespace_().name(), \"\")"),
+            R"""(absl::StrCat("/", "v1", "/", request.namespace_().name()))"""),
         // Method9
         MethodVarsTestValues("google.protobuf.Service.Method9",
                              "method_http_query_parameters",

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_HTTP_OPTION_UTILS_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_HTTP_OPTION_UTILS_H
 
+#include "generator/internal/http_annotation_parser.h"
 #include "generator/internal/printer.h"
 #include "absl/types/variant.h"
 #include <google/protobuf/descriptor.h>
@@ -40,6 +41,7 @@ struct HttpExtensionInfo {
   std::string path_prefix;
   std::string path_suffix;
   std::vector<RestPathPiece> rest_path;
+  std::string rest_path_verb;
 };
 
 /**

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -428,8 +428,9 @@ TEST_F(HttpOptionUtilsTest, SetHttpDerivedMethodVarsExtensionInfoSingleParam) {
               Eq("\"parent=\", request.parent()"));
   EXPECT_THAT(vars.at("method_request_body"), Eq("*"));
   EXPECT_THAT(vars.at("method_http_verb"), Eq("Post"));
-  EXPECT_THAT(vars.at("method_rest_path"),
-              Eq("absl::StrCat(\"/v1/\", request.parent(), \"/databases\")"));
+  EXPECT_THAT(
+      vars.at("method_rest_path"),
+      Eq(R"""(absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"))"""));
 }
 
 TEST_F(HttpOptionUtilsTest,
@@ -445,9 +446,9 @@ TEST_F(HttpOptionUtilsTest,
                  "request.instance()"));
   EXPECT_THAT(vars.at("method_request_body"), Eq("*"));
   EXPECT_THAT(vars.at("method_http_verb"), Eq("Post"));
-  EXPECT_THAT(vars.at("method_rest_path"),
-              Eq("absl::StrCat(\"/v1/projects/\", request.project(), "
-                 "\"/instances/\", request.instance(), \"/databases\")"));
+  EXPECT_THAT(
+      vars.at("method_rest_path"),
+      Eq(R"""(absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/", "instances", "/", request.instance(), "/", "databases"))"""));
 }
 
 TEST_F(HttpOptionUtilsTest,
@@ -460,9 +461,9 @@ TEST_F(HttpOptionUtilsTest,
   SetHttpDerivedMethodVars(ParseHttpExtension(*method), *method, vars);
   EXPECT_THAT(vars.at("method_request_body"), Eq("*"));
   EXPECT_THAT(vars.at("method_http_verb"), Eq("Post"));
-  auto const* expected_rest_path =
-      R"""(absl::StrCat("/v1/projects/", request.project(), "/instances/", request.instance(), "/databases"))""";
-  EXPECT_THAT(vars.at("method_rest_path"), Eq(expected_rest_path));
+  EXPECT_THAT(
+      vars.at("method_rest_path"),
+      Eq(R"""(absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/", "instances", "/", request.instance(), "/", "databases"))"""));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersNonGet) {

--- a/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub.cc
+++ b/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub.cc
@@ -47,8 +47,9 @@ DefaultAcceleratorTypesRestStub::AggregatedListAcceleratorTypes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::AcceleratorTypeAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/acceleratorTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "acceleratorTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -66,9 +67,9 @@ DefaultAcceleratorTypesRestStub::GetAcceleratorTypes(
         GetAcceleratorTypesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::AcceleratorType>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/acceleratorTypes/",
-                   request.accelerator_type(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "acceleratorTypes", "/", request.accelerator_type()),
       {});
 }
 
@@ -80,8 +81,9 @@ DefaultAcceleratorTypesRestStub::ListAcceleratorTypes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::AcceleratorTypeList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/acceleratorTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "acceleratorTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/addresses/v1/internal/addresses_rest_stub.cc
+++ b/google/cloud/compute/addresses/v1/internal/addresses_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultAddressesRestStub::AggregatedListAddresses(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::AddressAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/addresses"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "addresses"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,10 @@ DefaultAddressesRestStub::AsyncDeleteAddresses(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/addresses/",
-                             request.address(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "addresses", "/",
+                             request.address())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,8 +97,9 @@ DefaultAddressesRestStub::GetAddresses(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Address>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/addresses/", request.address(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "addresses", "/", request.address()),
       {});
 }
 
@@ -115,8 +117,9 @@ DefaultAddressesRestStub::AsyncInsertAddresses(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.address_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/addresses")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "addresses")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -132,8 +135,9 @@ DefaultAddressesRestStub::ListAddresses(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::AddressList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/addresses"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "addresses"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -156,9 +160,10 @@ DefaultAddressesRestStub::AsyncMove(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_addresses_move_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/addresses/",
-                             request.address(), "/move")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "addresses", "/",
+                             request.address(), "/", "move")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -182,9 +187,10 @@ DefaultAddressesRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/addresses/",
-                             request.resource(), "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "addresses", "/",
+                             request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub.cc
+++ b/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultAutoscalersRestStub::AggregatedListAutoscalers(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::AutoscalerAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/autoscalers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "autoscalers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,10 @@ DefaultAutoscalersRestStub::AsyncDeleteAutoscalers(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/autoscalers/",
-                             request.autoscaler(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "autoscalers", "/",
+                             request.autoscaler())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,8 +97,9 @@ DefaultAutoscalersRestStub::GetAutoscalers(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Autoscaler>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/autoscalers/", request.autoscaler(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "autoscalers", "/", request.autoscaler()),
       {});
 }
 
@@ -115,8 +117,9 @@ DefaultAutoscalersRestStub::AsyncInsertAutoscalers(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.autoscaler_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/autoscalers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "autoscalers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -132,8 +135,9 @@ DefaultAutoscalersRestStub::ListAutoscalers(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::AutoscalerList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/autoscalers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "autoscalers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -156,8 +160,9 @@ DefaultAutoscalersRestStub::AsyncPatchAutoscalers(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.autoscaler_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/autoscalers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "autoscalers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -180,8 +185,9 @@ DefaultAutoscalersRestStub::AsyncUpdateAutoscalers(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.autoscaler_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/autoscalers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "autoscalers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
+++ b/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
@@ -58,9 +58,10 @@ DefaultBackendBucketsRestStub::AsyncAddSignedUrlKey(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.signed_url_key_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendBuckets/",
-                             request.backend_bucket(), "/addSignedUrlKey")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendBuckets", "/", request.backend_bucket(),
+                             "/", "addSignedUrlKey")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -83,9 +84,9 @@ DefaultBackendBucketsRestStub::AsyncDeleteBackendBuckets(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendBuckets/",
-                             request.backend_bucket(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendBuckets", "/", request.backend_bucket())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -108,9 +109,10 @@ DefaultBackendBucketsRestStub::AsyncDeleteSignedUrlKey(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendBuckets/",
-                             request.backend_bucket(), "/deleteSignedUrlKey")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendBuckets", "/", request.backend_bucket(),
+                             "/", "deleteSignedUrlKey")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -126,8 +128,9 @@ DefaultBackendBucketsRestStub::GetBackendBuckets(
         GetBackendBucketsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::BackendBucket>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/backendBuckets/", request.backend_bucket(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "backendBuckets", "/",
+                   request.backend_bucket()),
       {});
 }
 
@@ -145,8 +148,9 @@ DefaultBackendBucketsRestStub::AsyncInsertBackendBuckets(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_bucket_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendBuckets")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendBuckets")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -162,8 +166,8 @@ DefaultBackendBucketsRestStub::ListBackendBuckets(
         ListBackendBucketsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::BackendBucketList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/backendBuckets"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "backendBuckets"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -186,9 +190,9 @@ DefaultBackendBucketsRestStub::AsyncPatchBackendBuckets(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_bucket_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendBuckets/",
-                             request.backend_bucket(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendBuckets", "/", request.backend_bucket())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -212,10 +216,10 @@ DefaultBackendBucketsRestStub::AsyncSetEdgeSecurityPolicy(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.security_policy_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendBuckets/",
-                             request.backend_bucket(),
-                             "/setEdgeSecurityPolicy")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendBuckets", "/", request.backend_bucket(),
+                             "/", "setEdgeSecurityPolicy")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -238,9 +242,9 @@ DefaultBackendBucketsRestStub::AsyncUpdateBackendBuckets(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_bucket_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendBuckets/",
-                             request.backend_bucket(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendBuckets", "/", request.backend_bucket())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
+++ b/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
@@ -58,9 +58,10 @@ DefaultBackendServicesRestStub::AsyncAddSignedUrlKey(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.signed_url_key_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendServices/",
-                             request.backend_service(), "/addSignedUrlKey")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendServices", "/", request.backend_service(),
+                             "/", "addSignedUrlKey")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -77,8 +78,9 @@ DefaultBackendServicesRestStub::AggregatedListBackendServices(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::BackendServiceAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/backendServices"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "backendServices"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -103,9 +105,10 @@ DefaultBackendServicesRestStub::AsyncDeleteBackendServices(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendServices/",
-                             request.backend_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendServices", "/",
+                             request.backend_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -128,10 +131,10 @@ DefaultBackendServicesRestStub::AsyncDeleteSignedUrlKey(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendServices/",
-                             request.backend_service(),
-                             "/deleteSignedUrlKey")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendServices", "/", request.backend_service(),
+                             "/", "deleteSignedUrlKey")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -147,8 +150,9 @@ DefaultBackendServicesRestStub::GetBackendServices(
         GetBackendServicesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::BackendService>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/backendServices/", request.backend_service(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "backendServices",
+                   "/", request.backend_service()),
       {});
 }
 
@@ -160,9 +164,9 @@ DefaultBackendServicesRestStub::GetHealth(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::BackendServiceGroupHealth>(
       *service_, rest_context, request.resource_group_reference_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/backendServices/", request.backend_service(),
-                   "/getHealth"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "backendServices",
+                   "/", request.backend_service(), "/", "getHealth"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -172,9 +176,9 @@ DefaultBackendServicesRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/backendServices/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "backendServices",
+                   "/", request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -194,8 +198,9 @@ DefaultBackendServicesRestStub::AsyncInsertBackendServices(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendServices")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendServices")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -212,8 +217,8 @@ DefaultBackendServicesRestStub::ListBackendServices(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::BackendServiceList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/backendServices"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "backendServices"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -236,9 +241,10 @@ DefaultBackendServicesRestStub::AsyncPatchBackendServices(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendServices/",
-                             request.backend_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendServices", "/",
+                             request.backend_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -262,10 +268,10 @@ DefaultBackendServicesRestStub::AsyncSetEdgeSecurityPolicy(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.security_policy_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendServices/",
-                             request.backend_service(),
-                             "/setEdgeSecurityPolicy")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendServices", "/", request.backend_service(),
+                             "/", "setEdgeSecurityPolicy")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -281,9 +287,9 @@ DefaultBackendServicesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/backendServices/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "backendServices",
+                   "/", request.resource(), "/", "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -301,9 +307,10 @@ DefaultBackendServicesRestStub::AsyncSetSecurityPolicy(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.security_policy_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendServices/",
-                             request.backend_service(), "/setSecurityPolicy")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendServices", "/", request.backend_service(),
+                             "/", "setSecurityPolicy")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -326,9 +333,10 @@ DefaultBackendServicesRestStub::AsyncUpdateBackendServices(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/backendServices/",
-                             request.backend_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "backendServices", "/",
+                             request.backend_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub.cc
+++ b/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub.cc
@@ -46,8 +46,8 @@ DefaultDiskTypesRestStub::AggregatedListDiskTypes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::DiskTypeAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/diskTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "diskTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -65,8 +65,9 @@ DefaultDiskTypesRestStub::GetDiskTypes(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskType>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/diskTypes/", request.disk_type(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "diskTypes", "/", request.disk_type()),
       {});
 }
 
@@ -77,8 +78,9 @@ DefaultDiskTypesRestStub::ListDiskTypes(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskTypeList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/diskTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "diskTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
+++ b/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultDisksRestStub::AsyncAddResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.disks_add_resource_policies_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.disk(), "/addResourcePolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/", request.disk(),
+                             "/", "addResourcePolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +79,8 @@ DefaultDisksRestStub::AggregatedListDisks(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::DiskAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/disks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "disks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -103,8 +104,9 @@ DefaultDisksRestStub::AsyncBulkInsert(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.bulk_insert_disk_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/bulkInsert")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/", "bulkInsert")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -127,9 +129,10 @@ DefaultDisksRestStub::AsyncCreateSnapshot(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.snapshot_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.disk(), "/createSnapshot")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/", request.disk(),
+                             "/", "createSnapshot")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -151,9 +154,10 @@ DefaultDisksRestStub::AsyncDeleteDisks(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.disk(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/",
+                             request.disk())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -167,8 +171,9 @@ StatusOr<google::cloud::cpp::compute::v1::Disk> DefaultDisksRestStub::GetDisks(
     google::cloud::cpp::compute::disks::v1::GetDisksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Disk>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/disks/", request.disk(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "disks", "/", request.disk()),
       {});
 }
 
@@ -179,9 +184,9 @@ DefaultDisksRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/disks/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "disks", "/", request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -200,8 +205,9 @@ DefaultDisksRestStub::AsyncInsertDisks(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.disk_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -216,8 +222,9 @@ DefaultDisksRestStub::ListDisks(
     google::cloud::cpp::compute::disks::v1::ListDisksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/disks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "disks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -241,9 +248,10 @@ DefaultDisksRestStub::AsyncRemoveResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.disks_remove_resource_policies_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.disk(), "/removeResourcePolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/", request.disk(),
+                             "/", "removeResourcePolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -266,9 +274,10 @@ DefaultDisksRestStub::AsyncResize(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.disks_resize_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.disk(), "/resize")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/", request.disk(),
+                             "/", "resize")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -284,9 +293,9 @@ DefaultDisksRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.zone_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/disks/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "disks", "/", request.resource(), "/", "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -303,9 +312,10 @@ DefaultDisksRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.zone_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.resource(), "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/",
+                             request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -329,9 +339,10 @@ DefaultDisksRestStub::AsyncStartAsyncReplication(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.disks_start_async_replication_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.disk(), "/startAsyncReplication")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/", request.disk(),
+                             "/", "startAsyncReplication")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -354,9 +365,10 @@ DefaultDisksRestStub::AsyncStopAsyncReplication(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.disk(), "/stopAsyncReplication")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/", request.disk(),
+                             "/", "stopAsyncReplication")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -380,9 +392,10 @@ DefaultDisksRestStub::AsyncStopGroupAsyncReplication(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.disks_stop_group_async_replication_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/disks/stopGroupAsyncReplication")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/",
+                             "stopGroupAsyncReplication")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -399,9 +412,10 @@ DefaultDisksRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/disks/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "disks", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -417,9 +431,10 @@ DefaultDisksRestStub::AsyncUpdateDisks(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.disk_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/disks/",
-                             request.disk(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "disks", "/",
+                             request.disk())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub.cc
@@ -60,9 +60,10 @@ DefaultExternalVpnGatewaysRestStub::AsyncDeleteExternalVpnGateways(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/externalVpnGateways/",
-                             request.external_vpn_gateway(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "externalVpnGateways", "/",
+                             request.external_vpn_gateway())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -79,9 +80,9 @@ DefaultExternalVpnGatewaysRestStub::GetExternalVpnGateways(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ExternalVpnGateway>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/externalVpnGateways/",
-                   request.external_vpn_gateway(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "externalVpnGateways",
+                   "/", request.external_vpn_gateway()),
       {});
 }
 
@@ -100,8 +101,9 @@ DefaultExternalVpnGatewaysRestStub::AsyncInsertExternalVpnGateways(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.external_vpn_gateway_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/externalVpnGateways")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "externalVpnGateways")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -118,8 +120,9 @@ DefaultExternalVpnGatewaysRestStub::ListExternalVpnGateways(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ExternalVpnGatewayList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/externalVpnGateways"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "externalVpnGateways"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -143,9 +146,10 @@ DefaultExternalVpnGatewaysRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.global_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/externalVpnGateways/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "externalVpnGateways", "/", request.resource(),
+                             "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -162,9 +166,9 @@ DefaultExternalVpnGatewaysRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/externalVpnGateways/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "externalVpnGateways",
+                   "/", request.resource(), "/", "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
@@ -60,8 +60,10 @@ DefaultFirewallPoliciesRestStub::AsyncAddAssociation(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_association_resource(),
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "/addAssociation")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/",
+                             "addAssociation")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -85,8 +87,9 @@ DefaultFirewallPoliciesRestStub::AsyncAddRule(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_rule_resource(),
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "/addRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "addRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -109,8 +112,9 @@ DefaultFirewallPoliciesRestStub::AsyncCloneRules(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "/cloneRules")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "cloneRules")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -133,8 +137,9 @@ DefaultFirewallPoliciesRestStub::AsyncDeleteFirewallPolicies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -150,8 +155,8 @@ DefaultFirewallPoliciesRestStub::GetFirewallPolicies(
         GetFirewallPoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallPolicy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                   request.firewall_policy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
+                   "/", "firewallPolicies", "/", request.firewall_policy()),
       {});
 }
 
@@ -163,8 +168,9 @@ DefaultFirewallPoliciesRestStub::GetAssociation(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyAssociation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                   request.firewall_policy(), "/getAssociation"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
+                   "/", "firewallPolicies", "/", request.firewall_policy(), "/",
+                   "getAssociation"),
       {std::make_pair("name", request.name())});
 }
 
@@ -175,8 +181,9 @@ DefaultFirewallPoliciesRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                   request.resource(), "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
+                   "/", "firewallPolicies", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -190,8 +197,9 @@ DefaultFirewallPoliciesRestStub::GetRule(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyRule>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                   request.firewall_policy(), "/getRule"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
+                   "/", "firewallPolicies", "/", request.firewall_policy(), "/",
+                   "getRule"),
       {std::make_pair("priority", std::to_string(request.priority()))});
 }
 
@@ -263,8 +271,9 @@ DefaultFirewallPoliciesRestStub::AsyncMove(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "/move")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "move")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -287,8 +296,9 @@ DefaultFirewallPoliciesRestStub::AsyncPatchFirewallPolicies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -312,8 +322,9 @@ DefaultFirewallPoliciesRestStub::AsyncPatchRule(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_rule_resource(),
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "/patchRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "patchRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -336,8 +347,10 @@ DefaultFirewallPoliciesRestStub::AsyncRemoveAssociation(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "/removeAssociation")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/",
+                             "removeAssociation")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -360,8 +373,9 @@ DefaultFirewallPoliciesRestStub::AsyncRemoveRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                             request.firewall_policy(), "/removeRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
+                             "global", "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "removeRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -378,8 +392,9 @@ DefaultFirewallPoliciesRestStub::SetIamPolicy(
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context,
       request.global_organization_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                   request.resource(), "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
+                   "/", "firewallPolicies", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -390,8 +405,9 @@ DefaultFirewallPoliciesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/locations/global/firewallPolicies/",
-                   request.resource(), "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
+                   "/", "firewallPolicies", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub.cc
+++ b/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub.cc
@@ -58,8 +58,9 @@ DefaultFirewallsRestStub::AsyncDeleteFirewalls(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewalls/", request.firewall(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "firewalls",
+                             "/", request.firewall())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -75,8 +76,9 @@ DefaultFirewallsRestStub::GetFirewalls(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Firewall>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewalls/", request.firewall(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewalls", "/",
+                   request.firewall()),
       {});
 }
 
@@ -94,8 +96,9 @@ DefaultFirewallsRestStub::AsyncInsertFirewalls(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewalls")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewalls")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -111,8 +114,8 @@ DefaultFirewallsRestStub::ListFirewalls(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewalls"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewalls"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -135,8 +138,9 @@ DefaultFirewallsRestStub::AsyncPatchFirewalls(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewalls/", request.firewall(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "firewalls",
+                             "/", request.firewall())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -159,8 +163,9 @@ DefaultFirewallsRestStub::AsyncUpdateFirewalls(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewalls/", request.firewall(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "firewalls",
+                             "/", request.firewall())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub.cc
+++ b/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub.cc
@@ -52,8 +52,9 @@ DefaultForwardingRulesRestStub::AggregatedListForwardingRules(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ForwardingRuleAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/forwardingRules"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "forwardingRules"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +79,10 @@ DefaultForwardingRulesRestStub::AsyncDeleteForwardingRules(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/forwardingRules/",
-                             request.forwarding_rule(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "forwardingRules", "/",
+                             request.forwarding_rule())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,9 +98,9 @@ DefaultForwardingRulesRestStub::GetForwardingRules(
         GetForwardingRulesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ForwardingRule>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/forwardingRules/",
-                   request.forwarding_rule(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "forwardingRules", "/", request.forwarding_rule()),
       {});
 }
 
@@ -116,9 +118,9 @@ DefaultForwardingRulesRestStub::AsyncInsertForwardingRules(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.forwarding_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/forwardingRules")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "forwardingRules")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -135,8 +137,9 @@ DefaultForwardingRulesRestStub::ListForwardingRules(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ForwardingRuleList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/forwardingRules"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "forwardingRules"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -159,9 +162,10 @@ DefaultForwardingRulesRestStub::AsyncPatchForwardingRules(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.forwarding_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/forwardingRules/",
-                             request.forwarding_rule(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "forwardingRules", "/",
+                             request.forwarding_rule())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -185,9 +189,10 @@ DefaultForwardingRulesRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/forwardingRules/",
-                             request.resource(), "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "forwardingRules", "/",
+                             request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -210,9 +215,10 @@ DefaultForwardingRulesRestStub::AsyncSetTarget(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/forwardingRules/",
-                             request.forwarding_rule(), "/setTarget")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "forwardingRules", "/",
+                             request.forwarding_rule(), "/", "setTarget")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub.cc
+++ b/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub.cc
@@ -58,8 +58,9 @@ DefaultGlobalAddressesRestStub::AsyncDeleteGlobalAddresses(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/addresses/", request.address(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "addresses",
+                             "/", request.address())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -75,8 +76,9 @@ DefaultGlobalAddressesRestStub::GetGlobalAddresses(
         GetGlobalAddressesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Address>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/addresses/", request.address(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "addresses", "/",
+                   request.address()),
       {});
 }
 
@@ -94,8 +96,9 @@ DefaultGlobalAddressesRestStub::AsyncInsertGlobalAddresses(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.address_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/addresses")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "addresses")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -111,8 +114,8 @@ DefaultGlobalAddressesRestStub::ListGlobalAddresses(
         ListGlobalAddressesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::AddressList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/addresses"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "addresses"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -136,9 +139,9 @@ DefaultGlobalAddressesRestStub::AsyncMove(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.global_addresses_move_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/addresses/", request.address(),
-                             "/move")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "addresses",
+                             "/", request.address(), "/", "move")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -162,9 +165,9 @@ DefaultGlobalAddressesRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.global_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/addresses/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "addresses",
+                             "/", request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub.cc
+++ b/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub.cc
@@ -60,9 +60,10 @@ DefaultGlobalForwardingRulesRestStub::AsyncDeleteGlobalForwardingRules(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/forwardingRules/",
-                             request.forwarding_rule(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "forwardingRules", "/",
+                             request.forwarding_rule())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +79,9 @@ DefaultGlobalForwardingRulesRestStub::GetGlobalForwardingRules(
         GetGlobalForwardingRulesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ForwardingRule>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/forwardingRules/", request.forwarding_rule(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "forwardingRules",
+                   "/", request.forwarding_rule()),
       {});
 }
 
@@ -97,8 +99,9 @@ DefaultGlobalForwardingRulesRestStub::AsyncInsertGlobalForwardingRules(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.forwarding_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/forwardingRules")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "forwardingRules")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -115,8 +118,8 @@ DefaultGlobalForwardingRulesRestStub::ListGlobalForwardingRules(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ForwardingRuleList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/forwardingRules"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "forwardingRules"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -139,9 +142,10 @@ DefaultGlobalForwardingRulesRestStub::AsyncPatchGlobalForwardingRules(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.forwarding_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/forwardingRules/",
-                             request.forwarding_rule(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "forwardingRules", "/",
+                             request.forwarding_rule())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -165,9 +169,10 @@ DefaultGlobalForwardingRulesRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.global_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/forwardingRules/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "forwardingRules", "/", request.resource(), "/",
+                             "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -190,9 +195,10 @@ DefaultGlobalForwardingRulesRestStub::AsyncSetTarget(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/forwardingRules/",
-                             request.forwarding_rule(), "/setTarget")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "forwardingRules", "/", request.forwarding_rule(),
+                             "/", "setTarget")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
@@ -63,10 +63,11 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncAttachNetworkEndpoints(
             *service, *rest_context,
             request
                 .global_network_endpoint_groups_attach_endpoints_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/global/networkEndpointGroups/",
-                         request.network_endpoint_group(),
-                         "/attachNetworkEndpoints")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "global", "/",
+                         "networkEndpointGroups", "/",
+                         request.network_endpoint_group(), "/",
+                         "attachNetworkEndpoints")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -90,9 +91,10 @@ DefaultGlobalNetworkEndpointGroupsRestStub::
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networkEndpointGroups/",
-                             request.network_endpoint_group(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "networkEndpointGroups", "/",
+                             request.network_endpoint_group())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -117,10 +119,11 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncDetachNetworkEndpoints(
             *service, *rest_context,
             request
                 .global_network_endpoint_groups_detach_endpoints_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/global/networkEndpointGroups/",
-                         request.network_endpoint_group(),
-                         "/detachNetworkEndpoints")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "global", "/",
+                         "networkEndpointGroups", "/",
+                         request.network_endpoint_group(), "/",
+                         "detachNetworkEndpoints")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -137,9 +140,10 @@ DefaultGlobalNetworkEndpointGroupsRestStub::GetGlobalNetworkEndpointGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroup>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/networkEndpointGroups/",
-                   request.network_endpoint_group(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "networkEndpointGroups", "/",
+                   request.network_endpoint_group()),
       {});
 }
 
@@ -159,8 +163,9 @@ DefaultGlobalNetworkEndpointGroupsRestStub::
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.network_endpoint_group_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networkEndpointGroups")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "networkEndpointGroups")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -177,8 +182,9 @@ DefaultGlobalNetworkEndpointGroupsRestStub::ListGlobalNetworkEndpointGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroupList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/networkEndpointGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "networkEndpointGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -196,9 +202,10 @@ DefaultGlobalNetworkEndpointGroupsRestStub::ListNetworkEndpoints(
   return rest_internal::Post<google::cloud::cpp::compute::v1::
                                  NetworkEndpointGroupsListNetworkEndpoints>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/networkEndpointGroups/",
-                   request.network_endpoint_group(), "/listNetworkEndpoints"));
+      absl::StrCat(
+          "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
+          "/", "global", "/", "networkEndpointGroups", "/",
+          request.network_endpoint_group(), "/", "listNetworkEndpoints"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub.cc
+++ b/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub.cc
@@ -47,8 +47,8 @@ DefaultGlobalOperationsRestStub::AggregatedListGlobalOperations(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::OperationAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/operations"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "operations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -65,8 +65,9 @@ Status DefaultGlobalOperationsRestStub::DeleteGlobalOperations(
         DeleteGlobalOperationsRequest const& request) {
   return rest_internal::Delete(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/operations/", request.operation(), ""));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "operations", "/",
+                   request.operation()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>
@@ -76,8 +77,9 @@ DefaultGlobalOperationsRestStub::GetGlobalOperations(
         GetGlobalOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/operations/", request.operation(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "operations", "/",
+                   request.operation()),
       {});
 }
 
@@ -88,8 +90,8 @@ DefaultGlobalOperationsRestStub::ListGlobalOperations(
         ListGlobalOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/operations"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "operations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -105,8 +107,9 @@ DefaultGlobalOperationsRestStub::Wait(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/operations/", request.operation(), "/wait"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "operations", "/",
+                   request.operation(), "/", "wait"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
+++ b/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
@@ -48,8 +48,8 @@ DefaultGlobalOrganizationOperationsRestStub::DeleteGlobalOrganizationOperations(
         DeleteGlobalOrganizationOperationsRequest const& request) {
   return rest_internal::Delete(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/locations/global/operations/",
-                   request.operation(), ""));
+      absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
+                   "/", "operations", "/", request.operation()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>
@@ -59,8 +59,8 @@ DefaultGlobalOrganizationOperationsRestStub::GetGlobalOrganizationOperations(
         GetGlobalOrganizationOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/locations/global/operations/",
-                   request.operation(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
+                   "/", "operations", "/", request.operation()),
       {std::make_pair("parent_id", request.parent_id())});
 }
 

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub.cc
@@ -62,9 +62,10 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/publicDelegatedPrefixes/",
-                             request.public_delegated_prefix(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "publicDelegatedPrefixes", "/",
+                             request.public_delegated_prefix())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,9 +82,10 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::GetGlobalPublicDelegatedPrefixes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefix>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/publicDelegatedPrefixes/",
-                   request.public_delegated_prefix(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "publicDelegatedPrefixes", "/",
+                   request.public_delegated_prefix()),
       {});
 }
 
@@ -103,8 +105,9 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.public_delegated_prefix_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/publicDelegatedPrefixes")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "publicDelegatedPrefixes")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -121,8 +124,9 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::ListGlobalPublicDelegatedPrefixes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefixList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/publicDelegatedPrefixes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "publicDelegatedPrefixes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -147,9 +151,10 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.public_delegated_prefix_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/publicDelegatedPrefixes/",
-                             request.public_delegated_prefix(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "publicDelegatedPrefixes", "/",
+                             request.public_delegated_prefix())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub.cc
+++ b/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultHealthChecksRestStub::AggregatedListHealthChecks(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HealthChecksAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/healthChecks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "healthChecks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,9 @@ DefaultHealthChecksRestStub::AsyncDeleteHealthChecks(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/healthChecks/", request.health_check(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "healthChecks", "/", request.health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,8 +96,9 @@ DefaultHealthChecksRestStub::GetHealthChecks(
         GetHealthChecksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HealthCheck>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/healthChecks/", request.health_check(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "healthChecks", "/",
+                   request.health_check()),
       {});
 }
 
@@ -115,8 +116,9 @@ DefaultHealthChecksRestStub::AsyncInsertHealthChecks(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/healthChecks")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "healthChecks")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -132,8 +134,8 @@ DefaultHealthChecksRestStub::ListHealthChecks(
         ListHealthChecksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HealthCheckList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/healthChecks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "healthChecks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -156,9 +158,9 @@ DefaultHealthChecksRestStub::AsyncPatchHealthChecks(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/healthChecks/", request.health_check(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "healthChecks", "/", request.health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -181,9 +183,9 @@ DefaultHealthChecksRestStub::AsyncUpdateHealthChecks(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/healthChecks/", request.health_check(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "healthChecks", "/", request.health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub.cc
+++ b/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultHttpHealthChecksRestStub::AsyncDeleteHttpHealthChecks(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/httpHealthChecks/",
-                             request.http_health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "httpHealthChecks", "/",
+                             request.http_health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -77,9 +78,9 @@ DefaultHttpHealthChecksRestStub::GetHttpHealthChecks(
         GetHttpHealthChecksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HttpHealthCheck>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/httpHealthChecks/", request.http_health_check(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "httpHealthChecks",
+                   "/", request.http_health_check()),
       {});
 }
 
@@ -97,8 +98,9 @@ DefaultHttpHealthChecksRestStub::AsyncInsertHttpHealthChecks(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.http_health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/httpHealthChecks")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "httpHealthChecks")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -115,8 +117,8 @@ DefaultHttpHealthChecksRestStub::ListHttpHealthChecks(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HttpHealthCheckList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/httpHealthChecks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "httpHealthChecks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -139,9 +141,10 @@ DefaultHttpHealthChecksRestStub::AsyncPatchHttpHealthChecks(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.http_health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/httpHealthChecks/",
-                             request.http_health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "httpHealthChecks", "/",
+                             request.http_health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -164,9 +167,10 @@ DefaultHttpHealthChecksRestStub::AsyncUpdateHttpHealthChecks(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.http_health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/httpHealthChecks/",
-                             request.http_health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "httpHealthChecks", "/",
+                             request.http_health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub.cc
+++ b/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultHttpsHealthChecksRestStub::AsyncDeleteHttpsHealthChecks(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/httpsHealthChecks/",
-                             request.https_health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "httpsHealthChecks", "/",
+                             request.https_health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -77,9 +78,9 @@ DefaultHttpsHealthChecksRestStub::GetHttpsHealthChecks(
         GetHttpsHealthChecksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HttpsHealthCheck>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/httpsHealthChecks/", request.https_health_check(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "httpsHealthChecks",
+                   "/", request.https_health_check()),
       {});
 }
 
@@ -97,8 +98,9 @@ DefaultHttpsHealthChecksRestStub::AsyncInsertHttpsHealthChecks(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.https_health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/httpsHealthChecks")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "httpsHealthChecks")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -115,8 +117,8 @@ DefaultHttpsHealthChecksRestStub::ListHttpsHealthChecks(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HttpsHealthCheckList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/httpsHealthChecks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "httpsHealthChecks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -139,9 +141,10 @@ DefaultHttpsHealthChecksRestStub::AsyncPatchHttpsHealthChecks(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.https_health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/httpsHealthChecks/",
-                             request.https_health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "httpsHealthChecks", "/",
+                             request.https_health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -164,9 +167,10 @@ DefaultHttpsHealthChecksRestStub::AsyncUpdateHttpsHealthChecks(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.https_health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/httpsHealthChecks/",
-                             request.https_health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "httpsHealthChecks", "/",
+                             request.https_health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/image_family_views/v1/internal/image_family_views_rest_stub.cc
+++ b/google/cloud/compute/image_family_views/v1/internal/image_family_views_rest_stub.cc
@@ -46,8 +46,9 @@ DefaultImageFamilyViewsRestStub::GetImageFamilyViews(
         GetImageFamilyViewsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ImageFamilyView>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/imageFamilyViews/", request.family(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "imageFamilyViews", "/", request.family()),
       {});
 }
 

--- a/google/cloud/compute/images/v1/internal/images_rest_stub.cc
+++ b/google/cloud/compute/images/v1/internal/images_rest_stub.cc
@@ -58,8 +58,9 @@ DefaultImagesRestStub::AsyncDeleteImages(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/images/", request.image(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "images",
+                             "/", request.image())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,9 +82,9 @@ DefaultImagesRestStub::AsyncDeprecate(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.deprecation_status_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/images/", request.image(),
-                             "/deprecate")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "images",
+                             "/", request.image(), "/", "deprecate")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,8 +99,9 @@ DefaultImagesRestStub::GetImages(
     google::cloud::cpp::compute::images::v1::GetImagesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Image>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/images/", request.image(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "images", "/",
+                   request.image()),
       {});
 }
 
@@ -110,8 +112,9 @@ DefaultImagesRestStub::GetFromFamily(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Image>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/images/family/", request.family(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "images", "/",
+                   "family", "/", request.family()),
       {});
 }
 
@@ -122,8 +125,9 @@ DefaultImagesRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/images/", request.resource(), "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "images", "/",
+                   request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -143,8 +147,8 @@ DefaultImagesRestStub::AsyncInsertImages(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.image_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/images")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "images")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -159,8 +163,8 @@ DefaultImagesRestStub::ListImages(
     google::cloud::cpp::compute::images::v1::ListImagesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ImageList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/images"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "images"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -183,8 +187,9 @@ DefaultImagesRestStub::AsyncPatchImages(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.image_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/images/", request.image(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "images",
+                             "/", request.image())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -200,8 +205,9 @@ DefaultImagesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/images/", request.resource(), "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "images", "/",
+                   request.resource(), "/", "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -218,9 +224,9 @@ DefaultImagesRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.global_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/images/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "images",
+                             "/", request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -237,9 +243,9 @@ DefaultImagesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/images/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "images", "/",
+                   request.resource(), "/", "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
@@ -62,10 +62,11 @@ DefaultInstanceGroupManagersRestStub::AsyncAbandonInstances(
             *service, *rest_context,
             request
                 .instance_group_managers_abandon_instances_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/abandonInstances")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "abandonInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -82,8 +83,9 @@ DefaultInstanceGroupManagersRestStub::AggregatedListInstanceGroupManagers(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManagerAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/instanceGroupManagers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "instanceGroupManagers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -110,11 +112,11 @@ DefaultInstanceGroupManagersRestStub::AsyncApplyUpdatesToInstances(
                 *service, *rest_context,
                 request
                     .instance_group_managers_apply_updates_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/instanceGroupManagers/",
-                             request.instance_group_manager(),
-                             "/applyUpdatesToInstances")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroupManagers", "/",
+                             request.instance_group_manager(), "/",
+                             "applyUpdatesToInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -138,10 +140,11 @@ DefaultInstanceGroupManagersRestStub::AsyncCreateInstances(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.instance_group_managers_create_instances_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/createInstances")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "createInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -164,10 +167,10 @@ DefaultInstanceGroupManagersRestStub::AsyncDeleteInstanceGroupManagers(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/instanceGroupManagers/",
-                             request.instance_group_manager(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroupManagers", "/",
+                             request.instance_group_manager())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -191,10 +194,11 @@ DefaultInstanceGroupManagersRestStub::AsyncDeleteInstances(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.instance_group_managers_delete_instances_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/deleteInstances")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "deleteInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -219,10 +223,11 @@ DefaultInstanceGroupManagersRestStub::AsyncDeletePerInstanceConfigs(
             *service, *rest_context,
             request
                 .instance_group_managers_delete_per_instance_configs_req_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/deletePerInstanceConfigs")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "deletePerInstanceConfigs")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -239,9 +244,10 @@ DefaultInstanceGroupManagersRestStub::GetInstanceGroupManagers(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManager>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instanceGroupManagers/",
-                   request.instance_group_manager(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instanceGroupManagers", "/",
+                   request.instance_group_manager()),
       {});
 }
 
@@ -260,9 +266,9 @@ DefaultInstanceGroupManagersRestStub::AsyncInsertInstanceGroupManagers(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_group_manager_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/instanceGroupManagers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroupManagers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -279,8 +285,9 @@ DefaultInstanceGroupManagersRestStub::ListInstanceGroupManagers(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManagerList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instanceGroupManagers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instanceGroupManagers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -298,9 +305,10 @@ DefaultInstanceGroupManagersRestStub::ListErrors(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManagersListErrorsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instanceGroupManagers/",
-                   request.instance_group_manager(), "/listErrors"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instanceGroupManagers", "/",
+                   request.instance_group_manager(), "/", "listErrors"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -319,9 +327,10 @@ DefaultInstanceGroupManagersRestStub::ListManagedInstances(
       google::cloud::cpp::compute::v1::
           InstanceGroupManagersListManagedInstancesResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instanceGroupManagers/",
-                   request.instance_group_manager(), "/listManagedInstances"));
+      absl::StrCat(
+          "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
+          "/", "zones", "/", request.zone(), "/", "instanceGroupManagers", "/",
+          request.instance_group_manager(), "/", "listManagedInstances"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -334,10 +343,10 @@ DefaultInstanceGroupManagersRestStub::ListPerInstanceConfigs(
       google::cloud::cpp::compute::v1::
           InstanceGroupManagersListPerInstanceConfigsResp>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instanceGroupManagers/",
-                   request.instance_group_manager(),
-                   "/listPerInstanceConfigs"));
+      absl::StrCat(
+          "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
+          "/", "zones", "/", request.zone(), "/", "instanceGroupManagers", "/",
+          request.instance_group_manager(), "/", "listPerInstanceConfigs"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -355,10 +364,10 @@ DefaultInstanceGroupManagersRestStub::AsyncPatchInstanceGroupManagers(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_group_manager_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/instanceGroupManagers/",
-                             request.instance_group_manager(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroupManagers", "/",
+                             request.instance_group_manager())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -383,10 +392,11 @@ DefaultInstanceGroupManagersRestStub::AsyncPatchPerInstanceConfigs(
             *service, *rest_context,
             request
                 .instance_group_managers_patch_per_instance_configs_req_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/patchPerInstanceConfigs")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "patchPerInstanceConfigs")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -411,10 +421,11 @@ DefaultInstanceGroupManagersRestStub::AsyncRecreateInstances(
             *service, *rest_context,
             request
                 .instance_group_managers_recreate_instances_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/recreateInstances")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "recreateInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -437,10 +448,10 @@ DefaultInstanceGroupManagersRestStub::AsyncResize(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/instanceGroupManagers/",
-                             request.instance_group_manager(), "/resize")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroupManagers", "/",
+                             request.instance_group_manager(), "/", "resize")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -465,10 +476,11 @@ DefaultInstanceGroupManagersRestStub::AsyncSetInstanceTemplate(
             *service, *rest_context,
             request
                 .instance_group_managers_set_instance_template_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/setInstanceTemplate")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "setInstanceTemplate")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -492,9 +504,11 @@ DefaultInstanceGroupManagersRestStub::AsyncSetTargetPools(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.instance_group_managers_set_target_pools_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(), "/setTargetPools")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "setTargetPools")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -519,10 +533,11 @@ DefaultInstanceGroupManagersRestStub::AsyncUpdatePerInstanceConfigs(
             *service, *rest_context,
             request
                 .instance_group_managers_update_per_instance_configs_req_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/updatePerInstanceConfigs")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "updatePerInstanceConfigs")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub.cc
+++ b/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultInstanceGroupsRestStub::AsyncAddInstances(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_groups_add_instances_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instanceGroups/",
-                             request.instance_group(), "/addInstances")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroups", "/",
+                             request.instance_group(), "/", "addInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +79,8 @@ DefaultInstanceGroupsRestStub::AggregatedListInstanceGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/instanceGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "instanceGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -104,9 +105,10 @@ DefaultInstanceGroupsRestStub::AsyncDeleteInstanceGroups(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instanceGroups/",
-                             request.instance_group(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroups", "/",
+                             request.instance_group())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -122,9 +124,9 @@ DefaultInstanceGroupsRestStub::GetInstanceGroups(
         GetInstanceGroupsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceGroup>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instanceGroups/", request.instance_group(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instanceGroups", "/", request.instance_group()),
       {});
 }
 
@@ -142,8 +144,9 @@ DefaultInstanceGroupsRestStub::AsyncInsertInstanceGroups(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.instance_group_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instanceGroups")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroups")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -159,8 +162,9 @@ DefaultInstanceGroupsRestStub::ListInstanceGroups(
         ListInstanceGroupsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceGroupList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instanceGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instanceGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -178,9 +182,10 @@ DefaultInstanceGroupsRestStub::ListInstances(
       google::cloud::cpp::compute::v1::InstanceGroupsListInstances>(
       *service_, rest_context,
       request.instance_groups_list_instances_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instanceGroups/", request.instance_group(),
-                   "/listInstances"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instanceGroups", "/", request.instance_group(), "/",
+                   "listInstances"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -198,9 +203,11 @@ DefaultInstanceGroupsRestStub::AsyncRemoveInstances(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_groups_remove_instances_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instanceGroups/",
-                             request.instance_group(), "/removeInstances")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroups", "/",
+                             request.instance_group(), "/",
+                             "removeInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -224,9 +231,10 @@ DefaultInstanceGroupsRestStub::AsyncSetNamedPorts(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_groups_set_named_ports_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instanceGroups/",
-                             request.instance_group(), "/setNamedPorts")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instanceGroups", "/",
+                             request.instance_group(), "/", "setNamedPorts")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub.cc
+++ b/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultInstanceTemplatesRestStub::AggregatedListInstanceTemplates(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceTemplateAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/instanceTemplates"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "instanceTemplates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -79,9 +80,10 @@ DefaultInstanceTemplatesRestStub::AsyncDeleteInstanceTemplates(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/instanceTemplates/",
-                             request.instance_template(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "instanceTemplates", "/",
+                             request.instance_template())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -97,9 +99,9 @@ DefaultInstanceTemplatesRestStub::GetInstanceTemplates(
         GetInstanceTemplatesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceTemplate>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/instanceTemplates/", request.instance_template(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "instanceTemplates",
+                   "/", request.instance_template()),
       {});
 }
 
@@ -110,9 +112,9 @@ DefaultInstanceTemplatesRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/instanceTemplates/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "instanceTemplates",
+                   "/", request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -132,8 +134,9 @@ DefaultInstanceTemplatesRestStub::AsyncInsertInstanceTemplates(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.instance_template_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/instanceTemplates")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "instanceTemplates")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -150,8 +153,8 @@ DefaultInstanceTemplatesRestStub::ListInstanceTemplates(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceTemplateList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/instanceTemplates"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "instanceTemplates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -167,9 +170,9 @@ DefaultInstanceTemplatesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/instanceTemplates/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "instanceTemplates",
+                   "/", request.resource(), "/", "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -180,9 +183,9 @@ DefaultInstanceTemplatesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/instanceTemplates/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "instanceTemplates",
+                   "/", request.resource(), "/", "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
+++ b/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
@@ -58,9 +58,10 @@ DefaultInstancesRestStub::AsyncAddAccessConfig(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.access_config_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/addAccessConfig")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "addAccessConfig")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,9 +85,10 @@ DefaultInstancesRestStub::AsyncAddResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_add_resource_policies_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/addResourcePolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "addResourcePolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -103,8 +105,8 @@ DefaultInstancesRestStub::AggregatedListInstances(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/instances"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "instances"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -129,9 +131,10 @@ DefaultInstancesRestStub::AsyncAttachDisk(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.attached_disk_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/attachDisk")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "attachDisk")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -155,9 +158,10 @@ DefaultInstancesRestStub::AsyncBulkInsert(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.bulk_insert_instance_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/instances/bulkInsert")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             "bulkInsert")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -180,9 +184,10 @@ DefaultInstancesRestStub::AsyncDeleteInstances(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -205,9 +210,10 @@ DefaultInstancesRestStub::AsyncDeleteAccessConfig(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/deleteAccessConfig")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "deleteAccessConfig")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -230,9 +236,10 @@ DefaultInstancesRestStub::AsyncDetachDisk(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/detachDisk")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "detachDisk")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -248,8 +255,9 @@ DefaultInstancesRestStub::GetInstances(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Instance>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.instance(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.instance()),
       {});
 }
 
@@ -262,9 +270,10 @@ DefaultInstancesRestStub::GetEffectiveFirewalls(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstancesGetEffectiveFirewallsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.instance(),
-                   "/getEffectiveFirewalls"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "getEffectiveFirewalls"),
       {std::make_pair("network_interface", request.network_interface())});
 }
 
@@ -275,9 +284,10 @@ DefaultInstancesRestStub::GetGuestAttributes(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::GuestAttributes>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.instance(),
-                   "/getGuestAttributes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "getGuestAttributes"),
       {std::make_pair("query_path", request.query_path()),
        std::make_pair("variable_key", request.variable_key())});
 }
@@ -289,9 +299,9 @@ DefaultInstancesRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -304,9 +314,9 @@ DefaultInstancesRestStub::GetScreenshot(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Screenshot>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.instance(),
-                   "/screenshot"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.instance(), "/", "screenshot"),
       {});
 }
 
@@ -317,9 +327,9 @@ DefaultInstancesRestStub::GetSerialPortOutput(
         GetSerialPortOutputRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SerialPortOutput>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.instance(),
-                   "/serialPort"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.instance(), "/", "serialPort"),
       {std::make_pair("port", std::to_string(request.port())),
        std::make_pair("start", request.start())});
 }
@@ -332,9 +342,10 @@ DefaultInstancesRestStub::GetShieldedInstanceIdentity(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ShieldedInstanceIdentity>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.instance(),
-                   "/getShieldedInstanceIdentity"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "getShieldedInstanceIdentity"),
       {});
 }
 
@@ -352,8 +363,9 @@ DefaultInstancesRestStub::AsyncInsertInstances(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.instance_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -369,8 +381,9 @@ DefaultInstancesRestStub::ListInstances(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -387,9 +400,9 @@ DefaultInstancesRestStub::ListReferrers(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceListReferrers>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.instance(),
-                   "/referrers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.instance(), "/", "referrers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -413,9 +426,11 @@ DefaultInstancesRestStub::AsyncRemoveResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_remove_resource_policies_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/removeResourcePolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/",
+                             "removeResourcePolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -437,9 +452,10 @@ DefaultInstancesRestStub::AsyncReset(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/reset")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "reset")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -461,9 +477,10 @@ DefaultInstancesRestStub::AsyncResume(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/resume")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "resume")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -478,9 +495,10 @@ Status DefaultInstancesRestStub::SendDiagnosticInterrupt(
         SendDiagnosticInterruptRequest const& request) {
   return rest_internal::Post(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.instance(),
-                   "/sendDiagnosticInterrupt"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "sendDiagnosticInterrupt"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -497,9 +515,11 @@ DefaultInstancesRestStub::AsyncSetDeletionProtection(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.resource(), "/setDeletionProtection")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.resource(), "/",
+                             "setDeletionProtection")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -522,9 +542,10 @@ DefaultInstancesRestStub::AsyncSetDiskAutoDelete(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setDiskAutoDelete")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setDiskAutoDelete")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -540,9 +561,9 @@ DefaultInstancesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.zone_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.resource(), "/", "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -560,9 +581,10 @@ DefaultInstancesRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -586,9 +608,10 @@ DefaultInstancesRestStub::AsyncSetMachineResources(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_set_machine_resources_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setMachineResources")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setMachineResources")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -612,9 +635,10 @@ DefaultInstancesRestStub::AsyncSetMachineType(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_set_machine_type_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setMachineType")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setMachineType")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -637,9 +661,10 @@ DefaultInstancesRestStub::AsyncSetMetadata(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.metadata_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setMetadata")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setMetadata")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -663,9 +688,10 @@ DefaultInstancesRestStub::AsyncSetMinCpuPlatform(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_set_min_cpu_platform_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setMinCpuPlatform")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setMinCpuPlatform")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -688,9 +714,10 @@ DefaultInstancesRestStub::AsyncSetName(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_set_name_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setName")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setName")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -713,9 +740,10 @@ DefaultInstancesRestStub::AsyncSetScheduling(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.scheduling_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setScheduling")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setScheduling")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -739,9 +767,10 @@ DefaultInstancesRestStub::AsyncSetServiceAccount(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_set_service_account_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setServiceAccount")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setServiceAccount")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -765,10 +794,11 @@ DefaultInstancesRestStub::AsyncSetShieldedInstanceIntegrityPolicy(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.shielded_instance_integrity_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(),
-                             "/setShieldedInstanceIntegrityPolicy")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/",
+                             "setShieldedInstanceIntegrityPolicy")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -790,9 +820,10 @@ DefaultInstancesRestStub::AsyncSetTags(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.tags_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/setTags")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "setTags")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -815,9 +846,11 @@ DefaultInstancesRestStub::AsyncSimulateMaintenanceEvent(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/simulateMaintenanceEvent")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/",
+                             "simulateMaintenanceEvent")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -839,9 +872,10 @@ DefaultInstancesRestStub::AsyncStart(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/start")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "start")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -865,9 +899,11 @@ DefaultInstancesRestStub::AsyncStartWithEncryptionKey(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_start_with_encryption_key_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/startWithEncryptionKey")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/",
+                             "startWithEncryptionKey")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -889,9 +925,10 @@ DefaultInstancesRestStub::AsyncStop(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/stop")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "stop")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -913,9 +950,10 @@ DefaultInstancesRestStub::AsyncSuspend(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/suspend")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "suspend")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -932,9 +970,10 @@ DefaultInstancesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/instances/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "instances", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -951,9 +990,10 @@ DefaultInstancesRestStub::AsyncUpdateInstances(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.instance_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -976,9 +1016,10 @@ DefaultInstancesRestStub::AsyncUpdateAccessConfig(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.access_config_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/updateAccessConfig")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "updateAccessConfig")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -1001,9 +1042,10 @@ DefaultInstancesRestStub::AsyncUpdateDisplayDevice(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.display_device_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/updateDisplayDevice")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/", "updateDisplayDevice")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -1026,9 +1068,11 @@ DefaultInstancesRestStub::AsyncUpdateNetworkInterface(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.network_interface_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(), "/updateNetworkInterface")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/",
+                             "updateNetworkInterface")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -1052,10 +1096,11 @@ DefaultInstancesRestStub::AsyncUpdateShieldedInstanceConfig(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.shielded_instance_config_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/instances/",
-                             request.instance(),
-                             "/updateShieldedInstanceConfig")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "instances", "/",
+                             request.instance(), "/",
+                             "updateShieldedInstanceConfig")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub.cc
+++ b/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub.cc
@@ -54,8 +54,9 @@ DefaultInterconnectAttachmentsRestStub::AggregatedListInterconnectAttachments(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectAttachmentAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/interconnectAttachments"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "interconnectAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -80,10 +81,10 @@ DefaultInterconnectAttachmentsRestStub::AsyncDeleteInterconnectAttachments(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/interconnectAttachments/",
-                             request.interconnect_attachment(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "interconnectAttachments",
+                             "/", request.interconnect_attachment())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -100,9 +101,10 @@ DefaultInterconnectAttachmentsRestStub::GetInterconnectAttachments(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectAttachment>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/interconnectAttachments/",
-                   request.interconnect_attachment(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "interconnectAttachments", "/",
+                   request.interconnect_attachment()),
       {});
 }
 
@@ -121,9 +123,10 @@ DefaultInterconnectAttachmentsRestStub::AsyncInsertInterconnectAttachments(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.interconnect_attachment_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/interconnectAttachments")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/",
+                             "interconnectAttachments")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -140,8 +143,9 @@ DefaultInterconnectAttachmentsRestStub::ListInterconnectAttachments(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectAttachmentList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/interconnectAttachments"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "interconnectAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -165,10 +169,10 @@ DefaultInterconnectAttachmentsRestStub::AsyncPatchInterconnectAttachments(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.interconnect_attachment_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/interconnectAttachments/",
-                             request.interconnect_attachment(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "interconnectAttachments",
+                             "/", request.interconnect_attachment())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -192,10 +196,10 @@ DefaultInterconnectAttachmentsRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/interconnectAttachments/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "interconnectAttachments",
+                             "/", request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub.cc
+++ b/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub.cc
@@ -48,9 +48,10 @@ DefaultInterconnectLocationsRestStub::GetInterconnectLocations(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectLocation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/interconnectLocations/",
-                   request.interconnect_location(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "interconnectLocations", "/",
+                   request.interconnect_location()),
       {});
 }
 
@@ -62,8 +63,9 @@ DefaultInterconnectLocationsRestStub::ListInterconnectLocations(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectLocationList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/interconnectLocations"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "interconnectLocations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_rest_stub.cc
+++ b/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_rest_stub.cc
@@ -49,9 +49,10 @@ DefaultInterconnectRemoteLocationsRestStub::GetInterconnectRemoteLocations(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectRemoteLocation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/interconnectRemoteLocations/",
-                   request.interconnect_remote_location(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "interconnectRemoteLocations", "/",
+                   request.interconnect_remote_location()),
       {});
 }
 
@@ -63,8 +64,9 @@ DefaultInterconnectRemoteLocationsRestStub::ListInterconnectRemoteLocations(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectRemoteLocationList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/interconnectRemoteLocations"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "interconnectRemoteLocations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub.cc
+++ b/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub.cc
@@ -58,9 +58,9 @@ DefaultInterconnectsRestStub::AsyncDeleteInterconnects(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/interconnects/", request.interconnect(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "interconnects", "/", request.interconnect())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -76,8 +76,9 @@ DefaultInterconnectsRestStub::GetInterconnects(
         GetInterconnectsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Interconnect>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/interconnects/", request.interconnect(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "interconnects", "/",
+                   request.interconnect()),
       {});
 }
 
@@ -89,9 +90,9 @@ DefaultInterconnectsRestStub::GetDiagnostics(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectsGetDiagnosticsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/interconnects/", request.interconnect(),
-                   "/getDiagnostics"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "interconnects", "/",
+                   request.interconnect(), "/", "getDiagnostics"),
       {});
 }
 
@@ -109,8 +110,9 @@ DefaultInterconnectsRestStub::AsyncInsertInterconnects(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.interconnect_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/interconnects")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "interconnects")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -126,8 +128,8 @@ DefaultInterconnectsRestStub::ListInterconnects(
         ListInterconnectsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InterconnectList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/interconnects"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "interconnects"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -150,9 +152,9 @@ DefaultInterconnectsRestStub::AsyncPatchInterconnects(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.interconnect_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/interconnects/", request.interconnect(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "interconnects", "/", request.interconnect())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -176,9 +178,10 @@ DefaultInterconnectsRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.global_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/interconnects/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "interconnects", "/", request.resource(), "/",
+                             "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/license_codes/v1/internal/license_codes_rest_stub.cc
+++ b/google/cloud/compute/license_codes/v1/internal/license_codes_rest_stub.cc
@@ -45,8 +45,9 @@ DefaultLicenseCodesRestStub::GetLicenseCodes(
         GetLicenseCodesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::LicenseCode>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/licenseCodes/", request.license_code(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "licenseCodes", "/",
+                   request.license_code()),
       {});
 }
 
@@ -58,9 +59,9 @@ DefaultLicenseCodesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/licenseCodes/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "licenseCodes", "/",
+                   request.resource(), "/", "testIamPermissions"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/licenses/v1/internal/licenses_rest_stub.cc
+++ b/google/cloud/compute/licenses/v1/internal/licenses_rest_stub.cc
@@ -58,8 +58,9 @@ DefaultLicensesRestStub::AsyncDeleteLicenses(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/licenses/", request.license(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "licenses",
+                             "/", request.license())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -75,8 +76,9 @@ DefaultLicensesRestStub::GetLicenses(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::License>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/licenses/", request.license(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "licenses", "/",
+                   request.license()),
       {});
 }
 
@@ -87,8 +89,9 @@ DefaultLicensesRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/licenses/", request.resource(), "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "licenses", "/",
+                   request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -108,8 +111,9 @@ DefaultLicensesRestStub::AsyncInsertLicenses(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.license_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/licenses")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "licenses")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -126,8 +130,8 @@ DefaultLicensesRestStub::ListLicenses(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::LicensesListResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/licenses"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "licenses"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -143,8 +147,9 @@ DefaultLicensesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/licenses/", request.resource(), "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "licenses", "/",
+                   request.resource(), "/", "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -155,9 +160,9 @@ DefaultLicensesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/licenses/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "licenses", "/",
+                   request.resource(), "/", "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub.cc
+++ b/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub.cc
@@ -58,9 +58,9 @@ DefaultMachineImagesRestStub::AsyncDeleteMachineImages(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/machineImages/", request.machine_image(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "machineImages", "/", request.machine_image())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -76,8 +76,9 @@ DefaultMachineImagesRestStub::GetMachineImages(
         GetMachineImagesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::MachineImage>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/machineImages/", request.machine_image(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "machineImages", "/",
+                   request.machine_image()),
       {});
 }
 
@@ -88,9 +89,9 @@ DefaultMachineImagesRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/machineImages/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "machineImages", "/",
+                   request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -110,8 +111,9 @@ DefaultMachineImagesRestStub::AsyncInsertMachineImages(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.machine_image_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/machineImages")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "machineImages")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -127,8 +129,8 @@ DefaultMachineImagesRestStub::ListMachineImages(
         ListMachineImagesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::MachineImageList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/machineImages"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "machineImages"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -144,9 +146,9 @@ DefaultMachineImagesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/machineImages/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "machineImages", "/",
+                   request.resource(), "/", "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -157,9 +159,9 @@ DefaultMachineImagesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/machineImages/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "machineImages", "/",
+                   request.resource(), "/", "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub.cc
+++ b/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub.cc
@@ -46,8 +46,8 @@ DefaultMachineTypesRestStub::AggregatedListMachineTypes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::MachineTypeAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/machineTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "machineTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -65,9 +65,9 @@ DefaultMachineTypesRestStub::GetMachineTypes(
         GetMachineTypesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::MachineType>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/machineTypes/", request.machine_type(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "machineTypes", "/", request.machine_type()),
       {});
 }
 
@@ -78,8 +78,9 @@ DefaultMachineTypesRestStub::ListMachineTypes(
         ListMachineTypesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::MachineTypeList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/machineTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "machineTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub.cc
+++ b/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultNetworkAttachmentsRestStub::AggregatedListNetworkAttachments(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkAttachmentAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/networkAttachments"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "networkAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -79,10 +80,10 @@ DefaultNetworkAttachmentsRestStub::AsyncDeleteNetworkAttachments(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/networkAttachments/",
-                             request.network_attachment(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "networkAttachments", "/",
+                             request.network_attachment())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,9 +99,10 @@ DefaultNetworkAttachmentsRestStub::GetNetworkAttachments(
         GetNetworkAttachmentsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NetworkAttachment>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/networkAttachments/",
-                   request.network_attachment(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "networkAttachments", "/",
+                   request.network_attachment()),
       {});
 }
 
@@ -111,9 +113,10 @@ DefaultNetworkAttachmentsRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/networkAttachments/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "networkAttachments", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -133,9 +136,9 @@ DefaultNetworkAttachmentsRestStub::AsyncInsertNetworkAttachments(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.network_attachment_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/networkAttachments")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "networkAttachments")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -152,8 +155,9 @@ DefaultNetworkAttachmentsRestStub::ListNetworkAttachments(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkAttachmentList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/networkAttachments"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "networkAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -169,9 +173,10 @@ DefaultNetworkAttachmentsRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/networkAttachments/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "networkAttachments", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -182,9 +187,10 @@ DefaultNetworkAttachmentsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/networkAttachments/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "networkAttachments", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub.cc
+++ b/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub.cc
@@ -57,8 +57,9 @@ DefaultNetworkEdgeSecurityServicesRestStub::
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 NetworkEdgeSecurityServiceAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/networkEdgeSecurityServices"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "networkEdgeSecurityServices"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -84,10 +85,11 @@ DefaultNetworkEdgeSecurityServicesRestStub::
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/networkEdgeSecurityServices/",
-                             request.network_edge_security_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/",
+                             "networkEdgeSecurityServices", "/",
+                             request.network_edge_security_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -104,9 +106,10 @@ DefaultNetworkEdgeSecurityServicesRestStub::GetNetworkEdgeSecurityServices(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEdgeSecurityService>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/networkEdgeSecurityServices/",
-                   request.network_edge_security_service(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "networkEdgeSecurityServices", "/",
+                   request.network_edge_security_service()),
       {});
 }
 
@@ -126,9 +129,10 @@ DefaultNetworkEdgeSecurityServicesRestStub::
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.network_edge_security_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/networkEdgeSecurityServices")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/",
+                             "networkEdgeSecurityServices")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -153,10 +157,11 @@ DefaultNetworkEdgeSecurityServicesRestStub::
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.network_edge_security_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/networkEdgeSecurityServices/",
-                             request.network_edge_security_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/",
+                             "networkEdgeSecurityServices", "/",
+                             request.network_edge_security_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub.cc
@@ -54,8 +54,9 @@ DefaultNetworkEndpointGroupsRestStub::AggregatedListNetworkEndpointGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroupAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/networkEndpointGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "networkEndpointGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -81,10 +82,11 @@ DefaultNetworkEndpointGroupsRestStub::AsyncAttachNetworkEndpoints(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.network_endpoint_groups_attach_endpoints_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/networkEndpointGroups/",
-                         request.network_endpoint_group(),
-                         "/attachNetworkEndpoints")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "networkEndpointGroups", "/",
+                         request.network_endpoint_group(), "/",
+                         "attachNetworkEndpoints")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -107,10 +109,10 @@ DefaultNetworkEndpointGroupsRestStub::AsyncDeleteNetworkEndpointGroups(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/networkEndpointGroups/",
-                             request.network_endpoint_group(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "networkEndpointGroups", "/",
+                             request.network_endpoint_group())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -134,10 +136,11 @@ DefaultNetworkEndpointGroupsRestStub::AsyncDetachNetworkEndpoints(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.network_endpoint_groups_detach_endpoints_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                         request.zone(), "/networkEndpointGroups/",
-                         request.network_endpoint_group(),
-                         "/detachNetworkEndpoints")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "zones", "/", request.zone(),
+                         "/", "networkEndpointGroups", "/",
+                         request.network_endpoint_group(), "/",
+                         "detachNetworkEndpoints")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -154,9 +157,10 @@ DefaultNetworkEndpointGroupsRestStub::GetNetworkEndpointGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroup>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/networkEndpointGroups/",
-                   request.network_endpoint_group(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "networkEndpointGroups", "/",
+                   request.network_endpoint_group()),
       {});
 }
 
@@ -175,9 +179,9 @@ DefaultNetworkEndpointGroupsRestStub::AsyncInsertNetworkEndpointGroups(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.network_endpoint_group_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(),
-                             "/networkEndpointGroups")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "networkEndpointGroups")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -194,8 +198,9 @@ DefaultNetworkEndpointGroupsRestStub::ListNetworkEndpointGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroupList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/networkEndpointGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "networkEndpointGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -214,9 +219,10 @@ DefaultNetworkEndpointGroupsRestStub::ListNetworkEndpoints(
                                  NetworkEndpointGroupsListNetworkEndpoints>(
       *service_, rest_context,
       request.network_endpoint_groups_list_endpoints_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/networkEndpointGroups/",
-                   request.network_endpoint_group(), "/listNetworkEndpoints"));
+      absl::StrCat(
+          "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
+          "/", "zones", "/", request.zone(), "/", "networkEndpointGroups", "/",
+          request.network_endpoint_group(), "/", "listNetworkEndpoints"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -227,9 +233,10 @@ DefaultNetworkEndpointGroupsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/networkEndpointGroups/",
-                   request.resource(), "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "networkEndpointGroups", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
@@ -61,9 +61,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncAddAssociation(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_association_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies/",
-                             request.firewall_policy(), "/addAssociation")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies", "/", request.firewall_policy(),
+                             "/", "addAssociation")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -87,9 +88,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncAddRule(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies/",
-                             request.firewall_policy(), "/addRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies", "/", request.firewall_policy(),
+                             "/", "addRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -112,9 +114,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncCloneRules(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies/",
-                             request.firewall_policy(), "/cloneRules")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies", "/", request.firewall_policy(),
+                             "/", "cloneRules")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -137,9 +140,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncDeleteNetworkFirewallPolicies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies/",
-                             request.firewall_policy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies", "/",
+                             request.firewall_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -155,8 +159,9 @@ DefaultNetworkFirewallPoliciesRestStub::GetNetworkFirewallPolicies(
         GetNetworkFirewallPoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallPolicy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewallPolicies/", request.firewall_policy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewallPolicies",
+                   "/", request.firewall_policy()),
       {});
 }
 
@@ -168,9 +173,9 @@ DefaultNetworkFirewallPoliciesRestStub::GetAssociation(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyAssociation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewallPolicies/", request.firewall_policy(),
-                   "/getAssociation"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewallPolicies",
+                   "/", request.firewall_policy(), "/", "getAssociation"),
       {std::make_pair("name", request.name())});
 }
 
@@ -181,9 +186,9 @@ DefaultNetworkFirewallPoliciesRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewallPolicies/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewallPolicies",
+                   "/", request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -197,9 +202,9 @@ DefaultNetworkFirewallPoliciesRestStub::GetRule(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyRule>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewallPolicies/", request.firewall_policy(),
-                   "/getRule"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewallPolicies",
+                   "/", request.firewall_policy(), "/", "getRule"),
       {std::make_pair("priority", std::to_string(request.priority()))});
 }
 
@@ -217,8 +222,9 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncInsertNetworkFirewallPolicies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -235,8 +241,8 @@ DefaultNetworkFirewallPoliciesRestStub::ListNetworkFirewallPolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewallPolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewallPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -259,9 +265,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncPatchNetworkFirewallPolicies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies/",
-                             request.firewall_policy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies", "/",
+                             request.firewall_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -285,9 +292,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncPatchRule(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies/",
-                             request.firewall_policy(), "/patchRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies", "/", request.firewall_policy(),
+                             "/", "patchRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -310,9 +318,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncRemoveAssociation(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies/",
-                             request.firewall_policy(), "/removeAssociation")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies", "/", request.firewall_policy(),
+                             "/", "removeAssociation")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -335,9 +344,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncRemoveRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/firewallPolicies/",
-                             request.firewall_policy(), "/removeRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "firewallPolicies", "/", request.firewall_policy(),
+                             "/", "removeRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -353,9 +363,9 @@ DefaultNetworkFirewallPoliciesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewallPolicies/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewallPolicies",
+                   "/", request.resource(), "/", "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -366,9 +376,9 @@ DefaultNetworkFirewallPoliciesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/firewallPolicies/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "firewallPolicies",
+                   "/", request.resource(), "/", "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
+++ b/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
@@ -59,9 +59,9 @@ DefaultNetworksRestStub::AsyncAddPeering(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.networks_add_peering_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networks/", request.network(),
-                             "/addPeering")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "networks",
+                             "/", request.network(), "/", "addPeering")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,8 +84,9 @@ DefaultNetworksRestStub::AsyncDeleteNetworks(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networks/", request.network(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "networks",
+                             "/", request.network())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,8 +102,9 @@ DefaultNetworksRestStub::GetNetworks(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Network>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/networks/", request.network(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "networks", "/",
+                   request.network()),
       {});
 }
 
@@ -114,9 +116,9 @@ DefaultNetworksRestStub::GetEffectiveFirewalls(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworksGetEffectiveFirewallsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/networks/", request.network(),
-                   "/getEffectiveFirewalls"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "networks", "/",
+                   request.network(), "/", "getEffectiveFirewalls"),
       {});
 }
 
@@ -134,8 +136,9 @@ DefaultNetworksRestStub::AsyncInsertNetworks(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.network_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networks")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "networks")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -151,8 +154,8 @@ DefaultNetworksRestStub::ListNetworks(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NetworkList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/networks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "networks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -169,9 +172,9 @@ DefaultNetworksRestStub::ListPeeringRoutes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ExchangedPeeringRoutesList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/networks/", request.network(),
-                   "/listPeeringRoutes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "networks", "/",
+                   request.network(), "/", "listPeeringRoutes"),
       {std::make_pair("direction", request.direction()),
        std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
@@ -197,8 +200,9 @@ DefaultNetworksRestStub::AsyncPatchNetworks(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.network_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networks/", request.network(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "networks",
+                             "/", request.network())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -222,9 +226,9 @@ DefaultNetworksRestStub::AsyncRemovePeering(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.networks_remove_peering_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networks/", request.network(),
-                             "/removePeering")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "networks",
+                             "/", request.network(), "/", "removePeering")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -247,9 +251,10 @@ DefaultNetworksRestStub::AsyncSwitchToCustomMode(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networks/", request.network(),
-                             "/switchToCustomMode")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "networks",
+                             "/", request.network(), "/",
+                             "switchToCustomMode")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -273,9 +278,9 @@ DefaultNetworksRestStub::AsyncUpdatePeering(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.networks_update_peering_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/networks/", request.network(),
-                             "/updatePeering")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "networks",
+                             "/", request.network(), "/", "updatePeering")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
+++ b/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultNodeGroupsRestStub::AsyncAddNodes(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.node_groups_add_nodes_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/nodeGroups/",
-                             request.node_group(), "/addNodes")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "nodeGroups", "/",
+                             request.node_group(), "/", "addNodes")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +79,8 @@ DefaultNodeGroupsRestStub::AggregatedListNodeGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NodeGroupAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/nodeGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "nodeGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -104,9 +105,10 @@ DefaultNodeGroupsRestStub::AsyncDeleteNodeGroups(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/nodeGroups/",
-                             request.node_group(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "nodeGroups", "/",
+                             request.node_group())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -130,9 +132,10 @@ DefaultNodeGroupsRestStub::AsyncDeleteNodes(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.node_groups_delete_nodes_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/nodeGroups/",
-                             request.node_group(), "/deleteNodes")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "nodeGroups", "/",
+                             request.node_group(), "/", "deleteNodes")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -148,8 +151,9 @@ DefaultNodeGroupsRestStub::GetNodeGroups(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeGroup>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/nodeGroups/", request.node_group(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "nodeGroups", "/", request.node_group()),
       {});
 }
 
@@ -160,9 +164,9 @@ DefaultNodeGroupsRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/nodeGroups/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "nodeGroups", "/", request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -182,8 +186,9 @@ DefaultNodeGroupsRestStub::AsyncInsertNodeGroups(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.node_group_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/nodeGroups")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "nodeGroups")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -199,8 +204,9 @@ DefaultNodeGroupsRestStub::ListNodeGroups(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeGroupList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/nodeGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "nodeGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -217,9 +223,9 @@ DefaultNodeGroupsRestStub::ListNodes(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::NodeGroupsListNodes>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/nodeGroups/", request.node_group(),
-                   "/listNodes"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "nodeGroups", "/", request.node_group(), "/", "listNodes"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -236,9 +242,10 @@ DefaultNodeGroupsRestStub::AsyncPatchNodeGroups(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.node_group_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/nodeGroups/",
-                             request.node_group(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "nodeGroups", "/",
+                             request.node_group())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -254,9 +261,9 @@ DefaultNodeGroupsRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.zone_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/nodeGroups/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "nodeGroups", "/", request.resource(), "/", "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -274,9 +281,10 @@ DefaultNodeGroupsRestStub::AsyncSetNodeTemplate(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.node_groups_set_node_template_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/nodeGroups/",
-                             request.node_group(), "/setNodeTemplate")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "nodeGroups", "/",
+                             request.node_group(), "/", "setNodeTemplate")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -301,10 +309,11 @@ DefaultNodeGroupsRestStub::AsyncSimulateMaintenanceEvent(
                 *service, *rest_context,
                 request
                     .node_groups_simulate_maintenance_event_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/nodeGroups/",
-                             request.node_group(),
-                             "/simulateMaintenanceEvent")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "nodeGroups", "/",
+                             request.node_group(), "/",
+                             "simulateMaintenanceEvent")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -321,9 +330,10 @@ DefaultNodeGroupsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/nodeGroups/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "nodeGroups", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub.cc
+++ b/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultNodeTemplatesRestStub::AggregatedListNodeTemplates(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NodeTemplateAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/nodeTemplates"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "nodeTemplates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,10 @@ DefaultNodeTemplatesRestStub::AsyncDeleteNodeTemplates(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/nodeTemplates/",
-                             request.node_template(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "nodeTemplates", "/",
+                             request.node_template())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,9 +97,9 @@ DefaultNodeTemplatesRestStub::GetNodeTemplates(
         GetNodeTemplatesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeTemplate>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/nodeTemplates/", request.node_template(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "nodeTemplates", "/", request.node_template()),
       {});
 }
 
@@ -109,9 +110,10 @@ DefaultNodeTemplatesRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/nodeTemplates/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "nodeTemplates", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -131,8 +133,9 @@ DefaultNodeTemplatesRestStub::AsyncInsertNodeTemplates(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.node_template_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/nodeTemplates")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "nodeTemplates")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -148,8 +151,9 @@ DefaultNodeTemplatesRestStub::ListNodeTemplates(
         ListNodeTemplatesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeTemplateList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/nodeTemplates"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "nodeTemplates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -165,9 +169,10 @@ DefaultNodeTemplatesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/nodeTemplates/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "nodeTemplates", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -178,9 +183,10 @@ DefaultNodeTemplatesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/nodeTemplates/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "nodeTemplates", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/node_types/v1/internal/node_types_rest_stub.cc
+++ b/google/cloud/compute/node_types/v1/internal/node_types_rest_stub.cc
@@ -46,8 +46,8 @@ DefaultNodeTypesRestStub::AggregatedListNodeTypes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NodeTypeAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/nodeTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "nodeTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -65,8 +65,9 @@ DefaultNodeTypesRestStub::GetNodeTypes(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeType>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/nodeTypes/", request.node_type(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "nodeTypes", "/", request.node_type()),
       {});
 }
 
@@ -77,8 +78,9 @@ DefaultNodeTypesRestStub::ListNodeTypes(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeTypeList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/nodeTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "nodeTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub.cc
+++ b/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultPacketMirroringsRestStub::AggregatedListPacketMirrorings(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PacketMirroringAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/packetMirrorings"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "packetMirrorings"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -79,10 +80,10 @@ DefaultPacketMirroringsRestStub::AsyncDeletePacketMirrorings(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/packetMirrorings/", request.packet_mirroring(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "packetMirrorings", "/",
+                             request.packet_mirroring())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,9 +99,9 @@ DefaultPacketMirroringsRestStub::GetPacketMirrorings(
         GetPacketMirroringsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::PacketMirroring>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/packetMirrorings/",
-                   request.packet_mirroring(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "packetMirrorings", "/", request.packet_mirroring()),
       {});
 }
 
@@ -118,9 +119,9 @@ DefaultPacketMirroringsRestStub::AsyncInsertPacketMirrorings(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.packet_mirroring_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/packetMirrorings")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "packetMirrorings")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -137,8 +138,9 @@ DefaultPacketMirroringsRestStub::ListPacketMirrorings(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PacketMirroringList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/packetMirrorings"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "packetMirrorings"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -161,10 +163,10 @@ DefaultPacketMirroringsRestStub::AsyncPatchPacketMirrorings(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.packet_mirroring_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/packetMirrorings/", request.packet_mirroring(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "packetMirrorings", "/",
+                             request.packet_mirroring())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -181,9 +183,10 @@ DefaultPacketMirroringsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/packetMirrorings/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "packetMirrorings", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
+++ b/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
@@ -58,8 +58,8 @@ DefaultProjectsRestStub::AsyncDisableXpnHost(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/disableXpnHost")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "disableXpnHost")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -83,8 +83,8 @@ DefaultProjectsRestStub::AsyncDisableXpnResource(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.projects_disable_xpn_resource_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/disableXpnResource")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "disableXpnResource")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -107,8 +107,8 @@ DefaultProjectsRestStub::AsyncEnableXpnHost(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/enableXpnHost")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "enableXpnHost")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -132,8 +132,8 @@ DefaultProjectsRestStub::AsyncEnableXpnResource(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.projects_enable_xpn_resource_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/enableXpnResource")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "enableXpnResource")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -149,7 +149,9 @@ DefaultProjectsRestStub::GetProjects(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Project>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), ""), {});
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project()),
+      {});
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Project>
@@ -159,7 +161,8 @@ DefaultProjectsRestStub::GetXpnHost(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Project>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/getXpnHost"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "getXpnHost"),
       {});
 }
 
@@ -171,8 +174,8 @@ DefaultProjectsRestStub::GetXpnResources(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ProjectsGetXpnResources>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/getXpnResources"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "getXpnResources"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -189,8 +192,8 @@ DefaultProjectsRestStub::ListXpnHosts(
   return rest_internal::Post<google::cloud::cpp::compute::v1::XpnHostList>(
       *service_, rest_context,
       request.projects_list_xpn_hosts_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/listXpnHosts"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "listXpnHosts"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -206,8 +209,8 @@ DefaultProjectsRestStub::AsyncMoveDisk(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.disk_move_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/moveDisk")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "moveDisk")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -231,8 +234,8 @@ DefaultProjectsRestStub::AsyncMoveInstance(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_move_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/moveInstance")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "moveInstance")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -255,8 +258,9 @@ DefaultProjectsRestStub::AsyncSetCommonInstanceMetadata(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.metadata_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/setCommonInstanceMetadata")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/",
+                             "setCommonInstanceMetadata")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -280,8 +284,8 @@ DefaultProjectsRestStub::AsyncSetDefaultNetworkTier(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.projects_set_default_network_tier_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/setDefaultNetworkTier")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "setDefaultNetworkTier")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -305,8 +309,8 @@ DefaultProjectsRestStub::AsyncSetUsageExportBucket(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.usage_export_location_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/setUsageExportBucket")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "setUsageExportBucket")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
@@ -61,9 +61,10 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncDeletePublicAdvertisedPrefixes(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/publicAdvertisedPrefixes/",
-                             request.public_advertised_prefix(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "publicAdvertisedPrefixes", "/",
+                             request.public_advertised_prefix())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -80,9 +81,10 @@ DefaultPublicAdvertisedPrefixesRestStub::GetPublicAdvertisedPrefixes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicAdvertisedPrefix>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/publicAdvertisedPrefixes/",
-                   request.public_advertised_prefix(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "publicAdvertisedPrefixes", "/",
+                   request.public_advertised_prefix()),
       {});
 }
 
@@ -101,8 +103,9 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncInsertPublicAdvertisedPrefixes(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.public_advertised_prefix_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/publicAdvertisedPrefixes")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "publicAdvertisedPrefixes")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,8 +122,9 @@ DefaultPublicAdvertisedPrefixesRestStub::ListPublicAdvertisedPrefixes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicAdvertisedPrefixList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/publicAdvertisedPrefixes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/",
+                   "publicAdvertisedPrefixes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -144,9 +148,10 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncPatchPublicAdvertisedPrefixes(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.public_advertised_prefix_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/publicAdvertisedPrefixes/",
-                             request.public_advertised_prefix(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "publicAdvertisedPrefixes", "/",
+                             request.public_advertised_prefix())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
@@ -54,8 +54,9 @@ DefaultPublicDelegatedPrefixesRestStub::AggregatedListPublicDelegatedPrefixes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefixAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/publicDelegatedPrefixes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "publicDelegatedPrefixes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -80,10 +81,10 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncDeletePublicDelegatedPrefixes(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/publicDelegatedPrefixes/",
-                             request.public_delegated_prefix(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "publicDelegatedPrefixes",
+                             "/", request.public_delegated_prefix())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -100,9 +101,10 @@ DefaultPublicDelegatedPrefixesRestStub::GetPublicDelegatedPrefixes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefix>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/publicDelegatedPrefixes/",
-                   request.public_delegated_prefix(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "publicDelegatedPrefixes", "/",
+                   request.public_delegated_prefix()),
       {});
 }
 
@@ -121,9 +123,10 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncInsertPublicDelegatedPrefixes(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.public_delegated_prefix_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/publicDelegatedPrefixes")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/",
+                             "publicDelegatedPrefixes")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -140,8 +143,9 @@ DefaultPublicDelegatedPrefixesRestStub::ListPublicDelegatedPrefixes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefixList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/publicDelegatedPrefixes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "publicDelegatedPrefixes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -165,10 +169,10 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncPatchPublicDelegatedPrefixes(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.public_delegated_prefix_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/publicDelegatedPrefixes/",
-                             request.public_delegated_prefix(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "publicDelegatedPrefixes",
+                             "/", request.public_delegated_prefix())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub.cc
+++ b/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultRegionAutoscalersRestStub::AsyncDeleteRegionAutoscalers(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/autoscalers/",
-                             request.autoscaler(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "autoscalers", "/",
+                             request.autoscaler())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -77,8 +78,9 @@ DefaultRegionAutoscalersRestStub::GetRegionAutoscalers(
         GetRegionAutoscalersRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Autoscaler>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/autoscalers/", request.autoscaler(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "autoscalers", "/", request.autoscaler()),
       {});
 }
 
@@ -96,8 +98,9 @@ DefaultRegionAutoscalersRestStub::AsyncInsertRegionAutoscalers(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.autoscaler_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/autoscalers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "autoscalers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -114,8 +117,9 @@ DefaultRegionAutoscalersRestStub::ListRegionAutoscalers(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RegionAutoscalerList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/autoscalers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "autoscalers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -138,8 +142,9 @@ DefaultRegionAutoscalersRestStub::AsyncPatchRegionAutoscalers(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.autoscaler_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/autoscalers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "autoscalers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -162,8 +167,9 @@ DefaultRegionAutoscalersRestStub::AsyncUpdateRegionAutoscalers(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.autoscaler_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/autoscalers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "autoscalers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub.cc
+++ b/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub.cc
@@ -60,9 +60,10 @@ DefaultRegionBackendServicesRestStub::AsyncDeleteRegionBackendServices(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/backendServices/",
-                             request.backend_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "backendServices", "/",
+                             request.backend_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,9 +79,9 @@ DefaultRegionBackendServicesRestStub::GetRegionBackendServices(
         GetRegionBackendServicesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::BackendService>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/backendServices/",
-                   request.backend_service(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "backendServices", "/", request.backend_service()),
       {});
 }
 
@@ -92,9 +93,10 @@ DefaultRegionBackendServicesRestStub::GetHealth(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::BackendServiceGroupHealth>(
       *service_, rest_context, request.resource_group_reference_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/backendServices/",
-                   request.backend_service(), "/getHealth"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "backendServices", "/", request.backend_service(), "/",
+                   "getHealth"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -104,9 +106,10 @@ DefaultRegionBackendServicesRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/backendServices/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "backendServices", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -126,9 +129,9 @@ DefaultRegionBackendServicesRestStub::AsyncInsertRegionBackendServices(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/backendServices")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "backendServices")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -145,8 +148,9 @@ DefaultRegionBackendServicesRestStub::ListRegionBackendServices(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::BackendServiceList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/backendServices"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "backendServices"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -169,9 +173,10 @@ DefaultRegionBackendServicesRestStub::AsyncPatchRegionBackendServices(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/backendServices/",
-                             request.backend_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "backendServices", "/",
+                             request.backend_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -187,9 +192,10 @@ DefaultRegionBackendServicesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/backendServices/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "backendServices", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -206,9 +212,10 @@ DefaultRegionBackendServicesRestStub::AsyncUpdateRegionBackendServices(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/backendServices/",
-                             request.backend_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "backendServices", "/",
+                             request.backend_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub.cc
+++ b/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub.cc
@@ -53,8 +53,8 @@ DefaultRegionCommitmentsRestStub::AggregatedListRegionCommitments(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::CommitmentAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/commitments"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "commitments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -72,8 +72,9 @@ DefaultRegionCommitmentsRestStub::GetRegionCommitments(
         GetRegionCommitmentsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Commitment>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/commitments/", request.commitment(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "commitments", "/", request.commitment()),
       {});
 }
 
@@ -91,8 +92,9 @@ DefaultRegionCommitmentsRestStub::AsyncInsertRegionCommitments(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.commitment_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/commitments")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "commitments")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -108,8 +110,9 @@ DefaultRegionCommitmentsRestStub::ListRegionCommitments(
         ListRegionCommitmentsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::CommitmentList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/commitments"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "commitments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -132,9 +135,10 @@ DefaultRegionCommitmentsRestStub::AsyncUpdateRegionCommitments(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.commitment_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/commitments/",
-                             request.commitment(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "commitments", "/",
+                             request.commitment())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub.cc
+++ b/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub.cc
@@ -45,8 +45,9 @@ DefaultRegionDiskTypesRestStub::GetRegionDiskTypes(
         GetRegionDiskTypesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskType>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/diskTypes/", request.disk_type(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "diskTypes", "/", request.disk_type()),
       {});
 }
 
@@ -58,8 +59,9 @@ DefaultRegionDiskTypesRestStub::ListRegionDiskTypes(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RegionDiskTypeList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/diskTypes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "diskTypes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
+++ b/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultRegionDisksRestStub::AsyncAddResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_disks_add_resource_policies_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.disk(), "/addResourcePolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.disk(), "/", "addResourcePolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,9 +85,10 @@ DefaultRegionDisksRestStub::AsyncBulkInsert(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.bulk_insert_disk_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/disks/bulkInsert")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             "bulkInsert")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -109,9 +111,10 @@ DefaultRegionDisksRestStub::AsyncCreateSnapshot(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.snapshot_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.disk(), "/createSnapshot")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.disk(), "/", "createSnapshot")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -134,9 +137,10 @@ DefaultRegionDisksRestStub::AsyncDeleteRegionDisks(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.disk(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.disk())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -152,8 +156,9 @@ DefaultRegionDisksRestStub::GetRegionDisks(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Disk>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/disks/", request.disk(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "disks", "/", request.disk()),
       {});
 }
 
@@ -164,9 +169,9 @@ DefaultRegionDisksRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/disks/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "disks", "/", request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -186,8 +191,9 @@ DefaultRegionDisksRestStub::AsyncInsertRegionDisks(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.disk_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -203,8 +209,9 @@ DefaultRegionDisksRestStub::ListRegionDisks(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/disks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "disks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -229,9 +236,10 @@ DefaultRegionDisksRestStub::AsyncRemoveResourcePolicies(
                 *service, *rest_context,
                 request
                     .region_disks_remove_resource_policies_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.disk(), "/removeResourcePolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.disk(), "/", "removeResourcePolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -255,9 +263,10 @@ DefaultRegionDisksRestStub::AsyncResize(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_disks_resize_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.disk(), "/resize")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.disk(), "/", "resize")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -273,9 +282,9 @@ DefaultRegionDisksRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/disks/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "disks", "/", request.resource(), "/", "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -293,9 +302,10 @@ DefaultRegionDisksRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.resource(), "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -319,9 +329,10 @@ DefaultRegionDisksRestStub::AsyncStartAsyncReplication(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_disks_start_async_replication_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.disk(), "/startAsyncReplication")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.disk(), "/", "startAsyncReplication")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -344,9 +355,10 @@ DefaultRegionDisksRestStub::AsyncStopAsyncReplication(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.disk(), "/stopAsyncReplication")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.disk(), "/", "stopAsyncReplication")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -370,9 +382,10 @@ DefaultRegionDisksRestStub::AsyncStopGroupAsyncReplication(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.disks_stop_group_async_replication_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/disks/stopGroupAsyncReplication")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             "stopGroupAsyncReplication")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -389,9 +402,10 @@ DefaultRegionDisksRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/disks/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "disks", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -408,9 +422,10 @@ DefaultRegionDisksRestStub::AsyncUpdateRegionDisks(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.disk_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/disks/",
-                             request.disk(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "disks", "/",
+                             request.disk())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub.cc
+++ b/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub.cc
@@ -61,10 +61,10 @@ DefaultRegionHealthCheckServicesRestStub::AsyncDeleteRegionHealthCheckServices(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/healthCheckServices/",
-                             request.health_check_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "healthCheckServices", "/",
+                             request.health_check_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,9 +81,10 @@ DefaultRegionHealthCheckServicesRestStub::GetRegionHealthCheckServices(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HealthCheckService>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/healthCheckServices/",
-                   request.health_check_service(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "healthCheckServices", "/",
+                   request.health_check_service()),
       {});
 }
 
@@ -102,9 +103,9 @@ DefaultRegionHealthCheckServicesRestStub::AsyncInsertRegionHealthCheckServices(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.health_check_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/healthCheckServices")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "healthCheckServices")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -121,8 +122,9 @@ DefaultRegionHealthCheckServicesRestStub::ListRegionHealthCheckServices(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HealthCheckServicesList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/healthCheckServices"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "healthCheckServices"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -146,10 +148,10 @@ DefaultRegionHealthCheckServicesRestStub::AsyncPatchRegionHealthCheckServices(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.health_check_service_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/healthCheckServices/",
-                             request.health_check_service(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "healthCheckServices", "/",
+                             request.health_check_service())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub.cc
+++ b/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub.cc
@@ -60,9 +60,10 @@ DefaultRegionHealthChecksRestStub::AsyncDeleteRegionHealthChecks(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/healthChecks/",
-                             request.health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "healthChecks", "/",
+                             request.health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,9 +79,9 @@ DefaultRegionHealthChecksRestStub::GetRegionHealthChecks(
         GetRegionHealthChecksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HealthCheck>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/healthChecks/", request.health_check(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "healthChecks", "/", request.health_check()),
       {});
 }
 
@@ -98,8 +99,9 @@ DefaultRegionHealthChecksRestStub::AsyncInsertRegionHealthChecks(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/healthChecks")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "healthChecks")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -115,8 +117,9 @@ DefaultRegionHealthChecksRestStub::ListRegionHealthChecks(
         ListRegionHealthChecksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HealthCheckList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/healthChecks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "healthChecks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -139,9 +142,10 @@ DefaultRegionHealthChecksRestStub::AsyncPatchRegionHealthChecks(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/healthChecks/",
-                             request.health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "healthChecks", "/",
+                             request.health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -164,9 +168,10 @@ DefaultRegionHealthChecksRestStub::AsyncUpdateRegionHealthChecks(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.health_check_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/healthChecks/",
-                             request.health_check(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "healthChecks", "/",
+                             request.health_check())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
@@ -63,10 +63,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncAbandonInstances(
             *service, *rest_context,
             request
                 .region_instance_group_managers_abandon_instances_request_resource(),
-            absl::StrCat(
-                "/compute/v1/projects/", request.project(), "/regions/",
-                request.region(), "/instanceGroupManagers/",
-                request.instance_group_manager(), "/abandonInstances")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "abandonInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -91,10 +92,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncApplyUpdatesToInstances(
             *service, *rest_context,
             request
                 .region_instance_group_managers_apply_updates_request_resource(),
-            absl::StrCat(
-                "/compute/v1/projects/", request.project(), "/regions/",
-                request.region(), "/instanceGroupManagers/",
-                request.instance_group_manager(), "/applyUpdatesToInstances")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "applyUpdatesToInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,10 +121,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncCreateInstances(
             *service, *rest_context,
             request
                 .region_instance_group_managers_create_instances_request_resource(),
-            absl::StrCat(
-                "/compute/v1/projects/", request.project(), "/regions/",
-                request.region(), "/instanceGroupManagers/",
-                request.instance_group_manager(), "/createInstances")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "createInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -146,10 +149,10 @@ DefaultRegionInstanceGroupManagersRestStub::
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/instanceGroupManagers/",
-                             request.instance_group_manager(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instanceGroupManagers",
+                             "/", request.instance_group_manager())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -174,10 +177,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncDeleteInstances(
             *service, *rest_context,
             request
                 .region_instance_group_managers_delete_instances_request_resource(),
-            absl::StrCat(
-                "/compute/v1/projects/", request.project(), "/regions/",
-                request.region(), "/instanceGroupManagers/",
-                request.instance_group_manager(), "/deleteInstances")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "deleteInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -202,11 +206,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncDeletePerInstanceConfigs(
             *service, *rest_context,
             request
                 .region_instance_group_manager_delete_instance_config_req_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/regions/", request.region(),
-                         "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/deletePerInstanceConfigs")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "deletePerInstanceConfigs")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -223,9 +227,10 @@ DefaultRegionInstanceGroupManagersRestStub::GetRegionInstanceGroupManagers(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManager>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceGroupManagers/",
-                   request.instance_group_manager(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceGroupManagers", "/",
+                   request.instance_group_manager()),
       {});
 }
 
@@ -245,9 +250,9 @@ DefaultRegionInstanceGroupManagersRestStub::
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_group_manager_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/instanceGroupManagers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instanceGroupManagers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -264,8 +269,9 @@ DefaultRegionInstanceGroupManagersRestStub::ListRegionInstanceGroupManagers(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RegionInstanceGroupManagerList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceGroupManagers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceGroupManagers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -283,9 +289,10 @@ DefaultRegionInstanceGroupManagersRestStub::ListErrors(
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 RegionInstanceGroupManagersListErrorsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceGroupManagers/",
-                   request.instance_group_manager(), "/listErrors"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceGroupManagers", "/",
+                   request.instance_group_manager(), "/", "listErrors"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -304,9 +311,10 @@ DefaultRegionInstanceGroupManagersRestStub::ListManagedInstances(
       google::cloud::cpp::compute::v1::
           RegionInstanceGroupManagersListInstancesResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceGroupManagers/",
-                   request.instance_group_manager(), "/listManagedInstances"));
+      absl::StrCat(
+          "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
+          "/", "regions", "/", request.region(), "/", "instanceGroupManagers",
+          "/", request.instance_group_manager(), "/", "listManagedInstances"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -319,10 +327,11 @@ DefaultRegionInstanceGroupManagersRestStub::ListPerInstanceConfigs(
       google::cloud::cpp::compute::v1::
           RegionInstanceGroupManagersListInstanceConfigsResp>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceGroupManagers/",
-                   request.instance_group_manager(),
-                   "/listPerInstanceConfigs"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceGroupManagers", "/",
+                   request.instance_group_manager(), "/",
+                   "listPerInstanceConfigs"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -341,10 +350,10 @@ DefaultRegionInstanceGroupManagersRestStub::
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_group_manager_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/instanceGroupManagers/",
-                             request.instance_group_manager(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instanceGroupManagers",
+                             "/", request.instance_group_manager())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -369,10 +378,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncPatchPerInstanceConfigs(
             *service, *rest_context,
             request
                 .region_instance_group_manager_patch_instance_config_req_resource(),
-            absl::StrCat(
-                "/compute/v1/projects/", request.project(), "/regions/",
-                request.region(), "/instanceGroupManagers/",
-                request.instance_group_manager(), "/patchPerInstanceConfigs")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "patchPerInstanceConfigs")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -397,10 +407,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncRecreateInstances(
                 *service, *rest_context,
                 request
                     .region_instance_group_managers_recreate_request_resource(),
-                absl::StrCat(
-                    "/compute/v1/projects/", request.project(), "/regions/",
-                    request.region(), "/instanceGroupManagers/",
-                    request.instance_group_manager(), "/recreateInstances")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instanceGroupManagers",
+                             "/", request.instance_group_manager(), "/",
+                             "recreateInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -423,10 +434,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncResize(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/instanceGroupManagers/",
-                             request.instance_group_manager(), "/resize")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instanceGroupManagers",
+                             "/", request.instance_group_manager(), "/",
+                             "resize")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -451,10 +463,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncSetInstanceTemplate(
             *service, *rest_context,
             request
                 .region_instance_group_managers_set_template_request_resource(),
-            absl::StrCat(
-                "/compute/v1/projects/", request.project(), "/regions/",
-                request.region(), "/instanceGroupManagers/",
-                request.instance_group_manager(), "/setInstanceTemplate")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "setInstanceTemplate")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -479,10 +492,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncSetTargetPools(
             *service, *rest_context,
             request
                 .region_instance_group_managers_set_target_pools_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/regions/", request.region(),
-                         "/instanceGroupManagers/",
-                         request.instance_group_manager(), "/setTargetPools")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "setTargetPools")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -507,11 +521,11 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncUpdatePerInstanceConfigs(
             *service, *rest_context,
             request
                 .region_instance_group_manager_update_instance_config_req_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/regions/", request.region(),
-                         "/instanceGroupManagers/",
-                         request.instance_group_manager(),
-                         "/updatePerInstanceConfigs")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "instanceGroupManagers", "/",
+                         request.instance_group_manager(), "/",
+                         "updatePerInstanceConfigs")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub.cc
+++ b/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub.cc
@@ -53,9 +53,9 @@ DefaultRegionInstanceGroupsRestStub::GetRegionInstanceGroups(
         GetRegionInstanceGroupsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceGroup>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceGroups/",
-                   request.instance_group(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceGroups", "/", request.instance_group()),
       {});
 }
 
@@ -67,8 +67,9 @@ DefaultRegionInstanceGroupsRestStub::ListRegionInstanceGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RegionInstanceGroupList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -86,9 +87,10 @@ DefaultRegionInstanceGroupsRestStub::ListInstances(
       google::cloud::cpp::compute::v1::RegionInstanceGroupsListInstances>(
       *service_, rest_context,
       request.region_instance_groups_list_instances_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceGroups/",
-                   request.instance_group(), "/listInstances"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceGroups", "/", request.instance_group(), "/",
+                   "listInstances"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -107,9 +109,10 @@ DefaultRegionInstanceGroupsRestStub::AsyncSetNamedPorts(
                 *service, *rest_context,
                 request
                     .region_instance_groups_set_named_ports_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/instanceGroups/",
-                             request.instance_group(), "/setNamedPorts")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instanceGroups", "/",
+                             request.instance_group(), "/", "setNamedPorts")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub.cc
+++ b/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub.cc
@@ -60,10 +60,10 @@ DefaultRegionInstanceTemplatesRestStub::AsyncDeleteRegionInstanceTemplates(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/instanceTemplates/", request.instance_template(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instanceTemplates", "/",
+                             request.instance_template())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -79,9 +79,9 @@ DefaultRegionInstanceTemplatesRestStub::GetRegionInstanceTemplates(
         GetRegionInstanceTemplatesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceTemplate>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceTemplates/",
-                   request.instance_template(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceTemplates", "/", request.instance_template()),
       {});
 }
 
@@ -99,9 +99,9 @@ DefaultRegionInstanceTemplatesRestStub::AsyncInsertRegionInstanceTemplates(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.instance_template_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/instanceTemplates")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instanceTemplates")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -118,8 +118,9 @@ DefaultRegionInstanceTemplatesRestStub::ListRegionInstanceTemplates(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceTemplateList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/instanceTemplates"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "instanceTemplates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/region_instances/v1/internal/region_instances_rest_stub.cc
+++ b/google/cloud/compute/region_instances/v1/internal/region_instances_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultRegionInstancesRestStub::AsyncBulkInsert(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.bulk_insert_instance_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/instances/bulkInsert")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "instances", "/",
+                             "bulkInsert")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
@@ -62,10 +62,10 @@ DefaultRegionNetworkEndpointGroupsRestStub::
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/networkEndpointGroups/",
-                             request.network_endpoint_group(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "networkEndpointGroups",
+                             "/", request.network_endpoint_group())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -82,9 +82,10 @@ DefaultRegionNetworkEndpointGroupsRestStub::GetRegionNetworkEndpointGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroup>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/networkEndpointGroups/",
-                   request.network_endpoint_group(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "networkEndpointGroups", "/",
+                   request.network_endpoint_group()),
       {});
 }
 
@@ -104,9 +105,9 @@ DefaultRegionNetworkEndpointGroupsRestStub::
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.network_endpoint_group_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/networkEndpointGroups")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "networkEndpointGroups")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -123,8 +124,9 @@ DefaultRegionNetworkEndpointGroupsRestStub::ListRegionNetworkEndpointGroups(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroupList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/networkEndpointGroups"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "networkEndpointGroups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
@@ -62,10 +62,11 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncAddAssociation(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_association_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies/", request.firewall_policy(),
-                             "/addAssociation")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/",
+                             "addAssociation")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -89,10 +90,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncAddRule(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies/", request.firewall_policy(),
-                             "/addRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "addRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -115,10 +116,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncCloneRules(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies/", request.firewall_policy(),
-                             "/cloneRules")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "cloneRules")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -142,10 +143,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies/", request.firewall_policy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies", "/",
+                             request.firewall_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -161,9 +162,9 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetRegionNetworkFirewallPolicies(
         GetRegionNetworkFirewallPoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallPolicy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/firewallPolicies/",
-                   request.firewall_policy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "firewallPolicies", "/", request.firewall_policy()),
       {});
 }
 
@@ -175,9 +176,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetAssociation(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyAssociation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/firewallPolicies/",
-                   request.firewall_policy(), "/getAssociation"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "firewallPolicies", "/", request.firewall_policy(), "/",
+                   "getAssociation"),
       {std::make_pair("name", request.name())});
 }
 
@@ -191,8 +193,9 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetEffectiveFirewalls(
       google::cloud::cpp::compute::v1::
           RegionNetworkFirewallPoliciesGetEffectiveFirewallsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/firewallPolicies/getEffectiveFirewalls"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "firewallPolicies", "/", "getEffectiveFirewalls"),
       {std::make_pair("network", request.network())});
 }
 
@@ -203,9 +206,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/firewallPolicies/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "firewallPolicies", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -219,9 +223,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetRule(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyRule>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/firewallPolicies/",
-                   request.firewall_policy(), "/getRule"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "firewallPolicies", "/", request.firewall_policy(), "/",
+                   "getRule"),
       {std::make_pair("priority", std::to_string(request.priority()))});
 }
 
@@ -240,9 +245,9 @@ DefaultRegionNetworkFirewallPoliciesRestStub::
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -259,8 +264,9 @@ DefaultRegionNetworkFirewallPoliciesRestStub::ListRegionNetworkFirewallPolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/firewallPolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "firewallPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -284,10 +290,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies/", request.firewall_policy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies", "/",
+                             request.firewall_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -311,10 +317,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncPatchRule(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.firewall_policy_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies/", request.firewall_policy(),
-                             "/patchRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "patchRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -337,10 +343,11 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncRemoveAssociation(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies/", request.firewall_policy(),
-                             "/removeAssociation")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/",
+                             "removeAssociation")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -363,10 +370,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncRemoveRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/firewallPolicies/", request.firewall_policy(),
-                             "/removeRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "firewallPolicies", "/",
+                             request.firewall_policy(), "/", "removeRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -382,9 +389,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/firewallPolicies/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "firewallPolicies", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -395,9 +403,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/firewallPolicies/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "firewallPolicies", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub.cc
+++ b/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub.cc
@@ -62,10 +62,10 @@ DefaultRegionNotificationEndpointsRestStub::
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/notificationEndpoints/",
-                             request.notification_endpoint(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "notificationEndpoints",
+                             "/", request.notification_endpoint())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -82,9 +82,10 @@ DefaultRegionNotificationEndpointsRestStub::GetRegionNotificationEndpoints(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NotificationEndpoint>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/notificationEndpoints/",
-                   request.notification_endpoint(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "notificationEndpoints", "/",
+                   request.notification_endpoint()),
       {});
 }
 
@@ -104,9 +105,9 @@ DefaultRegionNotificationEndpointsRestStub::
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.notification_endpoint_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/notificationEndpoints")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "notificationEndpoints")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -123,8 +124,9 @@ DefaultRegionNotificationEndpointsRestStub::ListRegionNotificationEndpoints(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NotificationEndpointList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/notificationEndpoints"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "notificationEndpoints"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub.cc
+++ b/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub.cc
@@ -45,8 +45,9 @@ Status DefaultRegionOperationsRestStub::DeleteRegionOperations(
         DeleteRegionOperationsRequest const& request) {
   return rest_internal::Delete(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/operations/", request.operation(), ""));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "operations", "/", request.operation()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>
@@ -56,8 +57,9 @@ DefaultRegionOperationsRestStub::GetRegionOperations(
         GetRegionOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/operations/", request.operation(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "operations", "/", request.operation()),
       {});
 }
 
@@ -68,8 +70,9 @@ DefaultRegionOperationsRestStub::ListRegionOperations(
         ListRegionOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/operations"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "operations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -85,9 +88,9 @@ DefaultRegionOperationsRestStub::Wait(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/operations/", request.operation(),
-                   "/wait"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "operations", "/", request.operation(), "/", "wait"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
+++ b/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
@@ -60,10 +60,10 @@ DefaultRegionSecurityPoliciesRestStub::AsyncDeleteRegionSecurityPolicies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/securityPolicies/", request.security_policy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "securityPolicies", "/",
+                             request.security_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -79,9 +79,9 @@ DefaultRegionSecurityPoliciesRestStub::GetRegionSecurityPolicies(
         GetRegionSecurityPoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SecurityPolicy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/securityPolicies/",
-                   request.security_policy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "securityPolicies", "/", request.security_policy()),
       {});
 }
 
@@ -99,9 +99,9 @@ DefaultRegionSecurityPoliciesRestStub::AsyncInsertRegionSecurityPolicies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.security_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/securityPolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "securityPolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -118,8 +118,9 @@ DefaultRegionSecurityPoliciesRestStub::ListRegionSecurityPolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SecurityPolicyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/securityPolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "securityPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -142,10 +143,10 @@ DefaultRegionSecurityPoliciesRestStub::AsyncPatchRegionSecurityPolicies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.security_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/securityPolicies/", request.security_policy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "securityPolicies", "/",
+                             request.security_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub.cc
+++ b/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub.cc
@@ -60,9 +60,10 @@ DefaultRegionSslCertificatesRestStub::AsyncDeleteRegionSslCertificates(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/sslCertificates/",
-                             request.ssl_certificate(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "sslCertificates", "/",
+                             request.ssl_certificate())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,9 +79,9 @@ DefaultRegionSslCertificatesRestStub::GetRegionSslCertificates(
         GetRegionSslCertificatesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslCertificate>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/sslCertificates/",
-                   request.ssl_certificate(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "sslCertificates", "/", request.ssl_certificate()),
       {});
 }
 
@@ -98,9 +99,9 @@ DefaultRegionSslCertificatesRestStub::AsyncInsertRegionSslCertificates(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.ssl_certificate_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/sslCertificates")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "sslCertificates")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -117,8 +118,9 @@ DefaultRegionSslCertificatesRestStub::ListRegionSslCertificates(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SslCertificateList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/sslCertificates"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "sslCertificates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub.cc
+++ b/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultRegionSslPoliciesRestStub::AsyncDeleteRegionSslPolicies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/sslPolicies/",
-                             request.ssl_policy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "sslPolicies", "/",
+                             request.ssl_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -77,8 +78,9 @@ DefaultRegionSslPoliciesRestStub::GetRegionSslPolicies(
         GetRegionSslPoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslPolicy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/sslPolicies/", request.ssl_policy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "sslPolicies", "/", request.ssl_policy()),
       {});
 }
 
@@ -96,8 +98,9 @@ DefaultRegionSslPoliciesRestStub::AsyncInsertRegionSslPolicies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.ssl_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/sslPolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "sslPolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -113,8 +116,9 @@ DefaultRegionSslPoliciesRestStub::ListRegionSslPolicies(
         ListRegionSslPoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslPoliciesList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/sslPolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "sslPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -132,8 +136,9 @@ DefaultRegionSslPoliciesRestStub::ListAvailableFeatures(
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 SslPoliciesListAvailableFeaturesResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/sslPolicies/listAvailableFeatures"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "sslPolicies", "/", "listAvailableFeatures"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -156,9 +161,10 @@ DefaultRegionSslPoliciesRestStub::AsyncPatchRegionSslPolicies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.ssl_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/sslPolicies/",
-                             request.ssl_policy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "sslPolicies", "/",
+                             request.ssl_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub.cc
@@ -60,10 +60,10 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncDeleteRegionTargetHttpProxies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetHttpProxies/", request.target_http_proxy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetHttpProxies", "/",
+                             request.target_http_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -79,9 +79,9 @@ DefaultRegionTargetHttpProxiesRestStub::GetRegionTargetHttpProxies(
         GetRegionTargetHttpProxiesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetHttpProxy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetHttpProxies/",
-                   request.target_http_proxy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetHttpProxies", "/", request.target_http_proxy()),
       {});
 }
 
@@ -99,9 +99,9 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncInsertRegionTargetHttpProxies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_http_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetHttpProxies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetHttpProxies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -118,8 +118,9 @@ DefaultRegionTargetHttpProxiesRestStub::ListRegionTargetHttpProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpProxyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetHttpProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetHttpProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -142,10 +143,10 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncSetUrlMap(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetHttpProxies/", request.target_http_proxy(),
-                             "/setUrlMap")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetHttpProxies", "/",
+                             request.target_http_proxy(), "/", "setUrlMap")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub.cc
@@ -61,10 +61,10 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncDeleteRegionTargetHttpsProxies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetHttpsProxies/",
-                             request.target_https_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetHttpsProxies", "/",
+                             request.target_https_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -80,9 +80,10 @@ DefaultRegionTargetHttpsProxiesRestStub::GetRegionTargetHttpsProxies(
         GetRegionTargetHttpsProxiesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetHttpsProxy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetHttpsProxies/",
-                   request.target_https_proxy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetHttpsProxies", "/",
+                   request.target_https_proxy()),
       {});
 }
 
@@ -100,9 +101,9 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncInsertRegionTargetHttpsProxies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_https_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetHttpsProxies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetHttpsProxies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,8 +120,9 @@ DefaultRegionTargetHttpsProxiesRestStub::ListRegionTargetHttpsProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpsProxyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetHttpsProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetHttpsProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -143,10 +145,10 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncPatchRegionTargetHttpsProxies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_https_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetHttpsProxies/",
-                             request.target_https_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetHttpsProxies", "/",
+                             request.target_https_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -171,9 +173,11 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncSetSslCertificates(
             *service, *rest_context,
             request
                 .region_target_https_proxies_set_ssl_certificates_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/regions/", request.region(), "/targetHttpsProxies/",
-                         request.target_https_proxy(), "/setSslCertificates")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "targetHttpsProxies", "/",
+                         request.target_https_proxy(), "/",
+                         "setSslCertificates")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -196,10 +200,10 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncSetUrlMap(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetHttpsProxies/",
-                             request.target_https_proxy(), "/setUrlMap")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetHttpsProxies", "/",
+                             request.target_https_proxy(), "/", "setUrlMap")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub.cc
@@ -60,10 +60,10 @@ DefaultRegionTargetTcpProxiesRestStub::AsyncDeleteRegionTargetTcpProxies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetTcpProxies/", request.target_tcp_proxy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetTcpProxies", "/",
+                             request.target_tcp_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -79,9 +79,9 @@ DefaultRegionTargetTcpProxiesRestStub::GetRegionTargetTcpProxies(
         GetRegionTargetTcpProxiesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetTcpProxy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetTcpProxies/",
-                   request.target_tcp_proxy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetTcpProxies", "/", request.target_tcp_proxy()),
       {});
 }
 
@@ -99,9 +99,9 @@ DefaultRegionTargetTcpProxiesRestStub::AsyncInsertRegionTargetTcpProxies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_tcp_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetTcpProxies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetTcpProxies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -118,8 +118,9 @@ DefaultRegionTargetTcpProxiesRestStub::ListRegionTargetTcpProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetTcpProxyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetTcpProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetTcpProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub.cc
+++ b/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub.cc
@@ -58,9 +58,10 @@ DefaultRegionUrlMapsRestStub::AsyncDeleteRegionUrlMaps(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/urlMaps/",
-                             request.url_map(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "urlMaps", "/",
+                             request.url_map())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -76,8 +77,9 @@ DefaultRegionUrlMapsRestStub::GetRegionUrlMaps(
         GetRegionUrlMapsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::UrlMap>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/urlMaps/", request.url_map(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "urlMaps", "/", request.url_map()),
       {});
 }
 
@@ -95,8 +97,9 @@ DefaultRegionUrlMapsRestStub::AsyncInsertRegionUrlMaps(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/urlMaps")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "urlMaps")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -112,8 +115,9 @@ DefaultRegionUrlMapsRestStub::ListRegionUrlMaps(
         ListRegionUrlMapsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::UrlMapList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/urlMaps"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "urlMaps"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -136,9 +140,10 @@ DefaultRegionUrlMapsRestStub::AsyncPatchRegionUrlMaps(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/urlMaps/",
-                             request.url_map(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "urlMaps", "/",
+                             request.url_map())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -161,9 +166,10 @@ DefaultRegionUrlMapsRestStub::AsyncUpdateRegionUrlMaps(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/urlMaps/",
-                             request.url_map(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "urlMaps", "/",
+                             request.url_map())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -181,9 +187,9 @@ DefaultRegionUrlMapsRestStub::Validate(
       google::cloud::cpp::compute::v1::UrlMapsValidateResponse>(
       *service_, rest_context,
       request.region_url_maps_validate_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/urlMaps/", request.url_map(),
-                   "/validate"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "urlMaps", "/", request.url_map(), "/", "validate"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/regions/v1/internal/regions_rest_stub.cc
+++ b/google/cloud/compute/regions/v1/internal/regions_rest_stub.cc
@@ -45,8 +45,8 @@ DefaultRegionsRestStub::GetRegions(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Region>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region()),
       {});
 }
 
@@ -57,7 +57,8 @@ DefaultRegionsRestStub::ListRegions(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::RegionList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/reservations/v1/internal/reservations_rest_stub.cc
+++ b/google/cloud/compute/reservations/v1/internal/reservations_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultReservationsRestStub::AggregatedListReservations(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ReservationAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/reservations"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "reservations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,10 @@ DefaultReservationsRestStub::AsyncDeleteReservations(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/reservations/",
-                             request.reservation(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "reservations", "/",
+                             request.reservation())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,8 +97,9 @@ DefaultReservationsRestStub::GetReservations(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Reservation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/reservations/", request.reservation(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "reservations", "/", request.reservation()),
       {});
 }
 
@@ -108,9 +110,10 @@ DefaultReservationsRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/reservations/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "reservations", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -130,8 +133,9 @@ DefaultReservationsRestStub::AsyncInsertReservations(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.reservation_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/reservations")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "reservations")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -147,8 +151,9 @@ DefaultReservationsRestStub::ListReservations(
         ListReservationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ReservationList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/reservations"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "reservations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -172,9 +177,10 @@ DefaultReservationsRestStub::AsyncResize(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.reservations_resize_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/reservations/",
-                             request.reservation(), "/resize")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "reservations", "/",
+                             request.reservation(), "/", "resize")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -190,9 +196,10 @@ DefaultReservationsRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.zone_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/reservations/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "reservations", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -203,9 +210,10 @@ DefaultReservationsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/reservations/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "reservations", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -222,9 +230,10 @@ DefaultReservationsRestStub::AsyncUpdateReservations(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.reservation_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/reservations/",
-                             request.reservation(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "reservations", "/",
+                             request.reservation())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub.cc
+++ b/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultResourcePoliciesRestStub::AggregatedListResourcePolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ResourcePolicyAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/resourcePolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "resourcePolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -79,10 +80,10 @@ DefaultResourcePoliciesRestStub::AsyncDeleteResourcePolicies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/resourcePolicies/", request.resource_policy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "resourcePolicies", "/",
+                             request.resource_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,9 +99,9 @@ DefaultResourcePoliciesRestStub::GetResourcePolicies(
         GetResourcePoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ResourcePolicy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/resourcePolicies/",
-                   request.resource_policy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "resourcePolicies", "/", request.resource_policy()),
       {});
 }
 
@@ -111,9 +112,10 @@ DefaultResourcePoliciesRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/resourcePolicies/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "resourcePolicies", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -133,9 +135,9 @@ DefaultResourcePoliciesRestStub::AsyncInsertResourcePolicies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.resource_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/resourcePolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "resourcePolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -152,8 +154,9 @@ DefaultResourcePoliciesRestStub::ListResourcePolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ResourcePolicyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/resourcePolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "resourcePolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -176,10 +179,10 @@ DefaultResourcePoliciesRestStub::AsyncPatchResourcePolicies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.resource_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/resourcePolicies/", request.resource_policy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "resourcePolicies", "/",
+                             request.resource_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -195,9 +198,10 @@ DefaultResourcePoliciesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/resourcePolicies/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "resourcePolicies", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -208,9 +212,10 @@ DefaultResourcePoliciesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/resourcePolicies/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "resourcePolicies", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/routers/v1/internal/routers_rest_stub.cc
+++ b/google/cloud/compute/routers/v1/internal/routers_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultRoutersRestStub::AggregatedListRouters(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RouterAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/routers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "routers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,10 @@ DefaultRoutersRestStub::AsyncDeleteRouters(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/routers/",
-                             request.router(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "routers", "/",
+                             request.router())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,8 +97,9 @@ DefaultRoutersRestStub::GetRouters(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Router>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/routers/", request.router(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "routers", "/", request.router()),
       {});
 }
 
@@ -109,9 +111,10 @@ DefaultRoutersRestStub::GetNatMappingInfo(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::VmEndpointNatMappingsList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/routers/", request.router(),
-                   "/getNatMappingInfo"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "routers", "/", request.router(), "/",
+                   "getNatMappingInfo"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("nat_name", request.nat_name()),
@@ -129,9 +132,10 @@ DefaultRoutersRestStub::GetRouterStatus(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RouterStatusResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/routers/", request.router(),
-                   "/getRouterStatus"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "routers", "/", request.router(), "/",
+                   "getRouterStatus"),
       {});
 }
 
@@ -149,8 +153,9 @@ DefaultRoutersRestStub::AsyncInsertRouters(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.router_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/routers")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "routers")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -166,8 +171,9 @@ DefaultRoutersRestStub::ListRouters(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::RouterList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/routers"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "routers"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -190,9 +196,10 @@ DefaultRoutersRestStub::AsyncPatchRouters(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.router_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/routers/",
-                             request.router(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "routers", "/",
+                             request.router())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -208,9 +215,9 @@ DefaultRoutersRestStub::Preview(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::RoutersPreviewResponse>(
       *service_, rest_context, request.router_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/routers/", request.router(),
-                   "/preview"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "routers", "/", request.router(), "/", "preview"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -227,9 +234,10 @@ DefaultRoutersRestStub::AsyncUpdateRouters(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.router_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/routers/",
-                             request.router(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "routers", "/",
+                             request.router())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/routes/v1/internal/routes_rest_stub.cc
+++ b/google/cloud/compute/routes/v1/internal/routes_rest_stub.cc
@@ -58,8 +58,9 @@ DefaultRoutesRestStub::AsyncDeleteRoutes(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/routes/", request.route(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "routes",
+                             "/", request.route())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -74,8 +75,9 @@ DefaultRoutesRestStub::GetRoutes(
     google::cloud::cpp::compute::routes::v1::GetRoutesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Route>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/routes/", request.route(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "routes", "/",
+                   request.route()),
       {});
 }
 
@@ -93,8 +95,8 @@ DefaultRoutesRestStub::AsyncInsertRoutes(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.route_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/routes")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "routes")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -109,8 +111,8 @@ DefaultRoutesRestStub::ListRoutes(
     google::cloud::cpp::compute::routes::v1::ListRoutesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::RouteList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/routes"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "routes"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
+++ b/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
@@ -60,9 +60,10 @@ DefaultSecurityPoliciesRestStub::AsyncAddRule(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.security_policy_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/securityPolicies/",
-                             request.security_policy(), "/addRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "securityPolicies", "/", request.security_policy(),
+                             "/", "addRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -79,8 +80,9 @@ DefaultSecurityPoliciesRestStub::AggregatedListSecurityPolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SecurityPoliciesAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/securityPolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "securityPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -105,9 +107,10 @@ DefaultSecurityPoliciesRestStub::AsyncDeleteSecurityPolicies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/securityPolicies/",
-                             request.security_policy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "securityPolicies", "/",
+                             request.security_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -123,8 +126,9 @@ DefaultSecurityPoliciesRestStub::GetSecurityPolicies(
         GetSecurityPoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SecurityPolicy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/securityPolicies/", request.security_policy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "securityPolicies",
+                   "/", request.security_policy()),
       {});
 }
 
@@ -136,9 +140,9 @@ DefaultSecurityPoliciesRestStub::GetRule(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SecurityPolicyRule>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/securityPolicies/", request.security_policy(),
-                   "/getRule"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "securityPolicies",
+                   "/", request.security_policy(), "/", "getRule"),
       {std::make_pair("priority", std::to_string(request.priority()))});
 }
 
@@ -156,8 +160,9 @@ DefaultSecurityPoliciesRestStub::AsyncInsertSecurityPolicies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.security_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/securityPolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "securityPolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -174,8 +179,8 @@ DefaultSecurityPoliciesRestStub::ListSecurityPolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SecurityPolicyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/securityPolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "securityPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -194,8 +199,9 @@ DefaultSecurityPoliciesRestStub::ListPreconfiguredExpressionSets(
       google::cloud::cpp::compute::v1::
           SecurityPoliciesListPreconfiguredExpressionSetsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/securityPolicies/listPreconfiguredExpressionSets"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "securityPolicies",
+                   "/", "listPreconfiguredExpressionSets"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -218,9 +224,10 @@ DefaultSecurityPoliciesRestStub::AsyncPatchSecurityPolicies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.security_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/securityPolicies/",
-                             request.security_policy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "securityPolicies", "/",
+                             request.security_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -244,9 +251,10 @@ DefaultSecurityPoliciesRestStub::AsyncPatchRule(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.security_policy_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/securityPolicies/",
-                             request.security_policy(), "/patchRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "securityPolicies", "/", request.security_policy(),
+                             "/", "patchRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -269,9 +277,10 @@ DefaultSecurityPoliciesRestStub::AsyncRemoveRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/securityPolicies/",
-                             request.security_policy(), "/removeRule")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "securityPolicies", "/", request.security_policy(),
+                             "/", "removeRule")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -295,9 +304,10 @@ DefaultSecurityPoliciesRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.global_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/securityPolicies/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "securityPolicies", "/", request.resource(), "/",
+                             "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub.cc
+++ b/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultServiceAttachmentsRestStub::AggregatedListServiceAttachments(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ServiceAttachmentAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/serviceAttachments"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "serviceAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -79,10 +80,10 @@ DefaultServiceAttachmentsRestStub::AsyncDeleteServiceAttachments(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/serviceAttachments/",
-                             request.service_attachment(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "serviceAttachments", "/",
+                             request.service_attachment())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,9 +99,10 @@ DefaultServiceAttachmentsRestStub::GetServiceAttachments(
         GetServiceAttachmentsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ServiceAttachment>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/serviceAttachments/",
-                   request.service_attachment(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "serviceAttachments", "/",
+                   request.service_attachment()),
       {});
 }
 
@@ -111,9 +113,10 @@ DefaultServiceAttachmentsRestStub::GetIamPolicy(
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/serviceAttachments/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "serviceAttachments", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -133,9 +136,9 @@ DefaultServiceAttachmentsRestStub::AsyncInsertServiceAttachments(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.service_attachment_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/serviceAttachments")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "serviceAttachments")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -152,8 +155,9 @@ DefaultServiceAttachmentsRestStub::ListServiceAttachments(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ServiceAttachmentList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/serviceAttachments"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "serviceAttachments"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -176,10 +180,10 @@ DefaultServiceAttachmentsRestStub::AsyncPatchServiceAttachments(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.service_attachment_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/serviceAttachments/",
-                             request.service_attachment(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "serviceAttachments", "/",
+                             request.service_attachment())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -195,9 +199,10 @@ DefaultServiceAttachmentsRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/serviceAttachments/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "serviceAttachments", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>
@@ -208,9 +213,10 @@ DefaultServiceAttachmentsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/serviceAttachments/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "serviceAttachments", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub.cc
+++ b/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub.cc
@@ -58,8 +58,9 @@ DefaultSnapshotsRestStub::AsyncDeleteSnapshots(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/snapshots/", request.snapshot(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "snapshots",
+                             "/", request.snapshot())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -75,8 +76,9 @@ DefaultSnapshotsRestStub::GetSnapshots(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Snapshot>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/snapshots/", request.snapshot(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "snapshots", "/",
+                   request.snapshot()),
       {});
 }
 
@@ -87,8 +89,9 @@ DefaultSnapshotsRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/snapshots/", request.resource(), "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "snapshots", "/",
+                   request.resource(), "/", "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -108,8 +111,9 @@ DefaultSnapshotsRestStub::AsyncInsertSnapshots(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.snapshot_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/snapshots")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "snapshots")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -125,8 +129,8 @@ DefaultSnapshotsRestStub::ListSnapshots(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SnapshotList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/snapshots"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "snapshots"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -142,8 +146,9 @@ DefaultSnapshotsRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/snapshots/", request.resource(), "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "snapshots", "/",
+                   request.resource(), "/", "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -161,9 +166,9 @@ DefaultSnapshotsRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.global_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/snapshots/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "snapshots",
+                             "/", request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -180,9 +185,9 @@ DefaultSnapshotsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/snapshots/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "snapshots", "/",
+                   request.resource(), "/", "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub.cc
+++ b/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub.cc
@@ -52,8 +52,9 @@ DefaultSslCertificatesRestStub::AggregatedListSslCertificates(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SslCertificateAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/sslCertificates"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "sslCertificates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +79,10 @@ DefaultSslCertificatesRestStub::AsyncDeleteSslCertificates(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/sslCertificates/",
-                             request.ssl_certificate(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "sslCertificates", "/",
+                             request.ssl_certificate())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,8 +98,9 @@ DefaultSslCertificatesRestStub::GetSslCertificates(
         GetSslCertificatesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslCertificate>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/sslCertificates/", request.ssl_certificate(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "sslCertificates",
+                   "/", request.ssl_certificate()),
       {});
 }
 
@@ -115,8 +118,9 @@ DefaultSslCertificatesRestStub::AsyncInsertSslCertificates(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.ssl_certificate_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/sslCertificates")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "sslCertificates")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -133,8 +137,8 @@ DefaultSslCertificatesRestStub::ListSslCertificates(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SslCertificateList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/sslCertificates"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "sslCertificates"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub.cc
+++ b/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultSslPoliciesRestStub::AggregatedListSslPolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SslPoliciesAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/sslPolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "sslPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,9 @@ DefaultSslPoliciesRestStub::AsyncDeleteSslPolicies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/sslPolicies/", request.ssl_policy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "sslPolicies", "/", request.ssl_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,8 +96,9 @@ DefaultSslPoliciesRestStub::GetSslPolicies(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslPolicy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/sslPolicies/", request.ssl_policy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "sslPolicies", "/",
+                   request.ssl_policy()),
       {});
 }
 
@@ -115,8 +116,9 @@ DefaultSslPoliciesRestStub::AsyncInsertSslPolicies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.ssl_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/sslPolicies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "sslPolicies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -132,8 +134,8 @@ DefaultSslPoliciesRestStub::ListSslPolicies(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslPoliciesList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/sslPolicies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "sslPolicies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -151,8 +153,9 @@ DefaultSslPoliciesRestStub::ListAvailableFeatures(
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 SslPoliciesListAvailableFeaturesResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/sslPolicies/listAvailableFeatures"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "sslPolicies", "/",
+                   "listAvailableFeatures"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -175,9 +178,9 @@ DefaultSslPoliciesRestStub::AsyncPatchSslPolicies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.ssl_policy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/sslPolicies/", request.ssl_policy(),
-                             "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "sslPolicies", "/", request.ssl_policy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub.cc
+++ b/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultSubnetworksRestStub::AggregatedListSubnetworks(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SubnetworkAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/subnetworks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "subnetworks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,10 @@ DefaultSubnetworksRestStub::AsyncDeleteSubnetworks(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/subnetworks/",
-                             request.subnetwork(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "subnetworks", "/",
+                             request.subnetwork())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -104,9 +105,10 @@ DefaultSubnetworksRestStub::AsyncExpandIpCidrRange(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.subnetworks_expand_ip_cidr_range_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/subnetworks/",
-                             request.subnetwork(), "/expandIpCidrRange")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "subnetworks", "/",
+                             request.subnetwork(), "/", "expandIpCidrRange")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -122,8 +124,9 @@ DefaultSubnetworksRestStub::GetSubnetworks(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Subnetwork>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/subnetworks/", request.subnetwork(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "subnetworks", "/", request.subnetwork()),
       {});
 }
 
@@ -134,9 +137,10 @@ DefaultSubnetworksRestStub::GetIamPolicy(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/subnetworks/", request.resource(),
-                   "/getIamPolicy"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "subnetworks", "/", request.resource(), "/",
+                   "getIamPolicy"),
       {std::make_pair(
           "options_requested_policy_version",
           std::to_string(request.options_requested_policy_version()))});
@@ -156,8 +160,9 @@ DefaultSubnetworksRestStub::AsyncInsertSubnetworks(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.subnetwork_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/subnetworks")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "subnetworks")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -173,8 +178,9 @@ DefaultSubnetworksRestStub::ListSubnetworks(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SubnetworkList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/subnetworks"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "subnetworks"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -191,8 +197,9 @@ DefaultSubnetworksRestStub::ListUsable(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::UsableSubnetworksAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/subnetworks/listUsable"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "subnetworks",
+                   "/", "listUsable"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -215,9 +222,10 @@ DefaultSubnetworksRestStub::AsyncPatchSubnetworks(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.subnetwork_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/subnetworks/",
-                             request.subnetwork(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "subnetworks", "/",
+                             request.subnetwork())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -233,9 +241,10 @@ DefaultSubnetworksRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/subnetworks/", request.resource(),
-                   "/setIamPolicy"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "subnetworks", "/", request.resource(), "/",
+                   "setIamPolicy"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -253,9 +262,11 @@ DefaultSubnetworksRestStub::AsyncSetPrivateIpGoogleAccess(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.subnetworks_set_private_ip_google_access_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/regions/", request.region(), "/subnetworks/",
-                         request.subnetwork(), "/setPrivateIpGoogleAccess")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "regions", "/",
+                         request.region(), "/", "subnetworks", "/",
+                         request.subnetwork(), "/",
+                         "setPrivateIpGoogleAccess")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -272,9 +283,10 @@ DefaultSubnetworksRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/subnetworks/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "subnetworks", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultTargetGrpcProxiesRestStub::AsyncDeleteTargetGrpcProxies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetGrpcProxies/",
-                             request.target_grpc_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetGrpcProxies", "/",
+                             request.target_grpc_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -77,9 +78,9 @@ DefaultTargetGrpcProxiesRestStub::GetTargetGrpcProxies(
         GetTargetGrpcProxiesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetGrpcProxy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetGrpcProxies/", request.target_grpc_proxy(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetGrpcProxies",
+                   "/", request.target_grpc_proxy()),
       {});
 }
 
@@ -97,8 +98,9 @@ DefaultTargetGrpcProxiesRestStub::AsyncInsertTargetGrpcProxies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_grpc_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetGrpcProxies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetGrpcProxies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -115,8 +117,8 @@ DefaultTargetGrpcProxiesRestStub::ListTargetGrpcProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetGrpcProxyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetGrpcProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetGrpcProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -139,9 +141,10 @@ DefaultTargetGrpcProxiesRestStub::AsyncPatchTargetGrpcProxies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_grpc_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetGrpcProxies/",
-                             request.target_grpc_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetGrpcProxies", "/",
+                             request.target_grpc_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultTargetHttpProxiesRestStub::AggregatedListTargetHttpProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpProxyAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/targetHttpProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "targetHttpProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -79,9 +80,10 @@ DefaultTargetHttpProxiesRestStub::AsyncDeleteTargetHttpProxies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetHttpProxies/",
-                             request.target_http_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetHttpProxies", "/",
+                             request.target_http_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -97,9 +99,9 @@ DefaultTargetHttpProxiesRestStub::GetTargetHttpProxies(
         GetTargetHttpProxiesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetHttpProxy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetHttpProxies/", request.target_http_proxy(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetHttpProxies",
+                   "/", request.target_http_proxy()),
       {});
 }
 
@@ -117,8 +119,9 @@ DefaultTargetHttpProxiesRestStub::AsyncInsertTargetHttpProxies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_http_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetHttpProxies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetHttpProxies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -135,8 +138,8 @@ DefaultTargetHttpProxiesRestStub::ListTargetHttpProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpProxyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetHttpProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetHttpProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -159,9 +162,10 @@ DefaultTargetHttpProxiesRestStub::AsyncPatchTargetHttpProxies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_http_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetHttpProxies/",
-                             request.target_http_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetHttpProxies", "/",
+                             request.target_http_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -184,9 +188,9 @@ DefaultTargetHttpProxiesRestStub::AsyncSetUrlMap(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/targetHttpProxies/", request.target_http_proxy(),
-                             "/setUrlMap")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "targetHttpProxies", "/",
+                             request.target_http_proxy(), "/", "setUrlMap")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub.cc
@@ -54,8 +54,9 @@ DefaultTargetHttpsProxiesRestStub::AggregatedListTargetHttpsProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpsProxyAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/targetHttpsProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "targetHttpsProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -80,9 +81,10 @@ DefaultTargetHttpsProxiesRestStub::AsyncDeleteTargetHttpsProxies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetHttpsProxies/",
-                             request.target_https_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetHttpsProxies", "/",
+                             request.target_https_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,9 +100,9 @@ DefaultTargetHttpsProxiesRestStub::GetTargetHttpsProxies(
         GetTargetHttpsProxiesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetHttpsProxy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetHttpsProxies/", request.target_https_proxy(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetHttpsProxies",
+                   "/", request.target_https_proxy()),
       {});
 }
 
@@ -118,8 +120,9 @@ DefaultTargetHttpsProxiesRestStub::AsyncInsertTargetHttpsProxies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_https_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetHttpsProxies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetHttpsProxies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -136,8 +139,8 @@ DefaultTargetHttpsProxiesRestStub::ListTargetHttpsProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpsProxyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetHttpsProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetHttpsProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -160,9 +163,10 @@ DefaultTargetHttpsProxiesRestStub::AsyncPatchTargetHttpsProxies(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_https_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetHttpsProxies/",
-                             request.target_https_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetHttpsProxies", "/",
+                             request.target_https_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -186,9 +190,10 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetCertificateMap(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.target_https_proxies_set_certificate_map_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/global/targetHttpsProxies/",
-                         request.target_https_proxy(), "/setCertificateMap")));
+            absl::StrCat(
+                "/", "compute", "/", "v1", "/", "projects", "/",
+                request.project(), "/", "global", "/", "targetHttpsProxies",
+                "/", request.target_https_proxy(), "/", "setCertificateMap")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -213,10 +218,11 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetQuicOverride(
                 *service, *rest_context,
                 request
                     .target_https_proxies_set_quic_override_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetHttpsProxies/",
-                             request.target_https_proxy(),
-                             "/setQuicOverride")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetHttpsProxies", "/",
+                             request.target_https_proxy(), "/",
+                             "setQuicOverride")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -241,9 +247,10 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetSslCertificates(
             *service, *rest_context,
             request
                 .target_https_proxies_set_ssl_certificates_request_resource(),
-            absl::StrCat("/compute/v1/projects/", request.project(),
-                         "/targetHttpsProxies/", request.target_https_proxy(),
-                         "/setSslCertificates")));
+            absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                         request.project(), "/", "targetHttpsProxies", "/",
+                         request.target_https_proxy(), "/",
+                         "setSslCertificates")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -267,9 +274,10 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetSslPolicy(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.ssl_policy_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetHttpsProxies/",
-                             request.target_https_proxy(), "/setSslPolicy")));
+                absl::StrCat(
+                    "/", "compute", "/", "v1", "/", "projects", "/",
+                    request.project(), "/", "global", "/", "targetHttpsProxies",
+                    "/", request.target_https_proxy(), "/", "setSslPolicy")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -292,9 +300,9 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetUrlMap(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/targetHttpsProxies/",
-                             request.target_https_proxy(), "/setUrlMap")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "targetHttpsProxies", "/",
+                             request.target_https_proxy(), "/", "setUrlMap")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub.cc
+++ b/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub.cc
@@ -52,8 +52,9 @@ DefaultTargetInstancesRestStub::AggregatedListTargetInstances(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetInstanceAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/targetInstances"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "targetInstances"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +79,10 @@ DefaultTargetInstancesRestStub::AsyncDeleteTargetInstances(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/targetInstances/",
-                             request.target_instance(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "targetInstances", "/",
+                             request.target_instance())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,9 +98,9 @@ DefaultTargetInstancesRestStub::GetTargetInstances(
         GetTargetInstancesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetInstance>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/targetInstances/",
-                   request.target_instance(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "targetInstances", "/", request.target_instance()),
       {});
 }
 
@@ -116,8 +118,9 @@ DefaultTargetInstancesRestStub::AsyncInsertTargetInstances(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_instance_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/zones/", request.zone(), "/targetInstances")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "zones", "/",
+                             request.zone(), "/", "targetInstances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -134,8 +137,9 @@ DefaultTargetInstancesRestStub::ListTargetInstances(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetInstanceList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/targetInstances"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "targetInstances"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub.cc
+++ b/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultTargetPoolsRestStub::AsyncAddHealthCheck(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_pools_add_health_check_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/targetPools/",
-                             request.target_pool(), "/addHealthCheck")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetPools", "/",
+                             request.target_pool(), "/", "addHealthCheck")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -85,9 +86,10 @@ DefaultTargetPoolsRestStub::AsyncAddInstance(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_pools_add_instance_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/targetPools/",
-                             request.target_pool(), "/addInstance")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetPools", "/",
+                             request.target_pool(), "/", "addInstance")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -104,8 +106,8 @@ DefaultTargetPoolsRestStub::AggregatedListTargetPools(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetPoolAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/targetPools"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "targetPools"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -130,9 +132,10 @@ DefaultTargetPoolsRestStub::AsyncDeleteTargetPools(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/targetPools/",
-                             request.target_pool(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetPools", "/",
+                             request.target_pool())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -148,9 +151,9 @@ DefaultTargetPoolsRestStub::GetTargetPools(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetPool>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetPools/", request.target_pool(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetPools", "/", request.target_pool()),
       {});
 }
 
@@ -162,9 +165,10 @@ DefaultTargetPoolsRestStub::GetHealth(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TargetPoolInstanceHealth>(
       *service_, rest_context, request.instance_reference_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetPools/", request.target_pool(),
-                   "/getHealth"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetPools", "/", request.target_pool(), "/",
+                   "getHealth"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -181,8 +185,9 @@ DefaultTargetPoolsRestStub::AsyncInsertTargetPools(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_pool_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/targetPools")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetPools")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -198,8 +203,9 @@ DefaultTargetPoolsRestStub::ListTargetPools(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetPoolList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetPools"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetPools"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -223,9 +229,10 @@ DefaultTargetPoolsRestStub::AsyncRemoveHealthCheck(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_pools_remove_health_check_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/targetPools/",
-                             request.target_pool(), "/removeHealthCheck")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetPools", "/",
+                             request.target_pool(), "/", "removeHealthCheck")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -249,9 +256,10 @@ DefaultTargetPoolsRestStub::AsyncRemoveInstance(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_pools_remove_instance_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/targetPools/",
-                             request.target_pool(), "/removeInstance")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetPools", "/",
+                             request.target_pool(), "/", "removeInstance")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -274,9 +282,10 @@ DefaultTargetPoolsRestStub::AsyncSetBackup(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/targetPools/",
-                             request.target_pool(), "/setBackup")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetPools", "/",
+                             request.target_pool(), "/", "setBackup")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub.cc
@@ -59,9 +59,10 @@ DefaultTargetSslProxiesRestStub::AsyncDeleteTargetSslProxies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetSslProxies/",
-                             request.target_ssl_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetSslProxies", "/",
+                             request.target_ssl_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -77,8 +78,9 @@ DefaultTargetSslProxiesRestStub::GetTargetSslProxies(
         GetTargetSslProxiesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetSslProxy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetSslProxies/", request.target_ssl_proxy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetSslProxies",
+                   "/", request.target_ssl_proxy()),
       {});
 }
 
@@ -96,8 +98,9 @@ DefaultTargetSslProxiesRestStub::AsyncInsertTargetSslProxies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_ssl_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetSslProxies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetSslProxies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -114,8 +117,8 @@ DefaultTargetSslProxiesRestStub::ListTargetSslProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetSslProxyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetSslProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetSslProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -140,10 +143,11 @@ DefaultTargetSslProxiesRestStub::AsyncSetBackendService(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_backend_service_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetSslProxies/",
-                             request.target_ssl_proxy(),
-                             "/setBackendService")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetSslProxies", "/",
+                             request.target_ssl_proxy(), "/",
+                             "setBackendService")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -168,10 +172,11 @@ DefaultTargetSslProxiesRestStub::AsyncSetCertificateMap(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_certificate_map_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetSslProxies/",
-                             request.target_ssl_proxy(),
-                             "/setCertificateMap")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetSslProxies", "/",
+                             request.target_ssl_proxy(), "/",
+                             "setCertificateMap")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -195,9 +200,10 @@ DefaultTargetSslProxiesRestStub::AsyncSetProxyHeader(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_ssl_proxies_set_proxy_header_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetSslProxies/",
-                             request.target_ssl_proxy(), "/setProxyHeader")));
+                absl::StrCat(
+                    "/", "compute", "/", "v1", "/", "projects", "/",
+                    request.project(), "/", "global", "/", "targetSslProxies",
+                    "/", request.target_ssl_proxy(), "/", "setProxyHeader")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -222,10 +228,11 @@ DefaultTargetSslProxiesRestStub::AsyncSetSslCertificates(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_ssl_certificates_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetSslProxies/",
-                             request.target_ssl_proxy(),
-                             "/setSslCertificates")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetSslProxies", "/",
+                             request.target_ssl_proxy(), "/",
+                             "setSslCertificates")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -249,9 +256,10 @@ DefaultTargetSslProxiesRestStub::AsyncSetSslPolicy(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.ssl_policy_reference_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetSslProxies/",
-                             request.target_ssl_proxy(), "/setSslPolicy")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetSslProxies", "/",
+                             request.target_ssl_proxy(), "/", "setSslPolicy")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultTargetTcpProxiesRestStub::AggregatedListTargetTcpProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetTcpProxyAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/targetTcpProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "targetTcpProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -79,9 +80,10 @@ DefaultTargetTcpProxiesRestStub::AsyncDeleteTargetTcpProxies(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetTcpProxies/",
-                             request.target_tcp_proxy(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetTcpProxies", "/",
+                             request.target_tcp_proxy())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -97,8 +99,9 @@ DefaultTargetTcpProxiesRestStub::GetTargetTcpProxies(
         GetTargetTcpProxiesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetTcpProxy>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetTcpProxies/", request.target_tcp_proxy(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetTcpProxies",
+                   "/", request.target_tcp_proxy()),
       {});
 }
 
@@ -116,8 +119,9 @@ DefaultTargetTcpProxiesRestStub::AsyncInsertTargetTcpProxies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_tcp_proxy_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetTcpProxies")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetTcpProxies")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -134,8 +138,8 @@ DefaultTargetTcpProxiesRestStub::ListTargetTcpProxies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetTcpProxyList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/targetTcpProxies"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "targetTcpProxies"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -160,10 +164,11 @@ DefaultTargetTcpProxiesRestStub::AsyncSetBackendService(
                 *service, *rest_context,
                 request
                     .target_tcp_proxies_set_backend_service_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetTcpProxies/",
-                             request.target_tcp_proxy(),
-                             "/setBackendService")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetTcpProxies", "/",
+                             request.target_tcp_proxy(), "/",
+                             "setBackendService")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -187,9 +192,10 @@ DefaultTargetTcpProxiesRestStub::AsyncSetProxyHeader(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_tcp_proxies_set_proxy_header_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/targetTcpProxies/",
-                             request.target_tcp_proxy(), "/setProxyHeader")));
+                absl::StrCat(
+                    "/", "compute", "/", "v1", "/", "projects", "/",
+                    request.project(), "/", "global", "/", "targetTcpProxies",
+                    "/", request.target_tcp_proxy(), "/", "setProxyHeader")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultTargetVpnGatewaysRestStub::AggregatedListTargetVpnGateways(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetVpnGatewayAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/targetVpnGateways"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/",
+                   "targetVpnGateways"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -79,10 +80,10 @@ DefaultTargetVpnGatewaysRestStub::AsyncDeleteTargetVpnGateways(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetVpnGateways/",
-                             request.target_vpn_gateway(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetVpnGateways", "/",
+                             request.target_vpn_gateway())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,9 +99,9 @@ DefaultTargetVpnGatewaysRestStub::GetTargetVpnGateways(
         GetTargetVpnGatewaysRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetVpnGateway>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetVpnGateways/",
-                   request.target_vpn_gateway(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetVpnGateways", "/", request.target_vpn_gateway()),
       {});
 }
 
@@ -118,9 +119,9 @@ DefaultTargetVpnGatewaysRestStub::AsyncInsertTargetVpnGateways(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_vpn_gateway_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetVpnGateways")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetVpnGateways")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -137,8 +138,9 @@ DefaultTargetVpnGatewaysRestStub::ListTargetVpnGateways(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetVpnGatewayList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/targetVpnGateways"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "targetVpnGateways"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -162,10 +164,10 @@ DefaultTargetVpnGatewaysRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(),
-                             "/targetVpnGateways/", request.resource(),
-                             "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "targetVpnGateways", "/",
+                             request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub.cc
+++ b/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultUrlMapsRestStub::AggregatedListUrlMaps(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::UrlMapsAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/urlMaps"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "urlMaps"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,8 +78,9 @@ DefaultUrlMapsRestStub::AsyncDeleteUrlMaps(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/urlMaps/", request.url_map(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "urlMaps",
+                             "/", request.url_map())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -95,8 +96,9 @@ DefaultUrlMapsRestStub::GetUrlMaps(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::UrlMap>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/urlMaps/", request.url_map(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "urlMaps", "/",
+                   request.url_map()),
       {});
 }
 
@@ -114,8 +116,9 @@ DefaultUrlMapsRestStub::AsyncInsertUrlMaps(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/urlMaps")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "urlMaps")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -139,9 +142,9 @@ DefaultUrlMapsRestStub::AsyncInvalidateCache(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.cache_invalidation_rule_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/urlMaps/", request.url_map(),
-                             "/invalidateCache")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "urlMaps",
+                             "/", request.url_map(), "/", "invalidateCache")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -157,8 +160,8 @@ DefaultUrlMapsRestStub::ListUrlMaps(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::UrlMapList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/urlMaps"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "urlMaps"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -181,8 +184,9 @@ DefaultUrlMapsRestStub::AsyncPatchUrlMaps(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/urlMaps/", request.url_map(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "urlMaps",
+                             "/", request.url_map())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -205,8 +209,9 @@ DefaultUrlMapsRestStub::AsyncUpdateUrlMaps(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/global/urlMaps/", request.url_map(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/", "urlMaps",
+                             "/", request.url_map())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -222,8 +227,9 @@ DefaultUrlMapsRestStub::Validate(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::UrlMapsValidateResponse>(
       *service_, rest_context, request.url_maps_validate_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/global/urlMaps/", request.url_map(), "/validate"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "global", "/", "urlMaps", "/",
+                   request.url_map(), "/", "validate"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultVpnGatewaysRestStub::AggregatedListVpnGateways(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::VpnGatewayAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/vpnGateways"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "vpnGateways"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,10 @@ DefaultVpnGatewaysRestStub::AsyncDeleteVpnGateways(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/vpnGateways/",
-                             request.vpn_gateway(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "vpnGateways", "/",
+                             request.vpn_gateway())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,9 +97,9 @@ DefaultVpnGatewaysRestStub::GetVpnGateways(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::VpnGateway>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/vpnGateways/", request.vpn_gateway(),
-                   ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "vpnGateways", "/", request.vpn_gateway()),
       {});
 }
 
@@ -110,9 +111,10 @@ DefaultVpnGatewaysRestStub::GetStatus(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::VpnGatewaysGetStatusResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/vpnGateways/", request.vpn_gateway(),
-                   "/getStatus"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "vpnGateways", "/", request.vpn_gateway(), "/",
+                   "getStatus"),
       {});
 }
 
@@ -130,8 +132,9 @@ DefaultVpnGatewaysRestStub::AsyncInsertVpnGateways(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.vpn_gateway_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/vpnGateways")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "vpnGateways")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -147,8 +150,9 @@ DefaultVpnGatewaysRestStub::ListVpnGateways(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::VpnGatewayList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/vpnGateways"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "vpnGateways"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -172,9 +176,10 @@ DefaultVpnGatewaysRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/vpnGateways/",
-                             request.resource(), "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "vpnGateways", "/",
+                             request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -191,9 +196,10 @@ DefaultVpnGatewaysRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/vpnGateways/", request.resource(),
-                   "/testIamPermissions"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "vpnGateways", "/", request.resource(), "/",
+                   "testIamPermissions"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub.cc
+++ b/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultVpnTunnelsRestStub::AggregatedListVpnTunnels(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::VpnTunnelAggregatedList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(),
-                   "/aggregated/vpnTunnels"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "aggregated", "/", "vpnTunnels"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("include_all_scopes",
                       request.include_all_scopes() ? "1" : "0"),
@@ -78,9 +78,10 @@ DefaultVpnTunnelsRestStub::AsyncDeleteVpnTunnels(
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/vpnTunnels/",
-                             request.vpn_tunnel(), "")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "vpnTunnels", "/",
+                             request.vpn_tunnel())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -96,8 +97,9 @@ DefaultVpnTunnelsRestStub::GetVpnTunnels(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::VpnTunnel>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/vpnTunnels/", request.vpn_tunnel(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "vpnTunnels", "/", request.vpn_tunnel()),
       {});
 }
 
@@ -115,8 +117,9 @@ DefaultVpnTunnelsRestStub::AsyncInsertVpnTunnels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.vpn_tunnel_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/vpnTunnels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "vpnTunnels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -132,8 +135,9 @@ DefaultVpnTunnelsRestStub::ListVpnTunnels(
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::VpnTunnelList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/regions/",
-                   request.region(), "/vpnTunnels"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "regions", "/", request.region(),
+                   "/", "vpnTunnels"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -157,9 +161,10 @@ DefaultVpnTunnelsRestStub::AsyncSetLabels(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_set_labels_request_resource(),
-                absl::StrCat("/compute/v1/projects/", request.project(),
-                             "/regions/", request.region(), "/vpnTunnels/",
-                             request.resource(), "/setLabels")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "regions", "/",
+                             request.region(), "/", "vpnTunnels", "/",
+                             request.resource(), "/", "setLabels")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub.cc
+++ b/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub.cc
@@ -44,8 +44,9 @@ Status DefaultZoneOperationsRestStub::DeleteZoneOperations(
         DeleteZoneOperationsRequest const& request) {
   return rest_internal::Delete(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/operations/", request.operation(), ""));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "operations", "/", request.operation()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>
@@ -55,8 +56,9 @@ DefaultZoneOperationsRestStub::GetZoneOperations(
         GetZoneOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/operations/", request.operation(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "operations", "/", request.operation()),
       {});
 }
 
@@ -67,8 +69,9 @@ DefaultZoneOperationsRestStub::ListZoneOperations(
         ListZoneOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/operations"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "operations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),
@@ -84,9 +87,9 @@ DefaultZoneOperationsRestStub::Wait(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), "/operations/", request.operation(),
-                   "/wait"));
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone(), "/",
+                   "operations", "/", request.operation(), "/", "wait"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/zones/v1/internal/zones_rest_stub.cc
+++ b/google/cloud/compute/zones/v1/internal/zones_rest_stub.cc
@@ -43,8 +43,8 @@ StatusOr<google::cloud::cpp::compute::v1::Zone> DefaultZonesRestStub::GetZones(
     google::cloud::cpp::compute::zones::v1::GetZonesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Zone>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
-                   request.zone(), ""),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones", "/", request.zone()),
       {});
 }
 
@@ -54,7 +54,8 @@ DefaultZonesRestStub::ListZones(
     google::cloud::cpp::compute::zones::v1::ListZonesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ZoneList>(
       *service_, rest_context, request,
-      absl::StrCat("/compute/v1/projects/", request.project(), "/zones"),
+      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                   request.project(), "/", "zones"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("order_by", request.order_by()),

--- a/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultDatabaseAdminRestStub::ListDatabases(
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListDatabasesResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/databases"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
       {std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
 }
@@ -68,7 +68,7 @@ DefaultDatabaseAdminRestStub::AsyncCreateDatabase(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/v1/", request.parent(), "/databases")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/", "databases")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -83,7 +83,7 @@ DefaultDatabaseAdminRestStub::GetDatabase(
     google::spanner::admin::database::v1::GetDatabaseRequest const& request) {
   return rest_internal::Get<google::spanner::admin::database::v1::Database>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), ""), {});
+      absl::StrCat("/", "v1", "/", request.name()), {});
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -98,7 +98,7 @@ DefaultDatabaseAdminRestStub::AsyncUpdateDatabase(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
             *service, *rest_context, request.database(),
-            absl::StrCat("/v1/", request.database().name(), "")));
+            absl::StrCat("/", "v1", "/", request.database().name())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,7 +119,7 @@ DefaultDatabaseAdminRestStub::AsyncUpdateDatabaseDdl(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/v1/", request.database(), "/ddl")));
+            absl::StrCat("/", "v1", "/", request.database(), "/", "ddl")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -131,8 +131,9 @@ DefaultDatabaseAdminRestStub::AsyncUpdateDatabaseDdl(
 Status DefaultDatabaseAdminRestStub::DropDatabase(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::database::v1::DropDatabaseRequest const& request) {
-  return rest_internal::Delete(*service_, rest_context, request,
-                               absl::StrCat("/v1/", request.database(), ""));
+  return rest_internal::Delete(
+      *service_, rest_context, request,
+      absl::StrCat("/", "v1", "/", request.database()));
 }
 
 StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
@@ -143,7 +144,7 @@ DefaultDatabaseAdminRestStub::GetDatabaseDdl(
   return rest_internal::Get<
       google::spanner::admin::database::v1::GetDatabaseDdlResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.database(), "/ddl"), {});
+      absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"), {});
 }
 
 StatusOr<google::iam::v1::Policy> DefaultDatabaseAdminRestStub::SetIamPolicy(
@@ -151,7 +152,7 @@ StatusOr<google::iam::v1::Policy> DefaultDatabaseAdminRestStub::SetIamPolicy(
     google::iam::v1::SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":setIamPolicy"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":setIamPolicy"));
 }
 
 StatusOr<google::iam::v1::Policy> DefaultDatabaseAdminRestStub::GetIamPolicy(
@@ -159,7 +160,7 @@ StatusOr<google::iam::v1::Policy> DefaultDatabaseAdminRestStub::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":getIamPolicy"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":getIamPolicy"));
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
@@ -168,7 +169,7 @@ DefaultDatabaseAdminRestStub::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const& request) {
   return rest_internal::Post<google::iam::v1::TestIamPermissionsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":testIamPermissions"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":testIamPermissions"));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -182,7 +183,7 @@ DefaultDatabaseAdminRestStub::AsyncCreateBackup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request.backup(),
-            absl::StrCat("/v1/", request.parent(), "/backups")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/", "backups")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -202,7 +203,8 @@ DefaultDatabaseAdminRestStub::AsyncCopyBackup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/v1/", request.parent(), "/backups:copy")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/", "backups",
+                         ":copy")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -217,7 +219,7 @@ DefaultDatabaseAdminRestStub::GetBackup(
     google::spanner::admin::database::v1::GetBackupRequest const& request) {
   return rest_internal::Get<google::spanner::admin::database::v1::Backup>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), ""), {});
+      absl::StrCat("/", "v1", "/", request.name()), {});
 }
 
 StatusOr<google::spanner::admin::database::v1::Backup>
@@ -226,14 +228,14 @@ DefaultDatabaseAdminRestStub::UpdateBackup(
     google::spanner::admin::database::v1::UpdateBackupRequest const& request) {
   return rest_internal::Patch<google::spanner::admin::database::v1::Backup>(
       *service_, rest_context, request.backup(),
-      absl::StrCat("/v1/", request.backup().name(), ""));
+      absl::StrCat("/", "v1", "/", request.backup().name()));
 }
 
 Status DefaultDatabaseAdminRestStub::DeleteBackup(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::database::v1::DeleteBackupRequest const& request) {
   return rest_internal::Delete(*service_, rest_context, request,
-                               absl::StrCat("/v1/", request.name(), ""));
+                               absl::StrCat("/", "v1", "/", request.name()));
 }
 
 StatusOr<google::spanner::admin::database::v1::ListBackupsResponse>
@@ -243,7 +245,7 @@ DefaultDatabaseAdminRestStub::ListBackups(
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListBackupsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/backups"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
@@ -261,7 +263,8 @@ DefaultDatabaseAdminRestStub::AsyncRestoreDatabase(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/v1/", request.parent(), "/databases:restore")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/", "databases",
+                         ":restore")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -278,7 +281,7 @@ DefaultDatabaseAdminRestStub::ListDatabaseOperations(
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListDatabaseOperationsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/databaseOperations"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseOperations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
@@ -292,7 +295,7 @@ DefaultDatabaseAdminRestStub::ListBackupOperations(
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListBackupOperationsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/backupOperations"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "backupOperations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
@@ -306,7 +309,7 @@ DefaultDatabaseAdminRestStub::ListDatabaseRoles(
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListDatabaseRolesResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/databaseRoles"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseRoles"),
       {std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
 }

--- a/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultInstanceAdminRestStub::ListInstanceConfigs(
   return rest_internal::Get<
       google::spanner::admin::instance::v1::ListInstanceConfigsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/instanceConfigs"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "instanceConfigs"),
       {std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
 }
@@ -65,7 +65,7 @@ DefaultInstanceAdminRestStub::GetInstanceConfig(
   return rest_internal::Get<
       google::spanner::admin::instance::v1::InstanceConfig>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), ""), {});
+      absl::StrCat("/", "v1", "/", request.name()), {});
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -80,7 +80,8 @@ DefaultInstanceAdminRestStub::AsyncCreateInstanceConfig(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/v1/", request.parent(), "/instanceConfigs")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/",
+                         "instanceConfigs")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,7 +102,7 @@ DefaultInstanceAdminRestStub::AsyncUpdateInstanceConfig(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/v1/", request.instance_config().name(), "")));
+            absl::StrCat("/", "v1", "/", request.instance_config().name())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -115,7 +116,7 @@ Status DefaultInstanceAdminRestStub::DeleteInstanceConfig(
     google::spanner::admin::instance::v1::DeleteInstanceConfigRequest const&
         request) {
   return rest_internal::Delete(*service_, rest_context, request,
-                               absl::StrCat("/v1/", request.name(), ""));
+                               absl::StrCat("/", "v1", "/", request.name()));
 }
 
 StatusOr<
@@ -127,7 +128,8 @@ DefaultInstanceAdminRestStub::ListInstanceConfigOperations(
   return rest_internal::Get<google::spanner::admin::instance::v1::
                                 ListInstanceConfigOperationsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/instanceConfigOperations"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/",
+                   "instanceConfigOperations"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token())});
@@ -140,7 +142,7 @@ DefaultInstanceAdminRestStub::ListInstances(
   return rest_internal::Get<
       google::spanner::admin::instance::v1::ListInstancesResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.parent(), "/instances"),
+      absl::StrCat("/", "v1", "/", request.parent(), "/", "instances"),
       {std::make_pair("page_size", std::to_string(request.page_size())),
        std::make_pair("page_token", request.page_token()),
        std::make_pair("filter", request.filter())});
@@ -152,7 +154,7 @@ DefaultInstanceAdminRestStub::GetInstance(
     google::spanner::admin::instance::v1::GetInstanceRequest const& request) {
   return rest_internal::Get<google::spanner::admin::instance::v1::Instance>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.name(), ""), {});
+      absl::StrCat("/", "v1", "/", request.name()), {});
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -167,7 +169,7 @@ DefaultInstanceAdminRestStub::AsyncCreateInstance(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/v1/", request.parent(), "/instances")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/", "instances")));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -188,7 +190,7 @@ DefaultInstanceAdminRestStub::AsyncUpdateInstance(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/v1/", request.instance().name(), "")));
+            absl::StrCat("/", "v1", "/", request.instance().name())));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -202,7 +204,7 @@ Status DefaultInstanceAdminRestStub::DeleteInstance(
     google::spanner::admin::instance::v1::DeleteInstanceRequest const&
         request) {
   return rest_internal::Delete(*service_, rest_context, request,
-                               absl::StrCat("/v1/", request.name(), ""));
+                               absl::StrCat("/", "v1", "/", request.name()));
 }
 
 StatusOr<google::iam::v1::Policy> DefaultInstanceAdminRestStub::SetIamPolicy(
@@ -210,7 +212,7 @@ StatusOr<google::iam::v1::Policy> DefaultInstanceAdminRestStub::SetIamPolicy(
     google::iam::v1::SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":setIamPolicy"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":setIamPolicy"));
 }
 
 StatusOr<google::iam::v1::Policy> DefaultInstanceAdminRestStub::GetIamPolicy(
@@ -218,7 +220,7 @@ StatusOr<google::iam::v1::Policy> DefaultInstanceAdminRestStub::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":getIamPolicy"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":getIamPolicy"));
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
@@ -227,7 +229,7 @@ DefaultInstanceAdminRestStub::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const& request) {
   return rest_internal::Post<google::iam::v1::TestIamPermissionsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/", request.resource(), ":testIamPermissions"));
+      absl::StrCat("/", "v1", "/", request.resource(), ":testIamPermissions"));
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/sql/v1/internal/sql_backup_runs_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_backup_runs_rest_stub.cc
@@ -45,8 +45,9 @@ DefaultSqlBackupRunsServiceRestStub::Delete(
     google::cloud::sql::v1::SqlBackupRunsDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/backupRuns/", request.id(), ""));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "backupRuns", "/",
+                   request.id()));
 }
 
 StatusOr<google::cloud::sql::v1::BackupRun>
@@ -55,8 +56,9 @@ DefaultSqlBackupRunsServiceRestStub::Get(
     google::cloud::sql::v1::SqlBackupRunsGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::BackupRun>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/backupRuns/", request.id(), ""),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "backupRuns", "/",
+                   request.id()),
       {});
 }
 
@@ -66,8 +68,8 @@ DefaultSqlBackupRunsServiceRestStub::Insert(
     google::cloud::sql::v1::SqlBackupRunsInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/backupRuns"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "backupRuns"));
 }
 
 StatusOr<google::cloud::sql::v1::BackupRunsListResponse>
@@ -76,8 +78,8 @@ DefaultSqlBackupRunsServiceRestStub::List(
     google::cloud::sql::v1::SqlBackupRunsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::BackupRunsListResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/backupRuns"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "backupRuns"),
       {std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("page_token", request.page_token())});
 }

--- a/google/cloud/sql/v1/internal/sql_connect_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_connect_rest_stub.cc
@@ -45,8 +45,9 @@ DefaultSqlConnectServiceRestStub::GetConnectSettings(
     google::cloud::sql::v1::GetConnectSettingsRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::ConnectSettings>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/connectSettings"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "connectSettings"),
       {});
 }
 
@@ -57,8 +58,9 @@ DefaultSqlConnectServiceRestStub::GenerateEphemeralCert(
   return rest_internal::Post<
       google::cloud::sql::v1::GenerateEphemeralCertResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), ":generateEphemeralCert"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(),
+                   ":generateEphemeralCert"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_databases_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_databases_rest_stub.cc
@@ -45,8 +45,9 @@ DefaultSqlDatabasesServiceRestStub::Delete(
     google::cloud::sql::v1::SqlDatabasesDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/databases/", request.database(), ""));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "databases", "/",
+                   request.database()));
 }
 
 StatusOr<google::cloud::sql::v1::Database>
@@ -55,8 +56,9 @@ DefaultSqlDatabasesServiceRestStub::Get(
     google::cloud::sql::v1::SqlDatabasesGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::Database>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/databases/", request.database(), ""),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "databases", "/",
+                   request.database()),
       {});
 }
 
@@ -66,8 +68,8 @@ DefaultSqlDatabasesServiceRestStub::Insert(
     google::cloud::sql::v1::SqlDatabasesInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/databases"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "databases"));
 }
 
 StatusOr<google::cloud::sql::v1::DatabasesListResponse>
@@ -76,8 +78,8 @@ DefaultSqlDatabasesServiceRestStub::List(
     google::cloud::sql::v1::SqlDatabasesListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::DatabasesListResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/databases"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "databases"),
       {});
 }
 
@@ -87,8 +89,9 @@ DefaultSqlDatabasesServiceRestStub::Patch(
     google::cloud::sql::v1::SqlDatabasesUpdateRequest const& request) {
   return rest_internal::Patch<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/databases/", request.database(), ""));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "databases", "/",
+                   request.database()));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -97,8 +100,9 @@ DefaultSqlDatabasesServiceRestStub::Update(
     google::cloud::sql::v1::SqlDatabasesUpdateRequest const& request) {
   return rest_internal::Put<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/databases/", request.database(), ""));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "databases", "/",
+                   request.database()));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_instances_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_instances_rest_stub.cc
@@ -45,8 +45,8 @@ DefaultSqlInstancesServiceRestStub::AddServerCa(
     google::cloud::sql::v1::SqlInstancesAddServerCaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/addServerCa"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "addServerCa"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -55,8 +55,8 @@ DefaultSqlInstancesServiceRestStub::Clone(
     google::cloud::sql::v1::SqlInstancesCloneRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/clone"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "clone"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -65,8 +65,8 @@ DefaultSqlInstancesServiceRestStub::Delete(
     google::cloud::sql::v1::SqlInstancesDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), ""));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance()));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -75,8 +75,8 @@ DefaultSqlInstancesServiceRestStub::DemoteMaster(
     google::cloud::sql::v1::SqlInstancesDemoteMasterRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/demoteMaster"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "demoteMaster"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -85,8 +85,8 @@ DefaultSqlInstancesServiceRestStub::Export(
     google::cloud::sql::v1::SqlInstancesExportRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/export"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "export"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -95,8 +95,8 @@ DefaultSqlInstancesServiceRestStub::Failover(
     google::cloud::sql::v1::SqlInstancesFailoverRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/failover"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "failover"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -105,8 +105,8 @@ DefaultSqlInstancesServiceRestStub::Reencrypt(
     google::cloud::sql::v1::SqlInstancesReencryptRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/reencrypt"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "reencrypt"));
 }
 
 StatusOr<google::cloud::sql::v1::DatabaseInstance>
@@ -115,8 +115,8 @@ DefaultSqlInstancesServiceRestStub::Get(
     google::cloud::sql::v1::SqlInstancesGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::DatabaseInstance>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), ""),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance()),
       {});
 }
 
@@ -126,8 +126,8 @@ DefaultSqlInstancesServiceRestStub::Import(
     google::cloud::sql::v1::SqlInstancesImportRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/import"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "import"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -136,7 +136,8 @@ DefaultSqlInstancesServiceRestStub::Insert(
     google::cloud::sql::v1::SqlInstancesInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances"));
 }
 
 StatusOr<google::cloud::sql::v1::InstancesListResponse>
@@ -145,7 +146,8 @@ DefaultSqlInstancesServiceRestStub::List(
     google::cloud::sql::v1::SqlInstancesListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::InstancesListResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances"),
       {std::make_pair("filter", request.filter()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("page_token", request.page_token())});
@@ -158,8 +160,8 @@ DefaultSqlInstancesServiceRestStub::ListServerCas(
   return rest_internal::Get<
       google::cloud::sql::v1::InstancesListServerCasResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/listServerCas"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "listServerCas"),
       {});
 }
 
@@ -169,8 +171,8 @@ DefaultSqlInstancesServiceRestStub::Patch(
     google::cloud::sql::v1::SqlInstancesPatchRequest const& request) {
   return rest_internal::Patch<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), ""));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance()));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -179,8 +181,9 @@ DefaultSqlInstancesServiceRestStub::PromoteReplica(
     google::cloud::sql::v1::SqlInstancesPromoteReplicaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/promoteReplica"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "promoteReplica"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -189,8 +192,9 @@ DefaultSqlInstancesServiceRestStub::ResetSslConfig(
     google::cloud::sql::v1::SqlInstancesResetSslConfigRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/resetSslConfig"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "resetSslConfig"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -199,8 +203,8 @@ DefaultSqlInstancesServiceRestStub::Restart(
     google::cloud::sql::v1::SqlInstancesRestartRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/restart"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "restart"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -209,8 +213,8 @@ DefaultSqlInstancesServiceRestStub::RestoreBackup(
     google::cloud::sql::v1::SqlInstancesRestoreBackupRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/restoreBackup"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "restoreBackup"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -219,8 +223,9 @@ DefaultSqlInstancesServiceRestStub::RotateServerCa(
     google::cloud::sql::v1::SqlInstancesRotateServerCaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/rotateServerCa"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "rotateServerCa"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -229,8 +234,8 @@ DefaultSqlInstancesServiceRestStub::StartReplica(
     google::cloud::sql::v1::SqlInstancesStartReplicaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/startReplica"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "startReplica"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -239,8 +244,8 @@ DefaultSqlInstancesServiceRestStub::StopReplica(
     google::cloud::sql::v1::SqlInstancesStopReplicaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/stopReplica"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "stopReplica"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -249,8 +254,8 @@ DefaultSqlInstancesServiceRestStub::TruncateLog(
     google::cloud::sql::v1::SqlInstancesTruncateLogRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/truncateLog"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "truncateLog"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -259,8 +264,8 @@ DefaultSqlInstancesServiceRestStub::Update(
     google::cloud::sql::v1::SqlInstancesUpdateRequest const& request) {
   return rest_internal::Put<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), ""));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance()));
 }
 
 StatusOr<google::cloud::sql::v1::SslCert>
@@ -270,8 +275,9 @@ DefaultSqlInstancesServiceRestStub::CreateEphemeral(
         request) {
   return rest_internal::Post<google::cloud::sql::v1::SslCert>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/createEphemeral"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "createEphemeral"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -281,8 +287,9 @@ DefaultSqlInstancesServiceRestStub::RescheduleMaintenance(
         request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/rescheduleMaintenance"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "rescheduleMaintenance"));
 }
 
 StatusOr<google::cloud::sql::v1::SqlInstancesVerifyExternalSyncSettingsResponse>
@@ -293,8 +300,9 @@ DefaultSqlInstancesServiceRestStub::VerifyExternalSyncSettings(
   return rest_internal::Post<
       google::cloud::sql::v1::SqlInstancesVerifyExternalSyncSettingsResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/verifyExternalSyncSettings"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "verifyExternalSyncSettings"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -304,8 +312,9 @@ DefaultSqlInstancesServiceRestStub::StartExternalSync(
         request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/startExternalSync"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "startExternalSync"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -315,8 +324,9 @@ DefaultSqlInstancesServiceRestStub::PerformDiskShrink(
         request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/performDiskShrink"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "performDiskShrink"));
 }
 
 StatusOr<google::cloud::sql::v1::SqlInstancesGetDiskShrinkConfigResponse>
@@ -327,8 +337,9 @@ DefaultSqlInstancesServiceRestStub::GetDiskShrinkConfig(
   return rest_internal::Get<
       google::cloud::sql::v1::SqlInstancesGetDiskShrinkConfigResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/getDiskShrinkConfig"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "getDiskShrinkConfig"),
       {});
 }
 
@@ -339,8 +350,9 @@ DefaultSqlInstancesServiceRestStub::ResetReplicaSize(
         request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/resetReplicaSize"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/",
+                   "resetReplicaSize"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_operations_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_operations_rest_stub.cc
@@ -45,8 +45,8 @@ DefaultSqlOperationsServiceRestStub::Get(
     google::cloud::sql::v1::SqlOperationsGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/operations/",
-                   request.operation(), ""),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "operations", "/", request.operation()),
       {});
 }
 
@@ -56,7 +56,8 @@ DefaultSqlOperationsServiceRestStub::List(
     google::cloud::sql::v1::SqlOperationsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::OperationsListResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/operations"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "operations"),
       {std::make_pair("instance", request.instance()),
        std::make_pair("max_results", std::to_string(request.max_results())),
        std::make_pair("page_token", request.page_token())});
@@ -67,8 +68,8 @@ Status DefaultSqlOperationsServiceRestStub::Cancel(
     google::cloud::sql::v1::SqlOperationsCancelRequest const& request) {
   return rest_internal::Post(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/operations/",
-                   request.operation(), "/cancel"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "operations", "/", request.operation(), "/", "cancel"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_ssl_certs_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_ssl_certs_rest_stub.cc
@@ -45,9 +45,9 @@ DefaultSqlSslCertsServiceRestStub::Delete(
     google::cloud::sql::v1::SqlSslCertsDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/sslCerts/", request.sha1_fingerprint(),
-                   ""));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "sslCerts", "/",
+                   request.sha1_fingerprint()));
 }
 
 StatusOr<google::cloud::sql::v1::SslCert>
@@ -56,9 +56,9 @@ DefaultSqlSslCertsServiceRestStub::Get(
     google::cloud::sql::v1::SqlSslCertsGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::SslCert>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/sslCerts/", request.sha1_fingerprint(),
-                   ""),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "sslCerts", "/",
+                   request.sha1_fingerprint()),
       {});
 }
 
@@ -68,8 +68,8 @@ DefaultSqlSslCertsServiceRestStub::Insert(
     google::cloud::sql::v1::SqlSslCertsInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::SslCertsInsertResponse>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/sslCerts"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "sslCerts"));
 }
 
 StatusOr<google::cloud::sql::v1::SslCertsListResponse>
@@ -78,8 +78,8 @@ DefaultSqlSslCertsServiceRestStub::List(
     google::cloud::sql::v1::SqlSslCertsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::SslCertsListResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/sslCerts"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "sslCerts"),
       {});
 }
 

--- a/google/cloud/sql/v1/internal/sql_tiers_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_tiers_rest_stub.cc
@@ -44,7 +44,9 @@ DefaultSqlTiersServiceRestStub::List(
     google::cloud::sql::v1::SqlTiersListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::TiersListResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/tiers"), {});
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "tiers"),
+      {});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_users_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_users_rest_stub.cc
@@ -44,8 +44,8 @@ DefaultSqlUsersServiceRestStub::Delete(
     google::cloud::sql::v1::SqlUsersDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/users"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "users"));
 }
 
 StatusOr<google::cloud::sql::v1::User> DefaultSqlUsersServiceRestStub::Get(
@@ -53,8 +53,9 @@ StatusOr<google::cloud::sql::v1::User> DefaultSqlUsersServiceRestStub::Get(
     google::cloud::sql::v1::SqlUsersGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::User>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/users/", request.name(), ""),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "users", "/",
+                   request.name()),
       {std::make_pair("host", request.host())});
 }
 
@@ -64,8 +65,8 @@ DefaultSqlUsersServiceRestStub::Insert(
     google::cloud::sql::v1::SqlUsersInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/users"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "users"));
 }
 
 StatusOr<google::cloud::sql::v1::UsersListResponse>
@@ -74,8 +75,8 @@ DefaultSqlUsersServiceRestStub::List(
     google::cloud::sql::v1::SqlUsersListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::UsersListResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/users"),
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "users"),
       {});
 }
 
@@ -85,8 +86,8 @@ DefaultSqlUsersServiceRestStub::Update(
     google::cloud::sql::v1::SqlUsersUpdateRequest const& request) {
   return rest_internal::Put<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
-      absl::StrCat("/v1/projects/", request.project(), "/instances/",
-                   request.instance(), "/users"));
+      absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
+                   "instances", "/", request.instance(), "/", "users"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
fixes #12196 

Regenerated code split into separate commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12405)
<!-- Reviewable:end -->
