### PR TITLE
fix(cmake)!: only compile protos if asked - trace

### DIFF
--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -214,8 +214,6 @@ set(external_googleapis_installed_libraries_list
     google_cloud_cpp_cloud_bigquery_protos
     google_cloud_cpp_cloud_common_common_protos
     google_cloud_cpp_cloud_texttospeech_protos
-    google_cloud_cpp_devtools_cloudtrace_v2_trace_protos
-    google_cloud_cpp_devtools_cloudtrace_v2_tracing_protos
     google_cloud_cpp_iam_protos
     google_cloud_cpp_iam_v1_iam_policy_protos
     google_cloud_cpp_iam_v1_options_protos
@@ -339,14 +337,6 @@ google_cloud_cpp_grpcpp_library(
 external_googleapis_set_version_and_alias(cloud_common_common_protos)
 target_link_libraries(google_cloud_cpp_cloud_common_common_protos
                       PUBLIC ${cloud_common_deps})
-
-external_googleapis_add_library(
-    "google/devtools/cloudtrace/v2/trace.proto" api_annotations_protos
-    api_field_behavior_protos api_resource_protos rpc_status_protos)
-external_googleapis_add_library(
-    "google/devtools/cloudtrace/v2/tracing.proto"
-    devtools_cloudtrace_v2_trace_protos api_annotations_protos
-    api_client_protos api_field_behavior_protos rpc_status_protos)
 
 google_cloud_cpp_load_protolist(cloud_bigquery_list "protolists/bigquery.list")
 google_cloud_cpp_load_protodeps(cloud_bigquery_deps "protodeps/bigquery.deps")

--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -23,6 +23,8 @@ set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "otel_internal")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/quickstart"
                          "${CMAKE_CURRENT_SOURCE_DIR}/samples")
