### PR TITLE
impl(bigtable): identify generated libraries

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/base64_transforms.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
@@ -92,8 +93,10 @@ std::shared_ptr<BigtableStub> CreateDecoratedStubs(
     stub = std::make_shared<BigtableAuth>(std::move(auth), std::move(stub));
   }
   stub = std::make_shared<BigtableMetadata>(
-      std::move(stub), std::multimap<std::string, std::string>{
-                           {"bigtable-features", FeaturesMetadata()}});
+      std::move(stub),
+      std::multimap<std::string, std::string>{
+          {"bigtable-features", FeaturesMetadata()}},
+      google::cloud::internal::HandCraftedLibClientHeader());
   if (google::cloud::internal::Contains(options.get<TracingComponentsOption>(),
                                         "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -67,7 +67,7 @@ class BigtableStubFactory : public ::testing::Test {
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request,
-        google::cloud::internal::ApiClientHeader("generator"));
+        google::cloud::internal::HandCraftedLibClientHeader());
   }
 
  private:

--- a/google/cloud/bigtable/internal/legacy_async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/legacy_async_row_reader_test.cc
@@ -74,7 +74,7 @@ class TableAsyncReadRowsTest : public bigtable::testing::TableTestFixture {
                       grpc::CompletionQueue*) {
           validate_metadata_fixture_.IsContextMDValid(
               *context, "google.bigtable.v2.Bigtable.ReadRows", r,
-              google::cloud::internal::ApiClientHeader());
+              google::cloud::internal::HandCraftedLibClientHeader());
           (*request_expectations_ptr)(r);
           return std::unique_ptr<
               MockClientAsyncReaderInterface<btproto::ReadRowsResponse>>(

--- a/google/cloud/bigtable/internal/legacy_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/legacy_row_reader_test.cc
@@ -191,9 +191,9 @@ TEST_F(LegacyRowReaderTest, ReadOneRowAppProfileId) {
   EXPECT_CALL(*client_, ReadRows)
       .WillOnce([](grpc::ClientContext* context, ReadRowsRequest const& req) {
         ValidateMetadataFixture fixture;
-        fixture.IsContextMDValid(*context,
-                                 "google.bigtable.v2.Bigtable.ReadRows", req,
-                                 google::cloud::internal::ApiClientHeader());
+        fixture.IsContextMDValid(
+            *context, "google.bigtable.v2.Bigtable.ReadRows", req,
+            google::cloud::internal::HandCraftedLibClientHeader());
         EXPECT_EQ("test-app-profile-id", req.app_profile_id());
         auto stream = std::make_unique<MockReadRowsReader>(
             "google.bigtable.v2.Bigtable.ReadRows");

--- a/google/cloud/bigtable/metadata_update_policy.cc
+++ b/google/cloud/bigtable/metadata_update_policy.cc
@@ -42,7 +42,7 @@ MetadataUpdatePolicy::MetadataUpdatePolicy(
     std::string const& resource_name,
     MetadataParamTypes const& metadata_param_type)
     : value_(metadata_param_type.type() + '=' + resource_name),
-      api_client_header_(internal::ApiClientHeader()) {}
+      api_client_header_(internal::HandCraftedLibClientHeader()) {}
 
 void MetadataUpdatePolicy::Setup(grpc::ClientContext& context) const {
   context.AddMetadata(std::string("x-goog-request-params"), value());

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -37,7 +37,8 @@ class TableApplyTest : public bigtable::testing::TableTestFixture {
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, request, google::cloud::internal::ApiClientHeader());
+        context, method, request,
+        google::cloud::internal::HandCraftedLibClientHeader());
   }
 
   std::function<grpc::Status(grpc::ClientContext* context,

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -35,7 +35,8 @@ class TableCheckAndMutateRowTest : public bigtable::testing::TableTestFixture {
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, request, google::cloud::internal::ApiClientHeader());
+        context, method, request,
+        google::cloud::internal::HandCraftedLibClientHeader());
   }
 
   std::function<

--- a/google/cloud/bigtable/table_readmodifywriterow_test.cc
+++ b/google/cloud/bigtable/table_readmodifywriterow_test.cc
@@ -47,7 +47,7 @@ class TableReadModifyWriteTest : public bigtable::testing::TableTestFixture {
                btproto::ReadModifyWriteRowResponse* response) {
       validate_metadata_fixture_.IsContextMDValid(
           *context, "google.bigtable.v2.Bigtable.ReadModifyWriteRow", request,
-          google::cloud::internal::ApiClientHeader());
+          google::cloud::internal::HandCraftedLibClientHeader());
       btproto::ReadModifyWriteRowRequest expected_request;
       EXPECT_TRUE(::google::protobuf::TextFormat::ParseFromString(
           expected_request_string, &expected_request));
@@ -277,7 +277,7 @@ TEST_F(TableReadModifyWriteTest, UnrecoverableFailureTest) {
             ::google::cloud::testing_util::ValidateMetadataFixture fixture;
             fixture.IsContextMDValid(
                 *context, "google.bigtable.v2.Bigtable.ReadModifyWriteRow",
-                request, google::cloud::internal::ApiClientHeader());
+                request, google::cloud::internal::HandCraftedLibClientHeader());
             return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh");
           });
 

--- a/google/cloud/bigtable/table_readrow_test.cc
+++ b/google/cloud/bigtable/table_readrow_test.cc
@@ -35,7 +35,8 @@ class TableReadRowTest : public bigtable::testing::TableTestFixture {
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, request, google::cloud::internal::ApiClientHeader());
+        context, method, request,
+        google::cloud::internal::HandCraftedLibClientHeader());
   }
 
  private:

--- a/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
+++ b/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
@@ -59,7 +59,7 @@ struct MockAsyncFailingRpcFactory {
                                             grpc::CompletionQueue*) {
       validate_metadata_fixture_.IsContextMDValid(
           *context, method, request,
-          google::cloud::internal::ApiClientHeader());
+          google::cloud::internal::HandCraftedLibClientHeader());
       RequestType expected;
       // Cannot use ASSERT_TRUE() here, it has an embedded "return;"
       EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -66,7 +66,7 @@ class MockResponseReader : public grpc::ClientReaderInterface<Response> {
     return [this](grpc::ClientContext* context, Request const& request) {
       validate_metadata_fixture_.IsContextMDValid(
           *context, method_, request,
-          google::cloud::internal::ApiClientHeader());
+          google::cloud::internal::HandCraftedLibClientHeader());
       return UniquePtr(this);
     };
   }


### PR DESCRIPTION
Use a different x-goog-api-client header for the RPCs using fully generated code vs. the RPCs using at least some hand-crafted code.

Part of the work for #12562

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12579)
<!-- Reviewable:end -->
