### PR TITLE
impl(GCS+gRPC): `InsertObjectRequest` for `AsyncClient`

### DIFF
--- a/google/cloud/storage/async_object_requests.h
+++ b/google/cloud/storage/async_object_requests.h
@@ -62,6 +62,54 @@ class WritePayload {
   absl::Cord impl_;
 };
 
+/**
+ * A request to insert object sans the data payload.
+ *
+ * This class can hold all the mandatory and optional parameters to insert an
+ * object **except** for the data payload. The ideal representation for the data
+ * payload depends on the type of request. For asynchronous requests the data
+ * must be in an owning type, such as `WritePayload`. For blocking request, a
+ * non-owning type (such as `absl::string_view`) can reduce data copying.
+ *
+ * This class is the public API for the library because it is required for
+ * mocking.
+ */
+class InsertObjectRequest {
+ public:
+  InsertObjectRequest() = default;
+  InsertObjectRequest(std::string bucket_name, std::string object_name)
+      : impl_(std::move(bucket_name), std::move(object_name)) {}
+
+  std::string const& bucket_name() const { return impl_.bucket_name(); }
+  std::string const& object_name() const { return impl_.object_name(); }
+
+  template <typename... O>
+  InsertObjectRequest& set_multiple_options(O&&... o) & {
+    impl_.set_multiple_options(std::forward<O>(o)...);
+    return *this;
+  }
+  template <typename... O>
+  InsertObjectRequest&& set_multiple_options(O&&... o) && {
+    return std::move(set_multiple_options(std::forward<O>(o)...));
+  }
+
+  template <typename O>
+  bool HasOption() const {
+    return impl_.HasOption<O>();
+  }
+  template <typename O>
+  O GetOption() const {
+    return impl_.GetOption<O>();
+  }
+
+ protected:
+  struct Impl : public storage::internal::InsertObjectRequestImpl<Impl> {
+    using storage::internal::InsertObjectRequestImpl<
+        Impl>::InsertObjectRequestImpl;
+  };
+  Impl impl_;
+};
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental
 }  // namespace cloud

--- a/google/cloud/storage/internal/grpc/configure_client_context.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context.cc
@@ -43,6 +43,15 @@ void ApplyRoutingHeaders(
                                                      request.bucket_name()));
 }
 
