### PR TITLE
ci(clang-tidy): disable modernize clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,14 @@
 #      `auto Foo() -> std::string { return ...; }`, we think the code is less
 #      readable in this form.
 #
+#  --modernize-concat-nested-namespaces: clang-tidy recommends
+#      `namespace google::cloud {}` over `namespace google { namespace cloud { } }`
+#      We think the code is more readable without nested namespaces.
+#
+#  --modernize-use-nodiscard: clang-tidy recommends adding a nodiscard annotation
+#      to functions where the return value should not be ignored.
+#      We think the code is more readable without the annotations.
+#
 #  -modernize-return-braced-init-list: We think removing typenames and using
 #      only braced-init can hurt readability.
 #
@@ -64,6 +72,8 @@ Checks: >
   -misc-const-correctness,
   -modernize-return-braced-init-list,
   -modernize-use-trailing-return-type,
+  -modernize-concat-nested-namespaces,
+  -modernize-use-nodiscard,
   -modernize-avoid-c-arrays,
   -performance-move-const-arg,
   -readability-braces-around-statements,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,11 +12,11 @@
 #
 #  --modernize-concat-nested-namespaces: clang-tidy recommends
 #      `namespace google::cloud {}` over `namespace google { namespace cloud { } }`
-#      We think the code is more readable without nested namespaces.
+#      We need to support C++14, which does not supported nested namespaces.
 #
 #  --modernize-use-nodiscard: clang-tidy recommends adding a nodiscard annotation
 #      to functions where the return value should not be ignored.
-#      We think the code is more readable without the annotations.
+#      We need to support C++14, which does not supported the annotation.
 #
 #  -modernize-return-braced-init-list: We think removing typenames and using
 #      only braced-init can hurt readability.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12614)
<!-- Reviewable:end -->
