### PR TITLE
cleanup: rest internal no bigtable protos dep

### DIFF
--- a/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
@@ -102,7 +102,6 @@ function (google_cloud_cpp_rest_protobuf_internal_add_test fname labels)
                 google_cloud_cpp_testing
                 google-cloud-cpp::common
                 google-cloud-cpp::iam_protos
-                google-cloud-cpp::bigtable_protos
                 absl::variant
                 GTest::gmock_main
                 GTest::gmock


### PR DESCRIPTION
Part of the work for #12485

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12490)
<!-- Reviewable:end -->
