### PR TITLE
impl(pubsub): identify generated libraries

### DIFF
--- a/google/cloud/pubsub/blocking_publisher_connection_test.cc
+++ b/google/cloud/pubsub/blocking_publisher_connection_test.cc
@@ -76,7 +76,7 @@ TEST(BlockingPublisherConnectionTest, Metadata) {
         google::cloud::testing_util::ValidateMetadataFixture fixture;
         fixture.IsContextMDValid(
             context, "google.pubsub.v1.Publisher.Publish", request,
-            google::cloud::internal::ApiClientHeader("generator"));
+            google::cloud::internal::HandCraftedLibClientHeader());
         google::pubsub::v1::PublishResponse response;
         for (auto const& m : request.messages()) {
           response.add_message_ids("ack-" + m.message_id());

--- a/google/cloud/pubsub/internal/publisher_stub_factory.cc
+++ b/google/cloud/pubsub/internal/publisher_stub_factory.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/internal/publisher_logging_decorator.h"
 #include "google/cloud/pubsub/internal/publisher_metadata_decorator.h"
 #include "google/cloud/pubsub/internal/publisher_round_robin_decorator.h"
+#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/log.h"
 
 namespace google {
@@ -35,7 +36,8 @@ std::shared_ptr<pubsub_internal::PublisherStub> DecoratePublisherStub(
                                                             std::move(stub));
   }
   stub = std::make_shared<pubsub_internal::PublisherMetadata>(
-      std::move(stub), std::multimap<std::string, std::string>{});
+      std::move(stub), std::multimap<std::string, std::string>{},
+      internal::HandCraftedLibClientHeader());
   if (internal::Contains(opts.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::PublisherLogging>(

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -80,7 +80,7 @@ TEST(PublisherConnectionTest, Metadata) {
         google::cloud::testing_util::ValidateMetadataFixture fixture;
         fixture.IsContextMDValid(
             *context, "google.pubsub.v1.Publisher.Publish", request,
-            google::cloud::internal::ApiClientHeader("generator"));
+            google::cloud::internal::HandCraftedLibClientHeader());
         google::pubsub::v1::PublishResponse response;
         for (auto const& m : request.messages()) {
           response.add_message_ids("ack-" + m.message_id());

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/credentials.h"
+#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
@@ -48,7 +49,8 @@ std::shared_ptr<pubsub_internal::SubscriberStub> DecorateSubscriberStub(
                                                              std::move(stub));
   }
   stub = std::make_shared<pubsub_internal::SubscriberMetadata>(
-      std::move(stub), std::multimap<std::string, std::string>{});
+      std::move(stub), std::multimap<std::string, std::string>{},
+      internal::HandCraftedLibClientHeader());
   auto const& tracing = opts.get<TracingComponentsOption>();
   if (internal::Contains(tracing, "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -137,7 +137,7 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsMetadata) {
                 metadata,
                 UnorderedElementsAre(
                     Pair("x-goog-api-client",
-                         google::cloud::internal::ApiClientHeader("generator")),
+                         google::cloud::internal::HandCraftedLibClientHeader()),
                     Pair("x-goog-request-params",
                          "subscription=" +
                              internal::UrlEncode(subscription.FullName()))));

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/pubsub/internal/subscriber_stub_factory.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/credentials.h"
+#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
 #include <memory>
@@ -281,7 +282,8 @@ std::shared_ptr<pubsub_internal::SubscriberStub> DecorateSubscriptionAdminStub(
                                                              std::move(stub));
   }
   stub = std::make_shared<pubsub_internal::SubscriberMetadata>(
-      std::move(stub), std::multimap<std::string, std::string>{});
+      std::move(stub), std::multimap<std::string, std::string>{},
+      internal::HandCraftedLibClientHeader());
   auto const& tracing = opts.get<TracingComponentsOption>();
   if (internal::Contains(tracing, "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -81,7 +81,7 @@ TEST(SubscriptionAdminConnectionTest, CreateWithMetadata) {
         testing_util::ValidateMetadataFixture fixture;
         fixture.IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.CreateSubscription", request,
-            google::cloud::internal::ApiClientHeader("generator"));
+            google::cloud::internal::HandCraftedLibClientHeader());
         EXPECT_EQ(subscription.FullName(), request.name());
         return make_status_or(request);
       });

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -76,7 +76,7 @@ TEST(TopicAdminConnectionTest, Metadata) {
         ::google::cloud::testing_util::ValidateMetadataFixture fixture;
         fixture.IsContextMDValid(
             context, "google.pubsub.v1.Publisher.CreateTopic", request,
-            google::cloud::internal::ApiClientHeader("generator"));
+            google::cloud::internal::HandCraftedLibClientHeader());
         return make_status_or(request);
       });
 


### PR DESCRIPTION
Use a different x-goog-api-client header for the RPCs using fully generated code vs. the RPCs using at least some hand-crafted code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12580)
<!-- Reviewable:end -->
