### PR TITLE
impl: only decorators inject x-goog-api-client

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/dataset_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_metadata.cc
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DatasetMetadata::DatasetMetadata(std::shared_ptr<DatasetRestStub> child)
     : child_(std::move(child)),
       api_client_header_(
-          google::cloud::internal::ApiClientHeader("bigquery_v2_dataset")) {}
+          google::cloud::internal::HandCraftedLibClientHeader()) {}
 
 StatusOr<GetDatasetResponse> DatasetMetadata::GetDataset(
     rest_internal::RestContext& context, GetDatasetRequest const& request) {

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_metadata_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_metadata_test.cc
@@ -69,7 +69,7 @@ TEST(DatasetMetadataTest, GetDataset) {
 
   auto result = metadata->GetDataset(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_dataset");
+  VerifyMetadataContext(context);
 }
 
 TEST(DatasetMetadataTest, ListDatasets) {
@@ -110,7 +110,7 @@ TEST(DatasetMetadataTest, ListDatasets) {
 
   auto result = metadata->ListDatasets(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_dataset");
+  VerifyMetadataContext(context);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata.cc
@@ -31,7 +31,7 @@ BigQueryJobMetadata::BigQueryJobMetadata(
     std::shared_ptr<BigQueryJobRestStub> child)
     : child_(std::move(child)),
       api_client_header_(
-          google::cloud::internal::ApiClientHeader("bigquery_v2_job")) {}
+          google::cloud::internal::HandCraftedLibClientHeader()) {}
 
 StatusOr<GetJobResponse> BigQueryJobMetadata::GetJob(
     rest_internal::RestContext& context, GetJobRequest const& request) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_metadata_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_metadata_test.cc
@@ -79,7 +79,7 @@ TEST(JobMetadataTest, GetJob) {
 
   auto result = metadata->GetJob(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_job");
+  VerifyMetadataContext(context);
 }
 
 TEST(JobMetadataTest, ListJobs) {
@@ -124,7 +124,7 @@ TEST(JobMetadataTest, ListJobs) {
 
   auto result = metadata->ListJobs(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_job");
+  VerifyMetadataContext(context);
 }
 
 TEST(JobMetadataTest, InsertJob) {
@@ -162,7 +162,7 @@ TEST(JobMetadataTest, InsertJob) {
 
   auto result = metadata->InsertJob(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_job");
+  VerifyMetadataContext(context);
 }
 
 TEST(JobMetadataTest, CancelJob) {
@@ -202,7 +202,7 @@ TEST(JobMetadataTest, CancelJob) {
 
   auto result = metadata->CancelJob(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_job");
+  VerifyMetadataContext(context);
 }
 
 TEST(JobMetadataTest, Query) {
@@ -231,7 +231,7 @@ TEST(JobMetadataTest, Query) {
 
   auto result = metadata->Query(context, job_request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_job");
+  VerifyMetadataContext(context);
 }
 
 TEST(JobMetadataTest, GetQueryResults) {
@@ -260,7 +260,7 @@ TEST(JobMetadataTest, GetQueryResults) {
 
   auto result = metadata->GetQueryResults(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_job");
+  VerifyMetadataContext(context);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/project_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_metadata.cc
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ProjectMetadata::ProjectMetadata(std::shared_ptr<ProjectRestStub> child)
     : child_(std::move(child)),
       api_client_header_(
-          google::cloud::internal::ApiClientHeader("bigquery_v2_project")) {}
+          google::cloud::internal::HandCraftedLibClientHeader()) {}
 
 StatusOr<ListProjectsResponse> ProjectMetadata::ListProjects(
     rest_internal::RestContext& context, ListProjectsRequest const& request) {

--- a/google/cloud/bigquery/v2/minimal/internal/project_metadata_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_metadata_test.cc
@@ -61,7 +61,7 @@ TEST(ProjectMetadataTest, ListProjects) {
 
   auto result = metadata->ListProjects(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_project");
+  VerifyMetadataContext(context);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/table_metadata.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_metadata.cc
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TableMetadata::TableMetadata(std::shared_ptr<TableRestStub> child)
     : child_(std::move(child)),
       api_client_header_(
-          google::cloud::internal::ApiClientHeader("bigquery_v2_table")) {}
+          google::cloud::internal::HandCraftedLibClientHeader()) {}
 
 StatusOr<GetTableResponse> TableMetadata::GetTable(
     rest_internal::RestContext& context, GetTableRequest const& request) {

--- a/google/cloud/bigquery/v2/minimal/internal/table_metadata_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_metadata_test.cc
@@ -61,7 +61,7 @@ TEST(TableMetadataTest, GetTable) {
 
   auto result = metadata->GetTable(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_table");
+  VerifyMetadataContext(context);
 }
 
 TEST(TableMetadataTest, ListTables) {
@@ -88,7 +88,7 @@ TEST(TableMetadataTest, ListTables) {
 
   auto result = metadata->ListTables(context, request);
   ASSERT_STATUS_OK(result);
-  VerifyMetadataContext(context, "bigquery_v2_table");
+  VerifyMetadataContext(context);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/testing/metadata_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/metadata_test_utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/testing/metadata_test_utils.h"
+#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/rest_options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
@@ -22,18 +23,15 @@ namespace cloud {
 namespace bigquery_v2_minimal_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::testing::Contains;
 using ::testing::ElementsAre;
-using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 
 static auto const kUserProject = "test-only-project";
 static auto const kQuotaUser = "test-quota-user";
 
-void VerifyMetadataContext(rest_internal::RestContext& context,
-                           std::string const& api_client_header) {
+void VerifyMetadataContext(rest_internal::RestContext& context) {
   EXPECT_THAT(context.GetHeader("x-goog-api-client"),
-              Contains(HasSubstr(api_client_header)));
+              ElementsAre(internal::HandCraftedLibClientHeader()));
   EXPECT_THAT(context.GetHeader("x-goog-request-params"), IsEmpty());
   EXPECT_THAT(context.GetHeader("x-goog-user-project"),
               ElementsAre(kUserProject));

--- a/google/cloud/bigquery/v2/minimal/testing/metadata_test_utils.h
+++ b/google/cloud/bigquery/v2/minimal/testing/metadata_test_utils.h
@@ -24,8 +24,7 @@ namespace bigquery_v2_minimal_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 Options GetMetadataOptions();
-void VerifyMetadataContext(rest_internal::RestContext& context,
-                           std::string const& api_client_header);
+void VerifyMetadataContext(rest_internal::RestContext& context);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_testing

--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
-#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/curl_handle_factory.h"
 #include "google/cloud/internal/curl_impl.h"
 #include "google/cloud/internal/curl_options.h"
@@ -110,8 +109,6 @@ CurlRestClient::CurlRestClient(std::string endpoint_address,
                                Options options)
     : endpoint_address_(std::move(endpoint_address)),
       handle_factory_(std::move(factory)),
-      x_goog_api_client_header_("x-goog-api-client: " +
-                                google::cloud::internal::ApiClientHeader()),
       options_(std::move(options)) {
   if (options_.has<UnifiedCredentialsOption>()) {
     credentials_ = MapCredentials(*options_.get<UnifiedCredentialsOption>());
@@ -130,7 +127,6 @@ StatusOr<std::unique_ptr<CurlImpl>> CurlRestClient::CreateCurlImpl(
     impl->SetHeader(auth_header.value());
   }
   impl->SetHeader(HostHeader(options, endpoint_address_));
-  impl->SetHeader(x_goog_api_client_header_);
   impl->SetHeaders(context, request);
   RestRequest::HttpParameters additional_parameters;
   // The UserIp option has been deprecated in favor of quotaUser. Only add the

--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -76,7 +76,6 @@ class CurlRestClient : public RestClient {
 
   std::string endpoint_address_;
   std::shared_ptr<CurlHandleFactory> handle_factory_;
-  std::string x_goog_api_client_header_;
   std::shared_ptr<oauth2_internal::Credentials> credentials_;
   Options options_;
 };

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -91,9 +91,7 @@ class RestClientIntegrationTest : public ::testing::Test {
 
     EXPECT_THAT(headers,
                 Contains(std::make_pair("content-type", "application/json")));
-    std::unique_ptr<HttpPayload> payload =
-        std::move(*response).ExtractPayload();
-    auto body = ReadAll(std::move(payload));
+    auto body = ReadAll(std::move(*response).ExtractPayload());
     EXPECT_STATUS_OK(body);
     auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
     EXPECT_FALSE(parsed_response.is_discarded());
@@ -160,8 +158,7 @@ TEST_F(RestClientIntegrationTest, Get) {
   auto response = std::move(response_status.value());
   EXPECT_THAT(response->StatusCode(), Eq(HttpStatusCode::kOk));
   EXPECT_GT(response->Headers().size(), 0);
-  std::unique_ptr<HttpPayload> payload = std::move(*response).ExtractPayload();
-  auto body = ReadAll(std::move(payload));
+  auto body = ReadAll(std::move(*response).ExtractPayload());
   EXPECT_STATUS_OK(body);
   EXPECT_GT(body->size(), 0);
 }
@@ -181,8 +178,7 @@ TEST_F(RestClientIntegrationTest, Delete) {
   auto response = std::move(response_status.value());
   EXPECT_THAT(response->StatusCode(), Eq(HttpStatusCode::kOk));
   EXPECT_GT(response->Headers().size(), 0);
-  std::unique_ptr<HttpPayload> payload = std::move(*response).ExtractPayload();
-  auto body = ReadAll(std::move(payload));
+  auto body = ReadAll(std::move(*response).ExtractPayload());
   EXPECT_STATUS_OK(body);
   EXPECT_GT(body->size(), 0);
   auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
@@ -211,8 +207,7 @@ TEST_F(RestClientIntegrationTest, PatchJsonContentType) {
   });
   ASSERT_STATUS_OK(response_status);
   auto response = std::move(response_status.value());
-  std::unique_ptr<HttpPayload> payload = std::move(*response).ExtractPayload();
-  auto body = ReadAll(std::move(payload));
+  auto body = ReadAll(std::move(*response).ExtractPayload());
   EXPECT_STATUS_OK(body);
   EXPECT_GT(body->size(), 0);
   auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
@@ -253,8 +248,7 @@ TEST_F(RestClientIntegrationTest, AnythingPostNoContentType) {
 
   EXPECT_THAT(headers, testing::Contains(
                            std::make_pair("content-type", "application/json")));
-  std::unique_ptr<HttpPayload> payload = std::move(*response).ExtractPayload();
-  auto body = ReadAll(std::move(payload));
+  auto body = ReadAll(std::move(*response).ExtractPayload());
   EXPECT_STATUS_OK(body);
   auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
   EXPECT_FALSE(parsed_response.is_discarded());
@@ -333,8 +327,7 @@ TEST_F(RestClientIntegrationTest, AnythingGetVerifyHeadersAsIfDecorated) {
     return client->Get(context, request);
   });
   ASSERT_STATUS_OK(response);
-  std::unique_ptr<HttpPayload> payload = std::move(**response).ExtractPayload();
-  auto body = ReadAll(std::move(payload));
+  auto body = ReadAll(std::move(**response).ExtractPayload());
   EXPECT_STATUS_OK(body);
   auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
   ASSERT_TRUE(parsed_response.is_object());
@@ -493,8 +486,7 @@ TEST_F(RestClientIntegrationTest, PostFormData) {
   ASSERT_TRUE(content_length != headers.end());
   EXPECT_GT(std::stoi(content_length->second), 0);
 
-  std::unique_ptr<HttpPayload> payload = std::move(*response).ExtractPayload();
-  auto body = ReadAll(std::move(payload));
+  auto body = ReadAll(std::move(*response).ExtractPayload());
   EXPECT_STATUS_OK(body);
   auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
   EXPECT_FALSE(parsed_response.is_discarded());

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -103,7 +103,6 @@ class RestClientIntegrationTest : public ::testing::Test {
     ASSERT_FALSE(http_method == parsed_response.end());
     EXPECT_THAT(http_method.value(), Eq(method));
 
-    auto sent_headers = ExtractHeaders(parsed_response);
     EXPECT_THAT(
         parsed_response,
         ResultOf(ExtractHeaders,
@@ -305,8 +304,7 @@ TEST_F(RestClientIntegrationTest, AnythingGetVerifyHeaders) {
     return client->Get(context, request);
   });
   ASSERT_STATUS_OK(response);
-  std::unique_ptr<HttpPayload> payload = std::move(**response).ExtractPayload();
-  auto body = ReadAll(std::move(payload));
+  auto body = ReadAll(std::move(**response).ExtractPayload());
   EXPECT_STATUS_OK(body);
   auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
   ASSERT_TRUE(parsed_response.is_object());

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/common_options.h"
 #include "google/cloud/credentials.h"
+#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/rest_client.h"
@@ -32,12 +33,26 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::Contains;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::Pair;
+using ::testing::ResultOf;
 using ::testing::StartsWith;
+
+std::map<std::string, std::string> ExtractHeaders(
+    nlohmann::json const& parsed_response) {
+  auto sent_headers = parsed_response.find("headers");
+  if (sent_headers == parsed_response.end()) return {};
+  std::map<std::string, std::string> result;
+  for (auto const& kv : sent_headers->items()) {
+    if (!kv.value().is_string()) return {};
+    result[kv.key()] = kv.value().get<std::string>();
+  }
+  return result;
+}
 
 class RestClientIntegrationTest : public ::testing::Test {
  protected:
@@ -88,25 +103,24 @@ class RestClientIntegrationTest : public ::testing::Test {
     ASSERT_FALSE(http_method == parsed_response.end());
     EXPECT_THAT(http_method.value(), Eq(method));
 
-    auto sent_headers = parsed_response.find("headers");
-    ASSERT_FALSE(sent_headers == parsed_response.end());
-    auto content_type = sent_headers->find("Content-Type");
-    ASSERT_FALSE(content_type == sent_headers->end());
-    EXPECT_THAT(content_type.value(), Eq("application/json"));
-    auto x_goog_api_client = sent_headers->find("X-Goog-Api-Client");
-    ASSERT_FALSE(x_goog_api_client == sent_headers->end());
-    EXPECT_THAT(x_goog_api_client.value(), HasSubstr("gl-cpp/"));
-    EXPECT_THAT(x_goog_api_client.value(), HasSubstr("gccl/"));
-    auto user_agent = sent_headers->find("User-Agent");
-    ASSERT_FALSE(user_agent == sent_headers->end());
-    EXPECT_THAT(user_agent.value(), HasSubstr("gcloud-cpp/"));
+    auto sent_headers = ExtractHeaders(parsed_response);
+    EXPECT_THAT(
+        parsed_response,
+        ResultOf(ExtractHeaders,
+                 AllOf(Contains(Pair("Content-Type", "application/json")),
+                       Contains(Pair("User-Agent", HasSubstr("gcloud-cpp/"))),
+                       // The metadata decorator adds this header, the
+                       // `CurlRestClient` should not duplicate it.
+                       Not(Contains(Pair("X-Goog-Api-Client", _))))));
+
     // TODO(#8396): httbin.org doesn't send back our content-length header on
     //  PUT methods.
     if (method == "POST" && request_content_length) {
-      auto sent_content_length = sent_headers->find("Content-Length");
-      ASSERT_FALSE(sent_content_length == sent_headers->end());
-      EXPECT_THAT(std::string(sent_content_length.value()),
-                  Eq(std::to_string(*request_content_length)));
+      EXPECT_THAT(
+          parsed_response,
+          ResultOf(ExtractHeaders,
+                   Contains(Pair("Content-Length",
+                                 std::to_string(*request_content_length)))));
     }
 
     auto response_json = parsed_response.find("json");
@@ -278,6 +292,67 @@ TEST_F(RestClientIntegrationTest, AnythingPostJsonContentType) {
   });
   VerifyJsonPayloadResponse("POST", json_payload_, std::move(response_status),
                             json_payload_.size());
+}
+
+TEST_F(RestClientIntegrationTest, AnythingGetVerifyHeaders) {
+  options_.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
+  auto client = MakeDefaultRestClient(url_, options_);
+  RestRequest request;
+  request.SetPath("anything");
+
+  auto response = RetryRestRequest([&] {
+    rest_internal::RestContext context;
+    return client->Get(context, request);
+  });
+  ASSERT_STATUS_OK(response);
+  std::unique_ptr<HttpPayload> payload = std::move(**response).ExtractPayload();
+  auto body = ReadAll(std::move(payload));
+  EXPECT_STATUS_OK(body);
+  auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
+  ASSERT_TRUE(parsed_response.is_object());
+
+  auto http_method = parsed_response.find("method");
+  ASSERT_FALSE(http_method == parsed_response.end());
+  EXPECT_THAT(http_method.value(), Eq("GET"));
+
+  EXPECT_THAT(
+      parsed_response,
+      ResultOf("sent headers are", ExtractHeaders,
+               AllOf(Contains(Pair("User-Agent", HasSubstr("gcloud-cpp"))),
+                     Not(Contains(Pair("X-Goog-Api-Client", _))))));
+}
+
+TEST_F(RestClientIntegrationTest, AnythingGetVerifyHeadersAsIfDecorated) {
+  options_.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
+  auto client = MakeDefaultRestClient(url_, options_);
+  RestRequest request;
+  request.SetPath("anything");
+
+  auto response = RetryRestRequest([&] {
+    rest_internal::RestContext context;
+    context.AddHeader("x-goog-api-client",
+                      internal::GeneratedLibClientHeader());
+    return client->Get(context, request);
+  });
+  ASSERT_STATUS_OK(response);
+  std::unique_ptr<HttpPayload> payload = std::move(**response).ExtractPayload();
+  auto body = ReadAll(std::move(payload));
+  EXPECT_STATUS_OK(body);
+  auto parsed_response = nlohmann::json::parse(*body, nullptr, false);
+  ASSERT_TRUE(parsed_response.is_object());
+
+  auto http_method = parsed_response.find("method");
+  ASSERT_FALSE(http_method == parsed_response.end());
+  EXPECT_THAT(http_method.value(), Eq("GET"));
+
+  EXPECT_THAT(
+      parsed_response,
+      ResultOf(
+          "sent headers are", ExtractHeaders,
+          AllOf(Contains(Pair("User-Agent", HasSubstr("gcloud-cpp"))),
+                Contains(Pair("X-Goog-Api-Client",
+                              AllOf(HasSubstr("gl-cpp/"), HasSubstr("gapic/"),
+                                    Not(HasSubstr("gccl/"))))))));
 }
 
 TEST_F(RestClientIntegrationTest, AnythingPutJsonContentTypeSingleSpan) {

--- a/google/cloud/storage/internal/rest/request_builder.cc
+++ b/google/cloud/storage/internal/rest/request_builder.cc
@@ -22,7 +22,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 RestRequestBuilder::RestRequestBuilder(std::string path)
-    : request_(google::cloud::rest_internal::RestRequest(std::move(path))) {}
+    : request_(google::cloud::rest_internal::RestRequest(std::move(path))
+                   .AddHeader("x-goog-api-client", x_goog_api_client())) {}
 
 RestRequestBuilder& RestRequestBuilder::AddOption(CustomHeader const& p) {
   if (p.has_value()) {

--- a/google/cloud/storage/internal/rest/request_builder_test.cc
+++ b/google/cloud/storage/internal/rest/request_builder_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/internal/api_client_header.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -25,8 +26,11 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+using google::cloud::internal::HandCraftedLibClientHeader;
 using google::cloud::rest_internal::RestRequest;
+using ::testing::ElementsAre;
 using ::testing::Eq;
+using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
 TEST(RestRequestBuilderTest, WellKnownParameterRequest) {
@@ -47,16 +51,11 @@ TEST(RestRequestBuilderTest, WellKnownParameterRequest) {
 
   RestRequest rest_request = std::move(builder).BuildRequest();
 
-  EXPECT_THAT(
-      rest_request.parameters(),
-      UnorderedElementsAre(
-          Eq(std::pair<std::string, std::string>("projection",
-                                                 "my_projection")),
-          Eq(std::pair<std::string, std::string>("foo", "bar")),
-          Eq(std::pair<std::string, std::string>("userProject", "my_project")),
-          Eq(std::pair<std::string, std::string>("maxResults", "42")),
-          Eq(std::pair<std::string, std::string>("prefix", "my_prefix")),
-          Eq(std::pair<std::string, std::string>("deleted", "true"))));
+  EXPECT_THAT(rest_request.parameters(),
+              UnorderedElementsAre(
+                  Pair("projection", "my_projection"), Pair("foo", "bar"),
+                  Pair("userProject", "my_project"), Pair("maxResults", "42"),
+                  Pair("prefix", "my_prefix"), Pair("deleted", "true")));
 }
 
 TEST(RestRequestBuilderTest, WellKnownHeaderRequest) {
@@ -75,14 +74,13 @@ TEST(RestRequestBuilderTest, WellKnownHeaderRequest) {
 
   RestRequest rest_request = std::move(builder).BuildRequest();
 
-  EXPECT_THAT(rest_request.headers(),
-              UnorderedElementsAre(
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "foo", {"bar", "baz"})),
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "content-type", {"application/json"})),
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "if-match", {"my_etag"}))));
+  EXPECT_THAT(
+      rest_request.headers(),
+      UnorderedElementsAre(
+          Pair("x-goog-api-client", ElementsAre(HandCraftedLibClientHeader())),
+          Pair("foo", ElementsAre("bar", "baz")),
+          Pair("content-type", ElementsAre("application/json")),
+          Pair("if-match", ElementsAre("my_etag"))));
 }
 
 TEST(RestRequestBuilderTest, CustomHeaderRequest) {
@@ -98,12 +96,12 @@ TEST(RestRequestBuilderTest, CustomHeaderRequest) {
 
   RestRequest rest_request = std::move(builder).BuildRequest();
 
-  EXPECT_THAT(rest_request.headers(),
-              UnorderedElementsAre(
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "my_header_key", {"my_header_value"})),
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "foo", {"bar"}))));
+  EXPECT_THAT(
+      rest_request.headers(),
+      UnorderedElementsAre(
+          Pair("x-goog-api-client", ElementsAre(HandCraftedLibClientHeader())),
+          Pair("my_header_key", ElementsAre("my_header_value")),
+          Pair("foo", ElementsAre("bar"))));
 }
 
 TEST(RestRequestBuilderTest, EncryptionKeyHeaderRequest) {
@@ -123,16 +121,14 @@ TEST(RestRequestBuilderTest, EncryptionKeyHeaderRequest) {
 
   RestRequest rest_request = std::move(builder).BuildRequest();
 
-  EXPECT_THAT(rest_request.headers(),
-              UnorderedElementsAre(
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "x-goog-encryption-key-sha256", {"my_sha256"})),
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "x-goog-encryption-key", {"my_key"})),
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "x-goog-encryption-algorithm", {"my_algorithm"})),
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "foo", {"bar"}))));
+  EXPECT_THAT(
+      rest_request.headers(),
+      UnorderedElementsAre(
+          Pair("x-goog-api-client", ElementsAre(HandCraftedLibClientHeader())),
+          Pair("x-goog-encryption-key-sha256", ElementsAre("my_sha256")),
+          Pair("x-goog-encryption-key", ElementsAre("my_key")),
+          Pair("x-goog-encryption-algorithm", ElementsAre("my_algorithm")),
+          Pair("foo", ElementsAre("bar"))));
 }
 
 TEST(RestRequestBuilderTest, SourceEncryptionKeyHeaderRequest) {
@@ -157,14 +153,13 @@ TEST(RestRequestBuilderTest, SourceEncryptionKeyHeaderRequest) {
   EXPECT_THAT(
       rest_request.headers(),
       UnorderedElementsAre(
-          Eq(std::pair<std::string const, std::vector<std::string>>(
-              "x-goog-copy-source-encryption-key-sha256", {"my_sha256"})),
-          Eq(std::pair<std::string const, std::vector<std::string>>(
-              "x-goog-copy-source-encryption-key", {"my_key"})),
-          Eq(std::pair<std::string const, std::vector<std::string>>(
-              "x-goog-copy-source-encryption-algorithm", {"my_algorithm"})),
-          Eq(std::pair<std::string const, std::vector<std::string>>("foo",
-                                                                    {"bar"}))));
+          Pair("x-goog-api-client", ElementsAre(HandCraftedLibClientHeader())),
+          Pair("x-goog-copy-source-encryption-key-sha256",
+               ElementsAre("my_sha256")),
+          Pair("x-goog-copy-source-encryption-key", ElementsAre("my_key")),
+          Pair("x-goog-copy-source-encryption-algorithm",
+               ElementsAre("my_algorithm")),
+          Pair("foo", ElementsAre("bar"))));
 }
 
 TEST(RestRequestBuilderTest, ComplexOptionRequest) {
@@ -190,10 +185,11 @@ TEST(RestRequestBuilderTest, ComplexOptionRequest) {
   RestRequest rest_request = std::move(builder).BuildRequest();
 
   EXPECT_THAT(rest_request.path(), Eq("service/path"));
-  EXPECT_THAT(rest_request.headers(),
-              UnorderedElementsAre(
-                  Eq(std::pair<std::string const, std::vector<std::string>>(
-                      "foo", {"bar"}))));
+  EXPECT_THAT(
+      rest_request.headers(),
+      UnorderedElementsAre(
+          Pair("x-goog-api-client", ElementsAre(HandCraftedLibClientHeader())),
+          Pair("foo", ElementsAre("bar"))));
 }
 
 }  // namespace


### PR DESCRIPTION
For automatically generated REST-based clients we were injecting the `x-goog-api-client` header twice: once in the generated `*RestMetadataDecorator` class and once more in the `rest_internal::CurlRestClient` class.

With this change the hand-crafted libraries inject the header explicitly, and use the new `HandCraftedLibClientHeader()` to do so. Meanwhile, the generated libraries inject the header only in the decorator.

Part of the work for #12562

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12578)
<!-- Reviewable:end -->
