### PR TITLE
fix(cmake)!: only compile protos if asked - bigtable

### DIFF
--- a/ci/gha/builds/external-account.sh
+++ b/ci/gha/builds/external-account.sh
@@ -31,9 +31,10 @@ mapfile -t ctest_args < <(ctest::common_args)
 # Federation, and sometimes BYOID (Bring Your Own ID).
 features=(
   # Enable the smallest set of libraries libraries that will compile gRPC and
-  # REST-based authentication components
+  # REST-based authentication components and tests.
   storage
   iam
+  bigtable
 )
 enable=$(printf ";%s" "${features[@]}")
 enable=${enable:1}

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -212,7 +212,6 @@ endif ()
 
 set(external_googleapis_installed_libraries_list
     # cmake-format: sort
-    google_cloud_cpp_bigtable_protos
     google_cloud_cpp_cloud_bigquery_protos
     google_cloud_cpp_cloud_common_common_protos
     google_cloud_cpp_cloud_speech_protos
@@ -367,14 +366,6 @@ google_cloud_cpp_grpcpp_library(
 external_googleapis_set_version_and_alias(cloud_bigquery_protos)
 target_link_libraries(google_cloud_cpp_cloud_bigquery_protos
                       PUBLIC ${cloud_bigquery_deps})
-
-google_cloud_cpp_load_protolist(bigtable_list "protolists/bigtable.list")
-google_cloud_cpp_load_protodeps(bigtable_deps "protodeps/bigtable.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_bigtable_protos ${bigtable_list} PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(bigtable_protos)
-target_link_libraries(google_cloud_cpp_bigtable_protos PUBLIC ${bigtable_deps})
 
 google_cloud_cpp_load_protolist(cloud_dialogflow_v2_list
                                 "protolists/dialogflow_es.list")
@@ -545,8 +536,7 @@ set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
 #
 string(
     CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
-           "google_cloud_cpp_bigtable_protos"
-           " google_cloud_cpp_cloud_bigquery_protos"
+           "google_cloud_cpp_cloud_bigquery_protos"
            " google_cloud_cpp_iam_protos"
            " google_cloud_cpp_pubsub_protos"
            " google_cloud_cpp_storage_protos"

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -536,7 +536,8 @@ set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
 #
 string(
     CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
-           "google_cloud_cpp_cloud_bigquery_protos"
+           "google_cloud_cpp_bigtable_protos"
+           " google_cloud_cpp_cloud_bigquery_protos"
            " google_cloud_cpp_iam_protos"
            " google_cloud_cpp_pubsub_protos"
            " google_cloud_cpp_storage_protos"

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -38,9 +38,19 @@ google_cloud_cpp_doxygen_targets("bigtable" DEPENDS cloud-docs
 
 include(GoogleCloudCppCommon)
 
-# Configure the location of proto files, particularly the googleapis protos.
-list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_THIRD_PARTY_DIR}/googleapis"
-     "${PROJECT_SOURCE_DIR}")
+include(CompileProtos)
+google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
+google_cloud_cpp_load_protolist(
+    bigtable_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/bigtable.list")
+google_cloud_cpp_load_protodeps(
+    bigtable_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/bigtable.deps")
+google_cloud_cpp_grpcpp_library(
+    google_cloud_cpp_bigtable_protos ${bigtable_list} PROTO_PATH_DIRECTORIES
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
+external_googleapis_set_version_and_alias(bigtable_protos)
+target_link_libraries(google_cloud_cpp_bigtable_protos PUBLIC ${bigtable_deps})
 
 # Enable unit tests
 include(CTest)
@@ -481,25 +491,19 @@ install(
     COMPONENT google_cloud_cpp_development)
 
 install(
-    TARGETS google_cloud_cpp_bigtable
+    TARGETS google_cloud_cpp_bigtable google_cloud_cpp_bigtable_protos
     EXPORT google_cloud_cpp_bigtable-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT google_cloud_cpp_runtime
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_runtime
-            NAMELINK_SKIP
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-# With CMake-3.12 and higher we could avoid this separate command (and the
-# duplication).
-install(
-    TARGETS google_cloud_cpp_bigtable
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development
-            NAMELINK_ONLY
+            NAMELINK_COMPONENT google_cloud_cpp_development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_development)
 
+google_cloud_cpp_install_proto_library_protos(google_cloud_cpp_bigtable_protos
+                                              "${EXTERNAL_GOOGLEAPIS_SOURCE}")
+google_cloud_cpp_install_proto_library_headers(google_cloud_cpp_bigtable_protos)
 google_cloud_cpp_install_headers("google_cloud_cpp_bigtable"
                                  "include/google/cloud/bigtable")
 google_cloud_cpp_install_headers("google_cloud_cpp_bigtable_mocks"
@@ -527,3 +531,5 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigtable-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigtable"
     COMPONENT google_cloud_cpp_development)
+
+external_googleapis_install_pc(google_cloud_cpp_bigtable_protos)


### PR DESCRIPTION
Part of the work for #8022 

My plan is to do #8022 in this release cycle. I will add one CHANGELOG entry when all the changes are complete.

Aside: That `PROTOBUF_IMPORT_DIRS` was a random thing that only existed in `bigtable`. It seems like something we learned did not matter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12462)
<!-- Reviewable:end -->
