### PR TITLE
fix(internal): add url encoding for minimal iam creds

### DIFF
--- a/google/cloud/internal/minimal_iam_credentials_stub.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include <google/iam/credentials/v1/iamcredentials.grpc.pb.h>
+#include "google/cloud/internal/url_encode.h"
 
 namespace google {
 namespace cloud {
@@ -91,7 +92,7 @@ class AsyncAccessTokenGeneratorMetadata : public MinimalIamCredentialsStub {
   future<StatusOr<GenerateAccessTokenResponse>> AsyncGenerateAccessToken(
       CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
       GenerateAccessTokenRequest const& request) override {
-    context->AddMetadata("x-goog-request-params", "name=" + request.name());
+    context->AddMetadata("x-goog-request-params", "name=" + internal::UrlEncode(request.name()));
     context->AddMetadata("x-goog-api-client", x_goog_api_client_);
     return child_->AsyncGenerateAccessToken(cq, std::move(context), request);
   }
@@ -99,7 +100,7 @@ class AsyncAccessTokenGeneratorMetadata : public MinimalIamCredentialsStub {
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       grpc::ClientContext& context,
       google::iam::credentials::v1::SignBlobRequest const& request) override {
-    context.AddMetadata("x-goog-request-params", "name=" + request.name());
+    context.AddMetadata("x-goog-request-params", "name=" + internal::UrlEncode(request.name()));
     context.AddMetadata("x-goog-api-client", x_goog_api_client_);
     return child_->SignBlob(context, request);
   }


### PR DESCRIPTION
Part of #12232 

I added no tests since `DISABLED_AsyncGenerateAccessTokenMetadata` should cover the case with the changes to the `ValidateMetadataFixture` in #12544

I tried undisabling the test and it passed using bazel, so I think the issue is something with the Cmake configuration for the iam protos, but nothing stood out to me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12548)
<!-- Reviewable:end -->
