### PR TITLE
fix(cmake)!: only compile protos if asked - dialogflow

### DIFF
--- a/ci/verify_current_targets/CMakeLists.txt
+++ b/ci/verify_current_targets/CMakeLists.txt
@@ -79,6 +79,7 @@ endforeach ()
 
 set(backwards_compat_proto_libraries
     # cmake-format: sortable
+    "cloud_dialogflow_v2_protos"
     "cloud_speech_protos"
     "cloud_texttospeech_protos"
     "devtools_cloudtrace_v2_trace_protos"

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -359,21 +359,6 @@ external_googleapis_set_version_and_alias(cloud_bigquery_protos)
 target_link_libraries(google_cloud_cpp_cloud_bigquery_protos
                       PUBLIC ${cloud_bigquery_deps})
 
-google_cloud_cpp_load_protolist(cloud_dialogflow_v2_list
-                                "protolists/dialogflow_es.list")
-google_cloud_cpp_load_protodeps(cloud_dialogflow_v2_deps
-                                "protodeps/dialogflow_es.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_cloud_dialogflow_v2_protos ${cloud_dialogflow_v2_list}
-    PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
-    "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(cloud_dialogflow_v2_protos)
-target_link_libraries(google_cloud_cpp_cloud_dialogflow_v2_protos
-                      PUBLIC ${cloud_dialogflow_v2_deps})
-
-list(APPEND external_googleapis_installed_libraries_list
-     google_cloud_cpp_cloud_dialogflow_v2_protos)
-
 google_cloud_cpp_load_protolist(cloud_texttospeech_list
                                 "protolists/texttospeech.list")
 google_cloud_cpp_load_protodeps(cloud_texttospeech_deps

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -14,91 +14,13 @@
 # limitations under the License.
 # ~~~
 
-include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Dialogflow API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Dialogflow API")
-set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
-set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "dialogflow_es_internal"
-                            "dialogflow_es_testing" "examples")
-set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
-                         ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
+include(GoogleCloudCppLibrary)
 
-include(GoogleCloudCppDoxygen)
-google_cloud_cpp_doxygen_targets("dialogflow_es" DEPENDS cloud-docs
-                                 google-cloud-cpp::dialogflow_es_protos)
+set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "__EMPTY__")
 
-include(GoogleCloudCppCommon)
-
-include(CompileProtos)
-google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-add_library(google_cloud_cpp_dialogflow_es_protos INTERFACE)
-set_target_properties(
-    google_cloud_cpp_dialogflow_es_protos
-    PROPERTIES EXPORT_NAME google-cloud-cpp::dialogflow_es_protos)
-add_library(google-cloud-cpp::dialogflow_es_protos ALIAS
-            google_cloud_cpp_dialogflow_es_protos)
-
-target_link_libraries(
-    google_cloud_cpp_dialogflow_es_protos
-    PUBLIC
-    INTERFACE google-cloud-cpp::cloud_dialogflow_v2_protos)
-
-file(
-    GLOB source_files
-    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-    "*.h" "*.cc" "internal/*.h" "internal/*.cc")
-list(SORT source_files)
-add_library(google_cloud_cpp_dialogflow_es ${source_files})
-target_include_directories(
-    google_cloud_cpp_dialogflow_es
-    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-           $<INSTALL_INTERFACE:include>)
-target_link_libraries(
-    google_cloud_cpp_dialogflow_es
-    PUBLIC google-cloud-cpp::grpc_utils google-cloud-cpp::common
-           google-cloud-cpp::dialogflow_es_protos)
-google_cloud_cpp_add_common_options(google_cloud_cpp_dialogflow_es)
-set_target_properties(
-    google_cloud_cpp_dialogflow_es
-    PROPERTIES EXPORT_NAME google-cloud-cpp::dialogflow_es
-               VERSION "${PROJECT_VERSION}"
-               SOVERSION "${PROJECT_VERSION_MAJOR}")
-target_compile_options(google_cloud_cpp_dialogflow_es
-                       PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-
-add_library(google-cloud-cpp::dialogflow_es ALIAS
-            google_cloud_cpp_dialogflow_es)
-
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
-# that they need absolute paths for their sources.
-file(
-    GLOB relative_mock_files
-    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-    "mocks/*.h")
-list(SORT relative_mock_files)
-set(mock_files)
-foreach (file IN LISTS relative_mock_files)
-    list(APPEND mock_files "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
-endforeach ()
-add_library(google_cloud_cpp_dialogflow_es_mocks INTERFACE)
-target_sources(google_cloud_cpp_dialogflow_es_mocks INTERFACE ${mock_files})
-target_link_libraries(
-    google_cloud_cpp_dialogflow_es_mocks
-    INTERFACE google-cloud-cpp::dialogflow_es GTest::gmock_main GTest::gmock
-              GTest::gtest)
-set_target_properties(
-    google_cloud_cpp_dialogflow_es_mocks
-    PROPERTIES EXPORT_NAME google-cloud-cpp::dialogflow_es_mocks)
-target_include_directories(
-    google_cloud_cpp_dialogflow_es_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_dialogflow_es_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+google_cloud_cpp_add_ga_grpc_library(
+    dialogflow_es "Dialogflow API" BACKWARDS_COMPAT_PROTO_TARGETS
+    "cloud_dialogflow_v2_protos")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dialogflow_es_quickstart "quickstart/quickstart.cc")
@@ -112,69 +34,3 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     set_tests_properties(dialogflow_es_quickstart
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()
-
-# Get the destination directories based on the GNU recommendations.
-include(GNUInstallDirs)
-
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT google_cloud_cpp_dialogflow_es-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_dialogflow_es"
-    COMPONENT google_cloud_cpp_development)
-
-# Install the libraries and headers in the locations determined by
-# GNUInstallDirs
-install(
-    TARGETS google_cloud_cpp_dialogflow_es google_cloud_cpp_dialogflow_es_protos
-    EXPORT google_cloud_cpp_dialogflow_es-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT google_cloud_cpp_runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_runtime
-            NAMELINK_SKIP
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-# With CMake-3.12 and higher we could avoid this separate command (and the
-# duplication).
-install(
-    TARGETS google_cloud_cpp_dialogflow_es google_cloud_cpp_dialogflow_es_protos
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development
-            NAMELINK_ONLY
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_proto_library_protos(
-    "google_cloud_cpp_dialogflow_es_protos" "${EXTERNAL_GOOGLEAPIS_SOURCE}")
-google_cloud_cpp_install_proto_library_headers(
-    "google_cloud_cpp_dialogflow_es_protos")
-google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_es"
-                                 "include/google/cloud/dialogflow_es")
-google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_es_mocks"
-                                 "include/google/cloud/dialogflow_es")
-
-google_cloud_cpp_add_pkgconfig(
-    dialogflow_es
-    "The Dialogflow API C++ Client Library"
-    "Provides C++ APIs to use the Dialogflow API."
-    "google_cloud_cpp_grpc_utils"
-    "google_cloud_cpp_common"
-    "google_cloud_cpp_dialogflow_es_protos")
-
-# Create and install the CMake configuration files.
-include(CMakePackageConfigHelpers)
-configure_file("config.cmake.in" "google_cloud_cpp_dialogflow_es-config.cmake"
-               @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_dialogflow_es-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_dialogflow_es-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_dialogflow_es-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_dialogflow_es"
-    COMPONENT google_cloud_cpp_development)
-
-external_googleapis_install_pc("google_cloud_cpp_dialogflow_es_protos")


### PR DESCRIPTION
Part of the work for #8022 and #12428 

This one has a legacy proto library with a name we don't like.

I forgot to include this library's legacy protos in the cmake install build, so that is done in this PR.

Also move `dialogflow_es` to the common cmake library helper.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12477)
<!-- Reviewable:end -->
