### PR TITLE
cleanup: iam_policy never became a feature

### DIFF
--- a/ci/cloudbuild/builds/lib/features.sh
+++ b/ci/cloudbuild/builds/lib/features.sh
@@ -60,7 +60,7 @@ function features::libraries() {
 function features::list_full() {
   local feature_list
   mapfile -t feature_list < <(features::libraries)
-  feature_list+=(experimental-opentelemetry experimental-storage-grpc grafeas iam_policy)
+  feature_list+=(experimental-opentelemetry experimental-storage-grpc grafeas)
   printf "%s\n" "${feature_list[@]}" | sort -u
 }
 


### PR DESCRIPTION
I missed this in #12506

`iam_policy` was never released as a feature, so we can remove it from this list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12651)
<!-- Reviewable:end -->
