### PR TITLE
cleanup(common): avoid bigtable in unit tests

### DIFF
--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -212,7 +212,6 @@ function (google_cloud_cpp_grpc_utils_add_test fname labels)
                 google_cloud_cpp_testing
                 google-cloud-cpp::common
                 google-cloud-cpp::iam_protos
-                google-cloud-cpp::bigtable_protos
                 absl::variant
                 GTest::gmock_main
                 GTest::gmock
@@ -296,8 +295,25 @@ if (BUILD_TESTING)
     endforeach ()
 
     foreach (fname ${google_cloud_cpp_grpc_utils_integration_tests})
-        google_cloud_cpp_grpc_utils_add_test("${fname}"
-                                             "integration-test-production")
+        google_cloud_cpp_add_executable(target "common" "${fname}")
+        target_link_libraries(
+            ${target}
+            PRIVATE google-cloud-cpp::grpc_utils
+                    google_cloud_cpp_testing_grpc
+                    google_cloud_cpp_testing
+                    google-cloud-cpp::common
+                    google-cloud-cpp::bigtable_protos
+                    google-cloud-cpp::iam_protos
+                    absl::variant
+                    GTest::gmock_main
+                    GTest::gmock
+                    GTest::gtest
+                    gRPC::grpc++
+                    gRPC::grpc)
+        google_cloud_cpp_add_common_options(${target})
+        add_test(NAME ${target} COMMAND ${target})
+        set_tests_properties(${target} PROPERTIES LABELS
+                                                  "integration-test-production")
     endforeach ()
 
     set(google_cloud_cpp_grpc_utils_benchmarks # cmake-format: sortable

--- a/google/cloud/internal/async_polling_loop_test.cc
+++ b/google/cloud/internal/async_polling_loop_test.cc
@@ -21,7 +21,7 @@
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
+#include <google/protobuf/timestamp.pb.h>
 #include <gmock/gmock.h>
 #include <chrono>
 
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
-using ::google::bigtable::admin::v2::Instance;
 using ::google::cloud::testing_util::AsyncSequencer;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
@@ -43,6 +42,7 @@ using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::Return;
 using TimerType = StatusOr<std::chrono::system_clock::time_point>;
+using Response = google::protobuf::Timestamp;
 
 struct StringOption {
   using Type = std::string;
@@ -85,8 +85,8 @@ AsyncCancelLongRunningOperation MakeCancel(
 }
 
 TEST(AsyncPollingLoopTest, ImmediateSuccess) {
-  Instance expected;
-  expected.set_name("test-instance-name");
+  Response expected;
+  expected.set_seconds(123456);
   google::longrunning::Operation op;
   op.set_name("test-op-name");
   op.set_done(true);
@@ -162,13 +162,13 @@ TEST(AsyncPollingLoopTest, ImmediateCancel) {
 }
 
 TEST(AsyncPollingLoopTest, PollThenSuccess) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)
@@ -230,13 +230,13 @@ TEST(AsyncPollingLoopTest, PollThenTimerError) {
 }
 
 TEST(AsyncPollingLoopTest, PollThenEventualSuccess) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)
@@ -289,13 +289,13 @@ TEST(AsyncPollingLoopTest, PollThenEventualSuccess) {
 }
 
 TEST(AsyncPollingLoopTest, PollThenExhaustedPollingPolicy) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)
@@ -336,13 +336,13 @@ TEST(AsyncPollingLoopTest, PollThenExhaustedPollingPolicy) {
 }
 
 TEST(AsyncPollingLoopTest, PollThenExhaustedPollingPolicyWithFailure) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)
@@ -382,13 +382,13 @@ TEST(AsyncPollingLoopTest, PollThenExhaustedPollingPolicyWithFailure) {
 }
 
 TEST(AsyncPollingLoopTest, PollLifetime) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   AsyncSequencer<TimerType> timer_sequencer;
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();

