### PR TITLE
fix(cmake): shared proto deps in pc files

### DIFF
--- a/cmake/GoogleCloudCppLibrary.cmake
+++ b/cmake/GoogleCloudCppLibrary.cmake
@@ -210,7 +210,7 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
                                         ${_opt_ADDITIONAL_PROTO_LISTS})
 
     set(shared_proto_dep_targets "${_opt_SHARED_PROTO_DEPS}")
-    list(TRANSFORM shared_proto_dep_targets PREPEND "google-cloud-cpp::")
+    list(TRANSFORM shared_proto_dep_targets PREPEND "google_cloud_cpp_")
     list(TRANSFORM shared_proto_dep_targets APPEND "_protos")
 
     # We used to offer the proto library by another name. Maintain backwards
@@ -307,9 +307,12 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
                                      "include/google/cloud/${library}")
 
     google_cloud_cpp_add_pkgconfig(
-        ${library} "The ${display_name} C++ Client Library"
+        ${library}
+        "The ${display_name} C++ Client Library"
         "Provides C++ APIs to use the ${display_name}"
-        "google_cloud_cpp_grpc_utils" "${protos_target}")
+        "google_cloud_cpp_grpc_utils"
+        "${protos_target}"
+        ${shared_proto_dep_targets})
 
     # Create and install the CMake configuration files.
     include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Part of the work for #8022, should have been done in #12514. Sorry for the churn.

We also need to add the shared proto deps to the package config file.

CMake readability note: I opted to link the private targets (`google_cloud_cpp_foo`) instead of the public ones (`google-cloud-cpp::foo`) because it saved me a variable and some list transforms. :shrug:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12518)
<!-- Reviewable:end -->
