### PR TITLE
impl(otel): use composite propagator over gRPC

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/noexcept_action.h"
+#include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
 #include <grpcpp/grpcpp.h>
@@ -90,8 +91,8 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanGrpc(
           options);
 }
 
-void InjectTraceContext(grpc::ClientContext& context, Options const& options) {
-  auto propagator = GetTextMapPropagator(options);
+void InjectTraceContext(grpc::ClientContext& context, Options const&) {
+  auto propagator = MakePropagator();
   auto current = opentelemetry::context::RuntimeContext::GetCurrent();
   GrpcClientCarrier carrier(context);
   propagator->Inject(carrier, current);

--- a/google/cloud/testing_util/google_cloud_cpp_testing_grpc.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing_grpc.bzl
@@ -24,6 +24,7 @@ google_cloud_cpp_testing_grpc_hdrs = [
     "mock_grpc_authentication_strategy.h",
     "mock_minimal_iam_credentials_stub.h",
     "validate_metadata.h",
+    "validate_propagator.h",
 ]
 
 google_cloud_cpp_testing_grpc_srcs = [
@@ -31,4 +32,5 @@ google_cloud_cpp_testing_grpc_srcs = [
     "is_proto_equal.cc",
     "mock_grpc_authentication_strategy.cc",
     "validate_metadata.cc",
+    "validate_propagator.cc",
 ]

--- a/google/cloud/testing_util/google_cloud_cpp_testing_grpc.cmake
+++ b/google/cloud/testing_util/google_cloud_cpp_testing_grpc.cmake
@@ -26,7 +26,9 @@ add_library(
     mock_grpc_authentication_strategy.h
     mock_minimal_iam_credentials_stub.h
     validate_metadata.cc
-    validate_metadata.h)
+    validate_metadata.h
+    validate_propagator.cc
+    validate_propagator.h)
 target_link_libraries(
     google_cloud_cpp_testing_grpc
     PUBLIC google-cloud-cpp::grpc_utils

--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -171,14 +171,6 @@ std::shared_ptr<SpanCatcher> InstallSpanCatcher() {
   return std::make_shared<SpanCatcher>();
 }
 
-std::shared_ptr<MockTextMapPropagator> InstallMockPropagator() {
-  namespace propagation = opentelemetry::context::propagation;
-  auto mock = std::make_shared<MockTextMapPropagator>();
-  propagation::GlobalTextMapPropagator::SetGlobalPropagator(
-      std::shared_ptr<propagation::TextMapPropagator>(mock));
-  return mock;
-}
-
 Options EnableTracing(Options options) {
   options.set<experimental::OpenTelemetryTracingOption>(true);
   return options;

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -238,14 +238,6 @@ class MockTextMapPropagator
               (const, noexcept, override));
 };
 
-/**
- * Note that this sets the global context propagator, which will persist from
- * one test in a test fixture to the next. Thus it is important that:
- * 1. a new propagator is installed for each test
- * 2. the tests within a fixture do not execute in parallel
- */
-std::shared_ptr<MockTextMapPropagator> InstallMockPropagator();
-
 // Returns options with OpenTelemetry tracing enabled. Uses the global tracer
 // provider.
 Options EnableTracing(Options options);

--- a/google/cloud/testing_util/validate_propagator.cc
+++ b/google/cloud/testing_util/validate_propagator.cc
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/testing_util/validate_propagator.h"
+#include "google/cloud/testing_util/validate_metadata.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace testing_util {
+namespace {
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::IsSupersetOf;
+using ::testing::Not;
+using ::testing::Pair;
+}  // namespace
+
+void ValidatePropagator(grpc::ClientContext& context) {
+  ValidateMetadataFixture fixture;
+  auto md = fixture.GetMetadata(context);
+  EXPECT_THAT(md, IsSupersetOf({Pair("x-cloud-trace-context", _),
+                                Pair("traceparent", _)}));
+}
+
+void ValidateNoPropagator(grpc::ClientContext& context) {
+  ValidateMetadataFixture fixture;
+  auto md = fixture.GetMetadata(context);
+  EXPECT_THAT(md, AllOf(Not(Contains(Pair("x-cloud-trace-context", _))),
+                        Not(Contains(Pair("traceparent", _)))));
+}
+
+}  // namespace testing_util
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/testing_util/validate_propagator.h
+++ b/google/cloud/testing_util/validate_propagator.h
@@ -1,0 +1,37 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_VALIDATE_PROPAGATOR_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_VALIDATE_PROPAGATOR_H
+
+#include "google/cloud/version.h"
+#include <grpcpp/client_context.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace testing_util {
+
+// Confirm that the context is being propagated over gRPC.
+void ValidatePropagator(grpc::ClientContext& context);
+
+// Confirm that no tracing headers are sent over gRPC.
+void ValidateNoPropagator(grpc::ClientContext& context);
+
+}  // namespace testing_util
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_VALIDATE_PROPAGATOR_H


### PR DESCRIPTION
Part of the work for #12451 

Send both `x-cloud-trace-context` and `traceparent` headers over gRPC when tracing with OTel.

Note that we allocate a few unique_ptrs per request now. In a follow up PR I will cache the propagator in the gRPC stubs, so we only do this once at stub creation time.

Bland test updates are relegated to a second commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12635)
<!-- Reviewable:end -->
