### PR TITLE
refactor(cmake): client proto library creation

### DIFF
--- a/cmake/GoogleCloudCppLibrary.cmake
+++ b/cmake/GoogleCloudCppLibrary.cmake
@@ -118,22 +118,8 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
     include(GoogleCloudCppCommon)
 
     include(CompileProtos)
-    google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-    google_cloud_cpp_load_protolist(
-        proto_list
-        "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/${library}.list")
-    if (_opt_ADDITIONAL_PROTO_LISTS)
-        list(APPEND proto_list "${_opt_ADDITIONAL_PROTO_LISTS}")
-    endif ()
-    google_cloud_cpp_load_protodeps(
-        proto_deps
-        "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/${library}.deps")
-    google_cloud_cpp_grpcpp_library(
-        ${protos_target} # cmake-format: sort
-        ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
-        "${PROTO_INCLUDE_DIR}")
-    external_googleapis_set_version_and_alias(${library}_protos)
-    target_link_libraries(${protos_target} PUBLIC ${proto_deps})
+    google_cloud_cpp_add_library_protos(${library} ADDITIONAL_PROTO_LISTS
+                                        ${_opt_ADDITIONAL_PROTO_LISTS})
 
     # We used to offer the proto library by another name. Maintain backwards
     # compatibility by providing an interface library with that name. Also make

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -38,19 +38,8 @@ google_cloud_cpp_doxygen_targets("bigtable" DEPENDS cloud-docs
 
 include(GoogleCloudCppCommon)
 
-include(CompileProtos)
-google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-google_cloud_cpp_load_protolist(
-    bigtable_list
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/bigtable.list")
-google_cloud_cpp_load_protodeps(
-    bigtable_deps
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/bigtable.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_bigtable_protos ${bigtable_list} PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(bigtable_protos)
-target_link_libraries(google_cloud_cpp_bigtable_protos PUBLIC ${bigtable_deps})
+include(GoogleCloudCppLibrary)
+google_cloud_cpp_add_library_protos(bigtable)
 
 # Enable unit tests
 include(CTest)
@@ -501,9 +490,6 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_install_proto_library_protos(google_cloud_cpp_bigtable_protos
-                                              "${EXTERNAL_GOOGLEAPIS_SOURCE}")
-google_cloud_cpp_install_proto_library_headers(google_cloud_cpp_bigtable_protos)
 google_cloud_cpp_install_headers("google_cloud_cpp_bigtable"
                                  "include/google/cloud/bigtable")
 google_cloud_cpp_install_headers("google_cloud_cpp_bigtable_mocks"
@@ -531,5 +517,3 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigtable-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigtable"
     COMPONENT google_cloud_cpp_development)
-
-external_googleapis_install_pc(google_cloud_cpp_bigtable_protos)

--- a/google/cloud/grafeas/CMakeLists.txt
+++ b/google/cloud/grafeas/CMakeLists.txt
@@ -18,19 +18,8 @@ include(GoogleapisConfig)
 
 include(GoogleCloudCppCommon)
 
-include(CompileProtos)
-google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-google_cloud_cpp_load_protolist(
-    grafeas_list
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/grafeas.list")
-google_cloud_cpp_load_protodeps(
-    grafeas_deps
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/grafeas.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_grafeas_protos ${grafeas_list} PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(grafeas_protos)
-target_link_libraries(google_cloud_cpp_grafeas_protos PUBLIC ${grafeas_deps})
+include(GoogleCloudCppLibrary)
+google_cloud_cpp_add_library_protos(grafeas)
 
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
@@ -63,11 +52,6 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_install_proto_library_protos("google_cloud_cpp_grafeas_protos"
-                                              "${EXTERNAL_GOOGLEAPIS_SOURCE}")
-google_cloud_cpp_install_proto_library_headers(
-    "google_cloud_cpp_grafeas_protos")
-
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)
 configure_file("config.cmake.in" "google_cloud_cpp_grafeas-config.cmake" @ONLY)
@@ -82,5 +66,3 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_grafeas-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_grafeas"
     COMPONENT google_cloud_cpp_development)
-
-external_googleapis_install_pc("google_cloud_cpp_grafeas_protos")

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -32,19 +32,8 @@ endif ()
 
 include(GoogleCloudCppCommon)
 
-include(CompileProtos)
-google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-google_cloud_cpp_load_protolist(
-    pubsub_list
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/pubsub.list")
-google_cloud_cpp_load_protodeps(
-    pubsub_deps
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/pubsub.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_pubsub_protos ${pubsub_list} PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(pubsub_protos)
-target_link_libraries(google_cloud_cpp_pubsub_protos PUBLIC ${pubsub_deps})
+include(GoogleCloudCppLibrary)
+google_cloud_cpp_add_library_protos(pubsub)
 
 add_library(
     google_cloud_cpp_pubsub # cmake-format: sort
@@ -410,9 +399,6 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_install_proto_library_protos(google_cloud_cpp_pubsub_protos
-                                              "${EXTERNAL_GOOGLEAPIS_SOURCE}")
-google_cloud_cpp_install_proto_library_headers(google_cloud_cpp_pubsub_protos)
 google_cloud_cpp_install_headers("google_cloud_cpp_pubsub"
                                  "include/google/cloud/pubsub")
 
@@ -454,8 +440,6 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
     COMPONENT google_cloud_cpp_development)
-
-external_googleapis_install_pc(google_cloud_cpp_pubsub_protos)
 
 google_cloud_cpp_add_pkgconfig(
     pubsub_mocks "Google Cloud C++ Pub/Sub Mocks"

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -31,20 +31,8 @@ google_cloud_cpp_doxygen_targets("pubsublite" DEPENDS cloud-docs
 
 include(GoogleCloudCppCommon)
 
-include(CompileProtos)
-google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-google_cloud_cpp_load_protolist(
-    proto_list
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/pubsublite.list")
-google_cloud_cpp_load_protodeps(
-    proto_deps
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/pubsublite.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_pubsublite_protos # cmake-format: sort
-    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
-    "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(pubsublite_protos)
-target_link_libraries(google_cloud_cpp_pubsublite_protos PUBLIC ${proto_deps})
+include(GoogleCloudCppLibrary)
+google_cloud_cpp_add_library_protos(pubsublite)
 
 add_library(
     google_cloud_cpp_pubsublite # cmake-format: sort
@@ -347,23 +335,10 @@ install(
             COMPONENT google_cloud_cpp_runtime
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_runtime
-            NAMELINK_SKIP
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-# With CMake-3.12 and higher we could avoid this separate command (and the
-# duplication).
-install(
-    TARGETS google_cloud_cpp_pubsublite google_cloud_cpp_pubsublite_protos
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development
-            NAMELINK_ONLY
+            NAMELINK_COMPONENT google_cloud_cpp_development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_install_proto_library_protos(
-    "google_cloud_cpp_pubsublite_protos" "${EXTERNAL_GOOGLEAPIS_SOURCE}")
-google_cloud_cpp_install_proto_library_headers(
-    "google_cloud_cpp_pubsublite_protos")
 google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite"
                                  "include/google/cloud/pubsublite")
 google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite_mocks"
@@ -392,5 +367,3 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsublite-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsublite"
     COMPONENT google_cloud_cpp_development)
-
-external_googleapis_install_pc("google_cloud_cpp_pubsublite_protos")

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -31,19 +31,8 @@ google_cloud_cpp_doxygen_targets("spanner" DEPENDS cloud-docs
 
 include(GoogleCloudCppCommon)
 
-include(CompileProtos)
-google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-google_cloud_cpp_load_protolist(
-    spanner_list
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/spanner.list")
-google_cloud_cpp_load_protodeps(
-    spanner_deps
-    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/spanner.deps")
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_spanner_protos ${spanner_list} PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
-external_googleapis_set_version_and_alias(spanner_protos)
-target_link_libraries(google_cloud_cpp_spanner_protos PUBLIC ${spanner_deps})
+include(GoogleCloudCppLibrary)
+google_cloud_cpp_add_library_protos(spanner)
 
 add_library(
     google_cloud_cpp_spanner # cmake-format: sort
@@ -550,9 +539,6 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_install_proto_library_protos(google_cloud_cpp_spanner_protos
-                                              "${EXTERNAL_GOOGLEAPIS_SOURCE}")
-google_cloud_cpp_install_proto_library_headers(google_cloud_cpp_spanner_protos)
 google_cloud_cpp_install_headers("google_cloud_cpp_spanner"
                                  "include/google/cloud/spanner")
 google_cloud_cpp_install_headers("google_cloud_cpp_spanner_mocks"
@@ -583,5 +569,3 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_spanner-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_spanner"
     COMPONENT google_cloud_cpp_development)
-
-external_googleapis_install_pc(google_cloud_cpp_spanner_protos)

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -35,20 +35,8 @@ if (NOT GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         google_cloud_cpp_storage_protos
         PROPERTIES EXPORT_NAME "google-cloud-cpp::storage_protos")
 else ()
-    include(CompileProtos)
-    google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
-    google_cloud_cpp_load_protolist(
-        storage_list
-        "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/storage.list")
-    google_cloud_cpp_load_protodeps(
-        storage_deps
-        "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/storage.deps")
-    google_cloud_cpp_grpcpp_library(
-        google_cloud_cpp_storage_protos ${storage_list} PROTO_PATH_DIRECTORIES
-        "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
-    external_googleapis_set_version_and_alias(storage_protos)
-    target_link_libraries(google_cloud_cpp_storage_protos
-                          PUBLIC ${storage_deps})
+    include(GoogleCloudCppLibrary)
+    google_cloud_cpp_add_library_protos(storage)
 
     add_library(
         google_cloud_cpp_storage_grpc # cmake-format: sort
@@ -191,14 +179,8 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_development)
 
-include(CompileProtos)
-google_cloud_cpp_install_proto_library_protos(google_cloud_cpp_storage_protos
-                                              "${EXTERNAL_GOOGLEAPIS_SOURCE}")
-google_cloud_cpp_install_proto_library_headers(google_cloud_cpp_storage_protos)
 google_cloud_cpp_install_headers(google_cloud_cpp_storage_grpc
                                  include/google/cloud/storage)
-
-external_googleapis_install_pc(google_cloud_cpp_storage_protos)
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
     # This is a bit weird, we add an additional link library to


### PR DESCRIPTION
Motivated by #8022 (and would have been wiser to do before sending many of the PRs). Also related to #12428 

Factor out the code to add proto libraries from protolists/protodeps. Use it in our handwritten libraries.

Our REST based libraries could probably use this too, but for now leave them alone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12484)
<!-- Reviewable:end -->