--- a/google/cloud/internal/async_rest_polling_loop_test.cc
+++ b/google/cloud/internal/async_rest_polling_loop_test.cc
@@ -21,7 +21,8 @@
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
+#include <google/protobuf/duration.pb.h>
+#include <google/protobuf/timestamp.pb.h>
 #include <gmock/gmock.h>
 
 namespace google {
@@ -30,7 +31,6 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::bigtable::admin::v2::Instance;
 using ::google::cloud::testing_util::AsyncSequencer;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
@@ -43,6 +43,8 @@ using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::Return;
 using TimerType = StatusOr<std::chrono::system_clock::time_point>;
+using Response = google::protobuf::Timestamp;
+using Request = google::protobuf::Duration;
 
 struct StringOption {
   using Type = std::string;
@@ -87,8 +89,8 @@ MakeCancel(std::shared_ptr<MockStub> const& mock) {
 }
 
 TEST(AsyncRestPollingLoopTest, ImmediateSuccess) {
-  Instance expected;
-  expected.set_name("test-instance-name");
+  Request expected;
+  expected.set_seconds(123456);
   google::longrunning::Operation op;
   op.set_name("test-op-name");
   op.set_done(true);
@@ -167,13 +169,13 @@ TEST(AsyncRestPollingLoopTest, ImmediateCancel) {
 }
 
 TEST(AsyncRestPollingLoopTest, PollThenSuccess) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)
@@ -236,13 +238,13 @@ TEST(AsyncRestPollingLoopTest, PollThenTimerError) {
 }
 
 TEST(AsyncRestPollingLoopTest, PollThenEventualSuccess) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)
@@ -296,13 +298,13 @@ TEST(AsyncRestPollingLoopTest, PollThenEventualSuccess) {
 }
 
 TEST(AsyncRestPollingLoopTest, PollThenExhaustedPollingPolicy) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)
@@ -343,13 +345,13 @@ TEST(AsyncRestPollingLoopTest, PollThenExhaustedPollingPolicy) {
 }
 
 TEST(AsyncRestPollingLoopTest, PollThenExhaustedPollingPolicyWithFailure) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   EXPECT_CALL(*mock_cq, MakeRelativeTimer)
@@ -389,13 +391,13 @@ TEST(AsyncRestPollingLoopTest, PollThenExhaustedPollingPolicyWithFailure) {
 }
 
 TEST(AsyncRestPollingLoopTest, PollLifetime) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   google::longrunning::Operation starting_op;
   starting_op.set_name("test-op-name");
   google::longrunning::Operation expected = starting_op;
   expected.set_done(true);
