### PR TITLE
impl(pubsub): use publisher tracing connection when otel is enabled

### DIFF
--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -21,11 +21,13 @@
 #include "google/cloud/pubsub/internal/flow_controlled_publisher_connection.h"
 #include "google/cloud/pubsub/internal/ordering_key_publisher_connection.h"
 #include "google/cloud/pubsub/internal/publisher_stub_factory.h"
+#include "google/cloud/pubsub/internal/publisher_tracing_connection.h"
 #include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
 #include "google/cloud/pubsub/internal/sequential_batch_sink.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/non_constructible.h"
+#include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/log.h"
 #include <memory>
 
@@ -59,14 +61,21 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
     }
     return pubsub_internal::RejectsWithOrderingKey::Create(
         pubsub_internal::BatchingPublisherConnection::Create(
-            std::move(topic), opts, {}, std::move(sink), std::move(cq)));
+            topic, opts, {}, std::move(sink), std::move(cq)));
   };
+  auto enable_open_telemetry = google::cloud::internal::TracingEnabled(opts);
   auto connection = make_connection();
   if (opts.get<pubsub::FullPublisherActionOption>() !=
       pubsub::FullPublisherAction::kIgnored) {
     connection = pubsub_internal::FlowControlledPublisherConnection::Create(
         std::move(opts), std::move(connection));
   }
+
+  if (enable_open_telemetry) {
+    connection = pubsub_internal::MakePublisherTracingConnection(
+        std::move(topic), std::move(connection));
+  }
+
   return std::make_shared<pubsub_internal::ContainingPublisherConnection>(
       std::move(background), std::move(connection));
 }

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -63,7 +63,7 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
         pubsub_internal::BatchingPublisherConnection::Create(
             topic, opts, {}, std::move(sink), std::move(cq)));
   };
-  auto enable_open_telemetry = google::cloud::internal::TracingEnabled(opts);
+  auto tracing_enabled = google::cloud::internal::TracingEnabled(opts);
   auto connection = make_connection();
   if (opts.get<pubsub::FullPublisherActionOption>() !=
       pubsub::FullPublisherAction::kIgnored) {
@@ -71,7 +71,7 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
         std::move(opts), std::move(connection));
   }
 
-  if (enable_open_telemetry) {
+  if (tracing_enabled) {
     connection = pubsub_internal::MakePublisherTracingConnection(
         std::move(topic), std::move(connection));
   }

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -24,11 +24,9 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
-#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/opentelemetry_options.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
-#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 namespace google {
 namespace cloud {
@@ -354,7 +352,7 @@ TEST(MakePublisherConnectionTest, TracingEnabled) {
   Topic const topic("test-project", "test-topic");
   EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([&](google::cloud::CompletionQueue&, auto,
-                    google::pubsub::v1::PublishRequest const& request) {
+                    google::pubsub::v1::PublishRequest const&) {
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         return make_ready_future(make_status_or(response));
@@ -377,7 +375,7 @@ TEST(MakePublisherConnectionTest, TracingDisabled) {
   Topic const topic("test-project", "test-topic");
   EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([&](google::cloud::CompletionQueue&, auto,
-                    google::pubsub::v1::PublishRequest const& request) {
+                    google::pubsub::v1::PublishRequest const&) {
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         return make_ready_future(make_status_or(response));
@@ -391,7 +389,6 @@ TEST(MakePublisherConnectionTest, TracingDisabled) {
 
   EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
 }
-
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -19,14 +19,14 @@
 #include "google/cloud/pubsub/testing/mock_publisher_stub.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/internal/api_client_header.h"
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/opentelemetry_options.h"
 #include "google/cloud/testing_util/async_sequencer.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
-#include "google/cloud/internal/opentelemetry.h"
-#include "google/cloud/opentelemetry_options.h"
-#include "google/cloud/testing_util/opentelemetry_matchers.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/publisher_connection.h"
 #include "google/cloud/pubsub/internal/defaults.h"
+#include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/pubsub/testing/mock_publisher_stub.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
@@ -23,6 +24,11 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/opentelemetry_options.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 namespace google {
 namespace cloud {
@@ -333,6 +339,60 @@ TEST(PublisherConnectionTest, HandleTransientEnabledRetry) {
   ASSERT_STATUS_OK(response);
   EXPECT_EQ("test-message-id-0", *response);
 }
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+using ::google::cloud::testing_util::DisableTracing;
+using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::InstallSpanCatcher;
+using ::google::cloud::testing_util::SpanNamed;
+using ::testing::Contains;
+using ::testing::IsEmpty;
+
+TEST(MakePublisherConnectionTest, TracingEnabled) {
+  auto span_catcher = InstallSpanCatcher();
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  Topic const topic("test-project", "test-topic");
+  EXPECT_CALL(*mock, AsyncPublish)
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+                    google::pubsub::v1::PublishRequest const& request) {
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-message-id-0");
+        return make_ready_future(make_status_or(response));
+      });
+  auto publisher =
+      MakeTestPublisherConnection(topic, mock, EnableTracing(Options{}));
+
+  auto response =
+      publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
+          .get();
+
+  EXPECT_THAT(
+      span_catcher->GetSpans(),
+      Contains(SpanNamed("projects/test-project/topics/test-topic send")));
+}
+
+TEST(MakePublisherConnectionTest, TracingDisabled) {
+  auto span_catcher = InstallSpanCatcher();
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  Topic const topic("test-project", "test-topic");
+  EXPECT_CALL(*mock, AsyncPublish)
+      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+                    google::pubsub::v1::PublishRequest const& request) {
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-message-id-0");
+        return make_ready_future(make_status_or(response));
+      });
+  auto publisher =
+      MakeTestPublisherConnection(topic, mock, DisableTracing(Options{}));
+
+  auto response =
+      publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
+          .get();
+
+  EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
+}
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
 Use the MakePublisherTracingConnection if the Open Telemetry tracing option is set

Closes #[12525](https://github.com/googleapis/google-cloud-cpp/issues/12525)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12634)
<!-- Reviewable:end -->
