### PR TITLE
ci: execute clang-format twice in generate-libraries

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -83,6 +83,10 @@ if [ -z "${GENERATE_GOLDEN_ONLY}" ]; then
     xargs -P "$(nproc)" -n 1 -0 clang-format -i
   git ls-files -z -- '*.h' '*.cc' '*.proto' |
     xargs -r -P "$(nproc)" -n 50 -0 sed -i 's/[[:blank:]]\+$//'
+  # TODO(#12621): Remove this second execution of clang-format when this issue
+  # is resolved.
+  git ls-files -z -- '*.h' '*.cc' '*.proto' |
+    xargs -P "$(nproc)" -n 1 -0 clang-format -i
 else
   io::log_red "Only formatting generated golden code."
   git ls-files -z -- 'generator/integration_tests/golden/**/*.h' \

--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -85,7 +85,7 @@ if [ -z "${GENERATE_GOLDEN_ONLY}" ]; then
     xargs -r -P "$(nproc)" -n 50 -0 sed -i 's/[[:blank:]]\+$//'
   # TODO(#12621): Remove this second execution of clang-format when this issue
   # is resolved.
-  git ls-files -z -- '*.h' '*.cc' '*.proto' |
+  git ls-files -z -- 'google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_connection_impl.cc' |
     xargs -P "$(nproc)" -n 1 -0 clang-format -i
 else
   io::log_red "Only formatting generated golden code."


### PR DESCRIPTION
workaround for #12621

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12622)
<!-- Reviewable:end -->
