### PR TITLE
feat(generator): generate shortname from api id

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -262,7 +262,6 @@ void GenerateMetadata(
   } map_vars[] = {
       {"name_pretty", "title"},
       {"api_id", "nameInServiceConfig"},
-      {"api_shortname", "api_short_name"},
       {"product_documentation", "documentation_uri"},
       {"issue_tracker", "issue_tracker"},
   };
@@ -277,6 +276,10 @@ void GenerateMetadata(
     }
     metadata[kv.metadata_name] = l->second;
   }
+  std::vector<std::string> id_components =
+      absl::StrSplit(metadata.value("api_id", ""), absl::MaxSplits('.', 1));
+  if (id_components.empty()) return;
+  metadata["api_shortname"] = std::string(id_components[0]);
 
   std::ofstream(destination + ".repo-metadata.json")
       << metadata.dump(4) << "\n";

--- a/google/cloud/config/v1/.repo-metadata.json
+++ b/google/cloud/config/v1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
     "api_id": "config.googleapis.com",
-    "api_shortname": "infra-manager",
+    "api_shortname": "config",
     "client_documentation": "https://cloud.google.com/cpp/docs/reference/config/latest",
     "distribution_name": "google-cloud-cpp",
     "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:536700%20status=open",


### PR DESCRIPTION
This ignores the `api_short_name` from the service YAML file and always uses the `nameInServiceConfig` aka `api_id` to generate the short name. Evidently the YAML files can have inconsistent names, and the short name and api id are required to match (which seems redundant).

Fixes #12552

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12575)
<!-- Reviewable:end -->
