### PR TITLE
fix(internal): add url encoding for minimal iam creds

### DIFF
--- a/google/cloud/internal/minimal_iam_credentials_stub.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
+#include "google/cloud/internal/url_encode.h"
 #include <google/iam/credentials/v1/iamcredentials.grpc.pb.h>
 
 namespace google {
@@ -91,7 +92,8 @@ class AsyncAccessTokenGeneratorMetadata : public MinimalIamCredentialsStub {
   future<StatusOr<GenerateAccessTokenResponse>> AsyncGenerateAccessToken(
       CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
       GenerateAccessTokenRequest const& request) override {
-    context->AddMetadata("x-goog-request-params", "name=" + request.name());
+    context->AddMetadata("x-goog-request-params",
+                         "name=" + internal::UrlEncode(request.name()));
     context->AddMetadata("x-goog-api-client", x_goog_api_client_);
     return child_->AsyncGenerateAccessToken(cq, std::move(context), request);
   }
@@ -99,7 +101,8 @@ class AsyncAccessTokenGeneratorMetadata : public MinimalIamCredentialsStub {
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       grpc::ClientContext& context,
       google::iam::credentials::v1::SignBlobRequest const& request) override {
-    context.AddMetadata("x-goog-request-params", "name=" + request.name());
+    context.AddMetadata("x-goog-request-params",
+                        "name=" + internal::UrlEncode(request.name()));
     context.AddMetadata("x-goog-api-client", x_goog_api_client_);
     return child_->SignBlob(context, request);
   }


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/12232

I added no tests since DISABLED_AsyncGenerateAccessTokenMetadata should cover the case with the changes to the ValidateMetadataFixture in https://github.com/googleapis/google-cloud-cpp/pull/12544

I tried undisabling the test and it passed using bazel, so I think the issue is something with the Cmake configuration for the iam protos, but nothing stood out to me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12558)
<!-- Reviewable:end -->
