### PR TITLE
cleanup(cmake): remove pre-3.13 workarounds

### DIFF
--- a/cmake/FindCurlWithTargets.cmake
+++ b/cmake/FindCurlWithTargets.cmake
@@ -31,23 +31,6 @@ else ()
     # CMake config module. We will need to fix up a few things if the module is
     # found this way.
     find_package(CURL REQUIRED)
-    # Before CMake 3.12 the module does not define a target, compare:
-    # https://cmake.org/cmake/help/v3.12/module/FindCURL.html vs
-    # https://cmake.org/cmake/help/v3.11/module/FindCURL.html
-    #
-    # Manually define the target if it does not exist so the rest of the code
-    # does not have to deal with these details:
-    if (NOT TARGET CURL::libcurl)
-        add_library(CURL::libcurl UNKNOWN IMPORTED)
-        set_property(
-            TARGET CURL::libcurl
-            APPEND
-            PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
-        set_property(
-            TARGET CURL::libcurl
-            APPEND
-            PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
-    endif ()
     # If the library is static, we need to explicitly link its dependencies. The
     # CMake module does not do so. However, we should not do so for shared
     # libraries, because the version of OpenSSL (for example) found by

--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -32,12 +32,6 @@ function (google_cloud_cpp_doxygen_targets_impl library)
     if (NOT GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN OR NOT DOXYGEN_FOUND)
         return()
     endif ()
-    if (CMAKE_VERSION VERSION_LESS "3.12")
-        # Old versions of CMake have really poor support for Doxygen generation.
-        message(
-            STATUS "Doxygen generation only enabled for cmake 3.12 and higher")
-        return()
-    endif ()
 
     cmake_parse_arguments(opt "RECURSIVE;THREADED" "" "INPUTS;TAGFILES;DEPENDS"
                           ${ARGN})

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -385,38 +385,36 @@ google_cloud_cpp_set_pkgconfig_paths()
 set(GOOGLE_CLOUD_CPP_PC_NAME "The Google APIS C++ Proto Library")
 set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Platforms.")
-# Note the use of spaces, `string(JOIN)` is not available in cmake-3.5, so we
-# need to add the separator ourselves.
-#
 # This list is for backwards compatibility purposes only. DO NOT add new
 # libraries to it.
-#
 string(
-    CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
-           "google_cloud_cpp_bigtable_protos"
-           " google_cloud_cpp_cloud_bigquery_protos"
-           " google_cloud_cpp_iam_protos"
-           " google_cloud_cpp_pubsub_protos"
-           " google_cloud_cpp_storage_protos"
-           " google_cloud_cpp_logging_protos"
-           " google_cloud_cpp_iam_v1_iam_policy_protos"
-           " google_cloud_cpp_iam_v1_options_protos"
-           " google_cloud_cpp_iam_v1_policy_protos"
-           " google_cloud_cpp_longrunning_operations_protos"
-           " google_cloud_cpp_api_auth_protos"
-           " google_cloud_cpp_api_annotations_protos"
-           " google_cloud_cpp_api_client_protos"
-           " google_cloud_cpp_api_field_behavior_protos"
-           " google_cloud_cpp_api_http_protos"
-           " google_cloud_cpp_rpc_status_protos"
-           " google_cloud_cpp_rpc_error_details_protos"
-           " google_cloud_cpp_type_expr_protos"
-           " grpc++"
-           " grpc"
-           " openssl"
-           " protobuf"
-           " zlib"
-           " libcares")
+    JOIN
+    " "
+    GOOGLE_CLOUD_CPP_PC_REQUIRES
+    "google_cloud_cpp_bigtable_protos"
+    "google_cloud_cpp_cloud_bigquery_protos"
+    "google_cloud_cpp_iam_protos"
+    "google_cloud_cpp_pubsub_protos"
+    "google_cloud_cpp_storage_protos"
+    "google_cloud_cpp_logging_protos"
+    "google_cloud_cpp_iam_v1_iam_policy_protos"
+    "google_cloud_cpp_iam_v1_options_protos"
+    "google_cloud_cpp_iam_v1_policy_protos"
+    "google_cloud_cpp_longrunning_operations_protos"
+    "google_cloud_cpp_api_auth_protos"
+    "google_cloud_cpp_api_annotations_protos"
+    "google_cloud_cpp_api_client_protos"
+    "google_cloud_cpp_api_field_behavior_protos"
+    "google_cloud_cpp_api_http_protos"
+    "google_cloud_cpp_rpc_status_protos"
+    "google_cloud_cpp_rpc_error_details_protos"
+    "google_cloud_cpp_type_expr_protos"
+    "grpc++"
+    "grpc"
+    "openssl"
+    "protobuf"
+    "zlib"
+    "libcares")
 set(GOOGLE_CLOUD_CPP_PC_LIBS "")
 google_cloud_cpp_set_pkgconfig_paths()
 configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"


### PR DESCRIPTION
Part of the work for #11781

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12542)
<!-- Reviewable:end -->