+void ApplyRoutingHeaders(
+    grpc::ClientContext& context,
+    storage_experimental::InsertObjectRequest const& request) {
+  context.AddMetadata(
+      "x-goog-request-params",
+      "bucket=" + google::cloud::internal::UrlEncode("projects/_/buckets/" +
+                                                     request.bucket_name()));
+}
+
 void ApplyRoutingHeaders(grpc::ClientContext& context,
                          storage::internal::UploadChunkRequest const& request) {
   static auto* slash_format =

--- a/google/cloud/storage/internal/grpc/configure_client_context.h
+++ b/google/cloud/storage/internal/grpc/configure_client_context.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CONFIGURE_CLIENT_CONTEXT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CONFIGURE_CLIENT_CONTEXT_H
 
+#include "google/cloud/storage/async_object_requests.h"
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/version.h"
@@ -75,6 +76,11 @@ void ApplyQueryParameters(grpc::ClientContext& ctx, Options const& options,
 void ApplyRoutingHeaders(
     grpc::ClientContext& context,
     storage::internal::InsertObjectMediaRequest const& request);
+
+/// @copydoc ApplyRoutingHeaders(grpc::ClientContext&,)
+void ApplyRoutingHeaders(
+    grpc::ClientContext& context,
+    storage_experimental::InsertObjectRequest const& request);
 
 /**
  * The generated `StorageMetadata` stub can not handle dynamic routing headers

--- a/google/cloud/storage/internal/grpc/configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context_test.cc
@@ -145,6 +145,17 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersInsertObjectMedia) {
                             "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
 }
 
+TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersInsertObject) {
+  storage_experimental::InsertObjectRequest req("test-bucket", "test-object");
+
+  grpc::ClientContext context;
+  ApplyRoutingHeaders(context, req);
+  auto metadata = GetMetadata(context);
+  EXPECT_THAT(metadata,
+              Contains(Pair("x-goog-request-params",
+                            "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
+}
+
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchSlash) {
   storage::internal::UploadChunkRequest req(
       "projects/_/buckets/test-bucket/blah/blah", 0, {},

--- a/google/cloud/storage/internal/grpc/object_request_parser.h
+++ b/google/cloud/storage/internal/grpc/object_request_parser.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_OBJECT_REQUEST_PARSER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_OBJECT_REQUEST_PARSER_H
 
+#include "google/cloud/storage/async_object_requests.h"
 #include "google/cloud/storage/internal/storage_connection.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/grpc_request_metadata.h"
@@ -42,6 +43,8 @@ StatusOr<google::storage::v2::UpdateObjectRequest> ToProto(
 StatusOr<google::storage::v2::UpdateObjectRequest> ToProto(
     storage::internal::UpdateObjectRequest const& request);
 
+StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
+    storage_experimental::InsertObjectRequest const& request);
 StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
     storage::internal::InsertObjectMediaRequest const& request);
 storage::internal::QueryResumableUploadResponse FromProto(

--- a/google/cloud/storage/internal/grpc/object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser_test.cc
@@ -729,6 +729,88 @@ TEST(GrpcObjectRequestParser, InsertObjectMediaRequestWithObjectMetadata) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcObjectRequestParser, InsertObjectRequestSimple) {
+  storage_proto::WriteObjectRequest expected;
+  EXPECT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        write_object_spec: {
+          resource: {
+            bucket: "projects/_/buckets/test-bucket-name"
+            name: "test-object-name"
+          }
+        }
+      )pb",
+      &expected));
+
+  storage_experimental::InsertObjectRequest request("test-bucket-name",
+                                                    "test-object-name");
+  auto actual = ToProto(request).value();
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcObjectRequestParser, InsertObjectRequestAllOptions) {
+  auto constexpr kTextProto = R"pb(
+    write_object_spec {
+      resource: {
+        bucket: "projects/_/buckets/test-bucket-name"
+        name: "test-object-name"
+        content_type: "test-content-type"
+        content_encoding: "test-content-encoding"
+        # Should not be set, the proto file says these values should
+        # not be included in the upload
+        #     crc32c:
+        #     md5_hash:
+        kms_key: "test-kms-key-name"
+      }
+      predefined_acl: "private"
+      if_generation_match: 0
+      if_generation_not_match: 7
+      if_metageneration_match: 42
+      if_metageneration_not_match: 84
+    })pb";
+  storage_proto::WriteObjectRequest expected;
+  EXPECT_TRUE(TextFormat::ParseFromString(kTextProto, &expected));
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
+
+  auto constexpr kContents = "The quick brown fox jumps over the lazy dog";
+
+  storage_experimental::InsertObjectRequest request("test-bucket-name",
+                                                    "test-object-name");
+  request.set_multiple_options(
+      storage::ContentType("test-content-type"),
+      storage::ContentEncoding("test-content-encoding"),
+      storage::Crc32cChecksumValue(storage::ComputeCrc32cChecksum(kContents)),
+      storage::MD5HashValue(storage::ComputeMD5Hash(kContents)),
+      storage::PredefinedAcl("private"), storage::IfGenerationMatch(0),
+      storage::IfGenerationNotMatch(7), storage::IfMetagenerationMatch(42),
+      storage::IfMetagenerationNotMatch(84), storage::Projection::Full(),
+      storage::UserProject("test-user-project"),
+      storage::QuotaUser("test-quota-user"), storage::UserIp("test-user-ip"),
+      storage::EncryptionKey::FromBinaryKey("01234567"),
+      storage::KmsKeyName("test-kms-key-name"));
+
+  auto actual = ToProto(request).value();
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcObjectRequestParser, InsertObjectRequestWithObjectMetadata) {
+  storage_proto::WriteObjectRequest expected;
+  auto& resource = *expected.mutable_write_object_spec()->mutable_resource();
+  resource = ExpectedFullObjectMetadata();
+  resource.set_bucket("projects/_/buckets/test-bucket-name");
+  resource.set_name("test-object-name");
+  resource.set_storage_class("STANDARD");
+
+  storage_experimental::InsertObjectRequest request("test-bucket-name",
+                                                    "test-object-name");
+  request.set_multiple_options(storage::WithObjectMetadata(
+      FullObjectMetadata().set_storage_class("STANDARD")));
+
+  auto actual = ToProto(request).value();
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
 TEST(GrpcObjectRequestParser, WriteObjectResponseSimple) {
   google::storage::v2::WriteObjectResponse input;
   ASSERT_TRUE(TextFormat::ParseFromString(

--- a/google/cloud/storage/internal/hash_function.h
+++ b/google/cloud/storage/internal/hash_function.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HASH_FUNCTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HASH_FUNCTION_H
 
+#include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/internal/hash_values.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status.h"
@@ -31,7 +32,6 @@ namespace internal {
 
 class ReadObjectRangeRequest;
 class ResumableUploadRequest;
-class InsertObjectMediaRequest;
 
 /**
  * Defines the interface to compute hash values during uploads and downloads.
@@ -85,6 +85,12 @@ class HashFunction {
   virtual HashValues Finish() = 0;
 };
 
+/// Create a hash function configured by several options.
+std::unique_ptr<HashFunction> CreateHashFunction(
+    Crc32cChecksumValue const& crc32c_value,
+    DisableCrc32cChecksum const& crc32c_disabled, MD5HashValue const& md5_value,
+    DisableMD5Hash const& md5_disabled);
+
 /// Create a no-op hash function
 std::unique_ptr<HashFunction> CreateNullHashFunction();
 
@@ -95,10 +101,6 @@ std::unique_ptr<HashFunction> CreateHashFunction(
 /// Create a hash function configured by @p request.
 std::unique_ptr<HashFunction> CreateHashFunction(
     ResumableUploadRequest const& request);
-
-/// Create a hash function configured by @p request.
-std::unique_ptr<HashFunction> CreateHashFunction(
-    InsertObjectMediaRequest const& request);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/hash_function_impl_test.cc
+++ b/google/cloud/storage/internal/hash_function_impl_test.cc
@@ -310,10 +310,8 @@ TEST(HashFunctionImplTest, CreateHashFunctionInsertObjectMedia) {
   auto const upload_cases = testing::UploadHashCases();
 
   for (auto const& test : upload_cases) {
-    auto function = CreateHashFunction(
-        InsertObjectMediaRequest("test-bucket", "test-object", kQuickFox)
-            .set_multiple_options(test.crc32_disabled, test.crc32_value,
-                                  test.md5_disabled, test.md5_value));
+    auto function = CreateHashFunction(test.crc32_value, test.crc32_disabled,
+                                       test.md5_value, test.md5_disabled);
     ASSERT_STATUS_OK(function->Update(/*offset=*/0, kQuickFox));
     auto const actual = function->Finish();
     EXPECT_EQ(test.crc32c_expected, actual.crc32c);

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -161,18 +161,21 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r) {
   return os << "}";
 }
 
