### PR TITLE
impl(otel): use composite propagator for REST

### DIFF
--- a/google/cloud/internal/rest_opentelemetry.cc
+++ b/google/cloud/internal/rest_opentelemetry.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/rest_context.h"
+#include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
 #include "absl/strings/match.h"
 #include <opentelemetry/context/propagation/global_propagator.h>
@@ -60,11 +61,12 @@ class RestClientCarrier
 
 }  // namespace
 
-void InjectTraceContext(RestContext& context, Options const& options) {
-  auto propagator = internal::GetTextMapPropagator(options);
+void InjectTraceContext(
+    RestContext& context,
+    opentelemetry::context::propagation::TextMapPropagator& propagator) {
   auto current = opentelemetry::context::RuntimeContext::GetCurrent();
   RestClientCarrier carrier(context);
-  propagator->Inject(carrier, current);
+  propagator.Inject(carrier, current);
 }
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanHttp(

--- a/google/cloud/internal/rest_opentelemetry.h
+++ b/google/cloud/internal/rest_opentelemetry.h
@@ -17,6 +17,7 @@
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include "google/cloud/internal/rest_request.h"
+#include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
 #include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/trace/span.h>
@@ -41,7 +42,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *
  * [header]: https://www.w3.org/TR/trace-context/#traceparent-header
  */
-void InjectTraceContext(RestContext& context, Options const& options);
+void InjectTraceContext(
+    RestContext& context,
+    opentelemetry::context::propagation::TextMapPropagator& propagator);
 
 /**
  * Make a span, setting attributes related to HTTP.


### PR DESCRIPTION
Fixes #11355 . Most of the remaining work for #12451 (there is an outstanding cleanup to remove unused functions).

Always use the composite propagator (`x-cloud-trace-context`, `traceparent`) over REST.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12643)
<!-- Reviewable:end -->
