### PR TITLE
impl(common): add internal::RemoveOptions<T...>(Options)

### DIFF
--- a/google/cloud/options.cc
+++ b/google/cloud/options.cc
@@ -25,6 +25,14 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
+Options RemoveOptionsImpl(std::set<std::type_index> const& remove,
+                          Options opts) {
+  for (auto ti : remove) {
+    opts.m_.erase(ti);
+  }
+  return opts;
+}
+
 void CheckExpectedOptionsImpl(std::set<std::type_index> const& expected,
                               Options const& opts, char const* const caller) {
   for (auto const& p : opts.m_) {

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -272,6 +272,23 @@ TEST(MergeOptions, Basics) {
   EXPECT_EQ(a.get<IntOption>(), 42);           // From a
 }
 
+TEST(RemoveOptions, Basics) {
+  auto opts = Options{}.set<IntOption>(42);
+  EXPECT_EQ(opts.get<IntOption>(), 42);
+  opts = internal::RemoveOptions<IntOption>(std::move(opts));
+  EXPECT_FALSE(opts.has<IntOption>());
+}
+
+TEST(RemoveOptions, BasicOptionsList) {
+  auto opts =
+      Options{}.set<IntOption>(42).set<BoolOption>(true).set<StringOption>(
+          "foo");
+  EXPECT_FALSE(internal::IsEmpty(opts));
+  opts = internal::RemoveOptions<TestOptionList, TestOptionList, BoolOption>(
+      std::move(opts));
+  EXPECT_TRUE(internal::IsEmpty(opts));
+}
+
 TEST(ExtractOption, Basics) {
   auto opts = Options{}.set<StringOption>("foo").set<IntOption>(42);
 


### PR DESCRIPTION
Add a helper function to remove all options in an `OptionList`.  This is intended as a companion to `internal::ExtractOption<T>(Options)`, for use in services where the `Options` passed to a client operation are split into two subsets: (1) those options passed explicitly to the connection layer and beyond, and (2) the remainder that are passed implicitly via thread-local state.

For example, in a `Client::Foo(..., Options opts)`, ...
```
  auto foo1_option = internal::ExtractOption<Foo1Option>(opts);
  auto foo2_option = internal::ExtractOption<Foo2Option>(opts);
  internal::OptionsSpan span(
      internal::RemoveOptions<ExplicitOptions>(std::move(opts)));
  return conn_->Foo(..., {foo1_option, foo2_option});
```
where `ExplicitOptions` contains all the option types in category (1).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12416)
<!-- Reviewable:end -->
