### PR TITLE
fix(GCS+gRPC): URL encode routing params for streaming writes

### DIFF
--- a/google/cloud/storage/internal/grpc/configure_client_context.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/grpc/configure_client_context.h"
+#include "google/cloud/internal/url_encode.h"
 #include <regex>
 
 namespace google {
@@ -36,8 +37,10 @@ void AddIdempotencyToken(grpc::ClientContext& ctx,
 void ApplyRoutingHeaders(
     grpc::ClientContext& context,
     storage::internal::InsertObjectMediaRequest const& request) {
-  context.AddMetadata("x-goog-request-params",
-                      "bucket=projects/_/buckets/" + request.bucket_name());
+  context.AddMetadata(
+      "x-goog-request-params",
+      "bucket=projects%2F_%2Fbuckets%2F" +
+          google::cloud::internal::UrlEncode(request.bucket_name()));
 }
 
 void ApplyRoutingHeaders(grpc::ClientContext& context,
@@ -49,7 +52,9 @@ void ApplyRoutingHeaders(grpc::ClientContext& context,
   for (auto const* re : {slash_format, colon_format}) {
     std::smatch match;
     if (!std::regex_match(request.upload_session_url(), match, *re)) continue;
-    context.AddMetadata("x-goog-request-params", "bucket=" + match[1].str());
+    context.AddMetadata(
+        "x-goog-request-params",
+        "bucket=" + google::cloud::internal::UrlEncode(match[1].str()));
   }
 }
 

--- a/google/cloud/storage/internal/grpc/configure_client_context.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context.cc
@@ -39,8 +39,8 @@ void ApplyRoutingHeaders(
     storage::internal::InsertObjectMediaRequest const& request) {
   context.AddMetadata(
       "x-goog-request-params",
-      "bucket=projects%2F_%2Fbuckets%2F" +
-          google::cloud::internal::UrlEncode(request.bucket_name()));
+      "bucket=" + google::cloud::internal::UrlEncode("projects/_/buckets/" +
+                                                     request.bucket_name()));
 }
 
 void ApplyRoutingHeaders(grpc::ClientContext& context,

--- a/google/cloud/storage/internal/grpc/configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context_test.cc
@@ -142,7 +142,7 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersInsertObjectMedia) {
   auto metadata = GetMetadata(context);
   EXPECT_THAT(metadata,
               Contains(Pair("x-goog-request-params",
-                            "bucket=projects/_/buckets/test-bucket")));
+                            "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
 }
 
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchSlash) {
@@ -155,7 +155,7 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchSlash) {
   auto metadata = GetMetadata(context);
   EXPECT_THAT(metadata,
               Contains(Pair("x-goog-request-params",
-                            "bucket=projects/_/buckets/test-bucket")));
+                            "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
 }
 
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchColon) {
@@ -168,7 +168,7 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchColon) {
   auto metadata = GetMetadata(context);
   EXPECT_THAT(metadata,
               Contains(Pair("x-goog-request-params",
-                            "bucket=projects/_/buckets/test-bucket")));
+                            "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
 }
 
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkNoMatch) {

--- a/google/cloud/storage/internal/grpc/stub_test.cc
+++ b/google/cloud/storage/internal/grpc/stub_test.cc
@@ -203,7 +203,7 @@ TEST_F(GrpcClientTest, UploadChunk) {
                     // Map JSON names to the `resource` subobject
                     Pair("x-goog-fieldmask", "resource(field1,field2)"),
                     Pair("x-goog-request-params",
-                         "bucket=projects/_/buckets/test-bucket")));
+                         "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
     ::testing::InSequence sequence;
     auto stream = std::make_unique<MockInsertStream>();
     EXPECT_CALL(*stream, Write).WillOnce(Return(false));
@@ -510,7 +510,7 @@ TEST_F(GrpcClientTest, InsertObjectMedia) {
                     // Map JSON names to the `resource` subobject
                     Pair("x-goog-fieldmask", "resource(field1,field2)"),
                     Pair("x-goog-request-params",
-                         "bucket=projects/_/buckets/test-bucket")));
+                         "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
     ::testing::InSequence sequence;
     auto stream = std::make_unique<MockInsertStream>();
     EXPECT_CALL(*stream, Write).WillOnce(Return(false));


### PR DESCRIPTION
Part of the work for #12232

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12448)
<!-- Reviewable:end -->
