### PR TITLE
fix: URL encode explicit routing values

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -322,7 +322,7 @@ TEST_F(MetadataDecoratorTest, ExplicitRouting) {
   // `google.api.routing` for Example 9:
   //
   // https://github.com/googleapis/googleapis/blob/70147caca58ebf4c8cd7b96f5d569a72723e11c1/google/api/routing.proto#L387-L390
-  std::string expected1 = "table_location=instances/instance_bar";
+  std::string expected1 = "table_location=instances%2Finstance_bar";
   std::string expected2 = "routing_id=prof_qux";
 
   EXPECT_CALL(*mock_, ExplicitRouting1)

--- a/generator/integration_tests/tests/golden_kitchen_sink_rest_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_rest_metadata_decorator_test.cc
@@ -246,10 +246,10 @@ TEST(KitchenSinkRestMetadataDecoratorTest, ExplicitRouting) {
             EXPECT_THAT(context.GetHeader("x-goog-quota-user"), IsEmpty());
             EXPECT_THAT(context.GetHeader("x-server-timeout"), IsEmpty());
             EXPECT_THAT(context.GetHeader("x-goog-request-params"),
-                        AnyOf(Contains("table_location=instances/"
+                        AnyOf(Contains("table_location=instances%2F"
                                        "instance_bar&routing_id=prof_qux"),
                               Contains("routing_id=prof_qux&table_location="
-                                       "instances/instance_bar")));
+                                       "instances%2Finstance_bar")));
             return TransientError();
           });
 

--- a/generator/integration_tests/tests/golden_thing_admin_rest_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_metadata_decorator_test.cc
@@ -216,9 +216,10 @@ TEST(ThingAdminRestMetadataDecoratorTest, DropDatabaseExplicitRoutingMatch) {
             EXPECT_THAT(
                 context.GetHeader("x-goog-request-params")[0],
                 AllOf(
-                    HasSubstr(std::string("project=projects/my_project")),
-                    HasSubstr(std::string("instance=instances/my_instance")),
-                    HasSubstr(std::string("database=databases/my_database"))));
+                    HasSubstr(std::string("project=projects%2Fmy_project")),
+                    HasSubstr(std::string("instance=instances%2Fmy_instance")),
+                    HasSubstr(
+                        std::string("database=databases%2Fmy_database"))));
             return TransientError();
           });
 