-InsertObjectMediaRequest::InsertObjectMediaRequest()
-    : hash_function_(CreateHashFunction(*this)) {}
+InsertObjectMediaRequest::InsertObjectMediaRequest() { reset_hash_function(); }
 
 InsertObjectMediaRequest::InsertObjectMediaRequest(std::string bucket_name,
                                                    std::string object_name,
                                                    absl::string_view payload)
-    : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
-      payload_(payload),
-      hash_function_(CreateHashFunction(*this)) {}
+    : InsertObjectRequestImpl<InsertObjectMediaRequest>(std::move(bucket_name),
+                                                        std::move(object_name)),
+      payload_(payload) {
+  reset_hash_function();
+}
 
 void InsertObjectMediaRequest::reset_hash_function() {
-  hash_function_ = CreateHashFunction(*this);
+  hash_function_ = CreateHashFunction(
+      GetOption<Crc32cChecksumValue>(), GetOption<DisableCrc32cChecksum>(),
+      GetOption<MD5HashValue>(), GetOption<DisableMD5Hash>());
 }
 
 void InsertObjectMediaRequest::set_payload(absl::string_view payload) {

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -95,6 +95,17 @@ class GetObjectMetadataRequest
 std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r);
 
 /**
+ * Refactors common attributes for `InsertObject*` requests.
+ */
+template <typename Derived>
+using InsertObjectRequestImpl = GenericObjectRequest<
+    Derived, ContentEncoding, ContentType, Crc32cChecksumValue,
+    DisableCrc32cChecksum, DisableMD5Hash, EncryptionKey, IfGenerationMatch,
+    IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
+    KmsKeyName, MD5HashValue, PredefinedAcl, Projection, UserProject,
+    UploadFromOffset, UploadLimit, WithObjectMetadata>;
+
+/**
  * Represents a request to the `Objects: insert` API with a string for the
  * media.
  *
@@ -103,13 +114,7 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r);
  * objects.
  */
 class InsertObjectMediaRequest
-    : public GenericObjectRequest<
-          InsertObjectMediaRequest, ContentEncoding, ContentType,
-          Crc32cChecksumValue, DisableCrc32cChecksum, DisableMD5Hash,
-          EncryptionKey, IfGenerationMatch, IfGenerationNotMatch,
-          IfMetagenerationMatch, IfMetagenerationNotMatch, KmsKeyName,
-          MD5HashValue, PredefinedAcl, Projection, UserProject,
-          UploadFromOffset, UploadLimit, WithObjectMetadata> {
+    : public InsertObjectRequestImpl<InsertObjectMediaRequest> {
  public:
   InsertObjectMediaRequest();
   InsertObjectMediaRequest(std::string bucket_name, std::string object_name,
@@ -120,7 +125,8 @@ class InsertObjectMediaRequest
 
   template <typename... O>
   InsertObjectMediaRequest& set_multiple_options(O&&... o) {
-    GenericObjectRequest::set_multiple_options(std::forward<O>(o)...);
+    InsertObjectRequestImpl<InsertObjectMediaRequest>::set_multiple_options(
+        std::forward<O>(o)...);
     reset_hash_function();
     return *this;
   }


### PR DESCRIPTION
We need a class to represent requests that insert objects via the `AsyncClient`. We cannot use the class from the synchronous client because that uses non-owning types for the data payload. And we also want the class in the public API (eventually) as it is needed for mocking.

Part of the work for #9131

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12503)
<!-- Reviewable:end -->
