### PR TITLE
test(storage): verify `ClientFromMock()` works

### DIFF
--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -326,7 +326,7 @@ TEST_F(ClientTest, DeprecatedClientFromMock) {
       ObjectMetadata{}.set_bucket("bucket").set_name("object/2"));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce(Return(TransientError()))
-      .WillRepeatedly(Return(response));
+      .WillOnce(Return(response));
 
   (void)client.ListObjects("bucket", Prefix("object/"));
 }

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -315,6 +315,22 @@ TEST_F(ClientTest, DeprecatedRetryPolicies) {
   (void)client.ListBuckets(OverrideDefaultProject("fake-project"));
 }
 
+TEST_F(ClientTest, DeprecatedClientFromMock) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client = testing::ClientFromMock(mock);
+
+  internal::ListObjectsResponse response;
+  response.items.push_back(
+      ObjectMetadata{}.set_bucket("bucket").set_name("object/1"));
+  response.items.push_back(
+      ObjectMetadata{}.set_bucket("bucket").set_name("object/2"));
+  EXPECT_CALL(*mock, ListObjects)
+      .WillOnce(Return(TransientError()))
+      .WillRepeatedly(Return(response));
+
+  (void)client.ListObjects("bucket", Prefix("object/"));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage


### PR DESCRIPTION
This function is deprecated, but not retired, we need to continue testing it, even if we stop using it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12449)
<!-- Reviewable:end -->
