### PR TITLE
cleanup: deal with a few more random include-what-you-use issues

### DIFF
--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/metadata_update_policy.h"
-#include "google/cloud/bigtable/admin_client.h"
+#include "google/cloud/bigtable/row_set.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/embedded_server_test_fixture.h"
 #include "google/cloud/internal/url_encode.h"

--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/default_completion_queue_impl.h"
+#include "google/cloud/status.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include "google/cloud/testing_util/mock_async_response_reader.h"
@@ -22,10 +23,18 @@
 #include <google/protobuf/duration.pb.h>
 #include <google/protobuf/timestamp.pb.h>
 #include <gmock/gmock.h>
+#include <grpcpp/completion_queue.h>
+#include <grpcpp/support/async_unary_call.h>
+#include <grpcpp/support/status.h>
+#include <algorithm>
 #include <chrono>
 #include <deque>
+#include <future>
 #include <memory>
+#include <mutex>
+#include <set>
 #include <thread>
+#include <type_traits>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/completion_queue_impl.h
+++ b/google/cloud/internal/completion_queue_impl.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
 #include <chrono>
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/default_completion_queue_impl.cc
+++ b/google/cloud/internal/default_completion_queue_impl.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include <grpcpp/alarm.h>
-#include <mutex>
 #include <sstream>
 
 // There is no way to unblock the gRPC event loop, not even calling Shutdown(),

--- a/google/cloud/internal/default_completion_queue_impl.h
+++ b/google/cloud/internal/default_completion_queue_impl.h
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <cinttypes>
 #include <deque>
+#include <mutex>
 #include <unordered_map>
 
 namespace google {


### PR DESCRIPTION
Includes an update to #12646, where the include was moved to a header.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12657)
<!-- Reviewable:end -->
