### PR TITLE
refactor(storage): move pre-computed hash usage

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -435,6 +435,8 @@ if (BUILD_TESTING)
         testing/storage_integration_test.h
         testing/temp_file.cc
         testing/temp_file.h
+        testing/upload_hash_cases.cc
+        testing/upload_hash_cases.h
         testing/write_base64.cc
         testing/write_base64.h)
     target_link_libraries(

--- a/google/cloud/storage/internal/hash_function_impl.cc
+++ b/google/cloud/storage/internal/hash_function_impl.cc
@@ -214,6 +214,31 @@ HashValues Crc32cHashFunction::Finish() {
   return HashValues{/*.crc32c=*/Base64Encode(hash), /*.md5=*/{}};
 }
 
+std::string PrecomputedHashFunction::Name() const {
+  return "precomputed(" + Format(precomputed_hash_) + ")";
+}
+
+void PrecomputedHashFunction::Update(absl::string_view /*buffer*/) {}
+
+Status PrecomputedHashFunction::Update(std::int64_t /*offset*/,
+                                       absl::string_view /*buffer*/) {
+  return Status{};
+}
+
+Status PrecomputedHashFunction::Update(std::int64_t /*offset*/,
+                                       absl::string_view /*buffer*/,
+                                       std::uint32_t /*buffer_crc*/) {
+  return Status{};
+}
+
+Status PrecomputedHashFunction::Update(std::int64_t /*offset*/,
+                                       absl::Cord const& /*buffer*/,
+                                       std::uint32_t /*buffer_crc*/) {
+  return Status{};
+}
+
+HashValues PrecomputedHashFunction::Finish() { return precomputed_hash_; }
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/hash_function_impl.h
+++ b/google/cloud/storage/internal/hash_function_impl.h
@@ -122,6 +122,30 @@ class Crc32cHashFunction : public HashFunction {
   std::int64_t minimum_offset_ = 0;
 };
 
+/**
+ * A hash function returning a pre-computed hash.
+ */
+class PrecomputedHashFunction : public HashFunction {
+ public:
+  explicit PrecomputedHashFunction(HashValues p)
+      : precomputed_hash_(std::move(p)) {}
+
+  PrecomputedHashFunction(PrecomputedHashFunction const&) = delete;
+  PrecomputedHashFunction& operator=(PrecomputedHashFunction const&) = delete;
+
+  std::string Name() const override;
+  void Update(absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer) override;
+  Status Update(std::int64_t offset, absl::string_view buffer,
+                std::uint32_t buffer_crc) override;
+  Status Update(std::int64_t offset, absl::Cord const& buffer,
+                std::uint32_t buffer_crc) override;
+  HashValues Finish() override;
+
+ private:
+  HashValues precomputed_hash_;
+};
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/hash_validator_impl.h"
 #include "google/cloud/storage/internal/object_metadata_parser.h"
 #include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/storage/testing/upload_hash_cases.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -224,60 +225,9 @@ TEST(HashValidatorImplTest, CreateHashFunctionRead) {
 }
 
 TEST(HashValidatorImplTest, CreateHashFunctionUpload) {
-  struct Test {
-    std::string crc32c_expected;
-    std::string md5_expected;
-    DisableCrc32cChecksum crc32_disabled;
-    Crc32cChecksumValue crc32_value;
-    DisableMD5Hash md5_disabled;
-    MD5HashValue md5_value;
-  } cases[]{
-      {"", "", DisableCrc32cChecksum(true), Crc32cChecksumValue(),
-       DisableMD5Hash(true), MD5HashValue()},
-      {"", "", DisableCrc32cChecksum(true), Crc32cChecksumValue(),
-       DisableMD5Hash(true), MD5HashValue(kEmptyStringMD5Hash)},
-      {"", kQuickFoxMD5Hash, DisableCrc32cChecksum(true), Crc32cChecksumValue(),
-       DisableMD5Hash(false), MD5HashValue()},
-      {"", "", DisableCrc32cChecksum(true), Crc32cChecksumValue(),
-       DisableMD5Hash(false), MD5HashValue(kEmptyStringMD5Hash)},
-      {"", "", DisableCrc32cChecksum(true),
-       Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(true),
-       MD5HashValue()},
-      {"", "", DisableCrc32cChecksum(true),
-       Crc32cChecksumValue(kEmptyStringMD5Hash), DisableMD5Hash(true),
-       MD5HashValue(kEmptyStringMD5Hash)},
-      {"", kQuickFoxMD5Hash, DisableCrc32cChecksum(true),
-       Crc32cChecksumValue(kEmptyStringMD5Hash), DisableMD5Hash(false),
-       MD5HashValue()},
-      {"", "", DisableCrc32cChecksum(true),
-       Crc32cChecksumValue(kEmptyStringMD5Hash), DisableMD5Hash(false),
-       MD5HashValue(kEmptyStringMD5Hash)},
+  auto const upload_cases = testing::UploadHashCases();
 
-      {kQuickFoxCrc32cChecksum, "", DisableCrc32cChecksum(false),
-       Crc32cChecksumValue(), DisableMD5Hash(true), MD5HashValue()},
-      {kQuickFoxCrc32cChecksum, "", DisableCrc32cChecksum(false),
-       Crc32cChecksumValue(), DisableMD5Hash(true),
-       MD5HashValue(kEmptyStringMD5Hash)},
-      {kQuickFoxCrc32cChecksum, kQuickFoxMD5Hash, DisableCrc32cChecksum(false),
-       Crc32cChecksumValue(), DisableMD5Hash(false), MD5HashValue()},
-      {kQuickFoxCrc32cChecksum, "", DisableCrc32cChecksum(false),
-       Crc32cChecksumValue(), DisableMD5Hash(false),
-       MD5HashValue(kEmptyStringMD5Hash)},
-      {"", "", DisableCrc32cChecksum(false),
-       Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(true),
-       MD5HashValue()},
-      {"", "", DisableCrc32cChecksum(false),
-       Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(true),
-       MD5HashValue(kEmptyStringMD5Hash)},
-      {"", kQuickFoxMD5Hash, DisableCrc32cChecksum(false),
-       Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(false),
-       MD5HashValue()},
-      {"", "", DisableCrc32cChecksum(false),
-       Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(false),
-       MD5HashValue(kEmptyStringMD5Hash)},
-  };
-
-  for (auto const& test : cases) {
+  for (auto const& test : upload_cases) {
     auto request =
         ResumableUploadRequest("test-bucket", "test-object")
             .set_multiple_options(test.crc32_disabled, test.crc32_value,

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -194,14 +194,7 @@ void InsertObjectMediaRequest::set_contents(std::string v) {
 }
 
 HashValues FinishHashes(InsertObjectMediaRequest const& request) {
-  auto hashes = HashValues{
-      /*.crc32c=*/request.GetOption<Crc32cChecksumValue>().value_or(
-          std::string{}),
-      /*.md5=*/request.GetOption<MD5HashValue>().value_or(std::string{}),
-  };
-  // Prefer the hashes provided via *Value options in the request. If those
-  // are not set, use the computed hashes from the data.
-  return Merge(std::move(hashes), request.hash_function().Finish());
+  return request.hash_function().Finish();
 }
 
 std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r) {

--- a/google/cloud/storage/storage_client_testing.bzl
+++ b/google/cloud/storage/storage_client_testing.bzl
@@ -31,6 +31,7 @@ storage_client_testing_hdrs = [
     "testing/retry_tests.h",
     "testing/storage_integration_test.h",
     "testing/temp_file.h",
+    "testing/upload_hash_cases.h",
     "testing/write_base64.h",
 ]
 
@@ -44,5 +45,6 @@ storage_client_testing_srcs = [
     "testing/retry_tests.cc",
     "testing/storage_integration_test.cc",
     "testing/temp_file.cc",
+    "testing/upload_hash_cases.cc",
     "testing/write_base64.cc",
 ]

--- a/google/cloud/storage/testing/upload_hash_cases.cc
+++ b/google/cloud/storage/testing/upload_hash_cases.cc
@@ -1,0 +1,67 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/testing/upload_hash_cases.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace testing {
+namespace {
+// These values were obtained using:
+// echo -n '' > foo.txt && gsutil hash foo.txt
+auto constexpr kEmptyStringCrc32cChecksum = "AAAAAA==";
+auto constexpr kEmptyStringMD5Hash = "1B2M2Y8AsgTpgAmY7PhCfg==";
+
+// /bin/echo -n 'The quick brown fox jumps over the lazy dog' > foo.txt
+// gsutil hash foo.txt
+auto constexpr kQuickFoxCrc32cChecksum = "ImIEBA==";
+auto constexpr kQuickFoxMD5Hash = "nhB9nTcrtoJr2B01QqQZ1g==";
+
+}  // namespace
+
+std::vector<UploadHashCase> UploadHashCases() {
+  return std::vector<UploadHashCase>{
+      // clang-format off
+      // DisableCrc32c == true, Crc32cChecksumValue == {} and change the MD5
+      {"", "",                  DisableCrc32cChecksum(true), Crc32cChecksumValue(), DisableMD5Hash(true),  MD5HashValue()},
+      {"", kEmptyStringMD5Hash, DisableCrc32cChecksum(true), Crc32cChecksumValue(), DisableMD5Hash(true),  MD5HashValue(kEmptyStringMD5Hash)},
+      {"", kQuickFoxMD5Hash,    DisableCrc32cChecksum(true), Crc32cChecksumValue(), DisableMD5Hash(false), MD5HashValue()},
+      {"", kEmptyStringMD5Hash, DisableCrc32cChecksum(true), Crc32cChecksumValue(), DisableMD5Hash(false), MD5HashValue(kEmptyStringMD5Hash)},
+
+      // DisableCrc32c == true, Crc32cChecksumValue == kEmptyStringCrc32cChecksum and change the MD5
+      {kEmptyStringCrc32cChecksum, "",                  DisableCrc32cChecksum(true),  Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(true),   MD5HashValue()},
+      {kEmptyStringCrc32cChecksum, kEmptyStringMD5Hash, DisableCrc32cChecksum(true),  Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(true),   MD5HashValue(kEmptyStringMD5Hash)},
+      {kEmptyStringCrc32cChecksum, kQuickFoxMD5Hash,    DisableCrc32cChecksum(true),  Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(false),  MD5HashValue()},
+      {kEmptyStringCrc32cChecksum, kEmptyStringMD5Hash, DisableCrc32cChecksum(true),  Crc32cChecksumValue(kEmptyStringCrc32cChecksum),  DisableMD5Hash(false), MD5HashValue(kEmptyStringMD5Hash)},
+
+      // DisableCrc32c == false, Crc32cChecksumValue == {} and change the MD5
+      {kQuickFoxCrc32cChecksum, "",                  DisableCrc32cChecksum(false), Crc32cChecksumValue(), DisableMD5Hash(true),  MD5HashValue()},
+      {kQuickFoxCrc32cChecksum, kEmptyStringMD5Hash, DisableCrc32cChecksum(false), Crc32cChecksumValue(), DisableMD5Hash(true),  MD5HashValue(kEmptyStringMD5Hash)},
+      {kQuickFoxCrc32cChecksum, kQuickFoxMD5Hash,    DisableCrc32cChecksum(false), Crc32cChecksumValue(), DisableMD5Hash(false), MD5HashValue()},
+      {kQuickFoxCrc32cChecksum, kEmptyStringMD5Hash, DisableCrc32cChecksum(false), Crc32cChecksumValue(), DisableMD5Hash(false), MD5HashValue(kEmptyStringMD5Hash)},
+
+      // DisableCrc32c == false, Crc32cChecksumValue == kEmptyStringCrc32Checksum and change the MD5
+      {kEmptyStringCrc32cChecksum, "",                  DisableCrc32cChecksum(false), Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(true),  MD5HashValue()},
+      {kEmptyStringCrc32cChecksum, kEmptyStringMD5Hash, DisableCrc32cChecksum(false), Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(true),  MD5HashValue(kEmptyStringMD5Hash)},
+      {kEmptyStringCrc32cChecksum, kQuickFoxMD5Hash,    DisableCrc32cChecksum(false), Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(false), MD5HashValue()},
+      {kEmptyStringCrc32cChecksum, kEmptyStringMD5Hash, DisableCrc32cChecksum(false), Crc32cChecksumValue(kEmptyStringCrc32cChecksum), DisableMD5Hash(false), MD5HashValue(kEmptyStringMD5Hash)},
+      // clang-format on
+  };
+}
+
+}  // namespace testing
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/testing/upload_hash_cases.h
+++ b/google/cloud/storage/testing/upload_hash_cases.h
@@ -1,0 +1,43 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_UPLOAD_HASH_CASES_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_UPLOAD_HASH_CASES_H
+
+#include "google/cloud/storage/options.h"
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace testing {
+
+struct UploadHashCase {
+  std::string crc32c_expected;
+  std::string md5_expected;
+  DisableCrc32cChecksum crc32_disabled;
+  Crc32cChecksumValue crc32_value;
+  DisableMD5Hash md5_disabled;
+  MD5HashValue md5_value;
+};
+
+std::vector<UploadHashCase> UploadHashCases();
+
+}  // namespace testing
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_UPLOAD_HASH_CASES_H


### PR DESCRIPTION
Represent any pre-computed hashes provided by the application as a `internal::HashFunction` object. That makes some of the (upcoming) code for async uploads slightly cleaner.