### PR TITLE
impl(pubsub): add data size accessor for publish span

### DIFF
--- a/google/cloud/pubsub/message.h
+++ b/google/cloud/pubsub/message.h
@@ -83,6 +83,7 @@ class Message {
   PubsubMessageDataType&& data() && {
     return std::move(*proto_.mutable_data());
   }
+  size_t data_size() const { return proto_.data().size(); }
   std::string const& message_id() const { return proto_.message_id(); }
   std::string const& ordering_key() const { return proto_.ordering_key(); }
   std::chrono::system_clock::time_point publish_time() const;

--- a/google/cloud/pubsub/message_test.cc
+++ b/google/cloud/pubsub/message_test.cc
@@ -69,6 +69,12 @@ TEST(Message, SetOrderingKey) {
   EXPECT_EQ(m0, move);
 }
 
+TEST(Message, GetDataSize) {
+  auto const m = MessageBuilder{}.SetData("four").Build();
+
+  EXPECT_EQ(m.data_size(), 4);
+}
+
 TEST(Message, InsertAttributeSimple) {
   auto const m0 = MessageBuilder{}
                       .InsertAttribute("k1", "v1")


### PR DESCRIPTION
Part of [12525](https://github.com/googleapis/google-cloud-cpp/issues/12525)