### PR TITLE
cleanup: remove spanner dep from grpc_utils unit tests

### DIFF
--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -191,7 +191,6 @@ cc_library(
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
         "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
-        "@com_google_googleapis//google/spanner/v1:spanner_cc_grpc",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in google_cloud_cpp_grpc_utils_unit_tests]
@@ -209,7 +208,6 @@ cc_library(
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
         "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
-        "@com_google_googleapis//google/spanner/v1:spanner_cc_grpc",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in google_cloud_cpp_grpc_utils_integration_tests]
@@ -223,7 +221,6 @@ cc_library(
         "@com_google_benchmark//:benchmark_main",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
         "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
-        "@com_google_googleapis//google/spanner/v1:spanner_cc_grpc",
     ],
 ) for test in google_cloud_cpp_grpc_utils_benchmarks]
 

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -213,7 +213,6 @@ function (google_cloud_cpp_grpc_utils_add_test fname labels)
                 google-cloud-cpp::common
                 google-cloud-cpp::iam_protos
                 google-cloud-cpp::bigtable_protos
-                google-cloud-cpp::spanner_protos
                 absl::variant
                 GTest::gmock_main
                 GTest::gmock


### PR DESCRIPTION
Motivated by #8022 

Use IAM protos instead of Spanner protos in `grpc_utils` unit test, so we can drop the dep on `spanner_protos`.