### PR TITLE
test(pubsublite): reduce quota requirements

### DIFF
--- a/google/cloud/pubsublite/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsublite/integration_tests/CMakeLists.txt
@@ -46,9 +46,7 @@ function (google_cloud_cpp_pubsublite_define_integration_tests)
                     GTest::gtest)
         google_cloud_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})
-        set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;integration-test-emulator")
+        set_tests_properties(${target} PROPERTIES LABELS "integration-test")
         add_dependencies(pubsublite-client-integration-tests ${target})
     endforeach ()
 

--- a/google/cloud/pubsublite/integration_tests/publisher_integration_test.cc
+++ b/google/cloud/pubsublite/integration_tests/publisher_integration_test.cc
@@ -106,7 +106,7 @@ class PublisherIntegrationTest : public testing_util::IntegrationTest {
     topic_name_ = topic.FullName();
 
     google::cloud::pubsublite::v1::Topic t;
-    t.mutable_partition_config()->set_count(3);
+    t.mutable_partition_config()->set_count(1);
     t.mutable_retention_config()->set_per_partition_bytes(kPartitionStorage);
     auto& capacity = *t.mutable_partition_config()->mutable_capacity();
     capacity.set_publish_mib_per_sec(kThroughputCapacityMiB);


### PR DESCRIPTION
Pub/Sub Lite topics consume at least 4MiB/s of throughput capacity per partition. The default quota is 64 MiB/s. With 3 partitions a few simultaneous runs of the test can consume all the quota.

This change reduces the number of partitions to 1, so we can run at least 16 tests simultaneously.

The test was also mislabeled, and was running in most builds even though it does not use an emulator.

We could also use Lite Reservations to further reduce the capacity requirements per run, but that seems like a problem for another day.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12417)
<!-- Reviewable:end -->