--- a/google/cloud/bigtable/internal/legacy_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/legacy_row_reader_test.cc
@@ -127,8 +127,7 @@ class LegacyRowReaderTest : public bigtable::testing::TableTestFixture {
       : TableTestFixture(CompletionQueue{}),
         retry_policy_(std::make_unique<NiceMock<MockRetryPolicy>>()),
         backoff_policy_(std::make_unique<NiceMock<MockBackoffPolicy>>()),
-        metadata_update_policy_(kTableName,
-                                bigtable::MetadataParamTypes::TABLE_NAME),
+        metadata_update_policy_(MakeMetadataUpdatePolicy(kTableName, "")),
         parser_factory_(
             std::make_unique<NiceMock<ReadRowsParserMockFactory>>()) {}
 

--- a/google/cloud/bigtable/metadata_update_policy.cc
+++ b/google/cloud/bigtable/metadata_update_policy.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/metadata_update_policy.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/api_client_header.h"
+#include "google/cloud/internal/url_encode.h"
 
 namespace google {
 namespace cloud {
@@ -58,8 +59,10 @@ bigtable::MetadataUpdatePolicy MakeMetadataUpdatePolicy(
   // The rule is the same for all RPCs in the Data API. We always include the
   // table name. We append an app profile id only if one was provided.
   return bigtable::MetadataUpdatePolicy(
-      table_name +
-          (app_profile_id.empty() ? "" : "&app_profile_id=" + app_profile_id),
+      internal::UrlEncode(table_name) +
+          (app_profile_id.empty()
+               ? ""
+               : "&app_profile_id=" + internal::UrlEncode(app_profile_id)),
       bigtable::MetadataParamTypes::TABLE_NAME);
 }
 

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/admin_client.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/embedded_server_test_fixture.h"
+#include "google/cloud/internal/url_encode.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <map>
@@ -32,7 +33,8 @@ class MetadataUpdatePolicyTest : public testing::EmbeddedServerTestFixture {};
 using ::testing::HasSubstr;
 
 TEST_F(MetadataUpdatePolicyTest, TableMetadata) {
-  grpc::string expected = "table_name=" + std::string(kTableName);
+  grpc::string expected =
+      "table_name=" + google::cloud::internal::UrlEncode(kTableName);
   auto reader = table_->ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
   // lets make the RPC call to send metadata
   reader.begin();
@@ -51,8 +53,8 @@ TEST_F(MetadataUpdatePolicyTest, TableWithNewTargetMetadata) {
                                            other_table_id);
 
   grpc::string expected =
-      "table_name=" +
-      TableName(other_project_id, other_instance_id, other_table_id);
+      "table_name=" + google::cloud::internal::UrlEncode(TableName(
+                          other_project_id, other_instance_id, other_table_id));
   auto reader =
       other_table.ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
   // lets make the RPC call to send metadata
@@ -78,7 +80,8 @@ TEST_F(MetadataUpdatePolicyTest, SimpleDefault) {
 TEST_F(MetadataUpdatePolicyTest, TableAppProfileMetadata) {
   auto table = Table(data_client_, "profile", kTableId);
   grpc::string expected =
-      "table_name=" + std::string(kTableName) + "&app_profile_id=profile";
+      "table_name=" + google::cloud::internal::UrlEncode(kTableName) +
+      "&app_profile_id=profile";
   auto reader = table.ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
   // lets make the RPC call to send metadata
   reader.begin();
@@ -94,7 +97,8 @@ TEST_F(MetadataUpdatePolicyTest, TableWithNewTargetAppProfileMetadata) {
   auto table =
       table_->WithNewTarget(kProjectId, kInstanceId, "profile", kTableId);
   grpc::string expected =
-      "table_name=" + std::string(kTableName) + "&app_profile_id=profile";
+      "table_name=" + google::cloud::internal::UrlEncode(kTableName) +
+      "&app_profile_id=profile";
   auto reader = table.ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
   // lets make the RPC call to send metadata
   reader.begin();

--- a/google/cloud/internal/routing_matcher.h
+++ b/google/cloud/internal/routing_matcher.h
@@ -15,6 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ROUTING_MATCHER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ROUTING_MATCHER_H
 
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/url_encode.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
 #include <functional>
@@ -52,11 +54,11 @@ struct RoutingMatcher {
       // When the optional regex is not engaged, it is implied that we should
       // match the whole field.
       if (!pattern.re) {
-        params.push_back(routing_key + field);
+        params.push_back(absl::StrCat(routing_key, UrlEncode(field)));
         return;
       }
       if (std::regex_match(field, match, *pattern.re)) {
-        params.push_back(routing_key + match[1].str());
+        params.push_back(absl::StrCat(routing_key, UrlEncode(match[1].str())));
         return;
       }
     }

--- a/google/cloud/testing_util/validate_metadata.cc
+++ b/google/cloud/testing_util/validate_metadata.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/testing_util/validate_metadata.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_replace_quiet.h"
+#include "google/cloud/internal/url_encode.h"
 #include "google/cloud/log.h"
 #include "google/cloud/status_or.h"
 #include "absl/strings/str_split.h"
@@ -136,7 +137,7 @@ RoutingHeaders FromRoutingRule(google::api::RoutingRule const& routing,
     // If the path_template is empty, we use the field's name as the routing
     // param key, and we match the entire value of the field.
     if (path_template.empty()) {
-      headers[rp.field()] = field;
+      headers[rp.field()] = internal::UrlEncode(field);
       continue;
     }
     // First we parse the path_template field to extract the routing param key
@@ -154,7 +155,7 @@ RoutingHeaders FromRoutingRule(google::api::RoutingRule const& routing,
     // Then we parse the field in the given request to see if it matches the
     // pattern we expect.
     if (std::regex_match(field, match, std::regex{pattern})) {
-      headers[std::move(param)] = match[1].str();
+      headers[std::move(param)] = internal::UrlEncode(match[1].str());
     }
   }
   return headers;


### PR DESCRIPTION
Part of the work for #12232 

Update the explicit routing matchers to url encode the values in the routing pairs.

Update the part of `testing_util::ValidateMetadataFixture` that computes the expected routing headers.

Then legacy bigtable also uses that testing helper, so we must update it in this PR. I separated the bigtable stuff into its own commit (hopefully) for clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12447)
<!-- Reviewable:end -->
