### PR TITLE
fix: more reliable vcpkg+protobuf install

### DIFF
--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -474,12 +474,9 @@ function (external_googleapis_install_pc target)
 endfunction ()
 
 # Find the proto include directory
-function (google_cloud_cpp_find_proto_include_dir VAR)
-    find_path(dir google/protobuf/descriptor.proto)
-    if (dir)
-        list(INSERT PROTOBUF_IMPORT_DIRS 0 "${PROTO_INCLUDE_DIR}")
+macro (google_cloud_cpp_find_proto_include_dir VAR)
+    find_path(${VAR} google/protobuf/descriptor.proto)
+    if (${VAR})
+        list(INSERT PROTOBUF_IMPORT_DIRS 0 "${${VAR}}")
     endif ()
-    set(${VAR}
-        ${dir}
-        PARENT_SCOPE)
-endfunction ()
+endmacro ()


### PR DESCRIPTION
Follow up to #10644

`PROTOBUF_IMPORT_DIRS` is a "List of additional directories to be searched for imported .proto files", according to https://cmake.org/cmake/help/v3.5/module/FindProtobuf.html

We were not setting it's value properly.

We were...
1. inserting an empty string
2. not setting the variable in the parent scope anyway

When I test these changes locally, I see `/usr/local/include` is added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12432)
<!-- Reviewable:end -->
