### PR TITLE
doc(otel): clarify when `OpenTelemetryTracingOption` applies

### DIFF
--- a/google/cloud/opentelemetry_options.h
+++ b/google/cloud/opentelemetry_options.h
@@ -39,6 +39,10 @@ namespace experimental {
  * Setting this option enables the generation of [traces] by the client
  * library. The library uses the global [tracer provider] to generate traces.
  *
+ * This option only takes affect if provided to `Make*Connection(...)`
+ * functions. If you use custom credentials, it must be provided to the
+ * `Make*Credentials(...)` in order to trace the authentication components.
+ *
  * @par Exporting traces
  * Providing this option to a client only enables the *generation* of traces. It
  * does not enable the *export* of traces.

--- a/google/cloud/opentelemetry_options.h
+++ b/google/cloud/opentelemetry_options.h
@@ -39,13 +39,15 @@ namespace experimental {
  * Setting this option enables the generation of [traces] by the client
  * library. The library uses the global [tracer provider] to generate traces.
  *
- * This option only takes affect if provided to `Make*Connection(...)`
- * functions. If you use custom credentials, it must be provided to the
- * `Make*Credentials(...)` in order to trace the authentication components.
+ * To create a client that traces, this option must be provided to the
+ * `Make*Connection(...)` factory functions. It does not have an effect when
+ * passed to a client's constructor. If you use custom credentials, this option
+ * must also be provided to the `Make*Credentials(...)` factory functions in
+ * order to trace the authentication components.
  *
  * @par Exporting traces
- * Providing this option to a client only enables the *generation* of traces. It
- * does not enable the *export* of traces.
+ * Providing this option only enables the *generation* of traces. It does not
+ * enable the *export* of traces.
  *
  * In order to export the traces, the application must set the global tracer
  * provider. The client library recommends using


### PR DESCRIPTION
Noticed while looking at #12332

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12670)
<!-- Reviewable:end -->
