### PR TITLE
ci(gha): support manual builds

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -112,7 +112,7 @@ jobs:
           github.event_name == 'schedule' ||
           github.event_name == 'push' ||
           github.event_name == 'workflow_dispatch' ||
-            contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+          contains(github.event.pull_request.labels.*.name, 'gha:full-build')
         }}
     secrets: inherit
   windows-cmake:
@@ -129,6 +129,6 @@ jobs:
           github.event_name == 'schedule' ||
           github.event_name == 'push' ||
           github.event_name == 'workflow_dispatch' ||
-            contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+          contains(github.event.pull_request.labels.*.name, 'gha:full-build')
         }}
     secrets: inherit

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -21,6 +21,7 @@ on:
     - reopened
   schedule:
     - cron: '0 5 * * 1,2,3,4,5'
+  workflow_dispatch:
 
 # Cancel in-progress runs of the workflow if somebody adds a new commit to the
 # PR or branch. That reduces billing, but it creates more noise about cancelled
@@ -70,10 +71,8 @@ jobs:
     if: |-
       ${{
         github.event_name == 'schedule' ||
-        (
-          github.event_name == 'push' &&
-          github.event.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        ) ||
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'gha:full-build')
       }}
     name: macOS-Bazel
@@ -89,10 +88,8 @@ jobs:
     if: |-
       ${{
         github.event_name == 'schedule' ||
-        (
-          github.event_name == 'push' &&
-          github.event.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        ) ||
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'gha:full-build')
       }}
     name: Windows-Bazel
@@ -113,11 +110,9 @@ jobs:
       full-matrix: |-
         ${{
           github.event_name == 'schedule' ||
-          (
-            github.event_name == 'push' &&
-            github.event.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-          ) ||
-          contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+          github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+            contains(github.event.pull_request.labels.*.name, 'gha:full-build')
         }}
     secrets: inherit
   windows-cmake:
@@ -132,10 +127,8 @@ jobs:
       full-matrix: |-
         ${{
           github.event_name == 'schedule' ||
-          (
-            github.event_name == 'push' &&
-            github.event.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-          ) ||
-          contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+          github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+            contains(github.event.pull_request.labels.*.name, 'gha:full-build')
         }}
     secrets: inherit


### PR DESCRIPTION
This will let us trigger full builds manually. This can be used to test changes affecting the full build before the scheduled time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12682)
<!-- Reviewable:end -->
