### PR TITLE
feat: support builds for only common libraries

### DIFF
--- a/ci/cloudbuild/builds/cmake-split-install.sh
+++ b/ci/cloudbuild/builds/cmake-split-install.sh
@@ -48,13 +48,13 @@ io::run cmake --build cmake-out/common-libraries
 io::run cmake --install cmake-out/common-libraries --prefix "${INSTALL_PREFIX}"
 
 io::log_h2 "Building and installing popular libraries"
-mapfile -t core_cmake_args < <(cmake::common_args cmake-out/core-libraries)
+mapfile -t core_cmake_args < <(cmake::common_args cmake-out/popular-libraries)
 io::run cmake "${core_cmake_args[@]}" "${install_args[@]}" \
   -DCMAKE_PREFIX_PATH="${INSTALL_PREFIX}" \
   -DGOOGLE_CLOUD_CPP_ENABLE="bigtable,pubsub,spanner,storage,iam,policytroubleshooter" \
   -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON
-io::run cmake --build cmake-out/core-libraries
-io::run cmake --install cmake-out/core-libraries --prefix "${INSTALL_PREFIX}"
+io::run cmake --build cmake-out/popular-libraries
+io::run cmake --install cmake-out/popular-libraries --prefix "${INSTALL_PREFIX}"
 
 io::log_h2 "Building and installing Compute"
 # We need a custom build directory

--- a/ci/cloudbuild/builds/cmake-split-install.sh
+++ b/ci/cloudbuild/builds/cmake-split-install.sh
@@ -38,23 +38,23 @@ install_args=(
   # Test with shared libraries because the problems are more obvious with them.
   -DBUILD_SHARED_LIBS=ON
 )
-io::log_h2 "Building and installing core libraries"
+
+io::log_h2 "Building and installing common libraries"
 # We need a custom build directory
+mapfile -t core_cmake_args < <(cmake::common_args cmake-out/common-libraries)
+io::run cmake "${core_cmake_args[@]}" "${install_args[@]}" \
+  -DGOOGLE_CLOUD_CPP_ENABLE="__common__"
+io::run cmake --build cmake-out/common-libraries
+io::run cmake --install cmake-out/common-libraries --prefix "${INSTALL_PREFIX}"
+
+io::log_h2 "Building and installing popular libraries"
 mapfile -t core_cmake_args < <(cmake::common_args cmake-out/core-libraries)
 io::run cmake "${core_cmake_args[@]}" "${install_args[@]}" \
-  -DGOOGLE_CLOUD_CPP_ENABLE="bigtable,iam,pubsub,storage,spanner"
+  -DCMAKE_PREFIX_PATH="${INSTALL_PREFIX}" \
+  -DGOOGLE_CLOUD_CPP_ENABLE="bigtable,pubsub,spanner,storage,iam,policytroubleshooter" \
+  -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON
 io::run cmake --build cmake-out/core-libraries
 io::run cmake --install cmake-out/core-libraries --prefix "${INSTALL_PREFIX}"
-
-io::log_h2 "Building and installing all feature"
-# We need a custom build directory
-mapfile -t feature_cmake_args < <(cmake::common_args cmake-out/features)
-io::run cmake "${feature_cmake_args[@]}" "${install_args[@]}" \
-  -DCMAKE_PREFIX_PATH="${INSTALL_PREFIX}" \
-  -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON \
-  -DGOOGLE_CLOUD_CPP_ENABLE="__ga_libraries__,-bigtable,-iam,-pubsub,-storage,-spanner,-compute"
-io::run cmake --build cmake-out/features
-io::run cmake --install cmake-out/features --prefix "${INSTALL_PREFIX}"
 
 io::log_h2 "Building and installing Compute"
 # We need a custom build directory
@@ -65,6 +65,16 @@ io::run cmake "${feature_cmake_args[@]}" "${install_args[@]}" \
   -DGOOGLE_CLOUD_CPP_ENABLE="compute"
 io::run cmake --build cmake-out/compute
 io::run cmake --install cmake-out/compute --prefix "${INSTALL_PREFIX}"
+
+io::log_h2 "Building and installing all features"
+# We need a custom build directory
+mapfile -t feature_cmake_args < <(cmake::common_args cmake-out/features)
+io::run cmake "${feature_cmake_args[@]}" "${install_args[@]}" \
+  -DCMAKE_PREFIX_PATH="${INSTALL_PREFIX}" \
+  -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON \
+  -DGOOGLE_CLOUD_CPP_ENABLE="__ga_libraries__,-bigtable,-pubsub,-storage,-spanner,-iam,-policytroubleshooter,-compute"
+io::run cmake --build cmake-out/features
+io::run cmake --install cmake-out/features --prefix "${INSTALL_PREFIX}"
 
 # Tests the installed artifacts by building all the quickstarts.
 # shellcheck disable=SC2046


### PR DESCRIPTION
In some package ecosystems it may be valuable to compile only the common libraries. Previously it was impossible to compile `grpc_utils` or `rest` unless some feature was also enabled that required these common components.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12660)
<!-- Reviewable:end -->
