### PR TITLE
impl(bigquery): Project benchmark program

### DIFF
--- a/google/cloud/bigquery/v2/minimal/benchmarks/benchmark.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/benchmark.cc
@@ -61,8 +61,6 @@ using ::google::cloud::bigquery_v2_minimal_internal::QueryRequest;
 using ::google::cloud::bigquery_v2_minimal_internal::Table;
 using ::google::cloud::bigquery_v2_minimal_internal::TableClient;
 using ::google::cloud::internal::MakeStreamRange;
-using std::chrono::steady_clock;
-using std::chrono::system_clock;
 
 namespace {
 double const kResultPercentiles[] = {0, 50, 90, 95, 99, 99.9, 100};
@@ -90,14 +88,6 @@ std::chrono::milliseconds ToChronoMillis(int m) {
 }
 
 }  // anonymous namespace
-
-// Converts TimePoint to time_t for printing progress.
-std::time_t ConvertSteadyClockToTime(std::chrono::steady_clock::time_point t) {
-  return system_clock::to_time_t(
-      std::chrono::system_clock::now() +
-      std::chrono::duration_cast<system_clock::duration>(t -
-                                                         steady_clock::now()));
-}
 
 void Benchmark::PrintThroughputResult(std::ostream& os,
                                       std::string const& test_name,

--- a/google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h
@@ -159,11 +159,6 @@ class ProjectBenchmark : public Benchmark {
 };
 
 /**
- * Time Conversion Utility function used by all benchmarks.
- */
-std::time_t ConvertSteadyClockToTime(std::chrono::steady_clock::time_point t);
-
-/**
  * Helper class to pretty print durations.
  */
 struct FormatDuration {

--- a/google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h
@@ -73,7 +73,7 @@ class Benchmark {
    */
   static void PrintThroughputResult(std::ostream& os,
                                     std::string const& test_name,
-                                    std::string const& phase,
+                                    std::string const& operation,
                                     BenchmarkResult const& result);
 
   /**
@@ -157,6 +157,11 @@ class ProjectBenchmark : public Benchmark {
   Config config_;
   std::shared_ptr<bigquery_v2_minimal_internal::ProjectClient> project_client_;
 };
+
+/**
+ * Time Conversion Utility function used by all benchmarks.
+ */
+std::time_t ConvertSteadyClockToTime(std::chrono::steady_clock::time_point t);
 
 /**
  * Helper class to pretty print durations.

--- a/google/cloud/bigquery/v2/minimal/benchmarks/benchmark_test.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/benchmark_test.cc
@@ -151,6 +151,8 @@ TEST(BenchmarkTest, PrintThroughputResult) {
 
   // The output includes "XX ops/s" where XX is the operations count.
   EXPECT_THAT(output, HasSubstr("345 ops/s"));
+  EXPECT_THAT(output, HasSubstr("Total elapsed time=10 seconds"));
+  EXPECT_THAT(output, HasSubstr("Total number of operations performed=3450"));
 }
 
 TEST(BenchmarkTest, PrintLatencyResult) {

--- a/google/cloud/bigquery/v2/minimal/benchmarks/dataset_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/dataset_benchmark_programs.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h"
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmarks_config.h"
 #include "google/cloud/internal/make_status.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include <cctype>
 #include <chrono>
@@ -29,7 +30,6 @@ using ::google::cloud::bigquery_v2_minimal_benchmarks::DatasetBenchmark;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::DatasetConfig;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::FormatDuration;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::OperationResult;
-using std::chrono::system_clock;
 
 char const kDescription[] =
     R"""(Measures the latency of Bigquery's `GetDataset()` and
@@ -92,15 +92,16 @@ OperationResult RunListDatasets(DatasetBenchmark& benchmark) {
 
 // Run an iteration of the test.
 google::cloud::StatusOr<DatasetBenchmarkResult> RunDatasetBenchmark(
-    DatasetBenchmark& benchmark, std::chrono::seconds test_duration) {
+    DatasetBenchmark& benchmark, absl::Duration test_duration) {
   DatasetBenchmarkResult result = {};
   auto generator = google::cloud::internal::MakeDefaultPRNG();
   std::uniform_int_distribution<int> prng_operation(0, 1);
 
-  auto start = system_clock::now();
+  auto start = absl::Now();
   auto mark = start + test_duration / kBenchmarkProgressMarks;
   auto end = start + test_duration;
-  for (auto now = start; now < end; now = system_clock::now()) {
+  auto local_time_zone = absl::LocalTimeZone();
+  for (auto now = start; now < end; now = absl::Now()) {
     if (prng_operation(generator) == 0) {
       // Call GetDataset.
       auto op_result = RunGetDataset(benchmark);
@@ -116,27 +117,15 @@ google::cloud::StatusOr<DatasetBenchmarkResult> RunDatasetBenchmark(
       }
       result.list_results.operations.emplace_back(op_result);
     }
-    std::time_t start_t = system_clock::to_time_t(start);
-    auto start_time = absl::FromTimeT(start_t);
-    std::time_t end_t = system_clock::to_time_t(end);
-    auto end_time = absl::FromTimeT(end_t);
-    std::time_t now_t = system_clock::to_time_t(now);
-    auto now_time = absl::FromTimeT(now_t);
     if (now >= mark) {
       mark = now + test_duration / kBenchmarkProgressMarks;
-      std::time_t mark_t = system_clock::to_time_t(mark);
-      auto mark_time = absl::FromTimeT(mark_t);
-      std::cout << "Start Time="
-                << absl::FormatTime(start_time, absl::LocalTimeZone())
+      std::cout << "Start Time=" << absl::FormatTime(start, local_time_zone)
                 << std::endl
                 << "Current Progress Mark="
-                << absl::FormatTime(now_time, absl::LocalTimeZone())
-                << std::endl
+                << absl::FormatTime(now, local_time_zone) << std::endl
                 << "Next Progress Mark="
-                << absl::FormatTime(mark_time, absl::LocalTimeZone())
-                << std::endl
-                << "End Time="
-                << absl::FormatTime(end_time, absl::LocalTimeZone())
+                << absl::FormatTime(mark, local_time_zone) << std::endl
+                << "End Time=" << absl::FormatTime(end, local_time_zone)
                 << std::endl
                 << "Number of GetDataset operations performed thus far= "
                 << result.get_results.operations.size()
@@ -144,11 +133,9 @@ google::cloud::StatusOr<DatasetBenchmarkResult> RunDatasetBenchmark(
                 << result.list_results.operations.size() << std::endl;
       std::cout << "..." << std::endl;
     } else if (now > end) {
-      std::cout << "Start Time="
-                << absl::FormatTime(start_time, absl::LocalTimeZone())
+      std::cout << "Start Time=" << absl::FormatTime(start, local_time_zone)
                 << std::endl
-                << "End Time="
-                << absl::FormatTime(end_time, absl::LocalTimeZone())
+                << "End Time=" << absl::FormatTime(end, local_time_zone)
                 << std::endl
                 << "Total Number of GetDataset operations= "
                 << result.get_results.operations.size()
@@ -190,7 +177,7 @@ int main(int argc, char* argv[]) {
 
   DatasetBenchmark benchmark(config);
   // Start the threads running the dataset benchmark test.
-  auto latency_test_start = system_clock::now();
+  auto latency_test_start = absl::Now();
   std::vector<std::future<google::cloud::StatusOr<DatasetBenchmarkResult>>>
       tasks;
   for (int i = 0; i != config.thread_count; ++i) {
@@ -200,7 +187,8 @@ int main(int argc, char* argv[]) {
       launch_policy = std::launch::deferred;
     }
     tasks.emplace_back(std::async(launch_policy, RunDatasetBenchmark,
-                                  std::ref(benchmark), config.test_duration));
+                                  std::ref(benchmark),
+                                  absl::FromChrono(config.test_duration)));
   }
 
   // Wait for the threads and combine all the results.
@@ -226,8 +214,7 @@ int main(int argc, char* argv[]) {
     ++count;
   }
   auto latency_test_elapsed =
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          system_clock::now() - latency_test_start);
+      absl::ToChronoMilliseconds(absl::Now() - latency_test_start);
   combined.get_results.elapsed = latency_test_elapsed;
   combined.list_results.elapsed = latency_test_elapsed;
   std::cout << " DONE. Elapsed Test Duration="

--- a/google/cloud/bigquery/v2/minimal/benchmarks/project_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/project_benchmark_programs.cc
@@ -13,13 +13,193 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h"
+#include "google/cloud/bigquery/v2/minimal/benchmarks/benchmarks_config.h"
+#include "google/cloud/internal/make_status.h"
+#include <cctype>
+#include <chrono>
+#include <future>
+#include <iomanip>
+#include <sstream>
 
-namespace google {
-namespace cloud {
-namespace bigquery_v2_minimal_benchmarks {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+using ::google::cloud::StatusCode;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::Benchmark;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::BenchmarkResult;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::Config;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::ConvertSteadyClockToTime;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::FormatDuration;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::OperationResult;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::ProjectBenchmark;
 
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigquery_v2_minimal_benchmarks
-}  // namespace cloud
-}  // namespace google
+char const kDescription[] =
+    R"""(Measures the latency of Bigquery's`ListProjects()` api.
+
+This benchmark measures the latency of Bigquery's `ListProjects()` api.
+The benchmark:
+- Starts T threads as supplied in the command-line, executing the
+  following loop:
+- Runs for the test duration as supplied in the command-line, constantly
+  executing this basic block:
+  - Makes a rest call to `ListProjects()` api.
+  - If the call fails, the test returns with the failure message.
+  - Reports progress based on the total executing time and where the
+    test is currently.
+
+The test then waits for all the threads to finish and:
+
+- Collects the results from all the threads.
+- Reports the total running time.
+- Reports the latency results, including p0 (minimum), p50, p90, p95, p99, p99.9, and
+  p100 (maximum) latencies.
+)""";
+
+// Helper functions and types for project benchmark program.
+namespace {
+// Number of Progress report threads.
+constexpr int kBenchmarkProgressMarks = 4;
+
+struct ProjectBenchmarkResult {
+  BenchmarkResult list_results;
+};
+
+// Gets a lists of projects.
+OperationResult RunListProjects(ProjectBenchmark& benchmark) {
+  std::deque<OperationResult> operations;
+  auto op = [&benchmark]() -> ::google::cloud::Status {
+    auto projects = benchmark.ListProjects();
+    int project_count = 0;
+    for (auto& project : projects) {
+      auto op_status = project.status();
+      if (!op_status.ok()) {
+        return op_status;
+      }
+      project_count++;
+    }
+
+    std::cout << "#"
+              << " ListProjects(): Total Items fetched: " << project_count
+              << std::endl;
+
+    return ::google::cloud::Status(StatusCode::kOk, "");
+  };
+  return Benchmark::TimeOperation(std::move(op));
+}
+
+// Run an iteration of the test.
+google::cloud::StatusOr<ProjectBenchmarkResult> RunProjectBenchmark(
+    ProjectBenchmark& benchmark, std::chrono::seconds test_duration) {
+  ProjectBenchmarkResult result = {};
+  std::uniform_int_distribution<int> prng_operation(0, 1);
+
+  auto start = std::chrono::steady_clock::now();
+  auto mark = start + test_duration / kBenchmarkProgressMarks;
+  auto end = start + test_duration;
+  for (auto now = start; now < end; now = std::chrono::steady_clock::now()) {
+    // Call ListProjects.
+    auto op_result = RunListProjects(benchmark);
+    if (!op_result.status.ok()) {
+      return op_result.status;
+    }
+    result.list_results.operations.emplace_back(op_result);
+
+    std::time_t start_t = ConvertSteadyClockToTime(start);
+    std::time_t end_t = ConvertSteadyClockToTime(end);
+    if (now >= mark) {
+      mark = now + test_duration / kBenchmarkProgressMarks;
+      std::time_t mark_t = ConvertSteadyClockToTime(mark);
+      std::time_t now_t = ConvertSteadyClockToTime(now);
+      std::cout << "Start Time=" << std::ctime(&start_t)
+                << "Current Progress Mark=" << std::ctime(&now_t)
+                << "Next Progress Mark=" << std::ctime(&mark_t)
+                << "End Time=" << std::ctime(&end_t)
+                << ", Number of ListProjects operations performed thus far= "
+                << result.list_results.operations.size() << std::endl;
+      std::cout << "..." << std::endl;
+    } else if (now > end) {
+      std::cout << "Start Time=" << std::ctime(&start_t)
+                << "End Time=" << std::ctime(&end_t)
+                << ", Total Number of ListProjects operations= "
+                << result.list_results.operations.size() << std::endl;
+      std::cout << "..." << std::endl;
+    }
+  }
+  return result;
+}
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) {
+  Config config;
+  {
+    std::vector<std::string> args{argv, argv + argc};
+    auto c = config.ParseArgs(args);
+    if (!c) {
+      std::cerr << "Error parsing command-line arguments: " << c.status()
+                << std::endl;
+      return 1;
+    }
+    config = *std::move(c);
+  }
+
+  if (config.ExitAfterParse()) {
+    if (config.wants_description) {
+      std::cout << kDescription << std::endl;
+    }
+    if (config.wants_help) {
+      config.PrintUsage();
+    }
+    std::cout << "Exiting..." << std::endl;
+    return 0;
+  }
+  std::cout << "# Project Benchmark STARTED For ListProjects() api with test "
+               "duration as ["
+            << config.test_duration.count() << "] seconds" << std::endl;
+
+  ProjectBenchmark benchmark(config);
+  // Start the threads running the project benchmark test.
+  auto latency_test_start = std::chrono::steady_clock::now();
+  std::vector<std::future<google::cloud::StatusOr<ProjectBenchmarkResult>>>
+      tasks;
+  // If the user requests only one thread, use the current thread.
+  auto launch_policy =
+      config.thread_count == 1 ? std::launch::deferred : std::launch::async;
+  for (int i = 0; i != config.thread_count; ++i) {
+    tasks.emplace_back(std::async(launch_policy, RunProjectBenchmark,
+                                  std::ref(benchmark), config.test_duration));
+  }
+
+  // Wait for the threads and combine all the results.
+  ProjectBenchmarkResult combined{};
+  int count = 0;
+  auto append = [](ProjectBenchmarkResult& destination,
+                   ProjectBenchmarkResult const& source) {
+    auto append_ops = [](BenchmarkResult& d, BenchmarkResult const& s) {
+      d.operations.insert(d.operations.end(), s.operations.begin(),
+                          s.operations.end());
+    };
+    append_ops(destination.list_results, source.list_results);
+  };
+  for (auto& future : tasks) {
+    auto result = future.get();
+    if (!result) {
+      std::cerr << "Standard exception raised by task[" << count
+                << "]: " << result.status() << std::endl;
+    } else {
+      append(combined, *result);
+    }
+    ++count;
+  }
+  auto latency_test_elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - latency_test_start);
+  combined.list_results.elapsed = latency_test_elapsed;
+  std::cout << " DONE. Elapsed Test Duration="
+            << FormatDuration(latency_test_elapsed) << std::endl;
+
+  Benchmark::PrintLatencyResult(std::cout, "Latency-Results", "ListProjects()",
+                                combined.list_results);
+
+  Benchmark::PrintThroughputResult(std::cout, "Throughput-Results",
+                                   "ListProjects()", combined.list_results);
+  std::cout << "# Project Benchmark ENDED" << std::endl;
+
+  return 0;
+}

--- a/google/cloud/bigquery/v2/minimal/benchmarks/project_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/project_benchmark_programs.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h"
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmarks_config.h"
 #include "google/cloud/internal/make_status.h"
+#include "absl/time/time.h"
 #include <cctype>
 #include <chrono>
 #include <future>
@@ -25,10 +26,10 @@ using ::google::cloud::StatusCode;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::Benchmark;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::BenchmarkResult;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::Config;
-using ::google::cloud::bigquery_v2_minimal_benchmarks::ConvertSteadyClockToTime;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::FormatDuration;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::OperationResult;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::ProjectBenchmark;
+using std::chrono::system_clock;
 
 char const kDescription[] =
     R"""(Measures the latency of Bigquery's`ListProjects()` api.
@@ -90,10 +91,10 @@ google::cloud::StatusOr<ProjectBenchmarkResult> RunProjectBenchmark(
   ProjectBenchmarkResult result = {};
   std::uniform_int_distribution<int> prng_operation(0, 1);
 
-  auto start = std::chrono::steady_clock::now();
+  auto start = system_clock::now();
   auto mark = start + test_duration / kBenchmarkProgressMarks;
   auto end = start + test_duration;
-  for (auto now = start; now < end; now = std::chrono::steady_clock::now()) {
+  for (auto now = start; now < end; now = system_clock::now()) {
     // Call ListProjects.
     auto op_result = RunListProjects(benchmark);
     if (!op_result.status.ok()) {
@@ -101,22 +102,38 @@ google::cloud::StatusOr<ProjectBenchmarkResult> RunProjectBenchmark(
     }
     result.list_results.operations.emplace_back(op_result);
 
-    std::time_t start_t = ConvertSteadyClockToTime(start);
-    std::time_t end_t = ConvertSteadyClockToTime(end);
+    std::time_t start_t = system_clock::to_time_t(start);
+    auto start_time = absl::FromTimeT(start_t);
+    std::time_t end_t = system_clock::to_time_t(end);
+    auto end_time = absl::FromTimeT(end_t);
+    std::time_t now_t = system_clock::to_time_t(now);
+    auto now_time = absl::FromTimeT(now_t);
     if (now >= mark) {
       mark = now + test_duration / kBenchmarkProgressMarks;
-      std::time_t mark_t = ConvertSteadyClockToTime(mark);
-      std::time_t now_t = ConvertSteadyClockToTime(now);
-      std::cout << "Start Time=" << std::ctime(&start_t)
-                << "Current Progress Mark=" << std::ctime(&now_t)
-                << "Next Progress Mark=" << std::ctime(&mark_t)
-                << "End Time=" << std::ctime(&end_t)
+      std::time_t mark_t = system_clock::to_time_t(mark);
+      auto mark_time = absl::FromTimeT(mark_t);
+      std::cout << "Start Time="
+                << absl::FormatTime(start_time, absl::LocalTimeZone())
+                << std::endl
+                << "Current Progress Mark="
+                << absl::FormatTime(now_time, absl::LocalTimeZone())
+                << std::endl
+                << "Next Progress Mark="
+                << absl::FormatTime(mark_time, absl::LocalTimeZone())
+                << std::endl
+                << "End Time="
+                << absl::FormatTime(end_time, absl::LocalTimeZone())
+                << std::endl
                 << ", Number of ListProjects operations performed thus far= "
                 << result.list_results.operations.size() << std::endl;
       std::cout << "..." << std::endl;
     } else if (now > end) {
-      std::cout << "Start Time=" << std::ctime(&start_t)
-                << "End Time=" << std::ctime(&end_t)
+      std::cout << "Start Time="
+                << absl::FormatTime(start_time, absl::LocalTimeZone())
+                << std::endl
+                << "End Time="
+                << absl::FormatTime(end_time, absl::LocalTimeZone())
+                << std::endl
                 << ", Total Number of ListProjects operations= "
                 << result.list_results.operations.size() << std::endl;
       std::cout << "..." << std::endl;
@@ -155,7 +172,7 @@ int main(int argc, char* argv[]) {
 
   ProjectBenchmark benchmark(config);
   // Start the threads running the project benchmark test.
-  auto latency_test_start = std::chrono::steady_clock::now();
+  auto latency_test_start = system_clock::now();
   std::vector<std::future<google::cloud::StatusOr<ProjectBenchmarkResult>>>
       tasks;
   // If the user requests only one thread, use the current thread.
@@ -189,7 +206,7 @@ int main(int argc, char* argv[]) {
   }
   auto latency_test_elapsed =
       std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - latency_test_start);
+          system_clock::now() - latency_test_start);
   combined.list_results.elapsed = latency_test_elapsed;
   std::cout << " DONE. Elapsed Test Duration="
             << FormatDuration(latency_test_elapsed) << std::endl;

--- a/google/cloud/bigquery/v2/minimal/benchmarks/project_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/project_benchmark_programs.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h"
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmarks_config.h"
 #include "google/cloud/internal/make_status.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include <cctype>
 #include <chrono>
@@ -29,7 +30,6 @@ using ::google::cloud::bigquery_v2_minimal_benchmarks::Config;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::FormatDuration;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::OperationResult;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::ProjectBenchmark;
-using std::chrono::system_clock;
 
 char const kDescription[] =
     R"""(Measures the latency of Bigquery's`ListProjects()` api.
@@ -87,14 +87,15 @@ OperationResult RunListProjects(ProjectBenchmark& benchmark) {
 
 // Run an iteration of the test.
 google::cloud::StatusOr<ProjectBenchmarkResult> RunProjectBenchmark(
-    ProjectBenchmark& benchmark, std::chrono::seconds test_duration) {
+    ProjectBenchmark& benchmark, absl::Duration test_duration) {
   ProjectBenchmarkResult result = {};
   std::uniform_int_distribution<int> prng_operation(0, 1);
 
-  auto start = system_clock::now();
+  auto start = absl::Now();
   auto mark = start + test_duration / kBenchmarkProgressMarks;
   auto end = start + test_duration;
-  for (auto now = start; now < end; now = system_clock::now()) {
+  auto local_time_zone = absl::LocalTimeZone();
+  for (auto now = start; now < end; now = absl::Now()) {
     // Call ListProjects.
     auto op_result = RunListProjects(benchmark);
     if (!op_result.status.ok()) {
@@ -102,37 +103,23 @@ google::cloud::StatusOr<ProjectBenchmarkResult> RunProjectBenchmark(
     }
     result.list_results.operations.emplace_back(op_result);
 
-    std::time_t start_t = system_clock::to_time_t(start);
-    auto start_time = absl::FromTimeT(start_t);
-    std::time_t end_t = system_clock::to_time_t(end);
-    auto end_time = absl::FromTimeT(end_t);
-    std::time_t now_t = system_clock::to_time_t(now);
-    auto now_time = absl::FromTimeT(now_t);
     if (now >= mark) {
       mark = now + test_duration / kBenchmarkProgressMarks;
-      std::time_t mark_t = system_clock::to_time_t(mark);
-      auto mark_time = absl::FromTimeT(mark_t);
-      std::cout << "Start Time="
-                << absl::FormatTime(start_time, absl::LocalTimeZone())
+      std::cout << "Start Time=" << absl::FormatTime(start, local_time_zone)
                 << std::endl
                 << "Current Progress Mark="
-                << absl::FormatTime(now_time, absl::LocalTimeZone())
-                << std::endl
+                << absl::FormatTime(now, local_time_zone) << std::endl
                 << "Next Progress Mark="
-                << absl::FormatTime(mark_time, absl::LocalTimeZone())
-                << std::endl
-                << "End Time="
-                << absl::FormatTime(end_time, absl::LocalTimeZone())
+                << absl::FormatTime(mark, local_time_zone) << std::endl
+                << "End Time=" << absl::FormatTime(end, local_time_zone)
                 << std::endl
                 << ", Number of ListProjects operations performed thus far= "
                 << result.list_results.operations.size() << std::endl;
       std::cout << "..." << std::endl;
     } else if (now > end) {
-      std::cout << "Start Time="
-                << absl::FormatTime(start_time, absl::LocalTimeZone())
+      std::cout << "Start Time=" << absl::FormatTime(start, local_time_zone)
                 << std::endl
-                << "End Time="
-                << absl::FormatTime(end_time, absl::LocalTimeZone())
+                << "End Time=" << absl::FormatTime(end, local_time_zone)
                 << std::endl
                 << ", Total Number of ListProjects operations= "
                 << result.list_results.operations.size() << std::endl;
@@ -172,7 +159,7 @@ int main(int argc, char* argv[]) {
 
   ProjectBenchmark benchmark(config);
   // Start the threads running the project benchmark test.
-  auto latency_test_start = system_clock::now();
+  auto latency_test_start = absl::Now();
   std::vector<std::future<google::cloud::StatusOr<ProjectBenchmarkResult>>>
       tasks;
   // If the user requests only one thread, use the current thread.
@@ -180,7 +167,8 @@ int main(int argc, char* argv[]) {
       config.thread_count == 1 ? std::launch::deferred : std::launch::async;
   for (int i = 0; i != config.thread_count; ++i) {
     tasks.emplace_back(std::async(launch_policy, RunProjectBenchmark,
-                                  std::ref(benchmark), config.test_duration));
+                                  std::ref(benchmark),
+                                  absl::FromChrono(config.test_duration)));
   }
 
   // Wait for the threads and combine all the results.
@@ -205,8 +193,7 @@ int main(int argc, char* argv[]) {
     ++count;
   }
   auto latency_test_elapsed =
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          system_clock::now() - latency_test_start);
+      absl::ToChronoMilliseconds(absl::Now() - latency_test_start);
   combined.list_results.elapsed = latency_test_elapsed;
   std::cout << " DONE. Elapsed Test Duration="
             << FormatDuration(latency_test_elapsed) << std::endl;

--- a/google/cloud/bigquery/v2/minimal/benchmarks/table_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/table_benchmark_programs.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h"
 #include "google/cloud/bigquery/v2/minimal/benchmarks/benchmarks_config.h"
 #include "google/cloud/internal/make_status.h"
+#include "absl/time/time.h"
 #include <cctype>
 #include <chrono>
 #include <future>
@@ -24,12 +25,11 @@
 using ::google::cloud::StatusCode;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::Benchmark;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::BenchmarkResult;
-using ::google::cloud::bigquery_v2_minimal_benchmarks::ConvertSteadyClockToTime;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::FormatDuration;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::OperationResult;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::TableBenchmark;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::TableConfig;
-using std::chrono::steady_clock;
+using std::chrono::system_clock;
 
 char const kDescription[] =
     R"""(Measures the latency of Bigquery's `GetTable()` and
@@ -97,10 +97,10 @@ google::cloud::StatusOr<TableBenchmarkResult> RunTableBenchmark(
   auto generator = google::cloud::internal::MakeDefaultPRNG();
   std::uniform_int_distribution<int> prng_operation(0, 1);
 
-  auto start = std::chrono::steady_clock::now();
+  auto start = system_clock::now();
   auto mark = start + test_duration / kBenchmarkProgressMarks;
   auto end = start + test_duration;
-  for (auto now = start; now < end; now = std::chrono::steady_clock::now()) {
+  for (auto now = start; now < end; now = system_clock::now()) {
     if (prng_operation(generator) == 0) {
       // Call GetTable.
       auto op_result = RunGetTable(benchmark);
@@ -116,24 +116,40 @@ google::cloud::StatusOr<TableBenchmarkResult> RunTableBenchmark(
       }
       result.list_results.operations.emplace_back(op_result);
     }
-    std::time_t start_t = ConvertSteadyClockToTime(start);
-    std::time_t end_t = ConvertSteadyClockToTime(end);
+    std::time_t start_t = system_clock::to_time_t(start);
+    auto start_time = absl::FromTimeT(start_t);
+    std::time_t end_t = system_clock::to_time_t(end);
+    auto end_time = absl::FromTimeT(end_t);
+    std::time_t now_t = system_clock::to_time_t(now);
+    auto now_time = absl::FromTimeT(now_t);
     if (now >= mark) {
       mark = now + test_duration / kBenchmarkProgressMarks;
-      std::time_t now_t = ConvertSteadyClockToTime(now);
-      std::time_t mark_t = ConvertSteadyClockToTime(mark);
-      std::cout << "Start Time=" << std::ctime(&start_t)
-                << "Current Progress Mark=" << std::ctime(&now_t)
-                << "Next Progress Mark=" << std::ctime(&mark_t)
-                << "End Time=" << std::ctime(&end_t)
+      std::time_t mark_t = system_clock::to_time_t(mark);
+      auto mark_time = absl::FromTimeT(mark_t);
+      std::cout << "Start Time="
+                << absl::FormatTime(start_time, absl::LocalTimeZone())
+                << std::endl
+                << "Current Progress Mark="
+                << absl::FormatTime(now_time, absl::LocalTimeZone())
+                << std::endl
+                << "Next Progress Mark="
+                << absl::FormatTime(mark_time, absl::LocalTimeZone())
+                << std::endl
+                << "End Time="
+                << absl::FormatTime(end_time, absl::LocalTimeZone())
+                << std::endl
                 << "Number of GetTable operations performed thus far= "
                 << result.get_results.operations.size()
                 << ", Number of ListTables operations performed thus far= "
                 << result.list_results.operations.size() << std::endl;
       std::cout << "..." << std::endl;
     } else if (now > end) {
-      std::cout << "Start Time=" << std::ctime(&start_t)
-                << "End Time=" << std::ctime(&end_t)
+      std::cout << "Start Time="
+                << absl::FormatTime(start_time, absl::LocalTimeZone())
+                << std::endl
+                << "End Time="
+                << absl::FormatTime(end_time, absl::LocalTimeZone())
+                << std::endl
                 << "Total Number of GetTable operations= "
                 << result.get_results.operations.size()
                 << ", Total Number of ListTables operations= "
@@ -174,7 +190,7 @@ int main(int argc, char* argv[]) {
 
   TableBenchmark benchmark(config);
   // Start the threads running the table benchmark test.
-  auto latency_test_start = std::chrono::steady_clock::now();
+  auto latency_test_start = system_clock::now();
   std::vector<std::future<google::cloud::StatusOr<TableBenchmarkResult>>> tasks;
   // If the user requests only one thread, use the current thread.
   auto launch_policy =
@@ -208,7 +224,7 @@ int main(int argc, char* argv[]) {
   }
   auto latency_test_elapsed =
       std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - latency_test_start);
+          system_clock::now() - latency_test_start);
   combined.get_results.elapsed = latency_test_elapsed;
   combined.list_results.elapsed = latency_test_elapsed;
   std::cout << " DONE. Elapsed Test Duration="

--- a/google/cloud/bigquery/v2/minimal/benchmarks/table_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/table_benchmark_programs.cc
@@ -24,12 +24,12 @@
 using ::google::cloud::StatusCode;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::Benchmark;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::BenchmarkResult;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::ConvertSteadyClockToTime;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::FormatDuration;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::OperationResult;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::TableBenchmark;
 using ::google::cloud::bigquery_v2_minimal_benchmarks::TableConfig;
 using std::chrono::steady_clock;
-using std::chrono::system_clock;
 
 char const kDescription[] =
     R"""(Measures the latency of Bigquery's `GetTable()` and
@@ -90,14 +90,6 @@ OperationResult RunListTables(TableBenchmark& benchmark) {
   return Benchmark::TimeOperation(std::move(op));
 }
 
-// Converts TimePoint to time_t for printing progress.
-std::time_t steady_clock_to_time_t(std::chrono::steady_clock::time_point t) {
-  return system_clock::to_time_t(
-      std::chrono::system_clock::now() +
-      std::chrono::duration_cast<system_clock::duration>(t -
-                                                         steady_clock::now()));
-}
-
 // Run an iteration of the test.
 google::cloud::StatusOr<TableBenchmarkResult> RunTableBenchmark(
     TableBenchmark& benchmark, std::chrono::seconds test_duration) {
@@ -124,19 +116,27 @@ google::cloud::StatusOr<TableBenchmarkResult> RunTableBenchmark(
       }
       result.list_results.operations.emplace_back(op_result);
     }
+    std::time_t start_t = ConvertSteadyClockToTime(start);
+    std::time_t end_t = ConvertSteadyClockToTime(end);
     if (now >= mark) {
       mark = now + test_duration / kBenchmarkProgressMarks;
-      std::time_t start_t = steady_clock_to_time_t(start);
-      std::time_t end_t = steady_clock_to_time_t(end);
-      std::time_t now_t = steady_clock_to_time_t(now);
-      std::time_t mark_t = steady_clock_to_time_t(mark);
+      std::time_t now_t = ConvertSteadyClockToTime(now);
+      std::time_t mark_t = ConvertSteadyClockToTime(mark);
       std::cout << "Start Time=" << std::ctime(&start_t)
                 << "Current Progress Mark=" << std::ctime(&now_t)
                 << "Next Progress Mark=" << std::ctime(&mark_t)
                 << "End Time=" << std::ctime(&end_t)
-                << "Number of GetTable operations= "
+                << "Number of GetTable operations performed thus far= "
                 << result.get_results.operations.size()
-                << ", Number of ListTables operations= "
+                << ", Number of ListTables operations performed thus far= "
+                << result.list_results.operations.size() << std::endl;
+      std::cout << "..." << std::endl;
+    } else if (now > end) {
+      std::cout << "Start Time=" << std::ctime(&start_t)
+                << "End Time=" << std::ctime(&end_t)
+                << "Total Number of GetTable operations= "
+                << result.get_results.operations.size()
+                << ", Total Number of ListTables operations= "
                 << result.list_results.operations.size() << std::endl;
       std::cout << "..." << std::endl;
     }

--- a/google/cloud/bigquery/v2/minimal/internal/project.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project.cc
@@ -53,14 +53,14 @@ void to_json(nlohmann::json& j, Project const& p) {
   j = nlohmann::json{{"kind", p.kind},
                      {"id", p.id},
                      {"friendlyName", p.friendly_name},
-                     {"numericId", p.numeric_id},
+                     {"numericId", std::to_string(p.numeric_id)},
                      {"projectReference", p.project_reference}};
 }
 void from_json(nlohmann::json const& j, Project& p) {
   SafeGetTo(p.kind, j, "kind");
   SafeGetTo(p.id, j, "id");
   SafeGetTo(p.friendly_name, j, "friendlyName");
-  SafeGetTo(p.numeric_id, j, "numericId");
+  p.numeric_id = GetNumberFromJson(j, "numericId");
   SafeGetTo(p.project_reference, j, "projectReference");
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/project_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_response.cc
@@ -69,16 +69,16 @@ StatusOr<ListProjectsResponse> ListProjectsResponse::BuildFromHttpResponse(
                                    GCP_ERROR_INFO());
   }
 
-  if (result.total_items > 0) {
-    for (auto const& kv : json->at("projects").items()) {
-      auto const& json_list_format_project_obj = kv.value();
-      if (!valid_project(json_list_format_project_obj)) {
-        return internal::InternalError("Not a valid Json Project object",
-                                       GCP_ERROR_INFO());
-      }
-      auto const& project = json_list_format_project_obj.get<Project>();
-      result.projects.push_back(project);
+  if (result.total_items == 0) return result;
+
+  for (auto const& kv : json->at("projects").items()) {
+    auto const& json_list_format_project_obj = kv.value();
+    if (!valid_project(json_list_format_project_obj)) {
+      return internal::InternalError("Not a valid Json Project object",
+                                     GCP_ERROR_INFO());
     }
+    auto const& project = json_list_format_project_obj.get<Project>();
+    result.projects.push_back(project);
   }
 
   return result;

--- a/google/cloud/bigquery/v2/minimal/internal/project_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_response.cc
@@ -31,7 +31,7 @@ bool valid_project(nlohmann::json const& j) {
 }
 
 bool valid_projects_list(nlohmann::json const& j) {
-  return (j.contains("kind") && j.contains("etag") && j.contains("projects"));
+  return (j.contains("kind") && j.contains("etag") && j.contains("totalItems"));
 }
 
 StatusOr<nlohmann::json> parse_json(std::string const& payload) {
@@ -63,19 +63,22 @@ StatusOr<ListProjectsResponse> ListProjectsResponse::BuildFromHttpResponse(
   result.kind = json->value("kind", "");
   result.etag = json->value("etag", "");
   result.next_page_token = json->value("nextPageToken", "");
-  if (!absl::SimpleAtoi(json->value("totalItems", "0"), &result.total_items)) {
+  result.total_items = json->value("totalItems", 0);
+  if (result.total_items < 0) {
     return internal::InternalError("Invalid value for totalItems",
                                    GCP_ERROR_INFO());
   }
 
-  for (auto const& kv : json->at("projects").items()) {
-    auto const& json_list_format_project_obj = kv.value();
-    if (!valid_project(json_list_format_project_obj)) {
-      return internal::InternalError("Not a valid Json Project object",
-                                     GCP_ERROR_INFO());
+  if (result.total_items > 0) {
+    for (auto const& kv : json->at("projects").items()) {
+      auto const& json_list_format_project_obj = kv.value();
+      if (!valid_project(json_list_format_project_obj)) {
+        return internal::InternalError("Not a valid Json Project object",
+                                       GCP_ERROR_INFO());
+      }
+      auto const& project = json_list_format_project_obj.get<Project>();
+      result.projects.push_back(project);
     }
-    auto const& project = json_list_format_project_obj.get<Project>();
-    result.projects.push_back(project);
   }
 
   return result;

--- a/google/cloud/bigquery/v2/minimal/internal/project_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_response_test.cc
@@ -76,6 +76,19 @@ TEST(ListProjectsResponseTest, SuccessSinglePage) {
   bigquery_v2_minimal_testing::AssertEquals(expected, projects[0]);
 }
 
+TEST(ListProjectsResponseTest, SuccessNoProjects) {
+  BigQueryHttpResponse http_response;
+  http_response.payload =
+      R"({"etag": "tag-1",
+          "kind": "kind-1",
+          "nextPageToken": "npt-123",
+          "totalItems": 0})";
+  auto const response =
+      ListProjectsResponse::BuildFromHttpResponse(http_response);
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(response->total_items, 0);
+}
+
 TEST(ListProjectsResponseTest, EmptyPayload) {
   BigQueryHttpResponse http_response;
   auto const response =
@@ -113,7 +126,7 @@ TEST(ListProjectsResponseTest, InvalidProject) {
       R"({"etag": "tag-1",
           "kind": "kind-1",
           "nextPageToken": "npt-123",
-          "totalItems": "1",
+          "totalItems": 1,
           "projects": [
               {
                 "id": "1",
@@ -132,7 +145,7 @@ TEST(ListProjectsResponseTest, InvalidTotalItems) {
       R"({"etag": "tag-1",
           "kind": "kind-1",
           "nextPageToken": "npt-123",
-          "totalItems": "invalid",
+          "totalItems": -1,
           "projects": []})";
   auto const response =
       ListProjectsResponse::BuildFromHttpResponse(http_response);

--- a/google/cloud/bigquery/v2/minimal/testing/project_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/project_test_utils.cc
@@ -45,7 +45,7 @@ std::string MakeProjectJsonText() {
   return R"({"kind":"p-kind")"
          R"(,"id":"p-id")"
          R"(,"friendlyName":"p-friendly-name")"
-         R"(,"numericId":123)"
+         R"(,"numericId":"123")"
          R"(,"projectReference":{)"
          R"("projectId":"p-project-id")"
          R"(})"
@@ -57,7 +57,7 @@ std::string MakeListProjectsResponseJsonText() {
   return R"({"etag": "tag-1",
           "kind": "kind-1",
           "nextPageToken": "npt-123",
-          "totalItems": "1",
+          "totalItems": 1,
           "projects": [)" +
          projects_json_txt + R"(]})";
 }
@@ -66,7 +66,7 @@ std::string MakeListProjectsResponseNoPageTokenJsonText() {
   auto projects_json_txt = MakeProjectJsonText();
   return R"({"etag": "tag-1",
           "kind": "kind-1",
-          "totalItems": "1",
+          "totalItems": 1,
           "projects": [)" +
          projects_json_txt + R"(]})";
 }


### PR DESCRIPTION
This benchmark PR includes the following changes

1) A Project benchmark program that runs theListProject apis end to end based on input parameters 
and prints latency and throughput results. See the Project benchmark program output here: https://paste.googleplex.com/5685157741723648

2) Minor refactor of common time conversion method used by all benchmarks.

3) Added more information in `PrintThroughputResults()`.

3) Fixed the following issues related to parsing of json projects response, as exposed by benchmark tests:

- Fixed json parsing of 64-bit numbers being returned as json strings and corresponding unit tests.
- Fixed the validation logic in `valid_projects_list()` (e.g. "projects" field is not always returned. It may not be returned for the last page when "totalItems" field is 0)
- Fixed handling of Empty projects list returned in the response. This can happen if totalItems in the json response has a value of 0 i.e last page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12685)
<!-- Reviewable:end -->
