### PR TITLE
docs(spanner): set max_delay to 16s

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3582,7 +3582,7 @@ void CustomRetryPolicy(std::vector<std::string> argv) {
             .set<spanner::SpannerBackoffPolicyOption>(
                 std::make_shared<spanner::ExponentialBackoffPolicy>(
                     /*initial_delay=*/std::chrono::milliseconds(500),
-                    /*maximum_delay=*/std::chrono::seconds(64),
+                    /*maximum_delay=*/std::chrono::seconds(16),
                     /*scaling=*/1.5))));
 
     std::int64_t rows_inserted;


### PR DESCRIPTION
Update the custom retry sample to use a max retry delay of 16 seconds, as that is smaller than the total timeout of 60 seconds. The current values are slightly confusing for users, as it could give the impression that retry delays are not counted towards the total timeout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12680)
<!-- Reviewable:end -->
