### PR TITLE
impl: url encode routing keys

### DIFF
--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -17,6 +17,7 @@
 #include "generator/internal/printer.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/url_encode.h"
 #include "google/cloud/log.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
@@ -108,9 +109,9 @@ void SetHttpDerivedMethodVars(
       method_vars["method_request_params"] = absl::StrJoin(
           info.field_substitutions, ", \"&\",",
           [&](std::string* out, std::pair<std::string, std::string> const& p) {
-            out->append(
-                absl::StrFormat("\"%s=\", request.%s()", p.first,
-                                FormatFieldAccessorCall(method, p.first)));
+            out->append(absl::StrFormat(
+                "\"%s=\", request.%s()", internal::UrlEncode(p.first),
+                FormatFieldAccessorCall(method, p.first)));
           });
       method_vars["method_request_body"] = info.body;
       method_vars["method_http_verb"] = info.http_verb;

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -20,6 +20,7 @@
 #include "generator/internal/printer.h"
 #include "generator/internal/routing.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/url_encode.h"
 #include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 #include <algorithm>
@@ -72,7 +73,7 @@ std::string SetMetadataText(google::protobuf::MethodDescriptor const& method,
     }
     text += "  static auto* " + kv.first + "_matcher = []{\n";
     text += "    return new google::cloud::internal::RoutingMatcher<$request_type$>{\n";
-    text += "      \"" + kv.first + "=\", {\n";
+    text += "      \"" + internal::UrlEncode(kv.first) + "=\", {\n";
     for (auto const& rp : kv.second) {
       text += "      {[]($request_type$ const& request) -> std::string const& {\n";
       text += "        return request." + rp.field_name + "();\n";

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -20,6 +20,7 @@
 #include "generator/internal/printer.h"
 #include "generator/internal/routing.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/url_encode.h"
 #include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 #include <algorithm>
@@ -65,7 +66,7 @@ std::string SetMetadataText(google::protobuf::MethodDescriptor const& method,
     }
     text += "  static auto* " + kv.first + "_matcher = []{\n";
     text += "    return new google::cloud::internal::RoutingMatcher<$request_type$>{\n";
-    text += "      \"" + kv.first + "=\", {\n";
+    text += "      \"" + internal::UrlEncode(kv.first) + "=\", {\n";
     for (auto const& rp : kv.second) {
       text += "      {[]($request_type$ const& request) -> std::string const& {\n";
       text += "        return request." + rp.field_name + "();\n";


### PR DESCRIPTION
Part of the work for #12232 

I am not adding any tests. I am almost certain that these keys cannot contain characters that need to be escaped. Note that there are no corresponding changes to any generated code...

But it is simple enough to encode them and the encoding is done at code generation time.... So whatever.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12440)
<!-- Reviewable:end -->
