### PR TITLE
impl: make external/googleapis/renovate.sh a little smarter

### DIFF
--- a/doc/contributor/howto-guide-update-googleapis-sha.md
+++ b/doc/contributor/howto-guide-update-googleapis-sha.md
@@ -20,36 +20,17 @@ Go to whatever directory holds your clone of the project, for example:
 cd $HOME/google-cloud-cpp
 ```
 
-Create a branch to make your changes
+## Create a branch to make your changes
 
 ```shell
 git checkout main
 git checkout -b chore-update-googleapis-sha-circa-$(date +%Y-%m-%d)
 ```
 
-## Run the "renovate.sh" script to update the Bazel/CMake dependencies
+## Run the "renovate.sh" script
 
 ```shell
 external/googleapis/renovate.sh
-```
-
-Commit those edits:
-
-```shell
-git commit -m"chore: update googleapis SHA circa $(date +%Y-%m-%d)" bazel cmake
-```
-
-## Update the generated libraries
-
-```shell
-external/googleapis/update_libraries.sh
-ci/cloudbuild/build.sh -t generate-libraries-pr
-```
-
-## Stage these changes
-
-```shell
-git add .
 ```
 
 ## Verify everything compiles
@@ -57,12 +38,6 @@ git add .
 ```shell
 bazel build //google/cloud/...
 ci/cloudbuild/build.sh -t cmake-install-pr
-```
-
-## Commit the generated changes
-
-```shell
-git commit -m"Regenerate libraries"
 ```
 
 ## Push the branch and create a pull request


### PR DESCRIPTION
Move some of the steps used to update the googleapis/googleapis version from the recipe documented in the how-to guide, to the `renovate.sh` script.

In particular, the script now updates the protodeps/protolists files, runs the generate-libraries build, and creates git commits ready to be pushed.

This is another step towards possibly automating the whole process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12647)
<!-- Reviewable:end -->
