### PR TITLE
fix(cmake)!: only compile protos if asked - storage

### DIFF
--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -218,8 +218,7 @@ set(external_googleapis_installed_libraries_list
     google_cloud_cpp_iam_v1_options_protos
     google_cloud_cpp_iam_v1_policy_protos
     google_cloud_cpp_logging_protos
-    google_cloud_cpp_longrunning_operations_protos
-    google_cloud_cpp_storage_protos)
+    google_cloud_cpp_longrunning_operations_protos)
 
 # These proto files cannot be added in the foreach() loop because they have
 # dependencies.
@@ -381,14 +380,6 @@ set_target_properties(
     PROPERTIES EXPORT_NAME google-cloud-cpp::logging_type_protos)
 target_link_libraries(google_cloud_cpp_logging_type_protos
                       INTERFACE google-cloud-cpp::logging_type_type_protos)
-
-google_cloud_cpp_load_protolist(storage_list "protolists/storage.list")
-google_cloud_cpp_load_protodeps(storage_deps "protodeps/storage.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_storage_protos ${storage_list} PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(storage_protos)
-target_link_libraries(google_cloud_cpp_storage_protos PUBLIC ${storage_deps})
 
 # Install the libraries and headers in the locations determined by
 # GNUInstallDirs

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -28,6 +28,12 @@ if (NOT GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
             google_cloud_cpp_storage_grpc
             INTERFACE GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
     endif ()
+    add_library(google_cloud_cpp_storage_protos INTERFACE)
+    add_library(google-cloud-cpp::storage_protos ALIAS
+                google_cloud_cpp_storage_protos)
+    set_target_properties(
+        google_cloud_cpp_storage_protos
+        PROPERTIES EXPORT_NAME "google-cloud-cpp::storage_protos")
 else ()
     include(CompileProtos)
     google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
@@ -185,6 +191,7 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_development)
 
+include(CompileProtos)
 google_cloud_cpp_install_proto_library_protos(google_cloud_cpp_storage_protos
                                               "${EXTERNAL_GOOGLEAPIS_SOURCE}")
 google_cloud_cpp_install_proto_library_headers(google_cloud_cpp_storage_protos)


### PR DESCRIPTION
Part of the work for #8022 

This one is a bit weird. I think the protos should only be built with GCS+gRPC. (As opposed to, `storage IN LISTS GOOGLE_CLOUD_CPP_ENABLE AND GOOGLE_CLOUD_CPP_ENABLE_GRPC`)

Conditionally include the raw gRPC client in the throughput benchmark only if GCS+gRPC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12481)
<!-- Reviewable:end -->
