### PR TITLE
impl(spanner): identify generated libraries

### DIFF
--- a/google/cloud/spanner/internal/database_admin_metadata.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata.cc
@@ -26,7 +26,8 @@ namespace gsad = ::google::spanner::admin::database;
 DatabaseAdminMetadata::DatabaseAdminMetadata(
     std::shared_ptr<DatabaseAdminStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(
+          google::cloud::internal::HandCraftedLibClientHeader()) {}
 
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminMetadata::AsyncCreateDatabase(

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -44,7 +44,8 @@ class DatabaseAdminMetadataTest : public ::testing::Test {
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, request, google::cloud::internal::ApiClientHeader());
+        context, method, request,
+        google::cloud::internal::HandCraftedLibClientHeader());
   }
 
   static Status TransientError() {

--- a/google/cloud/spanner/internal/instance_admin_metadata.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata.cc
@@ -26,7 +26,8 @@ namespace gsai = ::google::spanner::admin::instance;
 InstanceAdminMetadata::InstanceAdminMetadata(
     std::shared_ptr<InstanceAdminStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(
+          google::cloud::internal::HandCraftedLibClientHeader()) {}
 
 StatusOr<gsai::v1::Instance> InstanceAdminMetadata::GetInstance(
     grpc::ClientContext& context, gsai::v1::GetInstanceRequest const& request) {

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -43,7 +43,8 @@ class InstanceAdminMetadataTest : public ::testing::Test {
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, request, google::cloud::internal::ApiClientHeader());
+        context, method, request,
+        google::cloud::internal::HandCraftedLibClientHeader());
   }
 
   static Status TransientError() {

--- a/google/cloud/spanner/internal/spanner_stub_factory.cc
+++ b/google/cloud/spanner/internal/spanner_stub_factory.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/log.h"
 #include <grpcpp/grpcpp.h>
@@ -38,8 +39,10 @@ std::shared_ptr<SpannerStub> DecorateSpannerStub(
     stub = std::make_shared<SpannerAuth>(std::move(auth), std::move(stub));
   }
   stub = std::make_shared<SpannerMetadata>(
-      std::move(stub), std::multimap<std::string, std::string>{
-                           {"google-cloud-resource-prefix", db.FullName()}});
+      std::move(stub),
+      std::multimap<std::string, std::string>{
+          {"google-cloud-resource-prefix", db.FullName()}},
+      internal::HandCraftedLibClientHeader());
   if (internal::Contains(opts.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<SpannerLogging>(


### PR DESCRIPTION
Use a different x-goog-api-client header for the RPCs using fully generated code vs. the RPCs using at least some hand-crafted code.

Part of the work #12562

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12581)
<!-- Reviewable:end -->
