### PR TITLE
chore: clang tidy fixes when no otel

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -41,8 +41,6 @@ using ::google::cloud::bigtable::testing::MockReadRowsStream;
 using ::google::cloud::testing_util::ScopedLog;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
-using ::google::cloud::testing_util::ValidateNoPropagator;
-using ::google::cloud::testing_util::ValidatePropagator;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
@@ -301,6 +299,8 @@ TEST_F(BigtableStubFactory, FeaturesFlags) {
 using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::ValidateNoPropagator;
+using ::google::cloud::testing_util::ValidatePropagator;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 

--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -119,7 +119,8 @@ std::shared_ptr<pubsub::PublisherConnection> MakePublisherTracingConnection(
 #else  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherTracingConnection(
-    pubsub::Topic, std::shared_ptr<pubsub::PublisherConnection> connection) {
+    pubsub::Topic,  // NOLINT(performance-unnecessary-value-param)
+    std::shared_ptr<pubsub::PublisherConnection> connection) {
   return connection;
 }
 


### PR DESCRIPTION
Every so often I run clang-tidy with OTel disabled and find some nits. If only there was a way to do this automatically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12652)
<!-- Reviewable:end -->
