### PR TITLE
cleanup(cmake): simplify cross library deps

### DIFF
--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -39,10 +39,8 @@ endforeach ()
 include(GoogleCloudCppDoxygen)
 set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES
     "${PROJECT_BINARY_DIR}/google/cloud/grafeas")
-google_cloud_cpp_doxygen_targets(
-    "binaryauthorization" DEPENDS cloud-docs
-    google-cloud-cpp::binaryauthorization_protos
-    google-cloud-cpp::grafeas_protos)
+google_cloud_cpp_doxygen_targets("binaryauthorization" DEPENDS cloud-docs
+                                 google-cloud-cpp::binaryauthorization_protos)
 
 include(GoogleCloudCppCommon)
 
@@ -186,8 +184,7 @@ google_cloud_cpp_add_pkgconfig(
     "Provides C++ APIs to use the Binary Authorization API."
     "google_cloud_cpp_grpc_utils"
     "google_cloud_cpp_common"
-    "google_cloud_cpp_binaryauthorization_protos"
-    "google_cloud_cpp_grafeas_protos")
+    "google_cloud_cpp_binaryauthorization_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/contentwarehouse/CMakeLists.txt
+++ b/google/cloud/contentwarehouse/CMakeLists.txt
@@ -37,10 +37,8 @@ endforeach ()
 include(GoogleCloudCppDoxygen)
 set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES
     "${PROJECT_BINARY_DIR}/google/cloud/documentai")
-google_cloud_cpp_doxygen_targets(
-    "contentwarehouse" DEPENDS cloud-docs
-    google-cloud-cpp::contentwarehouse_protos
-    google-cloud-cpp::documentai_protos)
+google_cloud_cpp_doxygen_targets("contentwarehouse" DEPENDS cloud-docs
+                                 google-cloud-cpp::contentwarehouse_protos)
 
 include(GoogleCloudCppCommon)
 
@@ -183,8 +181,7 @@ google_cloud_cpp_add_pkgconfig(
     "Provides C++ APIs to use the Document AI Warehouse API."
     "google_cloud_cpp_grpc_utils"
     "google_cloud_cpp_common"
-    "google_cloud_cpp_contentwarehouse_protos"
-    "google_cloud_cpp_documentai_protos")
+    "google_cloud_cpp_contentwarehouse_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Motivated by #12428 

These libraries have dependencies on other libraries' protos.

`binaryauthorization_protos` depends on `grafeas_protos` and `contentwarehouse_protos` depends on `documentai_protos` already. So we do not need this extra stuff.

I looked into the history, and adding the extra `google-cloud-cpp::foo_protos` to `google_cloud_cpp_doxygen_targets()` seems to be a misdiagnosis of the problem that is solved by adding `google/cloud/foo` to `GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES`.

With this change, the cmake to generate these targets becomes standard, and they can adopt the common helpers. I am splitting the PRs up for atomicity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12453)
<!-- Reviewable:end -->
