### PR TITLE
ci: alternative url for `libpfm`

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -39,6 +39,21 @@ def google_cloud_cpp_development_deps(name = None):
             workspace functions.
     """
 
+    # This is needed by com_google_benchmark. We cache it because
+    # sourceforge.net can have outages and that breaks the build.
+    maybe(
+        http_archive,
+        name = "libpfm",
+        build_file = str(Label("//bazel:libpfm.BUILD")),
+        sha256 = "5da5f8872bde14b3634c9688d980f68bda28b510268723cc12973eedbab9fecc",
+        type = "tar.gz",
+        strip_prefix = "libpfm-4.11.0",
+        urls = [
+            "https://storage.googleapis.com/cloud-cpp-community-archive/libpfm/libpfm-4.11.0.tar.gz",
+            "https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.11.0.tar.gz/download",
+        ],
+    )
+
     # This is only needed to run the microbenchmarks.
     maybe(
         http_archive,

--- a/bazel/libpfm.BUILD
+++ b/bazel/libpfm.BUILD
@@ -1,0 +1,33 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
+
+filegroup(
+    name = "pfm_srcs",
+    srcs = glob(["**"]),
+)
+
+make(
+    name = "libpfm",
+    copts = [
+        "-Wno-format-truncation",
+        "-Wno-use-after-free",
+    ],
+    lib_name = "libpfm",
+    lib_source = ":pfm_srcs",
+    visibility = [
+        "//visibility:public",
+    ],
+)


### PR DESCRIPTION
It seems that sourceforge.net is down.  Provide an alternative URL to download `libpfm`, and indirect dependency via google/benchmark.  We do not use this dep, but the download failure breaks our build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12568)
<!-- Reviewable:end -->
