### PR TITLE
refactor: scaffolding knows about cmake library helper

### DIFF
--- a/cmake/GoogleCloudCppLibrary.cmake
+++ b/cmake/GoogleCloudCppLibrary.cmake
@@ -33,15 +33,23 @@
 #   `asset` sets this.
 #
 function (google_cloud_cpp_add_ga_grpc_library library display_name)
-    cmake_parse_arguments(_opt "" "" "ADDITIONAL_PROTO_LISTS" ${ARGN})
+    cmake_parse_arguments(_opt "EXPERIMENTAL" "" "ADDITIONAL_PROTO_LISTS"
+                          ${ARGN})
     set(library_target "google_cloud_cpp_${library}")
     set(mocks_target "google_cloud_cpp_${library}_mocks")
     set(protos_target "google_cloud_cpp_${library}_protos")
+    set(library_alias "google-cloud-cpp::${library}")
+    if (_opt_EXPERIMENTAL)
+        set(library_alias "google-cloud-cpp::experimental-${library}")
+    endif ()
 
     include(GoogleapisConfig)
     set(DOXYGEN_PROJECT_NAME "${display_name} C++ Client")
     set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the ${display_name}")
     set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
+    if (_opt_EXPERIMENTAL)
+        set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
+    endif ()
     set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
     set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
 
@@ -100,13 +108,13 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
     google_cloud_cpp_add_common_options(${library_target})
     set_target_properties(
         ${library_target}
-        PROPERTIES EXPORT_NAME google-cloud-cpp::${library}
+        PROPERTIES EXPORT_NAME ${library_alias}
                    VERSION "${PROJECT_VERSION}"
                    SOVERSION "${PROJECT_VERSION_MAJOR}")
     target_compile_options(${library_target}
                            PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-    add_library(google-cloud-cpp::${library} ALIAS ${library_target})
+    add_library(${library_alias} ALIAS ${library_target})
 
     # Create a header-only library for the mocks. We use a CMake `INTERFACE`
     # library for these, a regular library would not work on macOS (where the
@@ -124,11 +132,10 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
     add_library(${mocks_target} INTERFACE)
     target_sources(${mocks_target} INTERFACE ${mock_files})
     target_link_libraries(
-        ${mocks_target} INTERFACE google-cloud-cpp::${library}
-                                  GTest::gmock_main GTest::gmock GTest::gtest)
-    set_target_properties(
-        ${mocks_target} PROPERTIES EXPORT_NAME
-                                   google-cloud-cpp::${library}_mocks)
+        ${mocks_target} INTERFACE ${library_alias} GTest::gmock_main
+                                  GTest::gmock GTest::gtest)
+    set_target_properties(${mocks_target} PROPERTIES EXPORT_NAME
+                                                     ${library_alias}_mocks)
     target_include_directories(
         ${mocks_target}
         INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -189,8 +196,7 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
 
     external_googleapis_install_pc("${protos_target}")
 
-    # google-cloud-cpp::${library} must be defined before we can add the
-    # samples.
+    # ${library_alias} must be defined before we can add the samples.
     if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
         foreach (dir IN LISTS GOOGLE_CLOUD_CPP_SERVICE_DIRS)
             google_cloud_cpp_add_samples_relative("${library}" "${dir}samples/")

--- a/doc/contributor/howto-guide-declare-a-library-ga.md
+++ b/doc/contributor/howto-guide-declare-a-library-ga.md
@@ -86,17 +86,10 @@ for lib in "${ga[@]}"; do sed -i 's/^Please note that the Google Cloud C/While t
 
 ### `google/cloud/${library}/CMakeLists.txt`:
 
-Change the definition of the `DOXYGEN_PROJECT_NUMBER` variable from
-`${PROJECT_VERSION} (Experimental)` to `${PROJECT_VERSION}`.
+Remove the EXPERIMENTAL keyword from the library definition.
 
 ```shell
-for lib in "${ga[@]}"; do sed -i 's;"\${PROJECT_VERSION} (Experimental)";"${PROJECT_VERSION}";' google/cloud/${lib}/CMakeLists.txt; done
-```
-
-Change the target name from `google-cloud-cpp::experimental-${library}`:
-
-```shell
-for lib in "${ga[@]}"; do sed -i 's/google-cloud-cpp::experimental-/google-cloud-cpp::/' google/cloud/${lib}/CMakeLists.txt; done
+for lib in "${ga[@]}"; do sed -i 's/EXPERIMENTAL//' google/cloud/${lib}/CMakeLists.txt; done
 ```
 
 ### `google/cloud/${library}/config.cmake.in`:

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -169,7 +169,7 @@ TEST_F(ScaffoldGenerator, Vars) {
             Contains(Pair("product_options_page", "google-cloud-test-options")),
             Contains(Pair("copyright_year", "2034")),
             Contains(Pair("library_prefix", "")),
-            Contains(Pair("doxygen_version_suffix", "")),
+            Contains(Pair("experimental", "")),
             Contains(Pair("construction", "")),
             Contains(Pair("status", HasSubstr("**GA**")))));
 
@@ -184,7 +184,7 @@ TEST_F(ScaffoldGenerator, Vars) {
             Contains(Pair("product_options_page", "google-cloud-test-options")),
             Contains(Pair("copyright_year", "2034")),
             Contains(Pair("library_prefix", "experimental-")),
-            Contains(Pair("doxygen_version_suffix", " (Experimental)")),
+            Contains(Pair("experimental", " EXPERIMENTAL")),
             Contains(Pair("construction", "\n:construction:\n")),
             Contains(Pair("status", HasSubstr("**experimental**")))));
 }
@@ -239,22 +239,12 @@ TEST_F(ScaffoldGenerator, CMakeLists) {
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
   EXPECT_THAT(actual, Not(HasSubstr("$library_prefix$")));
-  EXPECT_THAT(actual, Not(HasSubstr("$doxygen_version_suffix$")));
-  EXPECT_THAT(actual, HasSubstr(R"""(include(CompileProtos)
-google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-google_cloud_cpp_load_protolist(
-    proto_list
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/test.list")
-google_cloud_cpp_load_protodeps(
-    proto_deps
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/test.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_test_protos # cmake-format: sort
-    ${proto_list}
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(test_protos)
-target_link_libraries(google_cloud_cpp_test_protos PUBLIC ${proto_deps})
+  EXPECT_THAT(actual, Not(HasSubstr("$experimental$")));
+  EXPECT_THAT(actual, HasSubstr(R"""(include(GoogleCloudCppLibrary)
+
+set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
+
+google_cloud_cpp_add_ga_grpc_library(test "Test Only API")
 )"""));
 
   EXPECT_THAT(actual, HasSubstr(R"""(add_executable(test_quickstart)"""));


### PR DESCRIPTION
Part of the work for #12428 

Transition the scaffolding. Add support for experimental libraries.

Yes, we are adding EXPERIMENTAL to the GA library helper... I definitely misnamed the helper function. I will switch it to something like `google_cloud_cpp_gapic(...)` when there are fewer outstanding PRs.

I tested it manually like this: https://github.com/dbolduc/google-cloud-cpp/commit/1bf9012a4835353bfdc9ab9aa1b31d0079bbdae9

![image](https://github.com/googleapis/google-cloud-cpp/assets/23088558/ba37ee5f-4307-4ba3-94d1-5a919d5df27b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12470)
<!-- Reviewable:end -->
