### PR TITLE
impl(otel): InstrumentationScope on root spans only

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -151,10 +151,14 @@ class Recordable final : public opentelemetry::sdk::trace::Recordable {
   void SetStatusImpl(opentelemetry::trace::StatusCode code,
                      opentelemetry::nostd::string_view description);
   void SetResourceImpl(opentelemetry::sdk::resource::Resource const& resource);
+  void SetInstrumentationScopeImpl();
 
   Project project_;
   google::devtools::cloudtrace::v2::Span span_;
   bool valid_ = true;
+
+  std::string scope_name_;
+  std::string scope_version_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #12450 

The effect of this PR is that "otel.scope.*" attributes are only set on root spans. They are superfluous on child spans.

---

The OTel implementation calls `SetInstrumentationScope(...)` before `SetIdentity(...)`, so if we want to set it only on the root span, we have to remember its value.

https://github.com/open-telemetry/opentelemetry-cpp/blob/0563a71ce3ea2c580f535996aeb8ce9246f2d703/sdk/src/trace/span.cc#L68-L71

---

I acknowledge that it would have been wiser to treat most if not all `Recordable::Set*` functions this way. ("this way" means writing the proto in `as_proto()`, not in `SetFoo()`). But in the interest of time, I only plan to move the ones I need for now, and will leave the rest as technical debt for my future self.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12668)
<!-- Reviewable:end -->
