### PR TITLE
cleanup(GCS+gRPC): `AsyncConnection` is not private

### DIFF
--- a/google/cloud/storage/async_client.cc
+++ b/google/cloud/storage/async_client.cc
@@ -24,18 +24,15 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using ::google::cloud::internal::MakeBackgroundThreadsFactory;
 
-AsyncClient::AsyncClient(
-    std::shared_ptr<google::cloud::BackgroundThreads> background,
-    std::shared_ptr<storage_internal::AsyncConnection> connection)
-    : background_(std::move(background)), connection_(std::move(connection)) {}
-
-AsyncClient MakeAsyncClient(Options opts) {
-  auto options = storage_internal::DefaultOptionsGrpc(std::move(opts));
-  auto background = MakeBackgroundThreadsFactory(options)();
-  auto connection = storage_internal::MakeAsyncConnection(background->cq(),
-                                                          std::move(options));
-  return AsyncClient(std::move(background), std::move(connection));
+AsyncClient::AsyncClient(Options options) {
+  options = storage_internal::DefaultOptionsGrpc(std::move(options));
+  background_ = MakeBackgroundThreadsFactory(options)();
+  connection_ = storage_internal::MakeAsyncConnection(background_->cq(),
+                                                      std::move(options));
 }
+
+AsyncClient::AsyncClient(std::shared_ptr<AsyncConnection> connection)
+    : connection_(std::move(connection)) {}
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental

--- a/google/cloud/storage/async_client.h
+++ b/google/cloud/storage/async_client.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_CLIENT_H
 
-#include "google/cloud/storage/internal/async/connection.h"
+#include "google/cloud/storage/async_connection.h"
 #include "google/cloud/storage/internal/async/write_payload_impl.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/version.h"
@@ -105,6 +105,11 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class AsyncClient {
  public:
+  /// Create a new client configured with @p options.
+  explicit AsyncClient(Options options = {});
+  /// Create a new client using @p connection. This is often used for mocking.
+  explicit AsyncClient(std::shared_ptr<AsyncConnection> connection);
+
   ~AsyncClient() = default;
 
   /**
@@ -267,10 +272,9 @@ class AsyncClient {
   }
 
  private:
-  friend AsyncClient MakeAsyncClient(Options opts);
   explicit AsyncClient(
       std::shared_ptr<google::cloud::BackgroundThreads> background,
-      std::shared_ptr<storage_internal::AsyncConnection> connection);
+      std::shared_ptr<AsyncConnection> connection);
 
   template <typename... RequestOptions>
   google::cloud::Options SpanOptions(RequestOptions&&... o) const {
@@ -279,13 +283,8 @@ class AsyncClient {
   }
 
   std::shared_ptr<google::cloud::BackgroundThreads> background_;
-  std::shared_ptr<storage_internal::AsyncConnection> connection_;
+  std::shared_ptr<AsyncConnection> connection_;
 };
-
-// TODO(#7142) - expose a factory function / constructor consuming
-//     std::shared_ptr<AsyncConnection> when we have a plan for mocking
-/// Creates a new GCS client exposing asynchronous APIs.
-AsyncClient MakeAsyncClient(Options opts = {});
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental

--- a/google/cloud/storage/async_connection.h
+++ b/google/cloud/storage/async_connection.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_CONNECTION_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_CONNECTION_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_CONNECTION_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_CONNECTION_H
 
 #include "google/cloud/storage/async_object_requests.h"
 #include "google/cloud/storage/async_object_responses.h"
@@ -27,17 +27,16 @@
 
 namespace google {
 namespace cloud {
-namespace storage_internal {
+namespace storage_experimental {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-// TODO(#7142) - move to the public API when we fix the mocking story for GCS
 /**
- * The `*Connection` object for `storage_experimental::AsyncClient`.
+ * The `*Connection` object for `AsyncClient`.
  *
  * This interface defines virtual methods for each of the user-facing overload
- * sets in `storage_experimental::AsyncClient`. This allows users to inject
- * custom behavior (e.g., with a Google Mock object) when writing tests that use
- * objects of type `storage_experimental::AsyncClient`.
+ * sets in `AsyncClient`. This allows users to inject custom behavior (e.g.,
+ * with a Google Mock object) when writing tests that use objects of type
+ * `AsyncClient`.
  *
  * To create a concrete instance, see `MakeAsyncConnection()`.
  *
@@ -57,9 +56,9 @@ class AsyncConnection {
    */
   struct InsertObjectParams {
     /// The metadata attributes to create the object.
-    storage_experimental::InsertObjectRequest request;
+    InsertObjectRequest request;
     /// The bulk payload, sometimes called the "media" or "contents".
-    storage_experimental::WritePayload payload;
+    WritePayload payload;
     /// Any options modifying the RPC behavior, including per-client and
     /// per-connection options.
     Options options;
@@ -77,13 +76,15 @@ class AsyncConnection {
    */
   struct ReadObjectParams {
     /// The metadata attributes to create the object.
-    storage_experimental::ReadObjectRequest request;
+    ReadObjectRequest request;
     /// Any options modifying the RPC behavior, including per-client and
     /// per-connection options.
     Options options;
   };
-  virtual future<storage_experimental::AsyncReadObjectRangeResponse>
-  AsyncReadObjectRange(ReadObjectParams p) = 0;
+
+  /// Read a range from an object returning all the contents.
+  virtual future<AsyncReadObjectRangeResponse> AsyncReadObjectRange(
+      ReadObjectParams p) = 0;
 
   /**
    * A thin wrapper around the `ComposeObject()` parameters.
@@ -93,7 +94,7 @@ class AsyncConnection {
    */
   struct ComposeObjectParams {
     /// The metadata attributes to create the object.
-    storage_experimental::ComposeObjectRequest request;
+    ComposeObjectRequest request;
     /// Any options modifying the RPC behavior, including per-client and
     /// per-connection options.
     Options options;
@@ -112,7 +113,7 @@ class AsyncConnection {
    */
   struct DeleteObjectParams {
     /// The metadata attributes to create the object.
-    storage_experimental::DeleteObjectRequest request;
+    DeleteObjectRequest request;
     /// Any options modifying the RPC behavior, including per-client and
     /// per-connection options.
     Options options;
@@ -123,8 +124,8 @@ class AsyncConnection {
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage_internal
+}  // namespace storage_experimental
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_CONNECTION_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_CONNECTION_H

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -32,7 +32,7 @@ namespace examples = ::google::cloud::storage::examples;
 
 void CreateClient() {
   //! [async-client]
-  auto client = google::cloud::storage_experimental::MakeAsyncClient();
+  auto client = google::cloud::storage_experimental::AsyncClient();
   // Use the client.
   //! [async-client]
 }
@@ -40,7 +40,7 @@ void CreateClient() {
 //! [async-client-with-dp]
 void CreateClientWithDP() {
   namespace g = ::google::cloud;
-  auto client = google::cloud::storage_experimental::MakeAsyncClient(
+  auto client = google::cloud::storage_experimental::AsyncClient(
       g::Options{}.set<g::EndpointOption>(
           "google-c2p:///storage.googleapis.com"));
   // Use the client.
@@ -215,7 +215,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "Running AsyncClientWithDP() example" << std::endl;
   CreateClientWithDPCommand({});
 
-  auto client = google::cloud::storage_experimental::MakeAsyncClient();
+  auto client = google::cloud::storage_experimental::AsyncClient();
 
   std::cout << "Running InsertObject() example" << std::endl;
   InsertObject(client, {bucket_name, object_name});
@@ -268,7 +268,7 @@ int main(int argc, char* argv[]) try {
         }
         throw examples::Usage{std::move(os).str()};
       }
-      auto client = google::cloud::storage_experimental::MakeAsyncClient();
+      auto client = google::cloud::storage_experimental::AsyncClient();
       command(client, std::move(argv));
     };
     return {name, std::move(adapter)};

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -18,12 +18,12 @@
 
 google_cloud_cpp_storage_grpc_hdrs = [
     "async_client.h",
+    "async_connection.h",
     "async_object_requests.h",
     "async_object_responses.h",
     "async_token.h",
     "grpc_plugin.h",
     "internal/async/accumulate_read_object.h",
-    "internal/async/connection.h",
     "internal/async/connection_fwd.h",
     "internal/async/connection_impl.h",
     "internal/async/insert_object.h",

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -42,6 +42,7 @@ else ()
         google_cloud_cpp_storage_grpc # cmake-format: sort
         async_client.cc
         async_client.h
+        async_connection.h
         async_object_requests.h
         async_object_responses.h
         async_token.h
@@ -49,7 +50,6 @@ else ()
         grpc_plugin.h
         internal/async/accumulate_read_object.cc
         internal/async/accumulate_read_object.h
-        internal/async/connection.h
         internal/async/connection_fwd.h
         internal/async/connection_impl.cc
         internal/async/connection_impl.h

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -176,8 +176,8 @@ future<Status> AsyncConnectionImpl::AsyncDeleteObject(DeleteObjectParams p) {
       proto, __func__);
 }
 
-std::shared_ptr<AsyncConnection> MakeAsyncConnection(CompletionQueue cq,
-                                                     Options options) {
+std::shared_ptr<storage_experimental::AsyncConnection> MakeAsyncConnection(
+    CompletionQueue cq, Options options) {
   options = storage_internal::DefaultOptionsGrpc(std::move(options));
   auto p = CreateStorageStub(cq, options);
   return std::make_shared<AsyncConnectionImpl>(
@@ -185,7 +185,7 @@ std::shared_ptr<AsyncConnection> MakeAsyncConnection(CompletionQueue cq,
       std::move(options));
 }
 
-std::shared_ptr<AsyncConnection> MakeAsyncConnection(
+std::shared_ptr<storage_experimental::AsyncConnection> MakeAsyncConnection(
     CompletionQueue cq, std::shared_ptr<StorageStub> stub, Options options) {
   return std::make_shared<AsyncConnectionImpl>(
       std::move(cq), std::shared_ptr<GrpcChannelRefresh>{}, std::move(stub),

--- a/google/cloud/storage/internal/async/connection_impl.h
+++ b/google/cloud/storage/internal/async/connection_impl.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_CONNECTION_IMPL_H
 
+#include "google/cloud/storage/async_connection.h"
 #include "google/cloud/storage/idempotency_policy.h"
-#include "google/cloud/storage/internal/async/connection.h"
 #include "google/cloud/storage/internal/invocation_id_generator.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/storage/retry_policy.h"
@@ -36,7 +36,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GrpcChannelRefresh;
 class StorageStub;
 
-class AsyncConnectionImpl : public AsyncConnection {
+class AsyncConnectionImpl : public storage_experimental::AsyncConnection {
  public:
   explicit AsyncConnectionImpl(CompletionQueue cq,
                                std::shared_ptr<GrpcChannelRefresh> refresh,
@@ -65,12 +65,12 @@ class AsyncConnectionImpl : public AsyncConnection {
   storage::internal::InvocationIdGenerator invocation_id_generator_;
 };
 
-/// Create a connection with the default stub.
-std::shared_ptr<AsyncConnection> MakeAsyncConnection(
+/// Create a connection and the default stub.
+std::shared_ptr<storage_experimental::AsyncConnection> MakeAsyncConnection(
     CompletionQueue cq, Options options = Options{});
 
 /// Create a connection with a custom stub (usually a mock).
-std::shared_ptr<AsyncConnection> MakeAsyncConnection(
+std::shared_ptr<storage_experimental::AsyncConnection> MakeAsyncConnection(
     CompletionQueue cq, std::shared_ptr<StorageStub> stub, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_test.cc
@@ -63,7 +63,7 @@ class AsyncConnectionImplTest : public ::testing::Test {
 
 auto constexpr kAuthority = "storage.googleapis.com";
 
-std::shared_ptr<AsyncConnection> MakeTestConnection(
+std::shared_ptr<storage_experimental::AsyncConnection> MakeTestConnection(
     CompletionQueue cq, std::shared_ptr<storage::testing::MockStorageStub> mock,
     Options options = {}) {
   using ms = std::chrono::milliseconds;

--- a/google/cloud/storage/tests/async_client_integration_test.cc
+++ b/google/cloud/storage/tests/async_client_integration_test.cc
@@ -55,7 +55,7 @@ TEST_F(AsyncClientIntegrationTest, ObjectCRUD) {
 
   auto object_name = MakeRandomObjectName();
 
-  auto async = MakeAsyncClient();
+  auto async = AsyncClient();
   auto insert = async
                     .InsertObject(bucket_name(), object_name, LoremIpsum(),
                                   gcs::IfGenerationMatch(0))
@@ -93,7 +93,7 @@ TEST_F(AsyncClientIntegrationTest, ComposeObject) {
   auto o2 = MakeRandomObjectName();
   auto destination = MakeRandomObjectName();
 
-  auto async = MakeAsyncClient();
+  auto async = AsyncClient();
   auto insert1 = async.InsertObject(bucket_name(), o1, LoremIpsum(),
                                     gcs::IfGenerationMatch(0));
   auto insert2 = async.InsertObject(bucket_name(), o2, LoremIpsum(),


### PR DESCRIPTION
This is now part of the `storage_experimental` namespace and it does not use internal symbols in its API. This makes it possible to mock `AsyncClient` without having to peer into the internal components of the library.

Fixes #12521

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12611)
<!-- Reviewable:end -->
