### PR TITLE
cleanup: remove dep on IAM admin in unit tests

### DIFF
--- a/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
@@ -101,7 +101,6 @@ function (google_cloud_cpp_rest_protobuf_internal_add_test fname labels)
                 google_cloud_cpp_testing_grpc
                 google_cloud_cpp_testing
                 google-cloud-cpp::common
-                google-cloud-cpp::iam_protos
                 absl::variant
                 GTest::gmock_main
                 GTest::gmock


### PR DESCRIPTION
Part of the work for #8022 

At some point I had to switch up the request type from a `google::protobuf::Duration`, because that gets printed in JSON as: `{"123.000000456s"}` instead of `{"seconds":123,"nanos":456}`. :unamused:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12513)
<!-- Reviewable:end -->
