### PR TITLE
cleanup(cmake)!: stop compiling `source_context.proto`

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -124,8 +124,6 @@ expected_dirs+=(
   # no gRPC services in google/cloud/workstations/logging
   ./include/google/cloud/workstations/logging
   ./include/google/cloud/workstations/logging/v1
-  ./include/google/devtools/source
-  ./include/google/devtools/source/v1
   # no gRPC services in google/identity/accesscontextmanager/type
   ./include/google/identity/accesscontextmanager/type
   ./include/google/logging/type

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -286,7 +286,6 @@ function (google_cloud_cpp_load_protodeps var file)
         "grafeas_v1_grafeas_protos\;grafeas_protos"
         "identity_accesscontextmanager_v1_accesscontextmanager_protos\;accesscontextmanager_protos"
         "cloud_osconfig_v1_osconfig_protos\;osconfig_protos"
-        "devtools_source_v1_source_protos\;devtools_source_v1_source_context_protos"
         "cloud_documentai_v1_documentai_protos\;documentai_protos")
 
     foreach (line IN LISTS contents)

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -74,7 +74,6 @@ set(EXTERNAL_GOOGLEAPIS_PROTO_FILES
     # does not appear in protolists/asset.list. In addition, it is not compiled
     # by any other library. So, added manually.
     "google/cloud/orgpolicy/v1/orgpolicy.proto"
-    "google/devtools/source/v1/source_context.proto"
     "google/longrunning/operations.proto"
     "google/rpc/code.proto"
     "google/rpc/context/attribute_context.proto"
@@ -219,7 +218,6 @@ set(external_googleapis_installed_libraries_list
     google_cloud_cpp_cloud_texttospeech_protos
     google_cloud_cpp_devtools_cloudtrace_v2_trace_protos
     google_cloud_cpp_devtools_cloudtrace_v2_tracing_protos
-    google_cloud_cpp_devtools_source_v1_source_context_protos
     google_cloud_cpp_iam_protos
     google_cloud_cpp_iam_v1_iam_policy_protos
     google_cloud_cpp_iam_v1_options_protos
@@ -354,9 +352,6 @@ external_googleapis_add_library(
     "google/devtools/cloudtrace/v2/tracing.proto"
     devtools_cloudtrace_v2_trace_protos api_annotations_protos
     api_client_protos api_field_behavior_protos rpc_status_protos)
-
-external_googleapis_add_library("google/devtools/source/v1/source_context.proto"
-                                api_annotations_protos)
 
 google_cloud_cpp_load_protolist(cloud_bigquery_list "protolists/bigquery.list")
 google_cloud_cpp_load_protodeps(cloud_bigquery_deps "protodeps/bigquery.deps")


### PR DESCRIPTION
Part of the work for #8022 

This proto was used by Cloud Debugger, which has been removed.

We are not offering any targets for backwards compatibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12459)
<!-- Reviewable:end -->
