### PR TITLE
fix(storage): trace auth when default credentials are assumed

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -290,9 +290,9 @@ Options DefaultOptionsWithCredentials(Options opts) {
         internal::MapCredentials(*google::cloud::MakeInsecureCredentials()),
         std::move(opts));
   }
-  return internal::DefaultOptions(
-      internal::MapCredentials(*google::cloud::MakeGoogleDefaultCredentials()),
-      std::move(opts));
+  auto credentials = internal::MapCredentials(
+      *google::cloud::MakeGoogleDefaultCredentials(opts));
+  return internal::DefaultOptions(std::move(credentials), std::move(opts));
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -216,7 +216,7 @@ Options DefaultOptionsGrpc(Options options) {
   if (!options.has<UnifiedCredentialsOption>() &&
       !options.has<GrpcCredentialOption>()) {
     options.set<UnifiedCredentialsOption>(
-        google::cloud::MakeGoogleDefaultCredentials());
+        google::cloud::MakeGoogleDefaultCredentials(options));
   }
   auto const testbench =
       GetEnv("CLOUD_STORAGE_EXPERIMENTAL_GRPC_TESTBENCH_ENDPOINT");


### PR DESCRIPTION
Fixes #12332

If tracing is enabled in the connection, and no credentials are supplied via Options, assume that the customer wants to trace the auth components.

For example, in our OTel tracing quickstart...

Before:
![image](https://github.com/googleapis/google-cloud-cpp/assets/23088558/08ab8e63-7491-4a2f-b945-4c3b27e400a4)

After:
![image](https://github.com/googleapis/google-cloud-cpp/assets/23088558/9edfb6e2-ef0f-47e9-a2e5-8727b93b08a8)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12672)
<!-- Reviewable:end -->
