### PR TITLE
impl(GCS+gRPC): a class to represent write payloads

### DIFF
--- a/google/cloud/storage/async_object_requests.h
+++ b/google/cloud/storage/async_object_requests.h
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_OBJECT_REQUESTS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_OBJECT_REQUESTS_H
+
+#include "google/cloud/storage/internal/async/write_payload_fwd.h"
+#include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/storage/version.h"
+#include "absl/strings/cord.h"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage_experimental {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * An opaque representation of the data for an object payload.
+ *
+ * While applications do not need to create instances of this class, they may
+ * need to use it in their mocks, to validate the contents of their requests.
+ */
+class WritePayload {
+ public:
+  /// Creates an empty payload.
+  WritePayload() = default;
+
+  /// Returns true if the payload has no data.
+  bool empty() const { return impl_.empty(); }
+
+  /// Returns the total size of the data.
+  std::size_t size() const { return impl_.size(); }
+
+  /**
+   * Returns views into the data.
+   *
+   * Note that changing `*this` in any way (assignment, destruction, etc.)
+   * invalidates all the returned buffers.
+   */
+  std::vector<absl::string_view> payload() const {
+    return {impl_.chunk_begin(), impl_.chunk_end()};
+  }
+
+ private:
+  friend struct storage_internal::WritePayloadImpl;
+  explicit WritePayload(absl::Cord impl) : impl_(std::move(impl)) {}
+
+  absl::Cord impl_;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_experimental
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_OBJECT_REQUESTS_H

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -18,6 +18,7 @@
 
 google_cloud_cpp_storage_grpc_hdrs = [
     "async_client.h",
+    "async_object_requests.h",
     "async_object_responses.h",
     "async_token.h",
     "grpc_plugin.h",
@@ -26,6 +27,8 @@ google_cloud_cpp_storage_grpc_hdrs = [
     "internal/async/connection_impl.h",
     "internal/async/insert_object.h",
     "internal/async/token_impl.h",
+    "internal/async/write_payload_fwd.h",
+    "internal/async/write_payload_impl.h",
     "internal/grpc/bucket_access_control_parser.h",
     "internal/grpc/bucket_metadata_parser.h",
     "internal/grpc/bucket_name.h",
@@ -65,6 +68,7 @@ google_cloud_cpp_storage_grpc_srcs = [
     "internal/async/connection_impl.cc",
     "internal/async/insert_object.cc",
     "internal/async/token_impl.cc",
+    "internal/async/write_payload_impl.cc",
     "internal/grpc/bucket_access_control_parser.cc",
     "internal/grpc/bucket_metadata_parser.cc",
     "internal/grpc/bucket_name.cc",

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -54,6 +54,7 @@ else ()
         google_cloud_cpp_storage_grpc # cmake-format: sort
         async_client.cc
         async_client.h
+        async_object_requests.h
         async_object_responses.h
         async_token.h
         grpc_plugin.cc
@@ -67,6 +68,9 @@ else ()
         internal/async/insert_object.h
         internal/async/token_impl.cc
         internal/async/token_impl.h
+        internal/async/write_payload_fwd.h
+        internal/async/write_payload_impl.cc
+        internal/async/write_payload_impl.h
         internal/grpc/bucket_access_control_parser.cc
         internal/grpc/bucket_access_control_parser.h
         internal/grpc/bucket_metadata_parser.cc
@@ -213,6 +217,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         internal/async/accumulate_read_object_test.cc
         internal/async/connection_impl_test.cc
         internal/async/insert_object_test.cc
+        internal/async/write_payload_impl_test.cc
         internal/grpc/bucket_access_control_parser_test.cc
         internal/grpc/bucket_metadata_parser_test.cc
         internal/grpc/bucket_name_test.cc

--- a/google/cloud/storage/internal/async/write_payload_fwd.h
+++ b/google/cloud/storage/internal/async/write_payload_fwd.h
@@ -1,0 +1,32 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_WRITE_PAYLOAD_FWD_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_WRITE_PAYLOAD_FWD_H
+
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+struct WritePayloadImpl;
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_WRITE_PAYLOAD_FWD_H

--- a/google/cloud/storage/internal/async/write_payload_impl.cc
+++ b/google/cloud/storage/internal/async/write_payload_impl.cc
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/async/write_payload_impl.h"
+#include <numeric>
+
+namespace google {
+namespace cloud {
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+absl::Cord MakeCord(std::string p) {
+  // The absl::Cord constructor from `std::string` splits the string into many
+  // small buffers (and allocates a container for each). We want to avoid copies
+  // and allocations.
+  auto holder = std::make_shared<std::string>(std::move(p));
+  auto contents = absl::string_view(holder->data(), holder->size());
+  return absl::MakeCordFromExternal(contents,
+                                    [b = std::move(holder)]() mutable {});
+}
+
+storage_experimental::WritePayload MakeWritePayload(std::vector<absl::Cord> p) {
+  auto full = std::accumulate(std::make_move_iterator(p.begin()),
+                              std::make_move_iterator(p.end()), absl::Cord(),
+                              [](absl::Cord a, absl::Cord b) {
+                                a.Append(std::move(b));
+                                return a;
+                              });
+  return WritePayloadImpl::Make(std::move(full));
+}
+
+storage_experimental::WritePayload MakeWritePayload(std::string p) {
+  return WritePayloadImpl::Make(MakeCord(std::move(p)));
+}
+
+storage_experimental::WritePayload MakeWritePayload(
+    std::vector<std::string> p) {
+  std::vector<absl::Cord> cords(p.size());
+  std::transform(std::make_move_iterator(p.begin()),
+                 std::make_move_iterator(p.end()), cords.begin(),
+                 [](std::string v) { return MakeCord(std::move(v)); });
+  return MakeWritePayload(std::move(cords));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/async/write_payload_impl.cc
+++ b/google/cloud/storage/internal/async/write_payload_impl.cc
@@ -30,27 +30,19 @@ absl::Cord MakeCord(std::string p) {
                                     [b = std::move(holder)]() mutable {});
 }
 
-storage_experimental::WritePayload MakeWritePayload(std::vector<absl::Cord> p) {
-  auto full = std::accumulate(std::make_move_iterator(p.begin()),
-                              std::make_move_iterator(p.end()), absl::Cord(),
-                              [](absl::Cord a, absl::Cord b) {
-                                a.Append(std::move(b));
-                                return a;
-                              });
-  return WritePayloadImpl::Make(std::move(full));
-}
-
 storage_experimental::WritePayload MakeWritePayload(std::string p) {
   return WritePayloadImpl::Make(MakeCord(std::move(p)));
 }
 
 storage_experimental::WritePayload MakeWritePayload(
     std::vector<std::string> p) {
-  std::vector<absl::Cord> cords(p.size());
-  std::transform(std::make_move_iterator(p.begin()),
-                 std::make_move_iterator(p.end()), cords.begin(),
-                 [](std::string v) { return MakeCord(std::move(v)); });
-  return MakeWritePayload(std::move(cords));
+  auto full = std::accumulate(std::make_move_iterator(p.begin()),
+                              std::make_move_iterator(p.end()), absl::Cord(),
+                              [](absl::Cord a, std::string b) {
+                                a.Append(MakeCord(std::move(b)));
+                                return a;
+                              });
+  return WritePayloadImpl::Make(std::move(full));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/write_payload_impl.h
+++ b/google/cloud/storage/internal/async/write_payload_impl.h
@@ -68,17 +68,18 @@ storage_experimental::WritePayload MakeWritePayload(std::vector<T> s) {
   return WritePayloadImpl::Make(MakeCord(std::move(s)));
 }
 
-storage_experimental::WritePayload MakeWritePayload(std::vector<absl::Cord> p);
 storage_experimental::WritePayload MakeWritePayload(std::vector<std::string> p);
 template <typename T,
           typename std::enable_if<IsPayloadType<T>::value, int>::type = 0>
 storage_experimental::WritePayload MakeWritePayload(
     std::vector<std::vector<T>> p) {
-  std::vector<absl::Cord> cords(p.size());
-  std::transform(std::make_move_iterator(p.begin()),
-                 std::make_move_iterator(p.end()), cords.begin(),
-                 [](std::vector<T> v) { return MakeCord(std::move(v)); });
-  return MakeWritePayload(std::move(cords));
+  auto full = std::accumulate(std::make_move_iterator(p.begin()),
+                              std::make_move_iterator(p.end()), absl::Cord(),
+                              [](absl::Cord a, std::vector<T> b) {
+                                a.Append(MakeCord(std::move(b)));
+                                return a;
+                              });
+  return WritePayloadImpl::Make(std::move(full));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/write_payload_impl.h
+++ b/google/cloud/storage/internal/async/write_payload_impl.h
@@ -1,0 +1,89 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_WRITE_PAYLOAD_IMPL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_WRITE_PAYLOAD_IMPL_H
+
+#include "google/cloud/storage/async_object_requests.h"
+#include "google/cloud/version.h"
+#include "absl/meta/type_traits.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+
+namespace google {
+namespace cloud {
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/// Groups helpers to access implementation details in
+/// `storage_experimental::WritePayload`.
+struct WritePayloadImpl {
+  static storage_experimental::WritePayload Make(absl::Cord impl) {
+    return storage_experimental::WritePayload(std::move(impl));
+  }
+  static absl::Cord GetImpl(storage_experimental::WritePayload const& p) {
+    return p.impl_;
+  }
+};
+
+template <typename T>
+using IsPayloadType = absl::disjunction<
+#if GOOGLE_CLOUD_CPP_CPP_VERSION >= 201703L
+    std::is_same<T, std::byte>,
+#endif
+    std::is_same<T, char>, std::is_same<T, signed char>,
+    std::is_same<T, unsigned char>, std::is_same<T, std::uint8_t>>;
+
+/// Create an `absl::Cord`, without copying the data in @p p.
+absl::Cord MakeCord(std::string p);
+
+/// Create an `absl::Cord`, without copying the data in @p p.
+template <typename T>
+absl::Cord MakeCord(std::vector<T> p) {
+  static_assert(IsPayloadType<T>::value, "unexpected value type");
+  auto holder = std::make_shared<std::vector<T>>(std::move(p));
+  auto contents = absl::string_view(
+      reinterpret_cast<char const*>(holder->data()), holder->size());
+  return absl::MakeCordFromExternal(contents,
+                                    [b = std::move(holder)]() mutable {});
+}
+
+storage_experimental::WritePayload MakeWritePayload(std::string p);
+template <typename T,
+          typename std::enable_if<IsPayloadType<T>::value, int>::type = 0>
+storage_experimental::WritePayload MakeWritePayload(std::vector<T> s) {
+  return WritePayloadImpl::Make(MakeCord(std::move(s)));
+}
+
+storage_experimental::WritePayload MakeWritePayload(std::vector<absl::Cord> p);
+storage_experimental::WritePayload MakeWritePayload(std::vector<std::string> p);
+template <typename T,
+          typename std::enable_if<IsPayloadType<T>::value, int>::type = 0>
+storage_experimental::WritePayload MakeWritePayload(
+    std::vector<std::vector<T>> p) {
+  std::vector<absl::Cord> cords(p.size());
+  std::transform(std::make_move_iterator(p.begin()),
+                 std::make_move_iterator(p.end()), cords.begin(),
+                 [](std::vector<T> v) { return MakeCord(std::move(v)); });
+  return MakeWritePayload(std::move(cords));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_WRITE_PAYLOAD_IMPL_H

--- a/google/cloud/storage/internal/async/write_payload_impl_test.cc
+++ b/google/cloud/storage/internal/async/write_payload_impl_test.cc
@@ -147,34 +147,6 @@ TYPED_TEST(Typed, MakeWritePayloadFromVector) {
   EXPECT_EQ(full, expected);
 }
 
-TEST(WritePayloadImpl, MakeWritePayloadVectorCord) {
-  auto const expected =
-      std::string{"The quick brown fox jumps over the lazy dog"};
-
-  auto const actual = MakeWritePayload(std::vector<absl::Cord>{
-      absl::Cord("The quick brown fox"), absl::Cord(" jumps over"),
-      absl::Cord(" the lazy dog")});
-  EXPECT_FALSE(actual.empty());
-  EXPECT_EQ(actual.size(), expected.size());
-  EXPECT_THAT(actual.payload(), Not(IsEmpty()));
-  auto full = absl::StrJoin(actual.payload(), "");
-  EXPECT_EQ(full, expected);
-}
-
-TEST(WritePayloadImpl, MakeWritePayloadString) {
-  auto const expected =
-      std::string{"The quick brown fox jumps over the lazy dog"};
-
-  auto const actual = MakeWritePayload(std::vector<absl::Cord>{
-      absl::Cord("The quick brown fox"), absl::Cord(" jumps over"),
-      absl::Cord(" the lazy dog")});
-  EXPECT_FALSE(actual.empty());
-  EXPECT_EQ(actual.size(), expected.size());
-  EXPECT_THAT(actual.payload(), Not(IsEmpty()));
-  auto full = absl::StrJoin(actual.payload(), "");
-  EXPECT_EQ(full, expected);
-}
-
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/write_payload_impl_test.cc
+++ b/google/cloud/storage/internal/async/write_payload_impl_test.cc
@@ -1,0 +1,182 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/async/write_payload_impl.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/internal/random.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+template <typename Collection,
+          typename std::enable_if<std::is_same<Collection, std::string>::value,
+                                  int>::type = 0>
+Collection ToCollection(std::string v) {
+  // This is not motivated by a desire to optimize this test helper function
+  // (though that is nice). The issue is that I (coryan@) could not figure out
+  // how to write a generic version of this function that works with
+  // `std::vector<std::byte>` and `std::string`.
+  return v;
+}
+
+template <typename Collection,
+          typename std::enable_if<!std::is_same<Collection, std::string>::value,
+                                  int>::type = 0>
+Collection ToCollection(std::string v) {
+  Collection result(v.size());
+  std::transform(v.begin(), v.end(), result.begin(), [](auto c) {
+    return static_cast<typename Collection::value_type>(c);
+  });
+  return result;
+}
+
+template <typename Collection>
+Collection RandomData(internal::DefaultPRNG& generator, std::size_t size) {
+  auto data = internal::Sample(generator, static_cast<int>(size),
+                               "abcdefghijklmnopqrstuvwxyz0123456789");
+  return ToCollection<Collection>(std::move(data));
+}
+
+TEST(WritePayloadImpl, Default) {
+  auto const actual = storage_experimental::WritePayload();
+  EXPECT_TRUE(actual.empty());
+  EXPECT_EQ(actual.size(), 0);
+  EXPECT_THAT(actual.payload(), IsEmpty());
+}
+
+TEST(WritePayloadImpl, Make) {
+  auto const expected =
+      std::string{"The quick brown fox jumps over the lazy dog"};
+  auto const actual = WritePayloadImpl::Make(absl::Cord(expected));
+  EXPECT_FALSE(actual.empty());
+  EXPECT_EQ(actual.size(), expected.size());
+  EXPECT_THAT(actual.payload(), Not(IsEmpty()));
+  auto full = absl::StrJoin(actual.payload(), "");
+  EXPECT_EQ(full, expected);
+}
+
+TEST(WritePayloadImpl, GetImpl) {
+  auto const expected =
+      std::string{"The quick brown fox jumps over the lazy dog"};
+  auto const actual = WritePayloadImpl::Make(absl::Cord(expected));
+  EXPECT_EQ(WritePayloadImpl::GetImpl(actual), absl::Cord(expected));
+}
+
+TEST(WritePayloadImpl, IsPayloadType) {
+  EXPECT_TRUE(IsPayloadType<char>::value);
+  EXPECT_TRUE(IsPayloadType<std::uint8_t>::value);
+  EXPECT_FALSE(IsPayloadType<std::string>::value);
+  EXPECT_FALSE(IsPayloadType<std::uint32_t>::value);
+}
+
+template <typename T>
+class Typed : public ::testing::Test {
+ public:
+  using TestType = T;
+};
+
+using TestVariations = ::testing::Types<
+#if GOOGLE_CLOUD_CPP_CPP_VERSION >= 201703L
+    std::vector<std::byte>,
+#endif
+    std::string, std::vector<char>, std::vector<signed char>,
+    std::vector<unsigned char>, std::vector<std::uint8_t> >;
+
+TYPED_TEST_SUITE(Typed, TestVariations);
+
+TYPED_TEST(Typed, MakeCord) {
+  using Collection = typename TestFixture::TestType;
+  static auto generator = internal::MakeDefaultPRNG();
+  auto constexpr kTestDataSize = 8 * 1024 * 1024L;
+  auto const buffer = RandomData<Collection>(generator, kTestDataSize);
+  auto const view = absl::string_view(
+      reinterpret_cast<char const*>(buffer.data()), buffer.size());
+
+  auto const actual = MakeCord(buffer);
+  auto chunks = actual.Chunks();
+  EXPECT_THAT(chunks, ElementsAre(view));
+}
+
+TYPED_TEST(Typed, MakeWritePayload) {
+  using Collection = typename TestFixture::TestType;
+
+  auto const expected =
+      std::string{"The quick brown fox jumps over the lazy dog"};
+
+  auto const actual = MakeWritePayload(ToCollection<Collection>(expected));
+  EXPECT_FALSE(actual.empty());
+  EXPECT_EQ(actual.size(), expected.size());
+  EXPECT_THAT(actual.payload(), Not(IsEmpty()));
+  auto full = absl::StrJoin(actual.payload(), "");
+  EXPECT_EQ(full, expected);
+}
+
+TYPED_TEST(Typed, MakeWritePayloadFromVector) {
+  using Collection = typename TestFixture::TestType;
+
+  static auto generator = internal::MakeDefaultPRNG();
+  auto constexpr kTestDataSize = 1024;
+  auto const part = RandomData<std::string>(generator, kTestDataSize);
+  auto const expected = part + part + part;
+  auto const actual = MakeWritePayload(std::vector<Collection>{
+      {ToCollection<Collection>(part), ToCollection<Collection>(part),
+       ToCollection<Collection>(part)}});
+  EXPECT_FALSE(actual.empty());
+  EXPECT_EQ(actual.size(), expected.size());
+  EXPECT_THAT(actual.payload(), Not(IsEmpty()));
+  auto full = absl::StrJoin(actual.payload(), "");
+  EXPECT_EQ(full, expected);
+}
+
+TEST(WritePayloadImpl, MakeWritePayloadVectorCord) {
+  auto const expected =
+      std::string{"The quick brown fox jumps over the lazy dog"};
+
+  auto const actual = MakeWritePayload(std::vector<absl::Cord>{
+      absl::Cord("The quick brown fox"), absl::Cord(" jumps over"),
+      absl::Cord(" the lazy dog")});
+  EXPECT_FALSE(actual.empty());
+  EXPECT_EQ(actual.size(), expected.size());
+  EXPECT_THAT(actual.payload(), Not(IsEmpty()));
+  auto full = absl::StrJoin(actual.payload(), "");
+  EXPECT_EQ(full, expected);
+}
+
+TEST(WritePayloadImpl, MakeWritePayloadString) {
+  auto const expected =
+      std::string{"The quick brown fox jumps over the lazy dog"};
+
+  auto const actual = MakeWritePayload(std::vector<absl::Cord>{
+      absl::Cord("The quick brown fox"), absl::Cord(" jumps over"),
+      absl::Cord(" the lazy dog")});
+  EXPECT_FALSE(actual.empty());
+  EXPECT_EQ(actual.size(), expected.size());
+  EXPECT_THAT(actual.payload(), Not(IsEmpty()));
+  auto full = absl::StrJoin(actual.payload(), "");
+  EXPECT_EQ(full, expected);
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -22,6 +22,7 @@ storage_client_grpc_unit_tests = [
     "internal/async/accumulate_read_object_test.cc",
     "internal/async/connection_impl_test.cc",
     "internal/async/insert_object_test.cc",
+    "internal/async/write_payload_impl_test.cc",
     "internal/grpc/bucket_access_control_parser_test.cc",
     "internal/grpc/bucket_metadata_parser_test.cc",
     "internal/grpc/bucket_name_test.cc",


### PR DESCRIPTION
We need a public API for object payloads. Applications may need to examine the contents of the upload in their mocks, to ensure their code is sending the right data.

We want the implementation of this type to be an `absl::Cord`, so we can pass the data to gRPC and Protobuf without copying the contents.

Part of the work for #9131

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12458)
<!-- Reviewable:end -->
