### PR TITLE
impl(storage): identify generated libraries

### DIFF
--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/storage/internal/storage_tracing_stub.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/log.h"
@@ -74,7 +75,8 @@ CreateDecoratedStubs(google::cloud::CompletionQueue cq, Options const& options,
     stub = std::make_shared<StorageAuth>(std::move(auth), std::move(stub));
   }
   stub = std::make_shared<StorageMetadata>(
-      std::move(stub), std::multimap<std::string, std::string>{});
+      std::move(stub), std::multimap<std::string, std::string>{},
+      internal::HandCraftedLibClientHeader());
   if (google::cloud::internal::Contains(options.get<TracingComponentsOption>(),
                                         "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -54,8 +54,7 @@ class StorageStubFactory : public ::testing::Test {
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, request,
-        google::cloud::internal::HandCraftedLibClientHeader());
+        context, method, request, storage::x_goog_api_client());
   }
 
  private:

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -55,7 +55,7 @@ class StorageStubFactory : public ::testing::Test {
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request,
-        google::cloud::internal::ApiClientHeader("generator"));
+        google::cloud::internal::HandCraftedLibClientHeader());
   }
 
  private:

--- a/google/cloud/storage/version.cc
+++ b/google/cloud/storage/version.cc
@@ -24,7 +24,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string version_string() { return ::google::cloud::version_string(); }
 
 std::string x_goog_api_client() {
-  return google::cloud::internal::ApiClientHeader();
+  return google::cloud::internal::HandCraftedLibClientHeader();
 }
 
 // These were sprinkled through the code, consolidated here because I could


### PR DESCRIPTION
Use a different x-goog-api-client header for the RPCs using fully generated code vs. the RPCs using at least some hand-crafted code.

Part of the work for #12562

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12582)
<!-- Reviewable:end -->
