### PR TITLE
chore(deps): tweak definition of libpfm dependency

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -44,14 +44,13 @@ def google_cloud_cpp_development_deps(name = None):
     maybe(
         http_archive,
         name = "libpfm",
-        build_file = str(Label("//bazel:libpfm.BUILD")),
-        sha256 = "5da5f8872bde14b3634c9688d980f68bda28b510268723cc12973eedbab9fecc",
-        type = "tar.gz",
-        strip_prefix = "libpfm-4.11.0",
         urls = [
             "https://storage.googleapis.com/cloud-cpp-community-archive/libpfm/libpfm-4.11.0.tar.gz",
-            "https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.11.0.tar.gz/download",
+            "https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.11.0.tar.gz",
         ],
+        sha256 = "5da5f8872bde14b3634c9688d980f68bda28b510268723cc12973eedbab9fecc",
+        strip_prefix = "libpfm-4.11.0",
+        build_file = Label("//bazel:libpfm.BUILD"),
     )
 
     # This is only needed to run the microbenchmarks.


### PR DESCRIPTION
Followup to #12568.

Remove the `str()` wrapper around `Label()`, which confuses the deps cacher script `bazel/deps-cache.py`.

Also remove the `/download` suffix from the URL, that similarly confused the deps cacher, and which appears to be superfluous.  This also removes the need for the `type` specifier.

Finally, reorder the `maybe()` arguments to match the other invocations. Provide an alternative URL to

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12573)
<!-- Reviewable:end -->
