### PR TITLE
test(spanner): avoid "europe-west9" in CreateInstanceConfig() tests

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -241,6 +241,10 @@ TEST_F(InstanceAdminClientTest, InstanceConfigUserManaged) {
   auto base_config_name = spanner_testing::PickInstanceConfig(
       project, generator_,
       [](google::spanner::admin::instance::v1::InstanceConfig const& config) {
+        // TODO(#11346): Remove once the incident clears out
+        for (auto const& replica_info : config.optional_replicas()) {
+          if (replica_info.location() == "europe-west9") return false;
+        }
         return !config.optional_replicas().empty();
       });
   ASSERT_THAT(base_config_name, Not(IsEmpty()));

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -4545,7 +4545,13 @@ void RunAllSlowInstanceTests(
         Basename(google::cloud::spanner_testing::PickInstanceConfig(
             google::cloud::Project(project_id), generator,
             [](google::spanner::admin::instance::v1::InstanceConfig const&
-                   config) { return !config.optional_replicas().empty(); }));
+                   config) {
+              // TODO(#11346): Remove once the incident clears out
+              for (auto const& replica_info : config.optional_replicas()) {
+                if (replica_info.location() == "europe-west9") return false;
+              }
+              return !config.optional_replicas().empty();
+            }));
     if (base_config_id.empty()) {
       throw std::runtime_error("Failed to pick a base config");
     }


### PR DESCRIPTION
Revert #12455.  Directed testing indicates there is still an issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12460)
<!-- Reviewable:end -->
