### PR TITLE
chore: exclude external/googleapis.patch from typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -49,6 +49,8 @@ extend-exclude = [
     "docfx/testing/inputs.cc",
     # Some of the tests also contain the same long hex strings.
     "docfx/doxygen2toc_test.cc",
+    # If we're using a post-download patch file for googleapis.
+    "external/googleapis.patch",
 ]
 
 [default]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12625)
<!-- Reviewable:end -->
