### PR TITLE
impl(generator): add support for google.protobuf.Any in discovery doc

### DIFF
--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -92,9 +92,9 @@ Status GenerateProtosFromDiscoveryDoc(
     std::set<std::string> operation_services = {});
 
 // Recurses through the json accumulating the values of any $ref fields
-// whether they exist in simple fields, arrays, maps, or nested messages
-// containing any of the aforementioned field types.
-std::set<std::string> FindAllRefValues(nlohmann::json const& json);
+// or google.protobuf.types whether they exist in simple fields, arrays, maps,
+// or nested messages containing any of the aforementioned field types.
+std::set<std::string> FindAllTypesToImport(nlohmann::json const& json);
 
 // Iterates through all types establishing edges based on their dependencies via
 // DiscoveryTypeVertex::AddNeedsType and DiscoveryTypeVertex::AddNeededByType.

--- a/generator/internal/discovery_type_vertex.h
+++ b/generator/internal/discovery_type_vertex.h
@@ -49,6 +49,9 @@ class DiscoveryTypeVertex {
   std::set<std::string> const& needed_by_resource() const {
     return needed_by_resource_;
   }
+  std::set<std::string> const& needs_protobuf_type() const {
+    return needs_protobuf_type_;
+  }
 
   bool IsSynthesizedRequestType() const;
 
@@ -61,6 +64,9 @@ class DiscoveryTypeVertex {
   // Adds the name of the resource that either directly or transitively depends
   // on this type.
   void AddNeededByResource(std::string resource_name);
+
+  // Adds the name of a "google.protobuf.*" type that exists as a field.
+  void AddNeedsProtobufType(std::string type);
 
   // Returns "optional ", "repeated ", or an empty string depending on the
   // field type.
@@ -141,6 +147,7 @@ class DiscoveryTypeVertex {
   std::set<DiscoveryTypeVertex*> needs_type_;
   std::set<DiscoveryTypeVertex*> needed_by_type_;
   std::set<std::string> needed_by_resource_;
+  std::set<std::string> needs_protobuf_type_;
 };
 
 }  // namespace generator_internal

--- a/generator/internal/discovery_type_vertex_test.cc
+++ b/generator/internal/discovery_type_vertex_test.cc
@@ -210,6 +210,10 @@ INSTANTIATE_TEST_SUITE_P(
             R"""({"type":"array","items":{"type":"integer","format":"int64"}})""",
             "int64", true, false, false, false},
         DetermineTypesSuccess{
+            "array_any",
+            R"""({"type":"array","items":{"type":"object","additionalProperties":{"type":"any"}}})""",
+            "google.protobuf.Any", true, false, false, false},
+        DetermineTypesSuccess{
             "array_nested_message",
             R"""({"type":"array","items":{"type":"object", "properties":{}}})""",
             "TestFieldItem", false, false, false, true},


### PR DESCRIPTION
Compute was permitted to add exactly one `google.protobuf.Any` equivalent json to the Discovery Document, in order to support uniform error reporting, as part of a new `Status` schema such that:
```
message Status {
  optional int32 code = 1;
  repeated google.protobuf.Any details = 2;
  optional string message = 3;
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12627)
<!-- Reviewable:end -->
