### PR TITLE
impl(common): introduce immutable options

### DIFF
--- a/google/cloud/options.cc
+++ b/google/cloud/options.cc
@@ -49,16 +49,25 @@ namespace {
 // The prevailing options for the current operation.  Thread local, so
 // additional propagation must be done whenever work for the operation
 // is done in another thread.
-Options& ThreadLocalOptions() {
-  thread_local Options current_options;
+std::shared_ptr<Options const>& ThreadLocalOptions() {
+  thread_local std::shared_ptr<Options const> current_options =
+      std::make_shared<Options const>();
   return current_options;
 }
 
 }  // namespace
 
-Options const& CurrentOptions() { return ThreadLocalOptions(); }
+Options const& CurrentOptions() { return *ThreadLocalOptions(); }
 
-OptionsSpan::OptionsSpan(Options opts) : opts_(std::move(opts)) {
+std::shared_ptr<Options const> SaveCurrentOptions() {
+  return ThreadLocalOptions();
+}
+
+OptionsSpan::OptionsSpan(Options opts)
+    : OptionsSpan(std::make_shared<Options const>(std::move(opts))) {}
+
+OptionsSpan::OptionsSpan(std::shared_ptr<Options const> opts)
+    : opts_(std::move(opts)) {
   using std::swap;
   swap(opts_, ThreadLocalOptions());
 }

--- a/google/cloud/options.cc
+++ b/google/cloud/options.cc
@@ -50,8 +50,7 @@ namespace {
 // additional propagation must be done whenever work for the operation
 // is done in another thread.
 std::shared_ptr<Options const>& ThreadLocalOptions() {
-  thread_local std::shared_ptr<Options const> current_options =
-      std::make_shared<Options const>();
+  thread_local auto current_options = std::make_shared<Options const>();
   return current_options;
 }
 

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -347,6 +347,12 @@ absl::optional<typename T::Type> ExtractOption(Options& opts) {
 Options const& CurrentOptions();
 
 /**
+ * Save the current options. Typically used to install them in a future
+ * `OptionsSpan` in a different thread.
+ */
+std::shared_ptr<Options const> SaveCurrentOptions();
+
+/**
  * RAII object to set/restore the prevailing options for the enclosing scope.
  *
  * @code
@@ -369,6 +375,7 @@ Options const& CurrentOptions();
 class ABSL_MUST_USE_RESULT OptionsSpan {
  public:
   explicit OptionsSpan(Options opts);
+  explicit OptionsSpan(std::shared_ptr<Options const> opts);
 
   // `OptionsSpan` should not be copied/moved.
   OptionsSpan(OptionsSpan const&) = delete;
@@ -383,7 +390,7 @@ class ABSL_MUST_USE_RESULT OptionsSpan {
   ~OptionsSpan();
 
  private:
-  Options opts_;
+  std::shared_ptr<Options const> opts_;
 };
 
 }  // namespace internal

--- a/google/cloud/options_benchmark.cc
+++ b/google/cloud/options_benchmark.cc
@@ -21,18 +21,21 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-// Run on (96 X 2000 MHz CPU s)
+// Run on (128 X 2250 MHz CPU s)
 // CPU Caches:
-//   L1 Data 32 KiB (x48)
-//   L1 Instruction 32 KiB (x48)
-//   L2 Unified 1024 KiB (x48)
-//   L3 Unified 39424 KiB (x2)
-// Load Average: 0.49, 0.35, 0.89
-// ----------------------------------------------------------------------
-// Benchmark                            Time             CPU   Iterations
-// ----------------------------------------------------------------------
-// BM_OptionsOneElementDefault       25.6 ns         25.6 ns     27332591
-// BM_OptionsOneElementPresent       28.0 ns         28.0 ns     24999101
+//   L1 Data 32 KiB (x64)
+//   L1 Instruction 32 KiB (x64)
+//   L2 Unified 512 KiB (x64)
+//   L3 Unified 16384 KiB (x16)
+// Load Average: 1.26, 1.39, 2.94
+// --------------------------------------------------------------------------
+// Benchmark                                Time             CPU   Iterations
+// --------------------------------------------------------------------------
+// BM_OptionsOneElementDefault           18.4 ns         18.4 ns     38006008
+// BM_OptionsOneElementPresent           45.8 ns         45.8 ns     15266572
+// BM_SimulateRpc                       10721 ns        10721 ns        64131
+// BM_SimulateStreamingRpc             891912 ns       891888 ns          774
+// BM_SimulateStreamingRpcWithSave      12547 ns        12547 ns        54804
 
 struct StringOptionDefault {
   using Type = std::string;


### PR DESCRIPTION
Once a `*Client` creates the first `OptionSpan` we can save the options as a `std::shared_ptr<Options const>`. This will let us reuse the options in new spans without copying. This is safe as the options in the current span were (and are) accessed as `Options const&`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12407)
<!-- Reviewable:end -->
