### PR TITLE
cleanup: deal with some include-what-you-use issues

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/internal/async_retry_loop.h"
 #include "google/cloud/internal/retry_loop.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <map>
+#include <string>
 #include <thread>
 
 namespace google {

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -14,10 +14,11 @@
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_FUTURE_GENERIC_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_FUTURE_GENERIC_H
+
 /**
  * @file
  *
- * Fully specialize `future<void>` and `promise<R>` for void.
+ * Implement `future<T>` and `promise<T>`.
  */
 
 #include "google/cloud/internal/future_base.h"
@@ -26,10 +27,12 @@
 #include "google/cloud/internal/future_then_meta.h"
 #include "google/cloud/version.h"
 #include "absl/meta/type_traits.h"
+#include <future>
 
 namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
  * Implement ISO/IEC TS 19571:2016 `future<T>`.
  */
@@ -141,7 +144,7 @@ class future final : private internal::future_base<T> {
 };
 
 /**
- * Implement `promise<T>` as defined in ISO/IEC TS 19571:2016.
+ * Implement ISO/IEC TS 19571:2016 `promise<T>`.
  */
 template <typename T>
 class promise final : private internal::promise_base<T> {

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -14,10 +14,11 @@
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_FUTURE_VOID_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_FUTURE_VOID_H
+
 /**
  * @file
  *
- * Fully specialize `future<void>` and `promise<R>` for void.
+ * Specialize `future<T>` and `promise<T>` for void.
  */
 
 #include "google/cloud/internal/future_base.h"
@@ -25,12 +26,14 @@
 #include "google/cloud/internal/future_impl.h"
 #include "google/cloud/internal/future_then_meta.h"
 #include "google/cloud/version.h"
+#include <future>
 
 namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
- * Implement ISO/IEC TS 19571:2016 future for void.
+ * Specialize ISO/IEC TS 19571:2016 future for void.
  */
 template <>
 class future<void> final : private internal::future_base<void> {
@@ -134,7 +137,7 @@ class future<void> final : private internal::future_base<void> {
 };
 
 /**
- * Specialize promise as defined in ISO/IEC TS 19571:2016 for void.
+ * Specialize ISO/IEC TS 19571:2016 promise for void.
  */
 template <>
 class promise<void> final : private internal::promise_base<void> {

--- a/google/cloud/internal/async_long_running_operation_test.cc
+++ b/google/cloud/internal/async_long_running_operation_test.cc
@@ -22,6 +22,7 @@
 #include <google/protobuf/duration.pb.h>
 #include <google/protobuf/timestamp.pb.h>
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/async_rest_long_running_operation_test.cc
+++ b/google/cloud/internal/async_rest_long_running_operation_test.cc
@@ -23,6 +23,7 @@
 #include <google/protobuf/duration.pb.h>
 #include <google/protobuf/timestamp.pb.h>
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/default_completion_queue_impl.cc
+++ b/google/cloud/internal/default_completion_queue_impl.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include <grpcpp/alarm.h>
+#include <mutex>
 #include <sstream>
 
 // There is no way to unblock the gRPC event loop, not even calling Shutdown(),

--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -34,6 +34,7 @@
 #include <chrono>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -21,7 +21,9 @@
 #include <google/protobuf/duration.pb.h>
 #include <google/protobuf/timestamp.pb.h>
 #include <gmock/gmock.h>
+#include <memory>
 #include <tuple>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/rest_stub_helpers_test.cc
+++ b/google/cloud/internal/rest_stub_helpers_test.cc
@@ -22,6 +22,8 @@
 #include <google/protobuf/timestamp.pb.h>
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/options.cc
+++ b/google/cloud/options.cc
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <set>
 #include <unordered_map>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -24,6 +24,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -22,7 +22,9 @@
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/log.h"
 #include <fstream>
+#include <memory>
 #include <thread>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/grpc/stub.h"
 #include "google/cloud/storage/internal/hybrid_stub.h"
 #include "google/cloud/internal/getenv.h"
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -27,6 +27,7 @@
 #include "google/cloud/storage/internal/storage_stub_factory.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/internal/async_retry_loop.h"
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl.cc
+++ b/google/cloud/storage/internal/connection_impl.cc
@@ -19,6 +19,7 @@
 #include "absl/strings/match.h"
 #include <sstream>
 #include <thread>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/grpc/stub.h
+++ b/google/cloud/storage/internal/grpc/stub.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/internal/hash_function_impl.h"
 #include "google/cloud/storage/internal/object_requests.h"
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/logging_stub.cc
+++ b/google/cloud/storage/internal/logging_stub.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/logging_stub.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/log.h"
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_write_streambuf.cc
+++ b/google/cloud/storage/internal/object_write_streambuf.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/version.h"
 #include <sstream>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_write_streambuf.h
+++ b/google/cloud/storage/internal/object_write_streambuf.h
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/version.h"
 #include <iostream>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/retry_object_read_source.h"
 #include "google/cloud/log.h"
 #include <algorithm>
+#include <string>
 #include <thread>
 
 namespace google {

--- a/google/cloud/storage/internal/retry_object_read_source.h
+++ b/google/cloud/storage/internal/retry_object_read_source.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/object_read_source.h"
 #include "google/cloud/storage/version.h"
 #include "absl/types/optional.h"
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_rewriter.cc
+++ b/google/cloud/storage/object_rewriter.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/object_rewriter.h"
 #include "google/cloud/storage/internal/storage_connection.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_rewriter.h
+++ b/google/cloud/storage/object_rewriter.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/storage_connection.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/invoke_result.h"
+#include <memory>
 #include <string>
 
 namespace google {

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -15,7 +15,10 @@
 #include "google/cloud/storage/parallel_upload.h"
 #include <nlohmann/json.hpp>
 #include <algorithm>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
Correct a mostly-random set of include-what-you-use problems by directly including the header previously found transitively.

Also tidy up some `future` comments while we're in the file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12646)
<!-- Reviewable:end -->
