### PR TITLE
cleanup: unused using

### DIFF
--- a/google/cloud/internal/async_retry_loop_test.cc
+++ b/google/cloud/internal/async_retry_loop_test.cc
@@ -37,7 +37,6 @@ using ::google::cloud::testing_util::AsyncSequencer;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockBackoffPolicy;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::AllOf;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::MockFunction;


### PR DESCRIPTION
It is only used in the OTel tests, and is defined lower in the file: https://github.com/dbolduc/google-cloud-cpp/blob/458be5aa4338344f1e8cf90a7339814357237263/google/cloud/internal/async_retry_loop_test.cc#L606

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12418)
<!-- Reviewable:end -->
