### PR TITLE
ci: ignore tests in single feature build

### DIFF
--- a/ci/cloudbuild/builds/cmake-single-feature.sh
+++ b/ci/cloudbuild/builds/cmake-single-feature.sh
@@ -54,17 +54,20 @@ check_pkgconfig_absolute() {
 
 for feature in __ga_libraries__ __experimental_libraries__; do
   io::run cmake -S . -B cmake-out/test-only-"${feature}" \
-    -DGOOGLE_CLOUD_CPP_ENABLE="${feature}"
+    -DGOOGLE_CLOUD_CPP_ENABLE="${feature}" \
+    -DBUILD_TESTING=OFF
 done
 
 for feature in "${features[@]}"; do
   io::run cmake -S . -B cmake-out/test-only-"${feature}" \
-    -DGOOGLE_CLOUD_CPP_ENABLE="${feature}"
+    -DGOOGLE_CLOUD_CPP_ENABLE="${feature}" \
+    -DBUILD_TESTING=OFF
   io::run check_pkgconfig_relative cmake-out/test-only-"${feature}"
 
   io::run cmake -S . -B cmake-out/test-only-"${feature}"-absolute-cmake-install \
     -DGOOGLE_CLOUD_CPP_ENABLE="${feature}" \
     -DCMAKE_INSTALL_INCLUDEDIR=/test-only/include \
-    -DCMAKE_INSTALL_LIBDIR=/test-only/lib
+    -DCMAKE_INSTALL_LIBDIR=/test-only/lib \
+    -DBUILD_TESTING=OFF
   io::run check_pkgconfig_absolute cmake-out/test-only-"${feature}"-absolute-cmake-install
 done


### PR DESCRIPTION
Part of the work for #8022 

The `single-feature` build is only concerned with verifying installed targets. It does not need to build the testing targets.

This matters, because tests in `grpc_utils` depend on some libraries protos (`bigtable_protos`, `iam_protos`, `spanner_protos`) and we are no longer going to compile these protos by default, unless those features are enabled.

For the build failure we are avoiding, see:
* GCB: https://console.cloud.google.com/cloud-build/builds;region=us-east1/224eb02b-5763-4638-8cfe-7232943dba5c;tab=detail?project=cloud-cpp-testing-resources
* Raw: https://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/12462/96c2c14c65e71a542e5bae5c3c4d5ea2725f8ccd/fedora-37-cmake-cmake-single-feature/log-224eb02b-5763-4638-8cfe-7232943dba5c.txt

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12464)
<!-- Reviewable:end -->
