### PR TITLE
fix(bigtable): the Location ctor takes project ids

### DIFF
--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -54,7 +54,7 @@ future<StatusOr<btadmin::Instance>> InstanceAdmin::CreateInstance(
   request.set_parent(project_name());
   for (auto& kv : *request.mutable_clusters()) {
     kv.second.set_location(
-        Location(project_name(), kv.second.location()).FullName());
+        Location(project_id(), kv.second.location()).FullName());
   }
   return connection_->CreateInstance(request);
 }
@@ -64,7 +64,7 @@ future<StatusOr<btadmin::Cluster>> InstanceAdmin::CreateCluster(
     std::string const& cluster_id) {
   google::cloud::internal::OptionsSpan span(options_);
   auto cluster = std::move(cluster_config).as_proto();
-  cluster.set_location(Location(project_name(), cluster.location()).FullName());
+  cluster.set_location(Location(project_id(), cluster.location()).FullName());
   btadmin::CreateClusterRequest request;
   request.mutable_cluster()->Swap(&cluster);
   request.set_parent(InstanceName(instance_id));

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -75,7 +75,7 @@ auto const kProfileName =
     "projects/the-project/instances/the-instance/appProfiles/the-profile";
 
 std::string LocationName(std::string const& location) {
-  return Location(Project(kProjectName), location).FullName();
+  return Location(Project(kProjectId), location).FullName();
 }
 
 Status FailingStatus() { return Status(StatusCode::kPermissionDenied, "fail"); }


### PR DESCRIPTION
Correct a few places where #12659 confused projects ids ("foo") and project names ("projects/foo").

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12675)
<!-- Reviewable:end -->
