### PR TITLE
chore: apikeys is GA

### DIFF
--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -36,8 +36,7 @@ set(GOOGLE_CLOUD_CPP_EXPERIMENTAL_LIBRARIES
     "pubsublite" "sql")
 
 set(GOOGLE_CLOUD_CPP_TRANSITION_LIBRARIES # cmake-format: sorted
-    # Transitioned circa 2023-02-22
-    "apikeys")
+)
 
 set(GOOGLE_CLOUD_CPP_GA_LIBRARIES
     # cmake-format: sorted
@@ -48,6 +47,7 @@ set(GOOGLE_CLOUD_CPP_GA_LIBRARIES
     "alloydb"
     "apigateway"
     "apigeeconnect"
+    "apikeys"
     "appengine"
     "artifactregistry"
     "asset"

--- a/google/cloud/apikeys/config.cmake.in
+++ b/google/cloud/apikeys/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_apikeys-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-apikeys)
-    add_library(google-cloud-cpp::experimental-apikeys ALIAS google-cloud-cpp::apikeys)
-endif ()

--- a/libraries.bzl
+++ b/libraries.bzl
@@ -23,7 +23,6 @@ GOOGLE_CLOUD_CPP_EXPERIMENTAL_LIBRARIES = [
 ]
 
 GOOGLE_CLOUD_CPP_TRANSITION_LIBRARIES = [
-    "apikeys",
 ]
 
 GOOGLE_CLOUD_CPP_GA_LIBRARIES = [
@@ -34,6 +33,7 @@ GOOGLE_CLOUD_CPP_GA_LIBRARIES = [
     "alloydb",
     "apigateway",
     "apigeeconnect",
+    "apikeys",
     "appengine",
     "artifactregistry",
     "asset",


### PR DESCRIPTION
I think it is safe to remove the `google-cloud-cpp::experimental-apikeys` alias after 6 months.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12426)
<!-- Reviewable:end -->
