### PR TITLE
cleanup(optimization): remove unused parameter in cmake

### DIFF
--- a/google/cloud/optimization/CMakeLists.txt
+++ b/google/cloud/optimization/CMakeLists.txt
@@ -191,8 +191,7 @@ install(
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_optimization"
     COMPONENT google_cloud_cpp_development)
 
-external_googleapis_install_pc("google_cloud_cpp_optimization_protos"
-                               "${PROJECT_SOURCE_DIR}/external/googleapis")
+external_googleapis_install_pc("google_cloud_cpp_optimization_protos")
 
 # google-cloud-cpp::optimization must be defined before we can add the samples.
 foreach (dir IN LISTS service_dirs)


### PR DESCRIPTION
This function only takes one argument and we are not using `${ARGN}` or anything.

https://github.com/googleapis/google-cloud-cpp/blob/eef7b7c2421b0ffa867b254f50fd1bbf7bdd7d07/cmake/CompileProtos.cmake#L465-L474

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12425)
<!-- Reviewable:end -->
