### PR TITLE
feat(common): add `Options::set<>() &&` overload

### DIFF
--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -125,9 +125,15 @@ class Options {
    * @param v the value to set the option T
    */
   template <typename T>
-  Options& set(ValueTypeT<T> v) {
+  Options& set(ValueTypeT<T> v) & {
     m_[typeid(T)] = std::make_unique<Data<T>>(std::move(v));
     return *this;
+  }
+
+  /// @copydoc set(ValueTypeT<T>) &
+  template <typename T>
+  Options&& set(ValueTypeT<T> v) && {
+    return std::move(set<T>(std::move(v)));
   }
 
   /**

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -115,7 +115,7 @@ class Options {
   //     https://godbolt.org/z/j4EKjdrv4
   // I suspect this is the problem addressed by:
   //     https://github.com/gcc-mirror/gcc/commit/c2fb0a1a2e7a0fb15cf3cf876f621902ccd273f0
-  Options& operator=(Options&& rhs) noexcept  {
+  Options& operator=(Options&& rhs) noexcept {
     Options tmp(std::move(rhs));
     std::swap(m_, tmp.m_);
     return *this;

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -108,8 +108,38 @@ class Options {
     std::swap(m_, tmp.m_);
     return *this;
   }
-  Options(Options&&) = default;
-  Options& operator=(Options&&) = default;
+  Options(Options&& rhs) noexcept = default;
+
+  // Older versions of GCC (or maybe libstdc++) crash with the default move
+  // assignment:
+  //     https://godbolt.org/z/j4EKjdrv4
+  // I suspect this is the problem addressed by:
+  //     https://github.com/gcc-mirror/gcc/commit/c2fb0a1a2e7a0fb15cf3cf876f621902ccd273f0
+  Options& operator=(Options&& rhs) noexcept  {
+    Options tmp(std::move(rhs));
+    std::swap(m_, tmp.m_);
+    return *this;
+  }
+
+  /**
+   * Sets option `T` to the value @p v and returns a reference to `*this`.
+   *
+   * @code
+   * struct FooOption {
+   *   using Type = int;
+   * };
+   * auto opts = Options{};
+   * opts.set<FooOption>(123);
+   * @endcode
+   *
+   * @tparam T the option type
+   * @param v the value to set the option T
+   */
+  template <typename T>
+  Options& set(ValueTypeT<T> v) & {
+    m_[typeid(T)] = std::make_unique<Data<T>>(std::move(v));
+    return *this;
+  }
 
   /**
    * Sets option `T` to the value @p v and returns a reference to `*this`.
@@ -125,15 +155,9 @@ class Options {
    * @param v the value to set the option T
    */
   template <typename T>
-  Options& set(ValueTypeT<T> v) & {
-    m_[typeid(T)] = std::make_unique<Data<T>>(std::move(v));
-    return *this;
-  }
-
-  /// @copydoc set(ValueTypeT<T>) &
-  template <typename T>
   Options&& set(ValueTypeT<T> v) && {
-    return std::move(set<T>(std::move(v)));
+    set<T>(std::move(v));
+    return std::move(*this);
   }
 
   /**

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -98,6 +98,26 @@ TEST(Options, Set) {
   EXPECT_EQ("foo", opts.get<StringOption>());
 }
 
+TEST(Options, SetRefRef) {
+  auto opts = Options{}.set<IntOption>({});
+  EXPECT_TRUE(opts.has<IntOption>());
+  EXPECT_EQ(0, opts.get<IntOption>());
+  opts = std::move(opts).set<IntOption>(123);
+  EXPECT_EQ(123, opts.get<IntOption>());
+
+  opts = Options{}.set<BoolOption>({});
+  EXPECT_TRUE(opts.has<BoolOption>());
+  EXPECT_EQ(false, opts.get<BoolOption>());
+  opts = std::move(opts).set<BoolOption>(true);
+  EXPECT_EQ(true, opts.get<BoolOption>());
+
+  opts = Options{}.set<StringOption>({});
+  EXPECT_TRUE(opts.has<StringOption>());
+  EXPECT_EQ("", opts.get<StringOption>());
+  opts = std::move(opts).set<StringOption>("foo");
+  EXPECT_EQ("foo", opts.get<StringOption>());
+}
+
 TEST(Options, Get) {
   Options opts;
 


### PR DESCRIPTION
In our examples and documentation we use expressions like `Options{}.set<A>(a).set<B>(b)` and then pass the result by value. To get a move constructor out of such expressions the `set<>` functions must have a `&&` overload.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12424)
<!-- Reviewable:end -->