+set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES
+    "${PROJECT_BINARY_DIR}/google/cloud/trace")
 
 include(GoogleCloudCppDoxygen)
 google_cloud_cpp_doxygen_targets("opentelemetry" DEPENDS cloud-docs

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -14,103 +14,15 @@
 # limitations under the License.
 # ~~~
 
-include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Trace API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Trace API")
-set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
-set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
-set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
+include(GoogleCloudCppLibrary)
 
-unset(mocks_globs)
-unset(source_globs)
-set(service_dirs "" "v1/" "v2/")
-foreach (dir IN LISTS service_dirs)
-    string(REPLACE "/" "_" ns "${dir}")
-    list(APPEND source_globs "${dir}*.h" "${dir}*.cc" "${dir}internal/*")
-    list(APPEND mocks_globs "${dir}mocks/*.h")
-    list(APPEND DOXYGEN_EXCLUDE_SYMBOLS "trace_${ns}internal")
-    if (NOT dir STREQUAL "")
-        list(APPEND DOXYGEN_EXAMPLE_PATH
-             "${CMAKE_CURRENT_SOURCE_DIR}/${dir}samples")
-    endif ()
-endforeach ()
+set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
 
-include(GoogleCloudCppDoxygen)
-google_cloud_cpp_doxygen_targets("trace" DEPENDS cloud-docs
-                                 google-cloud-cpp::trace_protos)
+google_cloud_cpp_add_ga_grpc_library(
+    trace "Cloud Trace API" BACKWARDS_COMPAT_PROTO_TARGETS
+    "devtools_cloudtrace_v2_trace_protos"
+    "devtools_cloudtrace_v2_tracing_protos")
 
-include(GoogleCloudCppCommon)
-
-include(CompileProtos)
-google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-google_cloud_cpp_load_protolist(
-    proto_list
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/trace.list")
-google_cloud_cpp_load_protodeps(
-    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/trace.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_trace_protos # cmake-format: sort
-    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
-    "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(trace_protos)
-target_link_libraries(google_cloud_cpp_trace_protos PUBLIC ${proto_deps})
-
-file(
-    GLOB source_files
-    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-    ${source_globs})
-list(SORT source_files)
-add_library(google_cloud_cpp_trace ${source_files})
-target_include_directories(
-    google_cloud_cpp_trace
-    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-           $<INSTALL_INTERFACE:include>)
-target_link_libraries(
-    google_cloud_cpp_trace
-    PUBLIC google-cloud-cpp::grpc_utils google-cloud-cpp::common
-           google-cloud-cpp::trace_protos)
-google_cloud_cpp_add_common_options(google_cloud_cpp_trace)
-set_target_properties(
-    google_cloud_cpp_trace
-    PROPERTIES EXPORT_NAME google-cloud-cpp::trace
-               VERSION "${PROJECT_VERSION}"
-               SOVERSION "${PROJECT_VERSION_MAJOR}")
-target_compile_options(google_cloud_cpp_trace
-                       PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-
-add_library(google-cloud-cpp::trace ALIAS google_cloud_cpp_trace)
-
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
-# that they need absolute paths for their sources.
-file(
-    GLOB relative_mock_files
-    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-    ${mocks_globs})
-list(SORT relative_mock_files)
-set(mock_files)
-foreach (file IN LISTS relative_mock_files)
-    list(APPEND mock_files "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
-endforeach ()
-add_library(google_cloud_cpp_trace_mocks INTERFACE)
-target_sources(google_cloud_cpp_trace_mocks INTERFACE ${mock_files})
-target_link_libraries(
-    google_cloud_cpp_trace_mocks
-    INTERFACE google-cloud-cpp::trace GTest::gmock_main GTest::gmock
-              GTest::gtest)
-set_target_properties(google_cloud_cpp_trace_mocks
-                      PROPERTIES EXPORT_NAME google-cloud-cpp::trace_mocks)
-target_include_directories(
-    google_cloud_cpp_trace_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_trace_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-
-include(CTest)
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_executable(trace_quickstart "quickstart/quickstart.cc")
     target_link_libraries(trace_quickstart PRIVATE google-cloud-cpp::trace)
@@ -122,74 +34,3 @@ if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     set_tests_properties(trace_quickstart
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()
-
-# Get the destination directories based on the GNU recommendations.
-include(GNUInstallDirs)
-
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT google_cloud_cpp_trace-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_trace"
-    COMPONENT google_cloud_cpp_development)
-
-# Install the libraries and headers in the locations determined by
-# GNUInstallDirs
-install(
-    TARGETS google_cloud_cpp_trace google_cloud_cpp_trace_protos
-    EXPORT google_cloud_cpp_trace-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT google_cloud_cpp_runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_runtime
-            NAMELINK_SKIP
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-# With CMake-3.12 and higher we could avoid this separate command (and the
-# duplication).
-install(
-    TARGETS google_cloud_cpp_trace google_cloud_cpp_trace_protos
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development
-            NAMELINK_ONLY
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_proto_library_protos("google_cloud_cpp_trace_protos"
-                                              "${EXTERNAL_GOOGLEAPIS_SOURCE}")
-google_cloud_cpp_install_proto_library_headers("google_cloud_cpp_trace_protos")
-google_cloud_cpp_install_headers("google_cloud_cpp_trace"
-                                 "include/google/cloud/trace")
-google_cloud_cpp_install_headers("google_cloud_cpp_trace_mocks"
-                                 "include/google/cloud/trace")
-
-google_cloud_cpp_add_pkgconfig(
-    trace
-    "The Cloud Trace API C++ Client Library"
-    "Provides C++ APIs to use the Cloud Trace API."
-    "google_cloud_cpp_grpc_utils"
-    "google_cloud_cpp_common"
-    "google_cloud_cpp_trace_protos")
-
-# Create and install the CMake configuration files.
-include(CMakePackageConfigHelpers)
-configure_file("config.cmake.in" "google_cloud_cpp_trace-config.cmake" @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_trace-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_trace-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_trace-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_trace"
-    COMPONENT google_cloud_cpp_development)
-
-external_googleapis_install_pc("google_cloud_cpp_trace_protos")
-
-# google-cloud-cpp::trace must be defined before we can add the samples.
-foreach (dir IN LISTS service_dirs)
-    if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-        google_cloud_cpp_add_samples_relative("trace" "${dir}samples/")
-    endif ()
-endforeach ()


### PR DESCRIPTION
Part of the work for #8022 and #12428

This one has 2 legacy proto libraries with names we don't like.

Also move `trace` to the common cmake library helper.

Note that we are checking that the proto libraries still exist:

https://github.com/googleapis/google-cloud-cpp/blob/82d88becf1b6c9c2403a6f03fd86cd5744c908ab/ci/verify_current_targets/CMakeLists.txt#L84-L85

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12478)
<!-- Reviewable:end -->
