### PR TITLE
fix(cmake): client libraries link to shared proto deps

### DIFF
--- a/cmake/GoogleCloudCppLibrary.cmake
+++ b/cmake/GoogleCloudCppLibrary.cmake
@@ -209,6 +209,10 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
     google_cloud_cpp_add_library_protos(${library} ADDITIONAL_PROTO_LISTS
                                         ${_opt_ADDITIONAL_PROTO_LISTS})
 
+    set(shared_proto_dep_targets "${_opt_SHARED_PROTO_DEPS}")
+    list(TRANSFORM shared_proto_dep_targets PREPEND "google-cloud-cpp::")
+    list(TRANSFORM shared_proto_dep_targets APPEND "_protos")
+
     # We used to offer the proto library by another name. Maintain backwards
     # compatibility by providing an interface library with that name. Also make
     # sure we install it as part of google_cloud_cpp_${library}-targets.
@@ -234,7 +238,7 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
     target_link_libraries(
         ${library_target}
         PUBLIC google-cloud-cpp::grpc_utils google-cloud-cpp::common
-               google-cloud-cpp::${library}_protos)
+               google-cloud-cpp::${library}_protos ${shared_proto_dep_targets})
     google_cloud_cpp_add_common_options(${library_target})
     set_target_properties(
         ${library_target}


### PR DESCRIPTION
Part of the work for #8022 

Client libraries link against shared proto libraries they depend on.

* GCB: https://console.cloud.google.com/cloud-build/builds;region=us-east1/286f07b1-a795-431c-a12a-8686219ae2fc;tab=detail?project=cloud-cpp-testing-resources
* Raw: https://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/12506/67da268e17e70c150cf74757df90c6d4f9b7740a/fedora-37-cxx20-cxx20/log-286f07b1-a795-431c-a12a-8686219ae2fc.txt