### PR TITLE
cleanup(storage): avoid deprecated C++ symbols

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -306,14 +306,6 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
         PROPERTY COMPILE_FLAGS "-Wno-maybe-uninitialized")
 endif ()
 
-if (MSVC)
-    set_property(
-        SOURCE internal/policy_document_request.cc
-        APPEND_STRING
-        PROPERTY COMPILE_FLAGS
-                 "-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING")
-endif ()
-
 set_target_properties(
     google_cloud_cpp_storage
     PROPERTIES EXPORT_NAME "google-cloud-cpp::storage"

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -78,17 +78,18 @@ inline bool IsEncoded(char c, std::int32_t mask) {
   return (static_cast<std::uint8_t>(c) & mask) == ((mask - 1) & mask);
 }
 
+// REQUIRES: pos < s.zie()
+// REQUIRES: n > 0
+// Note that all call sites are in this file, so it is trivial to verify the
+// requirements are satisfied.
 Status ValidateUTF8Encoding(absl::string_view s, std::size_t pos,
                             std::size_t n) {
-  // `pos` is always <= s.size().
   if (s.size() - pos < n) {
     return InvalidArgumentError(
         absl::StrCat("Expected UTF-8 string, found partial UTF-8 encoding at ",
                      pos, " string=<", s, ">"),
         GCP_ERROR_INFO());
   }
-  // Note that this function is always called with `n > 0`. All the call sites
-  // are in this file.
   for (auto i = pos + 1; i != pos + n; ++i) {
     if (IsEncoded(s[i], kMaskTrail)) continue;
     return InvalidArgumentError(

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -83,16 +83,18 @@ Status ValidateUTF8Encoding(absl::string_view s, std::size_t pos,
   // `pos` is always <= s.size().
   if (s.size() - pos < n) {
     return InvalidArgumentError(
-        absl::StrCat("Expected UTF-8 string, found partial UTF8 encoding at ",
+        absl::StrCat("Expected UTF-8 string, found partial UTF-8 encoding at ",
                      pos, " string=<", s, ">"),
         GCP_ERROR_INFO());
   }
-  // Note that `n > 0` because `n > s.size() - pos >= 0`.
+  // Note that this function is always called with `n > 0`. All the call sites
+  // are in this file.
   for (auto i = pos + 1; i != pos + n; ++i) {
     if (IsEncoded(s[i], kMaskTrail)) continue;
     return InvalidArgumentError(
-        absl::StrCat("Expected UTF-8 string, found incorrect UTF8 encoding at ",
-                     pos, " string=<", s, ">"),
+        absl::StrCat(
+            "Expected UTF-8 string, found incorrect UTF-8 encoding at ", pos,
+            " string=<", s, ">"),
         GCP_ERROR_INFO());
   }
   return Status{};
@@ -195,7 +197,7 @@ StatusOr<std::string> EscapeUTF8(absl::string_view s) {
     }
     if (!matched) {
       return InvalidArgumentError(
-          absl::StrCat("Expected UTF-8 string, found non-UTF8 character (",
+          absl::StrCat("Expected UTF-8 string, found non-UTF-8 character (",
                        static_cast<int>(s[pos]), ") at ", pos, " string=<", s,
                        ">"),
           GCP_ERROR_INFO());

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -15,11 +15,13 @@
 #include "google/cloud/storage/internal/policy_document_request.h"
 #include "google/cloud/storage/internal/curl/handle.h"
 #include "google/cloud/storage/internal/openssl_util.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/internal/make_status.h"
+#include "absl/functional/function_ref.h"
+#include "absl/strings/str_format.h"
 #include <nlohmann/json.hpp>
-#include <codecvt>
 #include <iomanip>
-#include <locale>
 #include <sstream>
 
 namespace google {
@@ -28,6 +30,8 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
+
+using ::google::cloud::internal::InvalidArgumentError;
 
 nlohmann::json TransformConditions(
     std::vector<PolicyDocumentCondition> const& conditions) {
@@ -56,94 +60,152 @@ nlohmann::json TransformConditions(
   return res;
 }
 
-/// If c is ASCII escape it and append it to result. Return if it is ASCII.
-bool EscapeAsciiChar(std::string& result, char32_t c) {
-  switch (c) {
-    case '\b':
-      result.append("\\b");
-      return true;
-    case '\f':
-      result.append("\\f");
-      return true;
-    case '\n':
-      result.append("\\n");
-      return true;
-    case '\r':
-      result.append("\\r");
-      return true;
-    case '\t':
-      result.append("\\t");
-      return true;
-    case '\v':
-      result.append("\\v");
-      return true;
+// https://en.wikipedia.org/wiki/UTF-8
+
+// The masks for 1-byte, 2-byte, 3-byte and 4-byte UTF-8 encodings. The bits
+// that are *set* in these masks are used to extract the marker bits, i.e.,
+// those indicating the length of the encoding. Negating the mask let's you
+// extract the value bits.
+auto constexpr kMask1 = 0b1000'0000U;
+auto constexpr kMask2 = 0b1110'0000U;
+auto constexpr kMask3 = 0b1111'0000U;
+auto constexpr kMask4 = 0b1111'1000U;
+
+// The mask for the trailing bytes.
+auto constexpr kMaskTrail = 0b1100'0000U;
+
+Status ValidateUTF8Encoding(absl::string_view s, std::size_t pos,
+                            std::size_t n) {
+  if (s.size() < pos + n) {
+    return InvalidArgumentError(
+        absl::StrCat("Expected UTF-8 string, found partial UTF8 encoding at ",
+                     pos, " string=<", s, ">"),
+        GCP_ERROR_INFO());
   }
-  char32_t constexpr kMaxAsciiChar = 127;
-  if (c > kMaxAsciiChar) {
-    return false;
+  auto sub = s.substr(pos, n);
+  for (std::size_t i = 1; i != n; ++i) {
+    if ((sub[i] & kMaskTrail) == 0b1000'0000) continue;
+    return InvalidArgumentError(
+        absl::StrCat("Expected UTF-8 string, found incorrect UTF8 encoding at ",
+                     pos, " string=<", s, ">"),
+        GCP_ERROR_INFO());
   }
-  result.append(1, static_cast<char>(c));
-  return true;
+  return Status{};
 }
+
+inline std::uint32_t ValueBits(char c, std::uint32_t mask) {
+  return static_cast<std::uint8_t>(c) & ~mask;
+}
+
+inline std::uint32_t Header2(char c) { return ValueBits(c, kMask2); }
+inline std::uint32_t Header3(char c) { return ValueBits(c, kMask3); }
+inline std::uint32_t Header4(char c) { return ValueBits(c, kMask4); }
+inline std::uint32_t Trailer(char c) { return ValueBits(c, kMaskTrail); }
+
+inline std::uint32_t DecodeUTF8(std::uint32_t e3, std::uint32_t e2,
+                                std::uint32_t e1, std::uint32_t e0) {
+  return ((((e3 << 6 | e2) << 6) | e1) << 6) | e0;
+}
+
+StatusOr<std::string> Escape1(absl::string_view s, std::size_t pos) {
+  auto status = ValidateUTF8Encoding(s, pos, 1);
+  if (!status.ok()) return status;
+  // Some characters need to be escaped.
+  switch (s[pos]) {
+    case '\b':
+      return std::string("\\b");
+    case '\f':
+      return std::string("\\f");
+    case '\n':
+      return std::string("\\n");
+    case '\r':
+      return std::string("\\r");
+    case '\t':
+      return std::string("\\t");
+    case '\v':
+      return std::string("\\v");
+  }
+  return std::string(s.substr(pos, 1));
+}
+
+StatusOr<std::string> Escape2(absl::string_view s, std::size_t pos) {
+  auto status = ValidateUTF8Encoding(s, pos, 2);
+  if (!status.ok()) return status;
+  auto const e = s.substr(pos, 2);
+  return absl::StrFormat("\\u%04x",
+                         DecodeUTF8(0, 0, Header2(e[0]), Trailer(e[1])));
+}
+
+StatusOr<std::string> Escape3(absl::string_view s, std::size_t pos) {
+  auto status = ValidateUTF8Encoding(s, pos, 3);
+  if (!status.ok()) return status;
+  auto const e = s.substr(pos, 3);
+  return absl::StrFormat(
+      "\\u%04x", DecodeUTF8(0, Header3(e[0]), Trailer(e[1]), Trailer(e[2])));
+}
+
+StatusOr<std::string> Escape4(absl::string_view s, std::size_t pos) {
+  auto status = ValidateUTF8Encoding(s, pos, 4);
+  if (!status.ok()) return status;
+  auto const e = s.substr(pos, 4);
+  auto codepoint =
+      DecodeUTF8(Header4(e[0]), Trailer(e[1]), Trailer(e[2]), Trailer(e[3]));
+  if (codepoint <= 0xFFFFU) return absl::StrFormat("\\u%04x", codepoint);
+  return absl::StrFormat("\\U%08x", codepoint);
+}
+
+StatusOr<std::string> EscapeUTF8(absl::string_view s) {
+  using Encoder =
+      absl::FunctionRef<StatusOr<std::string>(absl::string_view, std::size_t)>;
+  struct {
+    std::uint32_t mask;
+    std::uint32_t value;
+    Encoder encode;
+  } const encodings[] = {
+      {kMask1, 0b0000'0000U, Escape1},
+      {kMask2, 0b1100'0000U, Escape2},
+      {kMask3, 0b1110'0000U, Escape3},
+      {kMask4, 0b1111'0000U, Escape4},
+  };
+  // Iterate over all the bytes in the input string. Interpreting each UTF-8
+  // sequence as needed.
+  std::string result;
+  std::size_t pos = 0;
+  while (pos != s.size()) {
+    // Test if s[pos] is a 1, 2, 3 or 4 byte UTF-8 codepoint. If it is matched
+    // add the escaped characters to `result`. If it is not matched return an
+    // error.
+    bool matched = false;
+    std::size_t n = 1;
+    for (auto const& e : encodings) {
+      if ((e.mask & s[pos]) == e.value) {
+        // The encoder will return an error if the encoding is too short or
+        // otherwise invalid.
+        auto r = e.encode(s, pos);
+        if (!r) return r;
+        result += *r;
+        matched = true;
+        break;
+      }
+      ++n;
+    }
+    if (!matched) {
+      return InvalidArgumentError(
+          absl::StrCat("Expected UTF-8 string, found non-UTF8 character (",
+                       static_cast<int>(s[pos]), ") at ", pos, " string=<", s,
+                       ">"),
+          GCP_ERROR_INFO());
+    }
+    // Skip all the bytes in the UTF-8 character.
+    pos += n;
+  }
+  return result;
+}
+
 }  // namespace
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-StatusOr<std::string> PostPolicyV4EscapeUTF8(std::string const& utf8_bytes) {
-  std::string result;
-
-#if (_MSC_VER >= 1900) && !defined(_LIBCPP_VERSION)
-  // Working around missing std::codecvt_utf8<char32_t> symbols in MSVC
-  // Microsoft bug number: VSO#143857
-  // Context:
-  // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error?forum=vcgeneral
-  using WideChar = __int32;
-#else   // (_MSC_VER >= 1900)
-  using WideChar = char32_t;
-#endif  // (_MSC_VER >= 1900)
-  std::wstring_convert<std::codecvt_utf8<WideChar>, WideChar> conv;
-  std::basic_string<WideChar> utf32;
-  try {
-    utf32 = conv.from_bytes(utf8_bytes);
-  } catch (std::exception const& ex) {
-    return Status(StatusCode::kInvalidArgument,
-                  std::string("string failed to parse as UTF-8: ") + ex.what());
-  }
-  utf32 = conv.from_bytes(utf8_bytes);
-  for (auto c : utf32) {
-    bool is_ascii = EscapeAsciiChar(result, c);
-    if (!is_ascii) {
-      // All unicode characters should be encoded as \udead.
-      std::ostringstream os;
-      os << "\\u" << std::setw(4) << std::setfill('0') << std::hex
-         << static_cast<std::uint32_t>(c);
-      result.append(os.str());
-    }
-  }
-  return result;
-}
-#else   // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-StatusOr<std::string> PostPolicyV4EscapeUTF8(std::string const&) {
-  return Status(StatusCode::kUnimplemented,
-                "Signing POST policies is unavailable with this compiler due "
-                "to the lack of exception support.");
-}
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-
 StatusOr<std::string> PostPolicyV4Escape(std::string const& utf8_bytes) {
-  std::string result;
-
-  for (char32_t c : utf8_bytes) {
-    bool is_ascii = EscapeAsciiChar(result, c);
-    if (!is_ascii) {
-      // We first try to escape the string assuming it's plain ASCII. If it
-      // turns out that there are non-ASCII characters, we fall back to
-      // interpreting it as proper UTF-8. We do it because it will be faster in
-      // the common case and, more importantly, this allows the common case to
-      // work properly on compilers which don't have UTF8 support.
-      return PostPolicyV4EscapeUTF8(utf8_bytes);
-    }
-  }
-  return result;
+  return EscapeUTF8(utf8_bytes);
 }
 
 std::string PolicyDocumentRequest::StringToSign() const {

--- a/google/cloud/storage/internal/policy_document_request_test.cc
+++ b/google/cloud/storage/internal/policy_document_request_test.cc
@@ -25,6 +25,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+using ::google::cloud::testing_util::IsOkAndHolds;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;
 
@@ -59,29 +60,52 @@ TEST(PolicyDocumentV4Request, SigningAccount) {
 }
 
 TEST(PostPolicyV4EscapeTest, OnlyAscii) {
-  EXPECT_EQ("\\\\b\\f\\n\\r\\t\\vabcd",
-            *PostPolicyV4Escape("\\\b\f\n\r\t\vabcd"));
+  EXPECT_THAT(PostPolicyV4Escape("\\\b\f\n\r\t\vabcd"),
+              IsOkAndHolds("\\\\b\\f\\n\\r\\t\\vabcd"));
 }
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 TEST(PostPolicyV4EscapeTest, InvalidUtf) {
   // In UTF8 a byte larger than 0x7f indicates that there is a byte following
   // it. Here we truncate the string to cause the UTF parser to fail.
   std::string invalid_utf8(1, '\x80');
   EXPECT_THAT(PostPolicyV4Escape(invalid_utf8),
               StatusIs(StatusCode::kInvalidArgument));
+
+  // Missing characters in encoding
+  EXPECT_THAT(PostPolicyV4Escape("\xC2"),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(PostPolicyV4Escape("\xED\x95"),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(PostPolicyV4Escape("\xF0\x90\x8D"),
+              StatusIs(StatusCode::kInvalidArgument));
+
+  // Encoding with invalid characters
+  EXPECT_THAT(PostPolicyV4Escape("\xC2\x20"),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(PostPolicyV4Escape("\xED\x95\x20"),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(PostPolicyV4Escape("\xF0\x90\x8D\x20"),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(PostPolicyV4Escape("\xFF"),
+              StatusIs(StatusCode::kInvalidArgument));
 }
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 TEST(PostPolicyV4EscapeTest, Simple) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_EQ("\127\065abcd$", *PostPolicyV4Escape("\127\065abcd$"));
+  EXPECT_THAT(PostPolicyV4Escape("\127\065abcd$"),
+              IsOkAndHolds("\127\065abcd$"));
   auto constexpr kUtf8Text = u8"\\\b\f\n\r\t\v\u0080\u0119";
   auto input = std::string{kUtf8Text, kUtf8Text + 11};
-  EXPECT_EQ("\\\\b\\f\\n\\r\\t\\v\\u0080\\u0119", *PostPolicyV4Escape(input));
-#else   // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THAT(PostPolicyV4Escape("ąę"), StatusIs(StatusCode::kUnimplemented));
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THAT(PostPolicyV4Escape(input),
+              IsOkAndHolds("\\\\b\\f\\n\\r\\t\\v\\u0080\\u0119"));
+  // Taken from the examples in https://en.wikipedia.org/wiki/UTF-8
+  EXPECT_THAT(PostPolicyV4Escape("\x24"), IsOkAndHolds("$"));
+  EXPECT_THAT(PostPolicyV4Escape("\xC2\xA3"), IsOkAndHolds("\\u00a3"));
+  EXPECT_THAT(PostPolicyV4Escape("\xD0\x98"), IsOkAndHolds("\\u0418"));
+  EXPECT_THAT(PostPolicyV4Escape("\xE0\xA4\xB9"), IsOkAndHolds("\\u0939"));
+  EXPECT_THAT(PostPolicyV4Escape("\xE2\x82\xAC"), IsOkAndHolds("\\u20ac"));
+  EXPECT_THAT(PostPolicyV4Escape("\xED\x95\x9C"), IsOkAndHolds("\\ud55c"));
+  EXPECT_THAT(PostPolicyV4Escape("\xF0\x90\x8D\x88"),
+              IsOkAndHolds("\\U00010348"));
 }
 
 TEST(PolicyDocumentV4Request, Printing) {


### PR DESCRIPTION
Use custom code to "escape" UTF-8 strings into the canonical format expected by the V4 signed URLs.  We were using `std::codecvt_utf8<>` which was deprecated in C++17.

Fixes #12550

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12563)
<!-- Reviewable:end -->
