### PR TITLE
impl(common): use immutable options

### DIFF
--- a/google/cloud/internal/async_retry_loop_test.cc
+++ b/google/cloud/internal/async_retry_loop_test.cc
@@ -149,7 +149,7 @@ TEST(AsyncRetryLoopTest, SuccessWithExplicitOptions) {
         EXPECT_EQ(options.get<TestOption>(), "Success");
         return make_ready_future(StatusOr<int>(2 * request));
       },
-      Options{}.set<TestOption>("Success"),
+      MakeImmutableOptions(Options{}.set<TestOption>("Success")),
       /*request=*/42, /*location=*/"error message");
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   StatusOr<int> actual = pending.get();
@@ -172,7 +172,9 @@ TEST(AsyncRetryLoopTest, TransientThenSuccess) {
         }
         return make_ready_future(StatusOr<int>(2 * request));
       },
-      Options{}.set<TestOption>("TransientThenSuccess"), 42, "error message");
+      MakeImmutableOptions(
+          Options{}.set<TestOption>("TransientThenSuccess")),
+      42, "error message");
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   StatusOr<int> actual = pending.get();
   ASSERT_THAT(actual.status(), IsOk());
@@ -193,7 +195,9 @@ TEST(AsyncRetryLoopTest, ReturnJustStatus) {
         }
         return make_ready_future(Status());
       },
-      Options{}.set<TestOption>("ReturnJustStatus"), 42, "error message");
+      MakeImmutableOptions(
+          Options{}.set<TestOption>("ReturnJustStatus")),
+      42, "error message");
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   Status actual = pending.get();
   ASSERT_THAT(actual, IsOk());
@@ -237,7 +241,9 @@ TEST(AsyncRetryLoopTest, UsesBackoffPolicy) {
         }
         return make_ready_future(StatusOr<int>(2 * request));
       },
-      Options{}.set<TestOption>("UsesBackoffPolicy"), 42, "error message");
+      MakeImmutableOptions(
+          Options{}.set<TestOption>("UsesBackoffPolicy")),
+      42, "error message");
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   StatusOr<int> actual = pending.get();
   ASSERT_THAT(actual.status(), IsOk());
@@ -254,8 +260,9 @@ TEST(AsyncRetryLoopTest, TransientFailureNonIdempotent) {
         return make_ready_future(StatusOr<int>(
             Status(StatusCode::kUnavailable, "test-message-try-again")));
       },
-      Options{}.set<TestOption>("TransientFailureNonIdempotent"), 42,
-      "test-location");
+      MakeImmutableOptions(
+          Options{}.set<TestOption>("TransientFailureNonIdempotent")),
+      42, "test-location");
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   StatusOr<int> actual = pending.get();
   EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable,
@@ -282,8 +289,9 @@ TEST(AsyncRetryLoopTest, PermanentFailureIdempotent) {
         return make_ready_future(StatusOr<int>(
             Status(StatusCode::kPermissionDenied, "test-message-uh-oh")));
       },
-      Options{}.set<TestOption>("PermanentFailureIdempotent"), 42,
-      "test-location");
+      MakeImmutableOptions(
+          Options{}.set<TestOption>("PermanentFailureIdempotent")),
+      42, "test-location");
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   StatusOr<int> actual = pending.get();
   EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied,
@@ -308,8 +316,9 @@ TEST(AsyncRetryLoopTest, TooManyTransientFailuresIdempotent) {
         return make_ready_future(StatusOr<int>(
             Status(StatusCode::kUnavailable, "test-message-try-again")));
       },
-      Options{}.set<TestOption>("TooManyTransientFailuresIdempotent"), 42,
-      "test-location");
+      MakeImmutableOptions(
+          Options{}.set<TestOption>("TooManyTransientFailuresIdempotent")),
+      42, "test-location");
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   StatusOr<int> actual = pending.get();
   EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable,
@@ -336,7 +345,9 @@ TEST(AsyncRetryLoopTest, ExhaustedDuringBackoff) {
         return make_ready_future(StatusOr<int>(
             Status(StatusCode::kUnavailable, "test-message-try-again")));
       },
-      Options{}.set<TestOption>("ExhaustedDuringBackoff"), 42, "test-location");
+      MakeImmutableOptions(
+          Options{}.set<TestOption>("ExhaustedDuringBackoff")),
+      42, "test-location");
   StatusOr<int> actual = pending.get();
   EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable,
                                HasSubstr("test-message-try-again")));
