### PR TITLE
impl(otel): resources on root span only

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -412,6 +412,7 @@ void Recordable::SetStatusImpl(opentelemetry::trace::StatusCode code,
 
 void Recordable::SetResourceImpl(
     opentelemetry::sdk::resource::Resource const& resource) {
+  if (!span_.parent_span_id().empty()) return;
   auto& attributes_proto = *span_.mutable_attributes();
   auto const& attributes = resource.GetAttributes();
   for (auto const& kv : attributes) {
@@ -424,6 +425,7 @@ void Recordable::SetResourceImpl(
                  label.second);
   }
 }
+
 void Recordable::SetInstrumentationScopeImpl() {
   if (!span_.parent_span_id().empty()) return;
   if (!scope_name_.empty()) {

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -736,10 +736,13 @@ TEST(Recordable, ConstantAttributesOnlyOnRootSpan) {
   auto scope =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
           "test-name");
+  auto resource =
+      opentelemetry::sdk::resource::Resource::Create({{"key", "value"}});
 
   auto rec = Recordable(Project(kProjectId));
   rec.SetInstrumentationScope(*scope);
   rec.SetIdentity(opentelemetry::trace::SpanContext::GetInvalid(), parent);
+  rec.SetResource(resource);
 
   auto proto = std::move(rec).as_proto();
   EXPECT_THAT(proto.parent_span_id(), Not(IsEmpty()));


### PR DESCRIPTION
Fixes #12450 

This PR uses some knowledge of the implementation. Namely that `SetResource()` gets called after `SetIdentity()`. In the long run, this may be brittle.

I am refactoring our Recordable class, but would like to get this bandaid in first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12683)
<!-- Reviewable:end -->
