### PR TITLE
ci: fix LIBRARIES substitution

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -169,6 +169,7 @@ if [[ -n "${TRIGGER_FLAG}" ]]; then
   test -r "${trigger_file}" || die "Cannot open ${trigger_file}"
   : "${BUILD_FLAG:="$(grep _BUILD_NAME "${trigger_file}" | awk '{print $2}')"}"
   : "${DISTRO_FLAG:="$(grep _DISTRO "${trigger_file}" | awk '{print $2}')"}"
+  : "${LIBRARIES:="$(grep _LIBRARIES "${trigger_file}" | awk '{print $2}')"}"
 fi
 
 if [[ -z "${BUILD_FLAG}" ]]; then

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -103,6 +103,7 @@ steps:
   secretEnv: ['CODECOV_TOKEN']
   env: [
     'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}',
+    'LIBRARIES=${_LIBRARIES}',
     'SCCACHE_GCS_BUCKET=${_CACHE_BUCKET}',
     'SCCACHE_GCS_KEY_PREFIX=sccache/${_DISTRO}-${_BUILD_NAME}',
     'SCCACHE_GCS_RW_MODE=READ_WRITE',

--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -60,6 +60,11 @@ function (google_cloud_cpp_doxygen_targets_impl library)
     else ()
         set(DOXYGEN_NUM_PROC_THREADS 1)
     endif ()
+
+    message(
+        "Performing Doxygen processing on library=${library} using DOXYGEN_NUM_PROC_THREADS=${DOXYGEN_NUM_PROC_THREADS}"
+    )
+
     set(DOXYGEN_FILE_PATTERNS "*.dox" "*.h")
     set(DOXYGEN_EXCLUDE_PATTERNS
         # We should skip internal directories to speed up the build. We do not


### PR DESCRIPTION
Correctly plumbs the value of LIBRARIES from the trigger data through to publish-docs.sh.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12499)
<!-- Reviewable:end -->