-  expected.mutable_metadata()->PackFrom(instance);
+  expected.mutable_metadata()->PackFrom(response);
 
   AsyncSequencer<TimerType> timer_sequencer;
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
@@ -629,8 +631,8 @@ MakeBespokeCancel(std::shared_ptr<MockBespokeOperationStub> const& mock) {
 }
 
 TEST(AsyncRestPollingLoopTest, PollThenSuccessWithBespokeOperationTypes) {
-  Instance instance;
-  instance.set_name("test-instance-name");
+  Response response;
+  response.set_seconds(123456);
   BespokeOperationType starting_op;
   starting_op.set_name("test-op-name");
   starting_op.set_is_done(false);

--- a/google/cloud/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/internal/async_retry_unary_rpc_test.cc
@@ -19,7 +19,8 @@
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include "google/cloud/testing_util/mock_async_response_reader.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
+#include <google/protobuf/duration.pb.h>
+#include <google/protobuf/timestamp.pb.h>
 #include <gmock/gmock.h>
 #include <thread>
 
@@ -29,13 +30,14 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
-namespace btadmin = ::google::bigtable::admin::v2;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::google::cloud::testing_util::MockAsyncResponseReader;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::testing::HasSubstr;
 using ::testing::Return;
+using Request = google::protobuf::Timestamp;
+using Response = google::protobuf::Duration;
 
 /**
  * A class to test the retry loop.
@@ -48,17 +50,15 @@ using ::testing::Return;
 class MockStub {
  public:
   MOCK_METHOD(
-      std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>,
+      std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<Response>>,
       AsyncGetTable,
-      (grpc::ClientContext*, btadmin::GetTableRequest const&,
-       grpc::CompletionQueue* cq));
+      (grpc::ClientContext*, Request const&, grpc::CompletionQueue* cq));
 
   MOCK_METHOD(
       std::unique_ptr<
           grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>,
       AsyncDeleteTable,
-      (grpc::ClientContext*, btadmin::DeleteTableRequest const&,
-       grpc::CompletionQueue* cq));
+      (grpc::ClientContext*, Request const&, grpc::CompletionQueue* cq));
 };
 
 // Each library defines its own retry policy class, typically by defining the
@@ -84,24 +84,23 @@ using RpcExponentialBackoffPolicy =
 TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
   MockStub mock;
 
-  using ReaderType = MockAsyncResponseReader<btadmin::Table>;
+  using ReaderType = MockAsyncResponseReader<Response>;
   auto reader = std::make_unique<ReaderType>();
   EXPECT_CALL(*reader, Finish)
-      .WillOnce([](btadmin::Table* table, grpc::Status* status, void*) {
+      .WillOnce([](Response* response, grpc::Status* status, void*) {
         // Initialize a value to make sure it is carried all the way back to
         // the caller.
-        table->set_name("fake/table/name/response");
+        response->set_seconds(123456);
         *status = grpc::Status::OK;
       });
 
   EXPECT_CALL(mock, AsyncGetTable)
-      .WillOnce([&reader](grpc::ClientContext*,
-                          btadmin::GetTableRequest const& request,
+      .WillOnce([&reader](grpc::ClientContext*, Request const& request,
                           grpc::CompletionQueue*) {
-        EXPECT_EQ("fake/table/name/request", request.name());
+        EXPECT_EQ(request.seconds(), 123456);
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             // This is safe, see comments in MockAsyncResponseReader.
-            btadmin::Table>>(reader.get());
+            Response>>(reader.get());
       });
 
   auto impl = std::make_shared<FakeCompletionQueueImpl>();
@@ -109,15 +108,14 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
 
   // Do some basic initialization of the request to verify the values get
   // carried to the mock.
-  btadmin::GetTableRequest request;
-  request.set_name("fake/table/name/request");
+  Request request;
+  request.set_seconds(123456);
 
   auto fut = StartRetryAsyncUnaryRpc(
       cq, __func__, RpcLimitedErrorCountRetryPolicy(3).clone(),
       RpcExponentialBackoffPolicy(10_us, 40_us, 2.0).clone(),
       Idempotency::kIdempotent,
-      [&mock](grpc::ClientContext* context,
-              btadmin::GetTableRequest const& request,
+      [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
         return mock.AsyncGetTable(context, request, cq);
       },
@@ -130,7 +128,7 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
   ASSERT_EQ(std::future_status::ready, fut.wait_for(0_us));
   auto result = fut.get();
   ASSERT_STATUS_OK(result);
-  EXPECT_EQ("fake/table/name/response", result->name());
+  EXPECT_EQ(result->seconds(), 123456);
 }
 
 TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
@@ -144,10 +142,9 @@ TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
       });
 
   EXPECT_CALL(mock, AsyncDeleteTable)
-      .WillOnce([&reader](grpc::ClientContext*,
-                          btadmin::DeleteTableRequest const& request,
+      .WillOnce([&reader](grpc::ClientContext*, Request const& request,
                           grpc::CompletionQueue*) {
-        EXPECT_EQ("fake/table/name/request", request.name());
+        EXPECT_EQ(request.seconds(), 123456);
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             // This is safe, see comments in MockAsyncResponseReader.
             google::protobuf::Empty>>(reader.get());
@@ -158,15 +155,14 @@ TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
 
   // Do some basic initialization of the request to verify the values get
   // carried to the mock.
-  btadmin::DeleteTableRequest request;
-  request.set_name("fake/table/name/request");
+  Request request;
+  request.set_seconds(123456);
 
   auto fut = StartRetryAsyncUnaryRpc(
       cq, __func__, RpcLimitedErrorCountRetryPolicy(3).clone(),
       RpcExponentialBackoffPolicy(10_us, 40_us, 2.0).clone(),
       Idempotency::kNonIdempotent,
-      [&mock](grpc::ClientContext* context,
-              btadmin::DeleteTableRequest const& request,
+      [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
         return mock.AsyncDeleteTable(context, request, cq);
       },
@@ -184,21 +180,20 @@ TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
 TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
   MockStub mock;
 
-  using ReaderType = MockAsyncResponseReader<btadmin::Table>;
+  using ReaderType = MockAsyncResponseReader<Response>;
   auto reader = std::make_unique<ReaderType>();
   EXPECT_CALL(*reader, Finish)
-      .WillOnce([](btadmin::Table*, grpc::Status* status, void*) {
+      .WillOnce([](Response*, grpc::Status* status, void*) {
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh");
       });
 
   EXPECT_CALL(mock, AsyncGetTable)
-      .WillOnce([&reader](grpc::ClientContext*,
-                          btadmin::GetTableRequest const& request,
+      .WillOnce([&reader](grpc::ClientContext*, Request const& request,
                           grpc::CompletionQueue*) {
-        EXPECT_EQ("fake/table/name/request", request.name());
+        EXPECT_EQ(request.seconds(), 123456);
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             // This is safe, see comments in MockAsyncResponseReader.
-            btadmin::Table>>(reader.get());
+            Response>>(reader.get());
       });
 
   auto impl = std::make_shared<FakeCompletionQueueImpl>();
@@ -206,15 +201,14 @@ TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
 
   // Do some basic initialization of the request to verify the values get
   // carried to the mock.
-  btadmin::GetTableRequest request;
-  request.set_name("fake/table/name/request");
+  Request request;
+  request.set_seconds(123456);
 
   auto fut = StartRetryAsyncUnaryRpc(
       cq, __func__, RpcLimitedErrorCountRetryPolicy(3).clone(),
       RpcExponentialBackoffPolicy(10_us, 40_us, 2.0).clone(),
       Idempotency::kIdempotent,
-      [&mock](grpc::ClientContext* context,
-              btadmin::GetTableRequest const& request,
+      [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
         return mock.AsyncGetTable(context, request, cq);
       },
@@ -235,8 +229,8 @@ TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
 TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
   MockStub mock;
 
-  using ReaderType = MockAsyncResponseReader<btadmin::Table>;
-  auto finish_failure = [](btadmin::Table*, grpc::Status* status, void*) {
+  using ReaderType = MockAsyncResponseReader<Response>;
+  auto finish_failure = [](Response*, grpc::Status* status, void*) {
     *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
 
@@ -248,26 +242,23 @@ TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
   EXPECT_CALL(*r3, Finish).WillOnce(finish_failure);
 
   EXPECT_CALL(mock, AsyncGetTable)
-      .WillOnce([&r1](grpc::ClientContext*,
-                      btadmin::GetTableRequest const& request,
+      .WillOnce([&r1](grpc::ClientContext*, Request const& request,
                       grpc::CompletionQueue*) {
-        EXPECT_EQ("fake/table/name/request", request.name());
+        EXPECT_EQ(request.seconds(), 123456);
         return std::unique_ptr<
-            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(r1.get());
+            grpc::ClientAsyncResponseReaderInterface<Response>>(r1.get());
       })
-      .WillOnce([&r2](grpc::ClientContext*,
-                      btadmin::GetTableRequest const& request,
+      .WillOnce([&r2](grpc::ClientContext*, Request const& request,
                       grpc::CompletionQueue*) {
-        EXPECT_EQ("fake/table/name/request", request.name());
+        EXPECT_EQ(request.seconds(), 123456);
         return std::unique_ptr<
-            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(r2.get());
+            grpc::ClientAsyncResponseReaderInterface<Response>>(r2.get());
       })
-      .WillOnce([&r3](grpc::ClientContext*,
-                      btadmin::GetTableRequest const& request,
+      .WillOnce([&r3](grpc::ClientContext*, Request const& request,
                       grpc::CompletionQueue*) {
-        EXPECT_EQ("fake/table/name/request", request.name());
+        EXPECT_EQ(request.seconds(), 123456);
         return std::unique_ptr<
-            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(r3.get());
+            grpc::ClientAsyncResponseReaderInterface<Response>>(r3.get());
       });
 
   auto impl = std::make_shared<FakeCompletionQueueImpl>();
@@ -275,15 +266,14 @@ TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
 
   // Do some basic initialization of the request to verify the values get
   // carried to the mock.
-  btadmin::GetTableRequest request;
-  request.set_name("fake/table/name/request");
+  Request request;
+  request.set_seconds(123456);
 
   auto fut = StartRetryAsyncUnaryRpc(
       cq, __func__, RpcLimitedErrorCountRetryPolicy(2).clone(),
       RpcExponentialBackoffPolicy(10_us, 40_us, 2.0).clone(),
       Idempotency::kIdempotent,
-      [&mock](grpc::ClientContext* context,
-              btadmin::GetTableRequest const& request,
+      [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
         return mock.AsyncGetTable(context, request, cq);
       },
@@ -324,10 +314,9 @@ TEST(AsyncRetryUnaryRpcTest, TransientOnNonIdempotent) {
       });
 
   EXPECT_CALL(mock, AsyncDeleteTable)
-      .WillOnce([&reader](grpc::ClientContext*,
-                          btadmin::DeleteTableRequest const& request,
+      .WillOnce([&reader](grpc::ClientContext*, Request const& request,
                           grpc::CompletionQueue*) {
-        EXPECT_EQ("fake/table/name/request", request.name());
+        EXPECT_EQ(request.seconds(), 123456);
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             // This is safe, see comments in MockAsyncResponseReader.
             google::protobuf::Empty>>(reader.get());
@@ -338,15 +327,14 @@ TEST(AsyncRetryUnaryRpcTest, TransientOnNonIdempotent) {
 
   // Do some basic initialization of the request to verify the values get
   // carried to the mock.
-  btadmin::DeleteTableRequest request;
-  request.set_name("fake/table/name/request");
+  Request request;
+  request.set_seconds(123456);
 
   auto fut = StartRetryAsyncUnaryRpc(
       cq, __func__, RpcLimitedErrorCountRetryPolicy(3).clone(),
       RpcExponentialBackoffPolicy(10_us, 40_us, 2.0).clone(),
       Idempotency::kNonIdempotent,
-      [&mock](grpc::ClientContext* context,
-              btadmin::DeleteTableRequest const& request,
+      [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
         return mock.AsyncDeleteTable(context, request, cq);
       },
@@ -389,7 +377,7 @@ TEST(AsyncRetryUnaryRpcTest, SetsTimeout) {
   EXPECT_CALL(*mock, IsPermanentFailure).WillRepeatedly(Return(false));
   EXPECT_CALL(*mock, Setup).Times(3);
 
-  using ReaderType = MockAsyncResponseReader<btadmin::Table>;
+  using ReaderType = MockAsyncResponseReader<Response>;
   std::vector<std::unique_ptr<ReaderType>> cleanup_readers;
 
   auto impl = std::make_shared<FakeCompletionQueueImpl>();
@@ -398,9 +386,8 @@ TEST(AsyncRetryUnaryRpcTest, SetsTimeout) {
       cq, __func__, std::move(mock),
       RpcExponentialBackoffPolicy(10_us, 40_us, 2.0).clone(),
       Idempotency::kIdempotent,
-      [&](grpc::ClientContext*, btadmin::GetTableRequest const&,
-          grpc::CompletionQueue*) {
-        auto finish_failure = [](btadmin::Table*, grpc::Status* status, void*) {
+      [&](grpc::ClientContext*, Request const&, grpc::CompletionQueue*) {
+        auto finish_failure = [](Response*, grpc::Status* status, void*) {
           *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
         };
         auto r = std::make_unique<ReaderType>();
@@ -410,9 +397,9 @@ TEST(AsyncRetryUnaryRpcTest, SetsTimeout) {
         auto* tmp = r.get();
         cleanup_readers.push_back(std::move(r));
         return std::unique_ptr<
-            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(tmp);
+            grpc::ClientAsyncResponseReaderInterface<Response>>(tmp);
       },
-      btadmin::GetTableRequest{});
+      Request{});
 
   while (!impl->empty()) impl->SimulateCompletion(true);
 

--- a/google/cloud/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/internal/async_retry_unary_rpc_test.cc
@@ -51,13 +51,13 @@ class MockStub {
  public:
   MOCK_METHOD(
       std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<Response>>,
-      AsyncGetTable,
+      AsyncGetResponse,
       (grpc::ClientContext*, Request const&, grpc::CompletionQueue* cq));
 
   MOCK_METHOD(
       std::unique_ptr<
           grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>,
-      AsyncDeleteTable,
+      AsyncDeleteResponse,
       (grpc::ClientContext*, Request const&, grpc::CompletionQueue* cq));
 };
 
@@ -94,7 +94,7 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
         *status = grpc::Status::OK;
       });
 
-  EXPECT_CALL(mock, AsyncGetTable)
+  EXPECT_CALL(mock, AsyncGetResponse)
       .WillOnce([&reader](grpc::ClientContext*, Request const& request,
                           grpc::CompletionQueue*) {
         EXPECT_EQ(request.seconds(), 123456);
@@ -117,7 +117,7 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
       Idempotency::kIdempotent,
       [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
-        return mock.AsyncGetTable(context, request, cq);
+        return mock.AsyncGetResponse(context, request, cq);
       },
       request);
 
@@ -141,7 +141,7 @@ TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
         *status = grpc::Status::OK;
       });
 
-  EXPECT_CALL(mock, AsyncDeleteTable)
+  EXPECT_CALL(mock, AsyncDeleteResponse)
       .WillOnce([&reader](grpc::ClientContext*, Request const& request,
                           grpc::CompletionQueue*) {
         EXPECT_EQ(request.seconds(), 123456);
@@ -164,7 +164,7 @@ TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
       Idempotency::kNonIdempotent,
       [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
-        return mock.AsyncDeleteTable(context, request, cq);
+        return mock.AsyncDeleteResponse(context, request, cq);
       },
       request);
 
@@ -187,7 +187,7 @@ TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh");
       });
 
-  EXPECT_CALL(mock, AsyncGetTable)
+  EXPECT_CALL(mock, AsyncGetResponse)
       .WillOnce([&reader](grpc::ClientContext*, Request const& request,
                           grpc::CompletionQueue*) {
         EXPECT_EQ(request.seconds(), 123456);
@@ -210,7 +210,7 @@ TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
       Idempotency::kIdempotent,
       [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
-        return mock.AsyncGetTable(context, request, cq);
+        return mock.AsyncGetResponse(context, request, cq);
       },
       request);
 
@@ -241,7 +241,7 @@ TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
   auto r3 = std::make_unique<ReaderType>();
   EXPECT_CALL(*r3, Finish).WillOnce(finish_failure);
 
-  EXPECT_CALL(mock, AsyncGetTable)
+  EXPECT_CALL(mock, AsyncGetResponse)
       .WillOnce([&r1](grpc::ClientContext*, Request const& request,
                       grpc::CompletionQueue*) {
         EXPECT_EQ(request.seconds(), 123456);
@@ -275,7 +275,7 @@ TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
       Idempotency::kIdempotent,
       [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
-        return mock.AsyncGetTable(context, request, cq);
+        return mock.AsyncGetResponse(context, request, cq);
       },
       request);
 
@@ -313,7 +313,7 @@ TEST(AsyncRetryUnaryRpcTest, TransientOnNonIdempotent) {
             grpc::Status(grpc::StatusCode::UNAVAILABLE, "maybe-try-again");
       });
 
-  EXPECT_CALL(mock, AsyncDeleteTable)
+  EXPECT_CALL(mock, AsyncDeleteResponse)
       .WillOnce([&reader](grpc::ClientContext*, Request const& request,
                           grpc::CompletionQueue*) {
         EXPECT_EQ(request.seconds(), 123456);
@@ -336,7 +336,7 @@ TEST(AsyncRetryUnaryRpcTest, TransientOnNonIdempotent) {
       Idempotency::kNonIdempotent,
       [&mock](grpc::ClientContext* context, Request const& request,
               grpc::CompletionQueue* cq) {
-        return mock.AsyncDeleteTable(context, request, cq);
+        return mock.AsyncDeleteResponse(context, request, cq);
       },
       request);
 

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -21,7 +21,6 @@
 #include "google/cloud/options.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <gmock/gmock.h>
 #include <fstream>
 


### PR DESCRIPTION
Part of the work for #12485 

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12488)
<!-- Reviewable:end -->
