### PR TITLE
impl(auth): identify generated libraries

### DIFF
--- a/google/cloud/internal/minimal_iam_credentials_stub.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub.cc
@@ -86,7 +86,8 @@ class AsyncAccessTokenGeneratorMetadata : public MinimalIamCredentialsStub {
   explicit AsyncAccessTokenGeneratorMetadata(
       std::shared_ptr<MinimalIamCredentialsStub> child)
       : child_(std::move(child)),
-        x_goog_api_client_(google::cloud::internal::ApiClientHeader()) {}
+        x_goog_api_client_(
+            google::cloud::internal::HandCraftedLibClientHeader()) {}
   ~AsyncAccessTokenGeneratorMetadata() override = default;
 
   future<StatusOr<GenerateAccessTokenResponse>> AsyncGenerateAccessToken(

--- a/google/cloud/internal/minimal_iam_credentials_stub_test.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub_test.cc
@@ -49,7 +49,8 @@ class MinimalIamCredentialsStubTest : public ::testing::Test {
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
                         google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, request, google::cloud::internal::ApiClientHeader());
+        context, method, request,
+        google::cloud::internal::HandCraftedLibClientHeader());
   }
 
   static Status TransientError() {


### PR DESCRIPTION
Use a different x-goog-api-client header for the RPCs using fully generated code vs. the RPCs using at least some hand-crafted code.

Part of the work for #12562

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12583)
<!-- Reviewable:end -->