@@ -364,7 +375,7 @@ TEST(AsyncRetryLoopTest, ExhaustedBeforeStart) {
             return make_ready_future(StatusOr<int>(
                 Status(StatusCode::kUnavailable, "test-message-try-again")));
           },
-          Options{}, 42, "test-location")
+          MakeImmutableOptions(Options{}), 42, "test-location")
           .get();
   EXPECT_THAT(actual, StatusIs(StatusCode::kDeadlineExceeded));
   auto const& metadata = actual.status().error_info().metadata();
@@ -403,7 +414,7 @@ TEST(AsyncRetryLoopTest, SetsTimeout) {
         return make_ready_future(
             StatusOr<int>(Status(StatusCode::kUnavailable, "try again")));
       },
-      Options{}, 42, "error message");
+      MakeImmutableOptions(Options{}), 42, "error message");
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   StatusOr<int> actual = pending.get();
   ASSERT_THAT(actual.status(), StatusIs(StatusCode::kUnavailable));
@@ -424,8 +435,9 @@ TEST(AsyncRetryLoopTest, ConfigureContext) {
       [&sequencer](auto&, auto, auto const&, auto const&) {
         return sequencer.PushBack();
       },
-      Options{}.set<GrpcSetupOption>(setup.AsStdFunction()), 42,
-      "error message");
+      MakeImmutableOptions(
+          Options{}.set<GrpcSetupOption>(setup.AsStdFunction())),
+      42, "error message");
 
   // Clear the current options before retrying.
   sequencer.PopFront().set_value(Status(StatusCode::kUnavailable, "try again"));
@@ -434,7 +446,6 @@ TEST(AsyncRetryLoopTest, ConfigureContext) {
 }
 
 TEST(AsyncRetryLoopTest, CallOptionsDuringCancel) {
-  auto options = Options{}.set<TestOption>("CallOptionsDuringCancel");
   promise<StatusOr<int>> p([] {
     EXPECT_EQ(CurrentOptions().get<TestOption>(), "CallOptionsDuringCancel");
   });
@@ -444,7 +455,9 @@ TEST(AsyncRetryLoopTest, CallOptionsDuringCancel) {
       TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
       background.cq(),
       [&p](auto&, auto, auto const&, auto const&) { return p.get_future(); },
-      options, 42, "error message");
+      MakeImmutableOptions(
+          Options{}.set<TestOption>("CallOptionsDuringCancel")),
+      42, "error message");
 
   OptionsSpan overlay(Options{}.set<TestOption>("uh-oh"));
   pending.cancel();
@@ -462,7 +475,7 @@ TEST_F(AsyncRetryLoopCancelTest, CancelAndSuccess) {
       [this](google::cloud::CompletionQueue&, auto, auto const&, int x) {
         return SimulateRequest(x);
       },
-      Options{}, 42, "test-location");
+      MakeImmutableOptions(Options{}), 42, "test-location");
 
   // First simulate a regular request that results in a transient failure.
   auto p = WaitForRequest();
@@ -493,7 +506,7 @@ TEST_F(AsyncRetryLoopCancelTest, CancelWithFailure) {
       [this](google::cloud::CompletionQueue&, auto, auto const&, int x) {
         return SimulateRequest(x);
       },
-      Options{}, 42, "test-location");
+      MakeImmutableOptions(Options{}), 42, "test-location");
 
   // First simulate a regular request.
   auto p = WaitForRequest();
@@ -528,7 +541,7 @@ TEST_F(AsyncRetryLoopCancelTest, CancelDuringTimer) {
       [this](google::cloud::CompletionQueue&, auto, auto const&, int x) {
         return SimulateRequest(x);
       },
-      Options{}, 42, "test-location");
+      MakeImmutableOptions(Options{}), 42, "test-location");
 
   // First simulate a regular request.
   auto p = WaitForRequest();
@@ -565,7 +578,7 @@ TEST_F(AsyncRetryLoopCancelTest, ShutdownDuringTimer) {
       [this](google::cloud::CompletionQueue&, auto, auto const&, int x) {
         return SimulateRequest(x);
       },
-      Options{}, 42, "test-location");
+      MakeImmutableOptions(Options{}), 42, "test-location");
 
   // First simulate a regular request.
   auto p = WaitForRequest();
@@ -611,7 +624,7 @@ TEST(AsyncRetryLoopTest, TracedBackoff) {
         return sequencer.PushBack().then(
             [](auto) { return StatusOr<int>(UnavailableError("try again")); });
       },
