### PR TITLE
ci: plumb through optional LIBRARIES substitution

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -273,6 +273,7 @@ if [[ -n "${CLOUD_FLAG}" ]]; then
   subs+=("_LOGS_BUCKET=${CLOUD_FLAG}_cloudbuild")
   subs+=("BRANCH_NAME=${BRANCH_NAME}")
   subs+=("COMMIT_SHA=${COMMIT_SHA}")
+  subs+=("_LIBRARIES=${LIBRARIES}")
   printf "Substitutions:\n"
   printf "  %s\n" "${subs[@]}"
   args=(

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -29,6 +29,7 @@ options:
     'CONSOLE_LOG_URL=https://console.cloud.google.com/cloud-build/builds;region=us-east1/${BUILD_ID};tab=detail?project=${PROJECT_ID}',
     'RAW_LOG_URL=https://storage.googleapis.com/${_LOGS_BUCKET}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}/log-${BUILD_ID}.txt'
   ]
+  substitutionOption: 'ALLOW_LOOSE'
   volumes:
     - name: 'home'
       path: '/h'


### PR DESCRIPTION
Since adding the LIBRARIES var, manually starting cloudbuilds via build.sh was failing due to this new substitution that was not handled as one of the special case vars defined here: https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_user-defined_substitutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12492)
<!-- Reviewable:end -->