-      EnableTracing(Options{}), 42, "error message");
+      MakeImmutableOptions(EnableTracing(Options{})), 42, "error message");
 
   OptionsSpan overlay(Options{});
   for (auto i = 0; i != kMaxRetries + 1; ++i) {
@@ -639,7 +652,8 @@ TEST(AsyncRetryLoopTest, CallSpanActiveThroughout) {
         EXPECT_THAT(span, IsActive());
         return sequencer.PushBack();
       },
-      EnableTracing(Options{}), 42, "error message");
+      MakeImmutableOptions(EnableTracing(Options{})), 42,
+      "error message");
 
   sequencer.PopFront().set_value(UnavailableError("try again"));
   sequencer.PopFront().set_value(0);
@@ -660,7 +674,8 @@ TEST(AsyncRetryLoopTest, CallSpanActiveDuringCancel) {
       TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
       background.cq(),
       [&](auto, auto, auto const&, auto) { return p.get_future(); },
-      EnableTracing(Options{}), 42, "error message");
+      MakeImmutableOptions(EnableTracing(Options{})), 42,
+      "error message");
 
   auto overlay = opentelemetry::trace::Scope(MakeSpan("overlay"));
   actual.cancel();

--- a/google/cloud/internal/call_context.h
+++ b/google/cloud/internal/call_context.h
@@ -37,12 +37,13 @@ namespace internal {
  * enabled, it also contains the parent span that encompasses the client call.
  */
 struct CallContext {
-  explicit CallContext(Options o) : options(std::move(o)) {}
+  explicit CallContext(ImmutableOptions o)
+      : options(std::move(o)) {}
   // TODO(#12359) - maybe this can be removed once the explicit options cleanup
   //     is done.
-  CallContext() : CallContext(CurrentOptions()) {}
+  CallContext() : CallContext(SaveCurrentOptions()) {}
 
-  Options options;
+  ImmutableOptions options;
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span =
       opentelemetry::trace::Tracer::GetCurrentSpan();

--- a/google/cloud/internal/call_context_test.cc
+++ b/google/cloud/internal/call_context_test.cc
@@ -27,21 +27,21 @@ struct IntOption {
 };
 
 TEST(CallContext, Options) {
-  EXPECT_FALSE(CallContext().options.has<IntOption>());
+  EXPECT_FALSE(CallContext().options->has<IntOption>());
   {
+    OptionsSpan span(Options{}.set<IntOption>(1));
     auto context = CallContext();
-    context.options.set<IntOption>(1);
     ScopedCallContext scope(context);
-    EXPECT_EQ(CallContext().options.get<IntOption>(), 1);
+    EXPECT_EQ(CallContext().options->get<IntOption>(), 1);
     {
+      OptionsSpan span2(Options{}.set<IntOption>(2));
       auto context = CallContext();
-      context.options.set<IntOption>(2);
       ScopedCallContext scope(context);
-      EXPECT_EQ(CallContext().options.get<IntOption>(), 2);
+      EXPECT_EQ(CallContext().options->get<IntOption>(), 2);
     }
-    EXPECT_EQ(CallContext().options.get<IntOption>(), 1);
+    EXPECT_EQ(CallContext().options->get<IntOption>(), 1);
   }
-  EXPECT_FALSE(CallContext().options.has<IntOption>());
+  EXPECT_FALSE(CallContext().options->has<IntOption>());
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/options.cc
+++ b/google/cloud/options.cc
@@ -49,8 +49,8 @@ namespace {
 // The prevailing options for the current operation.  Thread local, so
 // additional propagation must be done whenever work for the operation
 // is done in another thread.
-Options& ThreadLocalOptions() {
-  thread_local Options current_options;
+ImmutableOptions& ThreadLocalOptions() {
+  thread_local auto current_options = MakeImmutableOptions(Options{});
   return current_options;
 }
 
@@ -58,7 +58,12 @@ Options& ThreadLocalOptions() {
 
 Options const& CurrentOptions() { return ThreadLocalOptions(); }
 
-OptionsSpan::OptionsSpan(Options opts) : opts_(std::move(opts)) {
+ImmutableOptions SaveCurrentOptions() { return ThreadLocalOptions(); }
+
+OptionsSpan::OptionsSpan(Options opts)
+    : OptionsSpan(MakeImmutableOptions(std::move(opts))) {}
+
+OptionsSpan::OptionsSpan(ImmutableOptions opts) : opts_(std::move(opts)) {
   using std::swap;
   swap(opts_, ThreadLocalOptions());
 }


### PR DESCRIPTION
One of the many changes to use `ImmutableOptions` in the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12409)
<!-- Reviewable:end -->
